### PR TITLE
perf(trino): drop the decimal schema cache and memoize prefilled values

### DIFF
--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/util/HudiAvroSerializer.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/util/HudiAvroSerializer.java
@@ -41,8 +41,6 @@ import io.trino.spi.type.SqlVarbinary;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
-import org.apache.avro.Conversions;
-import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -50,6 +48,7 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.DateTimeException;
 import java.time.Instant;
@@ -60,7 +59,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -70,7 +68,6 @@ import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateType.DATE;
-import static io.trino.spi.type.Decimals.encodeShortScaledValue;
 import static io.trino.spi.type.Decimals.writeBigDecimal;
 import static io.trino.spi.type.Decimals.writeShortDecimal;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -108,7 +105,6 @@ public class HudiAvroSerializer
             1, // 9 digits after the dot
     };
 
-    private static final AvroDecimalConverter DECIMAL_CONVERTER = new AvroDecimalConverter();
     private final PrefilledColumnValues prefilledColumnValues;
 
     private final List<HiveColumnHandle> columnHandles;
@@ -262,8 +258,13 @@ public class HudiAvroSerializer
                     }
                     else if (value instanceof GenericData.Fixed fixed) {
                         verify(decimalType.isShort(), "The type should be short decimal");
-                        BigDecimal decimal = DECIMAL_CONVERTER.convert(decimalType.getPrecision(), decimalType.getScale(), fixed.bytes());
-                        type.writeLong(output, encodeShortScaledValue(decimal, decimalType.getScale()));
+                        // Avro stores a decimal as its unscaled value in big-endian two's complement, which is
+                        // exactly what Trino's short decimal holds. Going through Avro's DecimalConversion and
+                        // Decimals.encodeShortScaledValue is a no-op round trip: DecimalConversion.fromBytes reads
+                        // only the scale (it ignores precision, and its schema argument entirely) to build
+                        // BigDecimal(unscaled, scale), and encodeShortScaledValue then calls setScale to that same
+                        // scale, which returns the BigDecimal unchanged, before taking the unscaled value back out.
+                        type.writeLong(output, new BigInteger(fixed.bytes()).longValueExact());
                     }
                     else {
                         throw new TrinoException(GENERIC_INTERNAL_ERROR,
@@ -543,23 +544,5 @@ public class HudiAvroSerializer
                 appendTo(valueType, entry.getValue(), valueBuilder);
             }
         });
-    }
-
-    static class AvroDecimalConverter
-    {
-        private static final Conversions.DecimalConversion AVRO_DECIMAL_CONVERSION = new Conversions.DecimalConversion();
-        // convert() runs once per decimal cell on the record read path, and building a Schema costs
-        // orders of magnitude more than the conversion itself. The (precision, scale) space is tiny
-        // and fixed per column, so cache the schemas globally.
-        private static final Map<Integer, Schema> DECIMAL_SCHEMAS = new ConcurrentHashMap<>();
-
-        BigDecimal convert(int precision, int scale, byte[] bytes)
-        {
-            // The key is unique because precision and scale are at most 38
-            Schema schema = DECIMAL_SCHEMAS.computeIfAbsent(
-                    precision * 100 + scale,
-                    key -> LogicalTypes.decimal(precision, scale).addToSchema(Schema.create(Schema.Type.BYTES)));
-            return AVRO_DECIMAL_CONVERSION.fromBytes(ByteBuffer.wrap(bytes), schema, schema.getLogicalType());
-        }
     }
 }

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/util/PrefilledColumnValues.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/util/PrefilledColumnValues.java
@@ -22,6 +22,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -50,6 +51,10 @@ public class PrefilledColumnValues
     private final String filePath;
     private final long fileSize;
     private final long fileModifiedTime;
+    // Resolved native value per column name, populated lazily. One instance belongs to one split and a
+    // split is read by a single driver thread, so a plain HashMap is enough; it also has to hold nulls,
+    // which a ConcurrentHashMap could not.
+    private final Map<String, Object> resolvedValues = new HashMap<>();
 
     public static PrefilledColumnValues create(HudiSplit hudiSplit)
     {
@@ -108,6 +113,24 @@ public class PrefilledColumnValues
     }
 
     private Object nativeValueOf(HiveColumnHandle columnHandle)
