### PR TITLE
fix(utilities): validate the common partitions before failing on a partition mismatch

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -616,7 +616,7 @@ public class HoodieMetadataTableValidator implements Serializable {
     HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
     // compare partitions
 
-    List<String> allPartitions = validatePartitions(engineContext, basePath, metaClient);
+    List<String> allPartitions = validatePartitions(engineContext, basePath, metaClient, baseFilesForCleaning);
     if (allPartitions.isEmpty()) {
       log.warn("The result of getting all partitions is null or empty, skip current validation. {}", taskLabels);
       return true;
@@ -745,7 +745,8 @@ public class HoodieMetadataTableValidator implements Serializable {
    * Compare the listing partitions result between metadata table and fileSystem.
    */
   @VisibleForTesting
-  List<String> validatePartitions(HoodieSparkEngineContext engineContext, StoragePath basePath, HoodieTableMetaClient metaClient) {
+  List<String> validatePartitions(HoodieSparkEngineContext engineContext, StoragePath basePath, HoodieTableMetaClient metaClient,
+                                  Set<String> baseFilesForCleaning) {
     // compare partitions
     HoodieTimeline completedTimeline = metaClient.getCommitsTimeline().filterCompletedInstants();
     List<String> allPartitionPathsFromFS = getPartitionsFromFileSystem(engineContext, metaClient, completedTimeline);
@@ -810,6 +811,12 @@ public class HoodieMetadataTableValidator implements Serializable {
         }
       }
       if (misMatch.get()) {
+        // The partition lists genuinely disagree, so this run fails either way. Before reporting it,
+        // validate the partitions both sides do agree on: throwing here skips the per-partition file
+        // validation the caller would otherwise run, which leaves the operator knowing only that the
+        // partition lists differ and nothing about whether the rest of the table is consistent.
+        List<String> commonPartitions = new ArrayList<>(allPartitionPathsFromFS);
+        commonPartitions.retainAll(allPartitionPathsMeta);
         String message = "Compare Partitions Failed! " + " Additional "
             + additionalFromFS.size() + " partitions from FS, but missing from MDT : \""
             + toStringWithThreshold(additionalFromFS, cfg.logDetailMaxLength)
@@ -817,12 +824,56 @@ public class HoodieMetadataTableValidator implements Serializable {
             + " partitions from MDT, but missing from FS listing : \""
             + toStringWithThreshold(actualAdditionalPartitionsInMDT, cfg.logDetailMaxLength)
             + "\".\n All " + allPartitionPathsFromFS.size() + " partitions from FS listing "
-            + toStringWithThreshold(allPartitionPathsFromFS, cfg.logDetailMaxLength);
+            + toStringWithThreshold(allPartitionPathsFromFS, cfg.logDetailMaxLength)
+            + "\n" + summarizeFileValidationForCommonPartitions(engineContext, metaClient, commonPartitions, baseFilesForCleaning);
         log.error(message);
         throw new HoodieValidationException(message);
       }
     }
     return allPartitionPathsMeta;
+  }
+
+  /**
+   * Validates the file listing for the partitions present on both sides and returns a summary of the
+   * outcome. Unlike the other {@code validate} methods here, this one never throws: it reports through
+   * its return value instead.
+   *
+   * <p>Only called once a partition mismatch has already been detected and this run is going to fail.
+   * The result is reported alongside the mismatch rather than thrown, so that the partition list
+   * difference stays the reported cause; a file level problem found here is extra detail about a run
+   * that was failing anyway. Any error raised while validating a common partition is captured for the
+   * same reason.
+   */
+  private String summarizeFileValidationForCommonPartitions(HoodieSparkEngineContext engineContext, HoodieTableMetaClient metaClient,
+                                                            List<String> commonPartitions, Set<String> baseFilesForCleaning) {
+    if (commonPartitions.isEmpty()) {
+      return "No partitions are common to FS listing and MDT, so there are no file listings to compare.";
+    }
+    try (HoodieMetadataValidationContext metadataTableBasedContext =
+             new HoodieMetadataValidationContext(engineContext, props, metaClient, true, cfg.viewStorageTypeForMetadata);
+         HoodieMetadataValidationContext fsBasedContext =
+             new HoodieMetadataValidationContext(engineContext, props, metaClient, false, cfg.viewStorageTypeForFSListing)) {
+      List<String> failures = engineContext.parallelize(commonPartitions, commonPartitions.size())
+          .map(partitionPath -> {
+            try {
+              validateFilesInPartition(metadataTableBasedContext, fsBasedContext, partitionPath, baseFilesForCleaning);
+              return "";
+            } catch (Exception e) {
+              return partitionPath + " (" + e.getMessage() + ")";
+            }
+          }).collectAsList().stream().filter(failure -> !failure.isEmpty()).collect(Collectors.toList());
+
+      if (failures.isEmpty()) {
+        return "File listings match for all " + commonPartitions.size() + " partitions common to FS listing and MDT.";
+      }
+      return "File listings also differ for " + failures.size() + " of the " + commonPartitions.size()
+          + " partitions common to FS listing and MDT : \"" + toStringWithThreshold(failures, cfg.logDetailMaxLength) + "\".";
+    } catch (Exception e) {
+      // Reporting the partition mismatch matters more than this supplementary check succeeding.
+      log.warn("Failed to validate file listings for the partitions common to FS listing and MDT.", e);
+      return "File listings for the " + commonPartitions.size()
+          + " partitions common to FS listing and MDT could not be compared : " + e.getMessage();
+    }
   }
 
   @VisibleForTesting

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -616,7 +616,7 @@ public class HoodieMetadataTableValidator implements Serializable {
     HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
     // compare partitions
 
-    List<String> allPartitions = validatePartitions(engineContext, basePath, metaClient);
+    List<String> allPartitions = validatePartitions(engineContext, basePath, metaClient, baseFilesForCleaning);
     if (allPartitions.isEmpty()) {
       log.warn("The result of getting all partitions is null or empty, skip current validation. {}", taskLabels);
       return true;
@@ -745,7 +745,8 @@ public class HoodieMetadataTableValidator implements Serializable {
    * Compare the listing partitions result between metadata table and fileSystem.
    */
   @VisibleForTesting
-  List<String> validatePartitions(HoodieSparkEngineContext engineContext, StoragePath basePath, HoodieTableMetaClient metaClient) {
+  List<String> validatePartitions(HoodieSparkEngineContext engineContext, StoragePath basePath, HoodieTableMetaClient metaClient,
+                                  Set<String> baseFilesForCleaning) {
     // compare partitions
     HoodieTimeline completedTimeline = metaClient.getCommitsTimeline().filterCompletedInstants();
     List<String> allPartitionPathsFromFS = getPartitionsFromFileSystem(engineContext, metaClient, completedTimeline);
@@ -810,6 +811,12 @@ public class HoodieMetadataTableValidator implements Serializable {
         }
       }
       if (misMatch.get()) {
+        // The partition lists genuinely disagree, so this run fails either way. Before reporting it,
+        // validate the partitions both sides do agree on: throwing here skips the per-partition file
+        // validation the caller would otherwise run, which leaves the operator knowing only that the
+        // partition lists differ and nothing about whether the rest of the table is consistent.
+        List<String> commonPartitions = new ArrayList<>(allPartitionPathsFromFS);
+        commonPartitions.retainAll(allPartitionPathsMeta);
         String message = "Compare Partitions Failed! " + " Additional "
             + additionalFromFS.size() + " partitions from FS, but missing from MDT : \""
             + toStringWithThreshold(additionalFromFS, cfg.logDetailMaxLength)
@@ -817,12 +824,54 @@ public class HoodieMetadataTableValidator implements Serializable {
             + " partitions from MDT, but missing from FS listing : \""
             + toStringWithThreshold(actualAdditionalPartitionsInMDT, cfg.logDetailMaxLength)
             + "\".\n All " + allPartitionPathsFromFS.size() + " partitions from FS listing "
-            + toStringWithThreshold(allPartitionPathsFromFS, cfg.logDetailMaxLength);
+            + toStringWithThreshold(allPartitionPathsFromFS, cfg.logDetailMaxLength)
+            + "\n" + validateFilesInCommonPartitions(engineContext, metaClient, commonPartitions, baseFilesForCleaning);
         log.error(message);
         throw new HoodieValidationException(message);
       }
     }
     return allPartitionPathsMeta;
+  }
+
+  /**
+   * Validates the file listing for the partitions present on both sides, and summarises the outcome.
+   *
+   * <p>Only called once a partition mismatch has already been detected and this run is going to fail.
+   * The result is reported alongside the mismatch rather than thrown, so that the partition list
+   * difference stays the reported cause; a file level problem found here is extra detail about a run
+   * that was failing anyway. Any error raised while validating a common partition is captured for the
+   * same reason.
+   */
+  private String validateFilesInCommonPartitions(HoodieSparkEngineContext engineContext, HoodieTableMetaClient metaClient,
+                                                 List<String> commonPartitions, Set<String> baseFilesForCleaning) {
+    if (commonPartitions.isEmpty()) {
+      return "No partitions are common to FS listing and MDT, so there are no file listings to compare.";
+    }
+    try (HoodieMetadataValidationContext metadataTableBasedContext =
+             new HoodieMetadataValidationContext(engineContext, props, metaClient, true, cfg.viewStorageTypeForMetadata);
+         HoodieMetadataValidationContext fsBasedContext =
+             new HoodieMetadataValidationContext(engineContext, props, metaClient, false, cfg.viewStorageTypeForFSListing)) {
+      List<String> failures = engineContext.parallelize(commonPartitions, commonPartitions.size())
+          .map(partitionPath -> {
+            try {
+              validateFilesInPartition(metadataTableBasedContext, fsBasedContext, partitionPath, baseFilesForCleaning);
+              return "";
+            } catch (Exception e) {
+              return partitionPath + " (" + e.getMessage() + ")";
+            }
+          }).collectAsList().stream().filter(failure -> !failure.isEmpty()).collect(Collectors.toList());
+
+      if (failures.isEmpty()) {
+        return "File listings match for all " + commonPartitions.size() + " partitions common to FS listing and MDT.";
+      }
+      return "File listings also differ for " + failures.size() + " of the " + commonPartitions.size()
+          + " partitions common to FS listing and MDT : \"" + toStringWithThreshold(failures, cfg.logDetailMaxLength) + "\".";
+    } catch (Exception e) {
+      // Reporting the partition mismatch matters more than this supplementary check succeeding.
+      log.warn("Failed to validate file listings for the partitions common to FS listing and MDT.", e);
+      return "File listings for the " + commonPartitions.size()
+          + " partitions common to FS listing and MDT could not be compared : " + e.getMessage();
+    }
   }
 
   @VisibleForTesting

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -576,7 +576,128 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     when(commitsTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
 
     // validate that all 3 partitions are returned
-    assertEquals(mdtPartitions, validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient));
+    assertEquals(mdtPartitions, validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient, Collections.emptySet()));
+  }
+
+  /**
+   * The comparison of the common partitions is supplementary, so it must never mask the mismatch that
+   * triggered it. Here the table is mocked and no metadata validation context can be opened against it,
+   * which is the same shape as that comparison failing in the field. The partition list difference still
+   * has to surface as the reported cause, with the failure to compare noted rather than thrown.
+   * See HUDI-3880.
+   */
+  @Test
+  void testPartitionMismatchSurvivesFailureToCompareCommonPartitions() throws IOException {
+    String common1 = "PARTITION1";
+    String common2 = "PARTITION2";
+    // present in FS listing only, and non-empty, so it is a genuine mismatch rather than a stale empty dir
+    String onlyInFs = "PARTITION3";
+
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(metaClient.getStorage()).thenReturn(storage);
+    // every partition holds a data file, so none of them is written off as empty
+    mockPartitionWithFiles(Arrays.asList(common1, common2, onlyInFs), storage);
+
+    validator.setMetadataPartitionsToReturn(Arrays.asList(common1, common2));
+    validator.setFsPartitionsToReturn(Arrays.asList(common1, common2, onlyInFs));
+
+    HoodieTimeline commitsTimeline = mock(HoodieTimeline.class);
+    HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
+    when(metaClient.getCommitsTimeline()).thenReturn(commitsTimeline);
+    when(commitsTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
+
+    HoodieValidationException exception = assertThrows(HoodieValidationException.class,
+        () -> validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient, Collections.emptySet()));
+
+    String message = exception.getMessage();
+    // the partition list difference stays the reported cause
+    assertTrue(message.contains("Compare Partitions Failed!"), message);
+    assertTrue(message.contains("PARTITION3"), message);
+    // the comparison could not run, and says so instead of claiming the common partitions are fine
+    assertTrue(message.contains("2 partitions common to FS listing and MDT could not be compared"), message);
+    assertFalse(message.contains("File listings match for all"), message);
+  }
+
+  /**
+   * Nothing overlaps, so there are no file listings to compare. The mismatch is still reported and the
+   * validator must not claim to have checked anything. See HUDI-3880.
+   */
+  @Test
+  void testDisjointPartitionsOnMismatch() throws IOException {
+    String onlyInMdt = "PARTITION1";
+    String onlyInFs = "PARTITION2";
+
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(metaClient.getStorage()).thenReturn(storage);
+    // both hold data, so neither is written off as empty
+    mockPartitionWithFiles(Arrays.asList(onlyInMdt, onlyInFs), storage);
+    when(storage.exists(new StoragePath(basePath + "/" + onlyInMdt))).thenReturn(true);
+
+    validator.setMetadataPartitionsToReturn(Collections.singletonList(onlyInMdt));
+    validator.setFsPartitionsToReturn(Collections.singletonList(onlyInFs));
+
+    HoodieTimeline commitsTimeline = mock(HoodieTimeline.class);
+    HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
+    when(metaClient.getCommitsTimeline()).thenReturn(commitsTimeline);
+    when(commitsTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
+
+    HoodieValidationException exception = assertThrows(HoodieValidationException.class,
+        () -> validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient, Collections.emptySet()));
+
+    String message = exception.getMessage();
+    assertTrue(message.contains("Compare Partitions Failed!"), message);
+    assertTrue(message.contains("No partitions are common to FS listing and MDT"), message);
+    // must not imply anything was verified
+    assertFalse(message.contains("File listings match for all"), message);
+  }
+
+  /**
+   * The partitions the two sides agree on must still be reported as matching when the only difference
+   * is an extra empty partition on the FS side, which is not a mismatch at all. Guards against the
+   * common partition check firing on runs that should pass. See HUDI-3880.
+   */
+  @Test
+  void testCommonPartitionsNotValidatedWhenNoMismatch() throws IOException {
+    String partition1 = "PARTITION1";
+    String partition2 = "PARTITION2";
+    String emptyExtraOnFs = "PARTITION3";
+
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(metaClient.getStorage()).thenReturn(storage);
+    mockPartitionWithFiles(Arrays.asList(partition1, partition2), storage);
+    // the extra FS partition holds only the partition marker, so it is empty and forgiven
+    StoragePathInfo markerOnly = mock(StoragePathInfo.class);
+    when(markerOnly.isFile()).thenReturn(true);
+    when(markerOnly.getPath()).thenReturn(new StoragePath(basePath, emptyExtraOnFs + "/.hoodie_partition_metadata"));
+    when(storage.listFiles(new StoragePath(basePath, emptyExtraOnFs))).thenReturn(Collections.singletonList(markerOnly));
+
+    List<String> mdtPartitions = Arrays.asList(partition1, partition2);
+    validator.setMetadataPartitionsToReturn(mdtPartitions);
+    validator.setFsPartitionsToReturn(Arrays.asList(partition1, partition2, emptyExtraOnFs));
+
+    HoodieTimeline commitsTimeline = mock(HoodieTimeline.class);
+    HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
+    when(metaClient.getCommitsTimeline()).thenReturn(commitsTimeline);
+    when(commitsTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
+
+    // returns normally, so the common partition check never runs and the caller does the file validation
+    assertEquals(mdtPartitions,
+        validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient, Collections.emptySet()));
   }
 
   @ParameterizedTest
@@ -646,7 +767,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
       validator.setPartitionCreationTime(Option.of(partition3CreationTime));
       // validate that exception is thrown since MDT has one additional partition.
       assertThrows(HoodieValidationException.class, () -> {
-        validator.validatePartitions(engineContext, baseStoragePath, metaClient);
+        validator.validatePartitions(engineContext, baseStoragePath, metaClient, Collections.emptySet());
       });
     } else {
       // 3rd partition creation time is > last completed instant
@@ -657,7 +778,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
       validator.setPartitionCreationTime(Option.of(TimelineUtils.generateInstantTime(true, timeGenerator)));
 
       // validate that all 3 partitions are returned
-      assertEquals(mdtPartitions, validator.validatePartitions(engineContext, baseStoragePath, metaClient));
+      assertEquals(mdtPartitions, validator.validatePartitions(engineContext, baseStoragePath, metaClient, Collections.emptySet()));
     }
   }
 
@@ -836,6 +957,55 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
       } else {
         assertThrows(HoodieValidationException.class, localValidator::run);
       }
+    });
+  }
+
+  /**
+   * End-to-end counterpart of the mocked partition mismatch tests, running against a real table so the
+   * file listings for the common partitions are genuinely compared rather than short circuited. One of
+   * the three partitions is removed from the file system, so the partition lists disagree while the two
+   * surviving partitions still match. The reported failure has to cover both. See HUDI-3880.
+   */
+  @Test
+  void testCommonPartitionsAreValidatedOnPartitionMismatchEndToEnd() throws Exception {
+    SparkRDDValidationUtils.withRDDPersistenceValidation(sparkSession, () -> {
+      Map<String, String> writeOptions = new HashMap<>();
+      writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+      writeOptions.put("hoodie.table.name", "test_table");
+      writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+      writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+      writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+      writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+
+      Dataset<Row> inserts = makeInsertDf("000", 100).cache();
+      inserts.write().format("hudi").options(writeOptions)
+          .mode(SaveMode.Overwrite)
+          .save(basePath);
+      inserts.unpersist(true);
+
+      HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+      config.basePath = "file:" + basePath;
+      config.validateLatestFileSlices = true;
+      config.validateAllFileGroups = true;
+      new HoodieMetadataTableValidator(jsc, config).run();
+
+      // drop one of the three partitions from the file system, leaving two that both sides still agree on
+      FileSystem fs = HadoopFSUtils.getFs(basePath, new Configuration(false));
+      fs.delete(new Path(basePath + "/" + HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH), true);
+
+      config = new HoodieMetadataTableValidator.Config();
+      config.basePath = "file:" + basePath;
+      config.validateLatestFileSlices = true;
+
+      HoodieMetadataTableValidator localValidator = new HoodieMetadataTableValidator(jsc, config);
+      HoodieValidationException exception =
+          assertThrows(HoodieValidationException.class, localValidator::run);
+
+      String message = exception.getMessage();
+      // the partition list difference stays the reported cause
+      assertTrue(message.contains("Compare Partitions Failed!"), message);
+      // and the two partitions both sides agree on were really compared, not just counted
+      assertTrue(message.contains("File listings match for all 2 partitions common to FS listing and MDT."), message);
     });
   }
 
