### PR TITLE
fix(common): stop warning with a stack trace when a partition metafile already exists

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionMetadata.java
@@ -113,7 +113,7 @@ public class HoodiePartitionMetadata {
               // to create it and all but the winner fail with an 'already exists' error. Losing that
               // race means the metafile is in place, which is what the caller asked for: retrying
               // would only re-observe the same file, and warning about it is pure noise.
-              if (!storage.exists(metaPath)) {
+              if (!metafileExistsAfterFailedWrite(metaPath, e)) {
                 throw e;
               }
               log.debug("Partition metafile {} was concurrently created by another task.", metaPath);
@@ -122,6 +122,28 @@ public class HoodiePartitionMetadata {
           return null;
         });
     retryHelper.start();
+  }
+
+  /**
+   * Whether the metafile is there after a write that failed, which is how a lost creation race is
+   * recognised.
+   * <p>
+   * The check is only ever used to soften the failure that was just caught, so it must not replace
+   * it. If storage cannot answer, report the metafile as absent and let the original failure be
+   * thrown: that keeps the caller's exception, and with it the retry classification the write
+   * failure was entitled to, rather than substituting a fresh {@link IOException} that
+   * {@link RetryHelper} would not retry.
+   *
+   * @param metaPath    the metafile being written.
+   * @param writeFailure the failure to attach the check failure to, should the check itself fail.
+   */
+  private boolean metafileExistsAfterFailedWrite(StoragePath metaPath, Exception writeFailure) {
+    try {
+      return storage.exists(metaPath);
+    } catch (IOException checkFailure) {
+      writeFailure.addSuppressed(checkFailure);
+      return false;
+    }
   }
 
   private void writeMetafile(StoragePath metaPath) throws IOException {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePartitionMetadata.java
@@ -106,20 +106,35 @@ public class HoodiePartitionMetadata {
     RetryHelper<Void, HoodieIOException>  retryHelper = new RetryHelper(1000, 3, 1000, HoodieIOException.class.getName())
         .tryWith(() -> {
           if (!storage.exists(metaPath)) {
-            if (format.isPresent()) {
-              writeMetafileInFormat(metaPath, format.get());
-            } else {
-              // Backwards compatible properties file format
-              try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-                props.store(os, "partition metadata");
-                Option<byte []> content = Option.of(os.toByteArray());
-                storage.createImmutableFileInPath(metaPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
+            try {
+              writeMetafile(metaPath);
+            } catch (IOException | HoodieIOException e) {
+              // The metafile is immutable, so tasks writing to the same partition concurrently race
+              // to create it and all but the winner fail with an 'already exists' error. Losing that
+              // race means the metafile is in place, which is what the caller asked for: retrying
+              // would only re-observe the same file, and warning about it is pure noise.
+              if (!storage.exists(metaPath)) {
+                throw e;
               }
+              log.debug("Partition metafile {} was concurrently created by another task.", metaPath);
             }
           }
           return null;
         });
     retryHelper.start();
+  }
+
+  private void writeMetafile(StoragePath metaPath) throws IOException {
+    if (format.isPresent()) {
+      writeMetafileInFormat(metaPath, format.get());
+    } else {
+      // Backwards compatible properties file format
+      try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+        props.store(os, "partition metadata");
+        Option<byte []> content = Option.of(os.toByteArray());
+        storage.createImmutableFileInPath(metaPath, content.map(HoodieInstantWriter::convertByteArrayToWriter));
+      }
+    }
   }
 
   private String getMetafileExtension() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/RetryHelper.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/RetryHelper.java
@@ -102,7 +102,12 @@ public class RetryHelper<T, R extends Exception> implements Serializable {
           log.error(message, e);
           throw e;
         }
-        log.warn("Task [{}] failed. current retry number {}, will retry after {} ms.", taskInfo, retries, waitTime, e);
+        // Only summarise the cause here: a retry that goes on to succeed does not warrant a stack
+        // trace, and printing one per attempt buries the genuine failures. The full trace is still
+        // logged at DEBUG, and at ERROR below once the retries are exhausted.
+        log.warn("Task [{}] failed with {}. current retry number {}, will retry after {} ms.",
+            taskInfo, summarise(e), retries, waitTime);
+        log.debug("Task [{}] failed, attempt {}.", taskInfo, retries, e);
         try {
           Thread.sleep(waitTime);
         } catch (InterruptedException ex) {
@@ -120,6 +125,20 @@ public class RetryHelper<T, R extends Exception> implements Serializable {
 
   public T start() throws R {
     return start(this.func);
+  }
+
+  /**
+   * Renders an exception as a single line, keeping the root cause so that the warning stays
+   * actionable without the whole stack trace.
+   */
+  @VisibleForTesting
+  static String summarise(Throwable t) {
+    Throwable rootCause = t;
+    while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+      rootCause = rootCause.getCause();
+    }
+    String summary = t.getClass().getName() + ": " + t.getMessage();
+    return rootCause == t ? summary : summary + ", caused by " + rootCause.getClass().getName() + ": " + rootCause.getMessage();
   }
 
   private boolean checkIfExceptionInRetryList(Exception e) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/RetryHelper.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/RetryHelper.java
@@ -102,11 +102,11 @@ public class RetryHelper<T, R extends Exception> implements Serializable {
           log.error(message, e);
           throw e;
         }
-        // Only summarise the cause here: a retry that goes on to succeed does not warrant a stack
+        // Only summarize the cause here: a retry that goes on to succeed does not warrant a stack
         // trace, and printing one per attempt buries the genuine failures. The full trace is still
         // logged at DEBUG, and at ERROR below once the retries are exhausted.
         log.warn("Task [{}] failed with {}. current retry number {}, will retry after {} ms.",
-            taskInfo, summarise(e), retries, waitTime);
+            taskInfo, summarize(e), retries, waitTime);
         log.debug("Task [{}] failed, attempt {}.", taskInfo, retries, e);
         try {
           Thread.sleep(waitTime);
@@ -132,7 +132,7 @@ public class RetryHelper<T, R extends Exception> implements Serializable {
    * actionable without the whole stack trace.
    */
   @VisibleForTesting
-  static String summarise(Throwable t) {
+  static String summarize(Throwable t) {
     Throwable rootCause = t;
     while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
       rootCause = rootCause.getCause();

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestLogAppender.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestLogAppender.java
@@ -44,7 +44,7 @@ import java.util.UUID;
  */
 public class HoodieTestLogAppender extends AbstractAppender {
 
-  private final List<LogEvent> log = new ArrayList<>();
+  private final List<LogEvent> capturedEvents = new ArrayList<>();
   private Logger attachedLogger;
 
   public HoodieTestLogAppender() {
@@ -54,11 +54,11 @@ public class HoodieTestLogAppender extends AbstractAppender {
   @Override
   public void append(LogEvent event) {
     // the event is mutable and gets reused, so keep an immutable copy
-    log.add(event.toImmutable());
+    capturedEvents.add(event.toImmutable());
   }
 
-  public List<LogEvent> getLog() {
-    return new ArrayList<>(log);
+  public List<LogEvent> getCapturedEvents() {
+    return new ArrayList<>(capturedEvents);
   }
 
   /**

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestLogAppender.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestLogAppender.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.testutils;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
@@ -64,7 +65,7 @@ public class HoodieTestLogAppender extends AbstractAppender {
    * Starts this appender and attaches it to the logger of the given class.
    */
   public HoodieTestLogAppender attachTo(Class<?> clazz) {
-    attachedLogger = (Logger) org.apache.logging.log4j.LogManager.getLogger(clazz);
+    attachedLogger = (Logger) LogManager.getLogger(clazz);
     start();
     attachedLogger.addAppender(this);
     return this;

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestLogAppender.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestLogAppender.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.testutils;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Collects the log events a logger emits, so a test can assert on what was logged.
+ * <p>
+ * Attach it around the code under test and detach it afterwards:
+ * <pre>{@code
+ * HoodieTestLogAppender appender = new HoodieTestLogAppender();
+ * appender.attachTo(SomeClass.class);
+ * try {
+ *   // exercise the code
+ * } finally {
+ *   appender.detach();
+ * }
+ * }</pre>
+ * Named so that surefire does not mistake it for a test class.
+ */
+public class HoodieTestLogAppender extends AbstractAppender {
+
+  private final List<LogEvent> log = new ArrayList<>();
+  private Logger attachedLogger;
+
+  public HoodieTestLogAppender() {
+    super(UUID.randomUUID().toString(), null, null, false, null);
+  }
+
+  @Override
+  public void append(LogEvent event) {
+    // the event is mutable and gets reused, so keep an immutable copy
+    log.add(event.toImmutable());
+  }
+
+  public List<LogEvent> getLog() {
+    return new ArrayList<>(log);
+  }
+
+  /**
+   * Starts this appender and attaches it to the logger of the given class.
+   */
+  public HoodieTestLogAppender attachTo(Class<?> clazz) {
+    attachedLogger = (Logger) org.apache.logging.log4j.LogManager.getLogger(clazz);
+    start();
+    attachedLogger.addAppender(this);
+    return this;
+  }
+
+  /**
+   * Detaches from the logger it was attached to and stops. Safe to call if never attached.
+   */
+  public void detach() {
+    if (attachedLogger != null) {
+      attachedLogger.removeAppender(this);
+      attachedLogger = null;
+    }
+    stop();
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
@@ -96,7 +96,7 @@ public class TestRetryHelper {
   }
 
   @Test
-  public void testSummariseKeepsRootCauseOnASingleLine() {
+  public void testSummarizeKeepsRootCauseOnASingleLine() {
     // a wrapped exception keeps both layers, so the warning stays actionable without a stack trace
     IOException wrapped = new IOException("Failed to create file /a/b/.hoodie_partition_metadata",
         new FileAlreadyExistsException("File already exists: /a/b/.hoodie_partition_metadata"));

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
@@ -22,9 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.FileAlreadyExistsException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,6 +52,21 @@ public class TestRetryHelper {
     retryHelper =  new RetryHelper(INTERVAL_TIME, NUM, INTERVAL_TIME, Exception.class.getName());
     retry = (boolean) privateOne.invoke(retryHelper, new UnsupportedOperationException("test"));
     assertTrue(retry);
+  }
+
+  @Test
+  public void testSummariseKeepsRootCauseOnASingleLine() {
+    // a wrapped exception keeps both layers, so the warning stays actionable without a stack trace
+    IOException wrapped = new IOException("Failed to create file /a/b/.hoodie_partition_metadata",
+        new FileAlreadyExistsException("File already exists: /a/b/.hoodie_partition_metadata"));
+    String summary = RetryHelper.summarise(wrapped);
+    assertTrue(summary.contains("java.io.IOException: Failed to create file /a/b/.hoodie_partition_metadata"), summary);
+    assertTrue(summary.contains("caused by java.nio.file.FileAlreadyExistsException"), summary);
+    assertFalse(summary.contains("\n"), "the summary must stay on a single line: " + summary);
+    assertFalse(summary.contains("\tat "), "the summary must not carry a stack trace: " + summary);
+
+    // an exception with no cause is rendered as-is
+    assertEquals("java.io.IOException: plain", RetryHelper.summarise(new IOException("plain")));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
@@ -18,16 +18,26 @@
 
 package org.apache.hudi.common.util;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -52,6 +62,44 @@ public class TestRetryHelper {
     retryHelper =  new RetryHelper(INTERVAL_TIME, NUM, INTERVAL_TIME, Exception.class.getName());
     retry = (boolean) privateOne.invoke(retryHelper, new UnsupportedOperationException("test"));
     assertTrue(retry);
+  }
+
+  /**
+   * The point of HUDI-9095: a retry that is going to be attempted again must not dump a stack trace
+   * into the log. The cause still has to be identifiable from the message itself.
+   */
+  @Test
+  public void testRetryWarningCarriesNoStackTrace() {
+    TestLogAppender appender = new TestLogAppender();
+    Logger logger = (Logger) LogManager.getLogger(RetryHelper.class);
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      AtomicInteger attempts = new AtomicInteger(0);
+      RetryHelper retryHelper = new RetryHelper(INTERVAL_TIME, 3, INTERVAL_TIME, (String) null, "save partition metafile");
+      assertDoesNotThrow(() -> retryHelper.start(() -> {
+        if (attempts.incrementAndGet() < 3) {
+          throw new IOException("Failed to create file /a/b/.hoodie_partition_metadata",
+              new FileAlreadyExistsException("File already exists: /a/b/.hoodie_partition_metadata"));
+        }
+        return true;
+      }));
+
+      List<LogEvent> warnings = appender.getLog().stream()
+          .filter(event -> Level.WARN.equals(event.getLevel())).collect(Collectors.toList());
+      assertFalse(warnings.isEmpty(), "the retries should still be reported at warn level");
+      for (LogEvent warning : warnings) {
+        assertNull(warning.getThrown(),
+            "the retry warning must not carry a throwable, otherwise the logger prints its stack trace");
+        String message = warning.getMessage().getFormattedMessage();
+        assertTrue(message.contains("save partition metafile"), message);
+        assertTrue(message.contains("java.io.IOException: Failed to create file /a/b/.hoodie_partition_metadata"), message);
+        assertTrue(message.contains("FileAlreadyExistsException"), "the root cause must survive: " + message);
+      }
+    } finally {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
   }
 
   @Test
@@ -82,5 +130,22 @@ public class TestRetryHelper {
         return true;
       });
     });
+  }
+
+  static class TestLogAppender extends AbstractAppender {
+    private final List<LogEvent> log = new ArrayList<>();
+
+    protected TestLogAppender() {
+      super(UUID.randomUUID().toString(), null, null, false, null);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      log.add(event.toImmutable());
+    }
+
+    List<LogEvent> getLog() {
+      return new ArrayList<>(log);
+    }
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
@@ -18,19 +18,16 @@
 
 package org.apache.hudi.common.util;
 
+import org.apache.hudi.common.testutils.HoodieTestLogAppender;
+
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.file.FileAlreadyExistsException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -70,10 +67,7 @@ public class TestRetryHelper {
    */
   @Test
   public void testRetryWarningCarriesNoStackTrace() {
-    TestLogAppender appender = new TestLogAppender();
-    Logger logger = (Logger) LogManager.getLogger(RetryHelper.class);
-    appender.start();
-    logger.addAppender(appender);
+    HoodieTestLogAppender appender = new HoodieTestLogAppender().attachTo(RetryHelper.class);
     try {
       AtomicInteger attempts = new AtomicInteger(0);
       RetryHelper retryHelper = new RetryHelper(INTERVAL_TIME, 3, INTERVAL_TIME, (String) null, "save partition metafile");
@@ -97,8 +91,7 @@ public class TestRetryHelper {
         assertTrue(message.contains("FileAlreadyExistsException"), "the root cause must survive: " + message);
       }
     } finally {
-      logger.removeAppender(appender);
-      appender.stop();
+      appender.detach();
     }
   }
 
@@ -107,14 +100,14 @@ public class TestRetryHelper {
     // a wrapped exception keeps both layers, so the warning stays actionable without a stack trace
     IOException wrapped = new IOException("Failed to create file /a/b/.hoodie_partition_metadata",
         new FileAlreadyExistsException("File already exists: /a/b/.hoodie_partition_metadata"));
-    String summary = RetryHelper.summarise(wrapped);
+    String summary = RetryHelper.summarize(wrapped);
     assertTrue(summary.contains("java.io.IOException: Failed to create file /a/b/.hoodie_partition_metadata"), summary);
     assertTrue(summary.contains("caused by java.nio.file.FileAlreadyExistsException"), summary);
     assertFalse(summary.contains("\n"), "the summary must stay on a single line: " + summary);
     assertFalse(summary.contains("\tat "), "the summary must not carry a stack trace: " + summary);
 
     // an exception with no cause is rendered as-is
-    assertEquals("java.io.IOException: plain", RetryHelper.summarise(new IOException("plain")));
+    assertEquals("java.io.IOException: plain", RetryHelper.summarize(new IOException("plain")));
   }
 
   @Test
@@ -132,20 +125,4 @@ public class TestRetryHelper {
     });
   }
 
-  static class TestLogAppender extends AbstractAppender {
-    private final List<LogEvent> log = new ArrayList<>();
-
-    protected TestLogAppender() {
-      super(UUID.randomUUID().toString(), null, null, false, null);
-    }
-
-    @Override
-    public void append(LogEvent event) {
-      log.add(event.toImmutable());
-    }
-
-    List<LogEvent> getLog() {
-      return new ArrayList<>(log);
-    }
-  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestRetryHelper.java
@@ -79,7 +79,7 @@ public class TestRetryHelper {
         return true;
       }));
 
-      List<LogEvent> warnings = appender.getLog().stream()
+      List<LogEvent> warnings = appender.getCapturedEvents().stream()
           .filter(event -> Level.WARN.equals(event.getLevel())).collect(Collectors.toList());
       assertFalse(warnings.isEmpty(), "the retries should still be reported at warn level");
       for (LogEvent warning : warnings) {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodiePartitionMetadata.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodiePartitionMetadata.java
@@ -20,10 +20,16 @@ package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.RetryHelper;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,11 +41,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -125,16 +133,54 @@ public class TestHoodiePartitionMetadata extends HoodieCommonTestHarness {
     // the existence check slips through the race window once, then observes the peer's file
     doReturn(false).doCallRealMethod().when(racingStorage).exists(metaPath);
 
-    long startMs = System.currentTimeMillis();
-    assertDoesNotThrow(() -> new HoodiePartitionMetadata(
-        racingStorage, "000000000002", new StoragePath(basePath), partitionPath, Option.empty()).trySave());
-    long elapsedMs = System.currentTimeMillis() - startMs;
+    // watch what the retry helper logs while the race is being lost
+    TestLogAppender appender = new TestLogAppender();
+    Logger retryLogger = (Logger) LogManager.getLogger(RetryHelper.class);
+    appender.start();
+    retryLogger.addAppender(appender);
+
+    long elapsedMs;
+    try {
+      long startMs = System.currentTimeMillis();
+      assertDoesNotThrow(() -> new HoodiePartitionMetadata(
+          racingStorage, "000000000002", new StoragePath(basePath), partitionPath, Option.empty()).trySave());
+      elapsedMs = System.currentTimeMillis() - startMs;
+    } finally {
+      retryLogger.removeAppender(appender);
+      appender.stop();
+    }
+
+    // the symptom from HUDI-9095: losing the race used to be reported as a warning with a full
+    // stack trace, even though the file the caller asked for is right there
+    List<String> problems = appender.getLog().stream()
+        .filter(event -> event.getLevel().isMoreSpecificThan(Level.WARN))
+        .map(event -> event.getMessage().getFormattedMessage())
+        .collect(Collectors.toList());
+    assertTrue(problems.isEmpty(),
+        "losing the metafile creation race must not be logged as a problem, got: " + problems);
 
     // Losing the race is a success, so it must not go through the retry helper: every retry sleeps
-    // for at least the initial 1s interval, which is what used to emit the stack trace warning.
+    // for at least the initial 1s interval.
     assertTrue(elapsedMs < 1000,
         "trySave should not retry when the metafile already exists, but it took " + elapsedMs + " ms");
     assertTrue(HoodiePartitionMetadata.hasPartitionMetadata(storage, partitionPath));
+  }
+
+  static class TestLogAppender extends AbstractAppender {
+    private final List<LogEvent> log = new ArrayList<>();
+
+    protected TestLogAppender() {
+      super(UUID.randomUUID().toString(), null, null, false, null);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      log.add(event.toImmutable());
+    }
+
+    List<LogEvent> getLog() {
+      return new ArrayList<>(log);
+    }
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodiePartitionMetadata.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodiePartitionMetadata.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.HoodieTestLogAppender;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.RetryHelper;
 import org.apache.hudi.exception.HoodieException;
@@ -26,10 +27,6 @@ import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +38,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -134,10 +130,7 @@ public class TestHoodiePartitionMetadata extends HoodieCommonTestHarness {
     doReturn(false).doCallRealMethod().when(racingStorage).exists(metaPath);
 
     // watch what the retry helper logs while the race is being lost
-    TestLogAppender appender = new TestLogAppender();
-    Logger retryLogger = (Logger) LogManager.getLogger(RetryHelper.class);
-    appender.start();
-    retryLogger.addAppender(appender);
+    HoodieTestLogAppender appender = new HoodieTestLogAppender().attachTo(RetryHelper.class);
 
     long elapsedMs;
     try {
@@ -146,8 +139,7 @@ public class TestHoodiePartitionMetadata extends HoodieCommonTestHarness {
           racingStorage, "000000000002", new StoragePath(basePath), partitionPath, Option.empty()).trySave());
       elapsedMs = System.currentTimeMillis() - startMs;
     } finally {
-      retryLogger.removeAppender(appender);
-      appender.stop();
+      appender.detach();
     }
 
     // the symptom from HUDI-9095: losing the race used to be reported as a warning with a full
@@ -164,23 +156,6 @@ public class TestHoodiePartitionMetadata extends HoodieCommonTestHarness {
     assertTrue(elapsedMs < 1000,
         "trySave should not retry when the metafile already exists, but it took " + elapsedMs + " ms");
     assertTrue(HoodiePartitionMetadata.hasPartitionMetadata(storage, partitionPath));
-  }
-
-  static class TestLogAppender extends AbstractAppender {
-    private final List<LogEvent> log = new ArrayList<>();
-
-    protected TestLogAppender() {
-      super(UUID.randomUUID().toString(), null, null, false, null);
-    }
-
-    @Override
-    public void append(LogEvent event) {
-      log.add(event.toImmutable());
-    }
-
-    List<LogEvent> getLog() {
-      return new ArrayList<>(log);
-    }
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodiePartitionMetadata.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodiePartitionMetadata.java
@@ -147,7 +147,7 @@ public class TestHoodiePartitionMetadata extends HoodieCommonTestHarness {
 
     // the symptom from HUDI-9095: losing the race used to be reported as a warning with a full
     // stack trace, even though the file the caller asked for is right there
-    List<String> problems = appender.getLog().stream()
+    List<String> problems = appender.getCapturedEvents().stream()
         .filter(event -> event.getLevel().isMoreSpecificThan(Level.WARN))
         .map(event -> event.getMessage().getFormattedMessage())
         .collect(Collectors.toList());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodiePartitionMetadata.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodiePartitionMetadata.java
@@ -43,13 +43,16 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
@@ -156,6 +159,41 @@ public class TestHoodiePartitionMetadata extends HoodieCommonTestHarness {
     assertTrue(elapsedMs < 1000,
         "trySave should not retry when the metafile already exists, but it took " + elapsedMs + " ms");
     assertTrue(HoodiePartitionMetadata.hasPartitionMetadata(storage, partitionPath));
+  }
+
+  @Test
+  public void testTrySaveKeepsWriteFailureWhenExistenceRecheckFails() throws IOException {
+    final StoragePath partitionPath = new StoragePath(basePath, "a/b/recheck-fails");
+    storage.createDirectory(partitionPath);
+    final StoragePath metaPath = new StoragePath(
+        partitionPath, HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX);
+
+    // a peer has the metafile, so the write below fails the way a lost race does
+    new HoodiePartitionMetadata(storage, "000000000001", new StoragePath(basePath), partitionPath, Option.empty()).trySave();
+
+    IOException recheckFailure = new IOException("storage unavailable");
+    HoodieStorage flakyStorage = directCreateStorage();
+    // Each attempt checks twice: once before writing, once after the write fails. Slip through the
+    // first so the write is reached, then fail the second. The write failure is retryable, so this
+    // has to hold for every attempt rather than only the first.
+    AtomicInteger checks = new AtomicInteger();
+    doAnswer(invocation -> {
+      if (checks.getAndIncrement() % 2 == 0) {
+        return false;
+      }
+      throw recheckFailure;
+    }).when(flakyStorage).exists(metaPath);
+
+    // The re-check only exists to recognise a lost race. When it cannot answer, the failure the
+    // caller gets has to remain the write failure: that is what RetryHelper classifies as
+    // retryable, whereas a bare IOException from the check is not in its retry list.
+    Exception thrown = assertThrows(Exception.class, () -> new HoodiePartitionMetadata(
+        flakyStorage, "000000000002", new StoragePath(basePath), partitionPath, Option.empty()).trySave());
+
+    assertNotSame(recheckFailure, thrown, "the check failure must not replace the write failure");
+    assertTrue(Arrays.stream(thrown.getSuppressed()).anyMatch(s -> s == recheckFailure),
+        "the check failure must be kept as suppressed rather than dropped, got: "
+            + Arrays.toString(thrown.getSuppressed()));
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodiePartitionMetadata.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodiePartitionMetadata.java
@@ -32,12 +32,22 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 /**
  * Tests {@link HoodiePartitionMetadata}.
@@ -87,6 +97,78 @@ public class TestHoodiePartitionMetadata extends HoodieCommonTestHarness {
     assertTrue(HoodiePartitionMetadata.hasPartitionMetadata(storage, partitionPath));
     assertEquals(Option.of(commitTime), readMetadata.readPartitionCreatedCommitTime());
     assertEquals(3, readMetadata.getPartitionDepth());
+  }
+
+  /**
+   * Storage that creates the metafile directly, without the temp-file-then-rename dance that
+   * local and HDFS storage use. That is what object stores do, and it is the case where the loser
+   * of a creation race sees an 'already exists' failure surface out of the storage layer.
+   */
+  private HoodieStorage directCreateStorage() {
+    HoodieStorage objectStore = spy(storage);
+    doReturn("s3a").when(objectStore).getScheme();
+    return objectStore;
+  }
+
+  @Test
+  public void testTrySaveWhenMetafileConcurrentlyCreated() throws IOException {
+    final StoragePath partitionPath = new StoragePath(basePath, "a/b/raced");
+    storage.createDirectory(partitionPath);
+    final StoragePath metaPath = new StoragePath(
+        partitionPath, HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX);
+
+    // a peer task has already won the race and written the metafile
+    new HoodiePartitionMetadata(storage, "000000000001", new StoragePath(basePath), partitionPath, Option.empty()).trySave();
+    assertTrue(storage.exists(metaPath));
+
+    HoodieStorage racingStorage = directCreateStorage();
+    // the existence check slips through the race window once, then observes the peer's file
+    doReturn(false).doCallRealMethod().when(racingStorage).exists(metaPath);
+
+    long startMs = System.currentTimeMillis();
+    assertDoesNotThrow(() -> new HoodiePartitionMetadata(
+        racingStorage, "000000000002", new StoragePath(basePath), partitionPath, Option.empty()).trySave());
+    long elapsedMs = System.currentTimeMillis() - startMs;
+
+    // Losing the race is a success, so it must not go through the retry helper: every retry sleeps
+    // for at least the initial 1s interval, which is what used to emit the stack trace warning.
+    assertTrue(elapsedMs < 1000,
+        "trySave should not retry when the metafile already exists, but it took " + elapsedMs + " ms");
+    assertTrue(HoodiePartitionMetadata.hasPartitionMetadata(storage, partitionPath));
+  }
+
+  @Test
+  public void testConcurrentTrySaveWritesOneMetafile() throws Exception {
+    final StoragePath partitionPath = new StoragePath(basePath, "a/b/parallel");
+    storage.createDirectory(partitionPath);
+    final int writers = 8;
+
+    ExecutorService pool = Executors.newFixedThreadPool(writers);
+    try {
+      CountDownLatch startLine = new CountDownLatch(1);
+      List<Future<?>> futures = new ArrayList<>();
+      for (int i = 0; i < writers; i++) {
+        final String commitTime = String.format("%012d", i + 1);
+        futures.add(pool.submit(() -> {
+          startLine.await();
+          new HoodiePartitionMetadata(directCreateStorage(), commitTime,
+              new StoragePath(basePath), partitionPath, Option.empty()).trySave();
+          return null;
+        }));
+      }
+      startLine.countDown();
+      for (Future<?> future : futures) {
+        // any writer failing the race would surface here
+        future.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertTrue(HoodiePartitionMetadata.hasPartitionMetadata(storage, partitionPath));
+    assertEquals(1, storage.listDirectEntries(partitionPath).stream()
+        .filter(e -> e.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX))
+        .count(), "exactly one partition metafile should be left behind");
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17374

Tasks writing to the same partition concurrently race to create `.hoodie_partition_metadata`. The
existence check in `HoodiePartitionMetadata.trySave()` narrows the window but cannot close it, so
the losers get an "already exists" error back from the storage layer. That error was handed to
`RetryHelper`, which logged a full stack trace at WARN and slept a second before retrying, only to
find the very file it had just been told about:

```
WARN RetryHelper: Catch Exception for N/A, will retry after 1000 ms.
org.apache.hudi.exception.HoodieIOException: Failed to create file
  .../.hoodie/metadata/column_stats/.hoodie_partition_metadata
        at org.apache.hudi.storage.HoodieStorage.createImmutableFileInPath(HoodieStorage.java:353)
        ... 40 frames ...
Caused by: org.apache.hadoop.fs.FileAlreadyExistsException: File already exists
```

The reporter saw it twice in one session, during `INSERT` and again during `CREATE INDEX`.

### Summary and Changelog

**`HoodiePartitionMetadata.trySave()` treats a lost race as the success it is.** The metafile is
immutable, so if a peer created it first, the file the caller asked for is in place. The write is
now wrapped so that on failure it re-checks for the metafile and only propagates the error if it is
genuinely absent. This removes the warning and a pointless one second stall per racing task.

The catch is a strict superset of what could previously produce the warning, which is what makes it
storage independent: `trySave` only ever retried `HoodieIOException`, `createImmutableFileInPath`
wraps every `IOException` into one, and the new catch is `IOException | HoodieIOException`. It does
not pattern match on the exception, it re-checks the filesystem, so whatever a given object store
throws for an existing key is handled.

**`RetryHelper` no longer prints a stack trace for every failed attempt.** A retry that goes on to
succeed does not warrant one, and printing it per attempt buries the genuine failures. The WARN now
carries a single line naming the failure and its root cause; the full trace is still logged at DEBUG,
and still at ERROR once the retries are exhausted.

These are separable, and reviewers may prefer them apart. The first alone closes the reported
symptom, verified below. The second is the reporter's literal suggestion, *"maybe we should avoid
logging stack traces in such warning messages"*, generalised to the other callers. Happy to split
the `RetryHelper` change into its own PR if that is preferred, since it touches twelve call sites
(lock manager, timeline client, Kafka consumer, Flink jobs) while the first change touches one
method.

### Impact

Concurrent writers no longer log an alarming stack trace, nor pay a retry backoff, for a benign
race. On a table with many partitions that is a real latency saving as well as quieter logs.

This surfaces on storage that creates the metafile directly. Local and HDFS storage write to a temp
file and rename, and a losing rename is already silent, so the noise is confined to object stores.
Note that means the reporter's original `file:///tmp` scenario no longer reproduces on master, since
`b6957f020d00` gave local storage the temp-file path.

No configuration or public API change.

### Risk Level

low

### Documentation Update

none

### Verification

| suite | result |
| --- | --- |
| `hudi-common`, `common.util.**` + `common.model.**` | 424 pass |
| `hudi-hadoop-common`, `common.model.**` + `storage.**` | 36 pass |
| `checkstyle:check`, both modules | clean |

Three tests were added, each confirmed to fail against the unmodified code:

- `TestHoodiePartitionMetadata.testTrySaveWhenMetafileConcurrentlyCreated` captures the log events
  emitted while the race is lost and asserts none is WARN or worse. Without the fix it fails with
  the warning it is meant to prevent: `Task [N/A] failed. current retry number 1, will retry after
  1000 ms.` It also asserts the call does not pay the retry backoff.
- `TestHoodiePartitionMetadata.testConcurrentTrySaveWritesOneMetafile` runs eight writers at the
  same partition and asserts one metafile and no failures.
- `TestRetryHelper.testRetryWarningCarriesNoStackTrace` drives a retry that eventually succeeds and
  asserts the WARN event carries no throwable, so the logger has no trace to print, while the
  message still names the failure and its root cause.

The object-store path is reached in tests by stubbing the storage scheme, not by writing to a real
bucket, so the behaviour against a live object store is argued from the exception-handling above
rather than observed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