+    {
+        // Every input to resolve() is a constant of the split, but appendTo is called once per prefilled
+        // column per record, and resolving re-parses the partition string each time ($file_modified_time
+        // even formats a timestamp and parses it straight back). Memoize per column so each one is
+        // resolved once per split. Keyed on the name rather than the handle because
+        // HiveColumnHandle.hashCode hashes seven fields through a varargs array, whereas a String caches
+        // its hash. containsKey rather than a null check: null is a legitimate resolved value, both for
+        // the hive-null convention and for the lenient fallback below.
+        String name = columnHandle.getName();
+        if (resolvedValues.containsKey(name)) {
+            return resolvedValues.get(name);
+        }
+        Object value = resolve(columnHandle);
+        resolvedValues.put(name, value);
+        return value;
+    }
+
+    private Object resolve(HiveColumnHandle columnHandle)
     {
         if (!isPrefilled(columnHandle)) {
             // Lenient null fill, e.g. for a hidden column Trino defines but Hudi does not populate.

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/util/PrefilledColumnValues.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/util/PrefilledColumnValues.java
@@ -46,6 +46,9 @@ import static io.trino.spi.type.TypeUtils.writeNativeValue;
  */
 public class PrefilledColumnValues
 {
+    // Absent-marker for the memo, so a not-yet-resolved column is distinguishable from one resolved to null
+    private static final Object UNRESOLVED = new Object();
+
     private final Map<String, HivePartitionKey> partitionKeysByName;
     private final String partitionName;
     private final String filePath;
@@ -119,14 +122,15 @@ public class PrefilledColumnValues
         // ($file_modified_time even formats a timestamp and parses it straight back). Memoize per column so
         // each one is resolved once per split. Keyed on the name rather than the handle because
         // HiveColumnHandle.hashCode hashes seven fields through a varargs array, whereas a String caches
-        // its hash. containsKey rather than a null check: null is a legitimate resolved value, both for
-        // the hive-null convention and for the lenient fallback below.
+        // its hash. A sentinel rather than a null check, because null is a legitimate resolved value -- both
+        // for the hive-null convention and for the lenient fallback below -- and getOrDefault keeps the hit
+        // path, the one taken per record, to a single hash lookup.
         String name = columnHandle.getName();
-        if (resolvedValues.containsKey(name)) {
-            return resolvedValues.get(name);
+        Object value = resolvedValues.getOrDefault(name, UNRESOLVED);
+        if (value == UNRESOLVED) {
+            value = computeNativeValue(columnHandle);
+            resolvedValues.put(name, value);
         }
-        Object value = computeNativeValue(columnHandle);
-        resolvedValues.put(name, value);
         return value;
     }
 

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/util/PrefilledColumnValues.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/util/PrefilledColumnValues.java
@@ -114,10 +114,10 @@ public class PrefilledColumnValues
 
     private Object nativeValueOf(HiveColumnHandle columnHandle)
     {
-        // Every input to resolve() is a constant of the split, but appendTo is called once per prefilled
-        // column per record, and resolving re-parses the partition string each time ($file_modified_time
-        // even formats a timestamp and parses it straight back). Memoize per column so each one is
-        // resolved once per split. Keyed on the name rather than the handle because
+        // Every input to computeNativeValue() is a constant of the split, but appendTo is called once per
+        // prefilled column per record, and computing re-parses the partition string each time
+        // ($file_modified_time even formats a timestamp and parses it straight back). Memoize per column so
+        // each one is resolved once per split. Keyed on the name rather than the handle because
         // HiveColumnHandle.hashCode hashes seven fields through a varargs array, whereas a String caches
         // its hash. containsKey rather than a null check: null is a legitimate resolved value, both for
         // the hive-null convention and for the lenient fallback below.
@@ -125,12 +125,12 @@ public class PrefilledColumnValues
         if (resolvedValues.containsKey(name)) {
             return resolvedValues.get(name);
         }
-        Object value = resolve(columnHandle);
+        Object value = computeNativeValue(columnHandle);
         resolvedValues.put(name, value);
         return value;
     }
 
-    private Object resolve(HiveColumnHandle columnHandle)
+    private Object computeNativeValue(HiveColumnHandle columnHandle)
     {
         if (!isPrefilled(columnHandle)) {
             // Lenient null fill, e.g. for a hidden column Trino defines but Hudi does not populate.

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestPrefilledColumnValues.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestPrefilledColumnValues.java
@@ -86,8 +86,8 @@ class TestPrefilledColumnValues
         Block block = singleValueBlock(values, handle);
         assertThat(block.isNull(0)).isTrue();
 
-        // Resolved values are memoized per column, and null is a legitimate resolved value, so a second
-        // read of the same column has to stay null rather than fall through and re-resolve.
+        // Values are resolved once per column and reused, so both read paths have to keep returning null
+        // for a hive-null column after the first read has populated the memo.
         BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 2);
         values.appendTo(handle, blockBuilder);
         values.appendTo(handle, blockBuilder);

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestPrefilledColumnValues.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestPrefilledColumnValues.java
@@ -81,9 +81,20 @@ class TestPrefilledColumnValues
     {
         // Trino's HivePartitionKey encodes a null partition value as the literal string "\N"
         PrefilledColumnValues values = prefilledValues(new HivePartitionKey("pk_string", "\\N"));
+        HiveColumnHandle handle = partitionKey("pk_string", VARCHAR, HiveType.HIVE_STRING);
 
-        Block block = singleValueBlock(values, partitionKey("pk_string", VARCHAR, HiveType.HIVE_STRING));
+        Block block = singleValueBlock(values, handle);
         assertThat(block.isNull(0)).isTrue();
+
+        // Resolved values are memoized per column, and null is a legitimate resolved value, so a second
+        // read of the same column has to stay null rather than fall through and re-resolve.
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 2);
+        values.appendTo(handle, blockBuilder);
+        values.appendTo(handle, blockBuilder);
+        Block repeated = blockBuilder.build();
+        assertThat(repeated.isNull(0)).isTrue();
+        assertThat(repeated.isNull(1)).isTrue();
+        assertThat(values.toRleBlock(handle, 1).isNull(0)).isTrue();
     }
 
     @Test

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/util/TestHudiAvroSerializer.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/util/TestHudiAvroSerializer.java
@@ -25,6 +25,8 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.DecimalType;
+import org.apache.avro.Conversions;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
@@ -34,6 +36,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -56,11 +59,9 @@ class TestHudiAvroSerializer
     public void testAppendShortDecimalFromAvroFixed(int precision, int scale, String value, long expectedUnscaled)
     {
         DecimalType type = DecimalType.createDecimalType(precision, scale);
-        byte[] bytes = unscaledBytes(value);
-        GenericData.Fixed fixed = new GenericData.Fixed(Schema.createFixed("fix", null, null, bytes.length), bytes);
 
         BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
-        HudiAvroSerializer.appendTo(type, fixed, blockBuilder);
+        HudiAvroSerializer.appendTo(type, avroDecimalFixed(precision, scale, value), blockBuilder);
         Block block = blockBuilder.build();
 
         assertThat(type.getLong(block, 0)).isEqualTo(expectedUnscaled);
@@ -107,9 +108,25 @@ class TestHudiAvroSerializer
         assertThat(VARCHAR.getSlice(page.getBlock(1), 2).toStringUtf8()).isEqualTo("three");
     }
 
-    private static byte[] unscaledBytes(String decimal)
+    /**
+     * Encodes the value the way an Avro writer does, via Avro's own conversion: a fixed sized from the
+     * precision, holding the unscaled value left-padded to that width with the sign byte (0xFF for
+     * negatives). Building the fixed from the minimal two's-complement encoding instead would leave the
+     * padding bytes, and so sign extension across them, untested.
+     */
+    private static GenericData.Fixed avroDecimalFixed(int precision, int scale, String value)
     {
-        return new BigDecimal(decimal).unscaledValue().toByteArray();
+        LogicalTypes.Decimal decimalType = LogicalTypes.decimal(precision, scale);
+        Schema fixedSchema = decimalType.addToSchema(
+                Schema.createFixed("fix", null, null, decimalFixedSize(precision)));
+        return (GenericData.Fixed) new Conversions.DecimalConversion()
+                .toFixed(new BigDecimal(value), fixedSchema, decimalType);
+    }
+
+    /** Bytes needed to hold the widest unscaled value at this precision, i.e. the fixed size Avro sizes a decimal to. */
+    private static int decimalFixedSize(int precision)
+    {
+        return BigInteger.TEN.pow(precision).subtract(BigInteger.ONE).toByteArray().length;
     }
 
     private static Schema recordSchema(String name)

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/util/TestHudiAvroSerializer.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/util/TestHudiAvroSerializer.java
@@ -29,10 +29,14 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -41,32 +45,39 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class TestHudiAvroSerializer
 {
-    @Test
-    public void testDecimalConverter()
+    /**
+     * A short decimal is stored in Trino as the unscaled value, which is exactly what Avro writes into the
+     * fixed bytes, so the read is a plain big-endian two's complement decode. The cases below pin the parts
+     * that decode gets wrong if it is ever rewritten: sign extension for negatives, scale 0, and the
+     * full-width value at the maximum short-decimal precision.
+     */
+    @ParameterizedTest
+    @MethodSource("shortDecimals")
+    public void testAppendShortDecimalFromAvroFixed(int precision, int scale, String value, long expectedUnscaled)
     {
-        HudiAvroSerializer.AvroDecimalConverter converter = new HudiAvroSerializer.AvroDecimalConverter();
-
-        assertThat(converter.convert(10, 2, unscaledBytes("123.45"))).isEqualTo(new BigDecimal("123.45"));
-        // Same (precision, scale) again: served from the cached schema
-        assertThat(converter.convert(10, 2, unscaledBytes("-0.07"))).isEqualTo(new BigDecimal("-0.07"));
-        // Same precision, different scale, and vice versa: must not collide in the cache
-        assertThat(converter.convert(10, 4, unscaledBytes("123.4567"))).isEqualTo(new BigDecimal("123.4567"));
-        assertThat(converter.convert(18, 2, unscaledBytes("9999999999999999.99"))).isEqualTo(new BigDecimal("9999999999999999.99"));
-        assertThat(converter.convert(5, 0, unscaledBytes("42"))).isEqualTo(new BigDecimal("42"));
-    }
-
-    @Test
-    public void testAppendShortDecimalFromAvroFixed()
-    {
-        DecimalType type = DecimalType.createDecimalType(10, 2);
-        byte[] bytes = unscaledBytes("123.45");
+        DecimalType type = DecimalType.createDecimalType(precision, scale);
+        byte[] bytes = unscaledBytes(value);
         GenericData.Fixed fixed = new GenericData.Fixed(Schema.createFixed("fix", null, null, bytes.length), bytes);
 
         BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
         HudiAvroSerializer.appendTo(type, fixed, blockBuilder);
         Block block = blockBuilder.build();
 
-        assertThat(type.getLong(block, 0)).isEqualTo(12345L);
+        assertThat(type.getLong(block, 0)).isEqualTo(expectedUnscaled);
+    }
+
+    private static Stream<Arguments> shortDecimals()
+    {
+        return Stream.of(
+                Arguments.of(10, 2, "123.45", 12345L),
+                Arguments.of(10, 2, "-0.07", -7L),
+                Arguments.of(10, 2, "0.00", 0L),
+                Arguments.of(10, 4, "123.4567", 1234567L),
+                Arguments.of(5, 0, "42", 42L),
+                Arguments.of(5, 0, "-42", -42L),
+                // Widest short decimal: 18 digits, both signs
+                Arguments.of(18, 2, "9999999999999999.99", 999999999999999999L),
+                Arguments.of(18, 2, "-9999999999999999.99", -999999999999999999L));
     }
 
     @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Follow-up to #19483, which merged with three unresolved review comments from @wombatu-kun. All three were right, and the first one invalidates that PR's central optimisation.

### Summary and Changelog

**The decimal schema cache was unnecessary, not mis-keyed.** #19483 replaced a per-value JSON schema parse with a `(precision, scale)`-keyed schema cache. But the cached schema is never actually needed: Avro's `Conversions.DecimalConversion.fromBytes` reads only the scale (it never touches precision, and does not reference its `schema` argument at all) to build `BigDecimal(unscaled, scale)`, and `Decimals.encodeShortScaledValue` then calls `setScale` to that same scale -- which `BigDecimal` short-circuits to `return this` -- before taking the unscaled value back out. The scale cancels end to end. So the pair reduces to `new BigInteger(fixed.bytes()).longValueExact()`, and `AvroDecimalConverter` plus its `ConcurrentHashMap` are deleted rather than re-keyed. That is also strictly faster than the cache: no map lookup, no `ByteBuffer`, no intermediate `BigDecimal`. Exception behaviour is unchanged (`NumberFormatException` on empty bytes, `ArithmeticException` on overflow, from the same `BigInteger` calls).

**`PrefilledColumnValues` now memoizes the resolved value per column.** `nativeValueOf` called `HiveUtil.getPrefilledColumnValue` on every invocation, and `appendTo` runs once per prefilled column per record from `buildRecordInPage`. Every input to that call is a constant of the split, so it is now resolved once per column and cached. Per call, the old path allocated a `byte[]` just to run a two-byte `isHiveNull` check, walked up to 14 chained type dispatches, allocated a `NullableValue` that was immediately discarded via `.getValue()`, and then parsed -- `utf8Slice` for varchar, a Joda multi-pattern parse for date, and for `$file_modified_time` a Joda print followed immediately by a re-parse of the same constant. This helps both read paths: the MOR record path goes from per-record to once, and the COW path from per-page to once.

Two implementation notes, both load-bearing: the memo is keyed on the column *name* rather than the handle, because `HiveColumnHandle.hashCode` hashes seven fields through a varargs array while a `String` caches its hash; and it uses `containsKey` rather than a null check, because `null` is a legitimate resolved value (the hive-`\N` convention, and the lenient fallback for a column the split cannot provide) -- which is also why it is a `HashMap` and not a `ConcurrentHashMap`.

**Tests.** `testDecimalConverter` is gone with its subject. `testAppendShortDecimalFromAvroFixed` is now parameterized over the cases that matter for the inlined decode -- both signs, scale 0, and the widest short decimal at precision 18 -- and drives the public `appendTo` path rather than an internal helper. It passes against both the old converter-based implementation and the new one, which is what pins the equivalence. `testHiveNullPartitionValue` gains repeated resolution of a hive-null column, the case a naive memo gets wrong.

### Impact

Faster Trino record-path reads. No behavior change.

### Risk Level

Low. The decimal change is a pure-function equivalence verified against the old implementation by the same test; the memo is split-scoped with no visible semantics change.

### Documentation Update

None.

### Notes for reviewers

Two pre-existing things noticed while verifying, deliberately left alone as unrelated to these threads:

- `HudiAvroSerializer`'s `else { writeBigDecimal(...) }` in the `SqlDecimal` branch is unreachable. The enclosing branch is `javaType == long.class`, which in trino-spi 481 means `ShortDecimalType`, so `isShort()` is always true there.
- Long decimals (precision 19-38) arriving as `GenericData.Fixed` are unsupported: `writeObject` accepts only `SqlDecimal` and throws `GENERIC_INTERNAL_ERROR` otherwise, and nothing wires `Int128` to the `Fixed` case.

Verified locally with JDK 25: `mvn -Phudi-trino,hudi-trino-tests -pl hudi-trino test` is green except `TestHudiMinioConnectorSmokeTest`, which needs a Docker environment I do not have locally (675/676).

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