@@ -1606,7 +1776,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
 
     // Test validation with truncation
     HoodieValidationException exception = assertThrows(HoodieValidationException.class, () -> {
-      validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient);
+      validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient, Collections.emptySet());
     });
     
     // Verify truncation in error message

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -574,7 +574,128 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     when(commitsTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
 
     // validate that all 3 partitions are returned
-    assertEquals(mdtPartitions, validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient));
+    assertEquals(mdtPartitions, validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient, Collections.emptySet()));
+  }
+
+  /**
+   * The comparison of the common partitions is supplementary, so it must never mask the mismatch that
+   * triggered it. Here the table is mocked and no metadata validation context can be opened against it,
+   * which is the same shape as that comparison failing in the field. The partition list difference still
+   * has to surface as the reported cause, with the failure to compare noted rather than thrown.
+   * See HUDI-3880.
+   */
+  @Test
+  void testPartitionMismatchSurvivesFailureToCompareCommonPartitions() throws IOException {
+    String common1 = "PARTITION1";
+    String common2 = "PARTITION2";
+    // present in FS listing only, and non-empty, so it is a genuine mismatch rather than a stale empty dir
+    String onlyInFs = "PARTITION3";
+
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(metaClient.getStorage()).thenReturn(storage);
+    // every partition holds a data file, so none of them is written off as empty
+    mockPartitionWithFiles(Arrays.asList(common1, common2, onlyInFs), storage);
+
+    validator.setMetadataPartitionsToReturn(Arrays.asList(common1, common2));
+    validator.setFsPartitionsToReturn(Arrays.asList(common1, common2, onlyInFs));
+
+    HoodieTimeline commitsTimeline = mock(HoodieTimeline.class);
+    HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
+    when(metaClient.getCommitsTimeline()).thenReturn(commitsTimeline);
+    when(commitsTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
+
+    HoodieValidationException exception = assertThrows(HoodieValidationException.class,
+        () -> validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient, Collections.emptySet()));
+
+    String message = exception.getMessage();
+    // the partition list difference stays the reported cause
+    assertTrue(message.contains("Compare Partitions Failed!"), message);
+    assertTrue(message.contains("PARTITION3"), message);
+    // the comparison could not run, and says so instead of claiming the common partitions are fine
+    assertTrue(message.contains("2 partitions common to FS listing and MDT could not be compared"), message);
+    assertFalse(message.contains("File listings match for all"), message);
+  }
+
+  /**
+   * Nothing overlaps, so there are no file listings to compare. The mismatch is still reported and the
+   * validator must not claim to have checked anything. See HUDI-3880.
+   */
+  @Test
+  void testDisjointPartitionsOnMismatch() throws IOException {
+    String onlyInMdt = "PARTITION1";
+    String onlyInFs = "PARTITION2";
+
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(metaClient.getStorage()).thenReturn(storage);
+    // both hold data, so neither is written off as empty
+    mockPartitionWithFiles(Arrays.asList(onlyInMdt, onlyInFs), storage);
+    when(storage.exists(new StoragePath(basePath + "/" + onlyInMdt))).thenReturn(true);
+
+    validator.setMetadataPartitionsToReturn(Collections.singletonList(onlyInMdt));
+    validator.setFsPartitionsToReturn(Collections.singletonList(onlyInFs));
+
+    HoodieTimeline commitsTimeline = mock(HoodieTimeline.class);
+    HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
+    when(metaClient.getCommitsTimeline()).thenReturn(commitsTimeline);
+    when(commitsTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
+
+    HoodieValidationException exception = assertThrows(HoodieValidationException.class,
+        () -> validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient, Collections.emptySet()));
+
+    String message = exception.getMessage();
+    assertTrue(message.contains("Compare Partitions Failed!"), message);
+    assertTrue(message.contains("No partitions are common to FS listing and MDT"), message);
+    // must not imply anything was verified
+    assertFalse(message.contains("File listings match for all"), message);
+  }
+
+  /**
+   * The partitions the two sides agree on must still be reported as matching when the only difference
+   * is an extra empty partition on the FS side, which is not a mismatch at all. Guards against the
+   * common partition check firing on runs that should pass. See HUDI-3880.
+   */
+  @Test
+  void testCommonPartitionsNotValidatedWhenNoMismatch() throws IOException {
+    String partition1 = "PARTITION1";
+    String partition2 = "PARTITION2";
+    String emptyExtraOnFs = "PARTITION3";
+
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(metaClient.getStorage()).thenReturn(storage);
+    mockPartitionWithFiles(Arrays.asList(partition1, partition2), storage);
+    // the extra FS partition holds only the partition marker, so it is empty and forgiven
+    StoragePathInfo markerOnly = mock(StoragePathInfo.class);
+    when(markerOnly.isFile()).thenReturn(true);
+    when(markerOnly.getPath()).thenReturn(new StoragePath(basePath, emptyExtraOnFs + "/.hoodie_partition_metadata"));
+    when(storage.listFiles(new StoragePath(basePath, emptyExtraOnFs))).thenReturn(Collections.singletonList(markerOnly));
+
+    List<String> mdtPartitions = Arrays.asList(partition1, partition2);
+    validator.setMetadataPartitionsToReturn(mdtPartitions);
+    validator.setFsPartitionsToReturn(Arrays.asList(partition1, partition2, emptyExtraOnFs));
+
+    HoodieTimeline commitsTimeline = mock(HoodieTimeline.class);
+    HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
+    when(metaClient.getCommitsTimeline()).thenReturn(commitsTimeline);
+    when(commitsTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
+
+    // returns normally, so the common partition check never runs and the caller does the file validation
+    assertEquals(mdtPartitions,
+        validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient, Collections.emptySet()));
   }
 
   @ParameterizedTest
@@ -644,7 +765,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
       validator.setPartitionCreationTime(Option.of(partition3CreationTime));
       // validate that exception is thrown since MDT has one additional partition.
       assertThrows(HoodieValidationException.class, () -> {
-        validator.validatePartitions(engineContext, baseStoragePath, metaClient);
+        validator.validatePartitions(engineContext, baseStoragePath, metaClient, Collections.emptySet());
       });
     } else {
       // 3rd partition creation time is > last completed instant
@@ -655,7 +776,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
       validator.setPartitionCreationTime(Option.of(TimelineUtils.generateInstantTime(true, timeGenerator)));
 
       // validate that all 3 partitions are returned
-      assertEquals(mdtPartitions, validator.validatePartitions(engineContext, baseStoragePath, metaClient));
+      assertEquals(mdtPartitions, validator.validatePartitions(engineContext, baseStoragePath, metaClient, Collections.emptySet()));
     }
   }
 
@@ -834,6 +955,55 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
       } else {
         assertThrows(HoodieValidationException.class, localValidator::run);
       }
+    });
+  }
+
+  /**
+   * End-to-end counterpart of the mocked partition mismatch tests, running against a real table so the
+   * file listings for the common partitions are genuinely compared rather than short circuited. One of
+   * the three partitions is removed from the file system, so the partition lists disagree while the two
+   * surviving partitions still match. The reported failure has to cover both. See HUDI-3880.
+   */
+  @Test
+  void testCommonPartitionsAreValidatedOnPartitionMismatchEndToEnd() throws Exception {
+    SparkRDDValidationUtils.withRDDPersistenceValidation(sparkSession, () -> {
+      Map<String, String> writeOptions = new HashMap<>();
+      writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+      writeOptions.put("hoodie.table.name", "test_table");
+      writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+      writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+      writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+      writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+
+      Dataset<Row> inserts = makeInsertDf("000", 100).cache();
+      inserts.write().format("hudi").options(writeOptions)
+          .mode(SaveMode.Overwrite)
+          .save(basePath);
+      inserts.unpersist(true);
+
+      HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+      config.basePath = "file:" + basePath;
+      config.validateLatestFileSlices = true;
+      config.validateAllFileGroups = true;
+      new HoodieMetadataTableValidator(jsc, config).run();
+
+      // drop one of the three partitions from the file system, leaving two that both sides still agree on
+      FileSystem fs = HadoopFSUtils.getFs(basePath, new Configuration(false));
+      fs.delete(new Path(basePath + "/" + HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH), true);
+
+      config = new HoodieMetadataTableValidator.Config();
+      config.basePath = "file:" + basePath;
+      config.validateLatestFileSlices = true;
+
+      HoodieMetadataTableValidator localValidator = new HoodieMetadataTableValidator(jsc, config);
+      HoodieValidationException exception =
+          assertThrows(HoodieValidationException.class, localValidator::run);
+
+      String message = exception.getMessage();
+      // the partition list difference stays the reported cause
+      assertTrue(message.contains("Compare Partitions Failed!"), message);
+      // and the two partitions both sides agree on were really compared, not just counted
+      assertTrue(message.contains("File listings match for all 2 partitions common to FS listing and MDT."), message);
     });
   }
 
@@ -1604,7 +1774,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
 
     // Test validation with truncation
     HoodieValidationException exception = assertThrows(HoodieValidationException.class, () -> {
-      validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient);
+      validator.validatePartitions(engineContext, new StoragePath(basePath), metaClient, Collections.emptySet());
     });
     
     // Verify truncation in error message


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15126 / [HUDI-3880](https://issues.apache.org/jira/browse/HUDI-3880).

`HoodieMetadataTableValidator` throws as soon as the partition list from the file
system and the partition list from the metadata table disagree:

```java
if (misMatch.get()) {
  String message = "Compare Partitions Failed! ...";
  log.error(message);
  throw new HoodieValidationException(message);
}
```

This happens in `validatePartitions(...)`, before the caller gets a chance to run
`validateFilesInPartition(...)` for any partition. So when the lists differ by a
single partition, the run reports only that the lists differ and says nothing
about whether the file listings for the other partitions are consistent. An
operator triaging a validation failure has to fix the partition-level difference
and re-run before learning whether anything else is wrong.

Most of the original ticket has already landed — the validator now forgives extra
file-system partitions that are empty, and metadata-table partitions belonging to
a commit newer than the one being validated. The remaining gap is this one: no
file listings are compared for the partitions the two sides *do* agree on.

### Summary and Changelog

Users get a more complete picture from a single failing validation run: when the
partition lists disagree, the report now also says whether the file listings for
the partitions both sides agree on are consistent.

- `validatePartitions(...)` now takes `baseFilesForCleaning` so it can run the
  same per-partition file validation the caller does.
- On a genuine mismatch, the intersection of the two partition lists is computed
  and `validateFilesInPartition(...)` is run for each partition in it. The result
  is appended to the exception message.
- The partition mismatch remains the reported cause and the validator still
  fails. The added comparison is supplementary, so if it cannot run — for example
  the metadata validation context fails to open — that is logged and noted in the
  message rather than allowed to mask the original mismatch.
- When the lists are disjoint the message says so explicitly, so the output never
  implies something was checked when it was not.
- Tests added to `TestHoodieMetadataTableValidator`: an end-to-end case on a real
  table (one partition removed from the file system, the other two compared), a
  disjoint-lists case, a case where the supplementary comparison itself fails, and
  a case where an extra empty file-system partition is not a mismatch at all.

Example of the new output, from the end-to-end test:

```
Compare Partitions Failed!  Additional 0 partitions from FS, but missing from MDT : ""
and additional 1 partitions from MDT, but missing from FS listing : "2015/03/16".
 All 2 partitions from FS listing 2016/03/15,2015/03/17
File listings match for all 2 partitions common to FS listing and MDT.
```

### Impact

Validator-only. No change to the write or read path, and no change to whether a
validation run passes or fails — only to how much a failing run tells you. The
extra work is a per-partition file comparison that runs solely on the failure
path, over the intersection of the two partition lists.

### Risk Level

low

Validator-only change confined to the failure path. The supplementary comparison
is wrapped so that a failure in it cannot mask the partition mismatch that
triggered it.

### Documentation Update

None. No new config, public API, or user-facing behaviour change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
