### PR TITLE
fix(flink): close lookup reader after cache reload attempts

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/HoodieLookupFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/HoodieLookupFunction.java
@@ -155,15 +155,16 @@ public class HoodieLookupFunction extends LookupFunction implements Serializable
       try {
         long count = 0;
         GenericRowData reuse = new GenericRowData(rowType.getFieldCount());
-        partitionReader.open();
-        RowData row;
-        while ((row = partitionReader.read(reuse)) != null) {
-          count++;
-          RowData rowData = serializer.copy(row);
-          RowData key = extractLookupKey(rowData);
-          cache.addRow(key, rowData);
+        try (HoodieLookupTableReader reader = partitionReader) {
+          reader.open();
+          RowData row;
+          while ((row = reader.read(reuse)) != null) {
+            count++;
+            RowData rowData = serializer.copy(row);
+            RowData key = extractLookupKey(rowData);
+            cache.addRow(key, rowData);
+          }
         }
-        partitionReader.close();
         currentCommit = latestCommitInstant.get();
         scheduleNextLoad();
         log.info("Loaded {} row(s) into lookup join cache", count);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/HoodieLookupTableReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/HoodieLookupTableReader.java
@@ -28,16 +28,19 @@ import org.apache.flink.table.data.RowData;
 
 import javax.annotation.Nullable;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.util.CloseableUtils.closeSuppressing;
+
 /**
  * Hudi look up table reader.
  */
-public class HoodieLookupTableReader implements Serializable {
+public class HoodieLookupTableReader implements Serializable, Closeable {
   private static final long serialVersionUID = 1L;
 
   private final SerializableSupplier<InputFormat<RowData, ?>> inputFormatSupplier;
@@ -53,11 +56,17 @@ public class HoodieLookupTableReader implements Serializable {
   }
 
   public void open() throws IOException {
+    close();
     this.inputFormat = inputFormatSupplier.get();
-    inputFormat.configure(conf);
-    this.inputSplits = Arrays.stream(inputFormat.createInputSplits(1)).collect(Collectors.toList());
-    ((RichInputFormat) inputFormat).openInputFormat();
-    inputFormat.open(inputSplits.remove(0));
+    try {
+      inputFormat.configure(conf);
+      this.inputSplits = Arrays.stream(inputFormat.createInputSplits(1)).collect(Collectors.toList());
+      ((RichInputFormat) inputFormat).openInputFormat();
+      inputFormat.open(inputSplits.remove(0));
+    } catch (IOException | RuntimeException e) {
+      closeSuppressing(this, e);
+      throw e;
+    }
   }
 
   @Nullable
@@ -77,12 +86,21 @@ public class HoodieLookupTableReader implements Serializable {
     return null;
   }
 
+  @Override
   public void close() throws IOException {
-    if (this.inputFormat != null) {
-      inputFormat.close();
+    InputFormat format = this.inputFormat;
+    this.inputFormat = null;
+    this.inputSplits = null;
+    if (format == null) {
+      return;
     }
-    if (inputFormat instanceof RichInputFormat) {
-      ((RichInputFormat) inputFormat).closeInputFormat();
+
+    if (format instanceof RichInputFormat) {
+      try (Closeable ignored = ((RichInputFormat) format)::closeInputFormat) {
+        format.close();
+      }
+    } else {
+      format.close();
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/lookup/TestHoodieLookupFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/lookup/TestHoodieLookupFunction.java
@@ -105,6 +105,25 @@ class TestHoodieLookupFunction {
   }
 
   @Test
+  void testReaderIsClosedWhenCacheReloadFails() throws Exception {
+    Configuration conf = getConf();
+    TestData.writeData(TestData.DATA_SET_SINGLE_INSERT, conf);
+
+    FailingLookupTableReader reader = new FailingLookupTableReader(conf);
+    HoodieLookupFunction function = newLookupFunction(reader, conf);
+    function.open(null);
+
+    Thread.currentThread().interrupt();
+    try {
+      assertThrows(RuntimeException.class, () -> function.lookup(lookupKey()));
+      assertEquals(1, reader.closeCount, "The failed reload attempt should close the reader");
+    } finally {
+      Thread.interrupted();
+      function.close();
+    }
+  }
+
+  @Test
   void testRocksDBCacheLifecycleAndLookupFailure() throws Exception {
     Configuration conf = getConf();
     conf.set(FlinkOptions.LOOKUP_JOIN_CACHE_TYPE, "rocksdb");
@@ -130,7 +149,7 @@ class TestHoodieLookupFunction {
     function.close();
   }
 
-  private HoodieLookupFunction newLookupFunction(CountingLookupTableReader reader, Configuration conf) {
+  private HoodieLookupFunction newLookupFunction(HoodieLookupTableReader reader, Configuration conf) {
     return new HoodieLookupFunction(
         reader,
         TestConfigurations.ROW_TYPE,
@@ -203,6 +222,29 @@ class TestHoodieLookupFunction {
     @Override
     public void close() throws IOException {
       // no-op
+    }
+  }
+
+  private static class FailingLookupTableReader extends HoodieLookupTableReader {
+    private int closeCount;
+
+    private FailingLookupTableReader(Configuration conf) {
+      super(() -> null, conf);
+    }
+
+    @Override
+    public void open() {
+      // no-op
+    }
+
+    @Override
+    public RowData read(RowData reuse) throws IOException {
+      throw new IOException("expected");
+    }
+
+    @Override
+    public void close() {
+      closeCount++;
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/lookup/TestHoodieLookupTableReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/lookup/TestHoodieLookupTableReader.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.lookup;
+
+import org.apache.hudi.exception.HoodieIOException;
+
+import org.apache.flink.api.common.io.RichInputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.table.data.RowData;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link HoodieLookupTableReader}.
+ */
+class TestHoodieLookupTableReader {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testOpenRollsBackPartiallyOpenedInputFormat() throws Exception {
+    RichInputFormat<RowData, InputSplit> inputFormat = mock(RichInputFormat.class);
+    InputSplit inputSplit = mock(InputSplit.class);
+    when(inputFormat.createInputSplits(1)).thenReturn(new InputSplit[] {inputSplit});
+    IOException openException = new IOException("expected open failure");
+    doThrow(openException).when(inputFormat).open(inputSplit);
+
+    HoodieLookupTableReader reader =
+        new HoodieLookupTableReader(() -> inputFormat, new Configuration());
+
+    assertSame(openException, assertThrows(IOException.class, reader::open));
+    verify(inputFormat).close();
+    verify(inputFormat).closeInputFormat();
+
+    reader.close();
+    verify(inputFormat, times(1)).close();
+    verify(inputFormat, times(1)).closeInputFormat();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testOpenPreservesFailureWhenRuntimeRollbackFails() throws Exception {
+    RichInputFormat<RowData, InputSplit> inputFormat = mock(RichInputFormat.class);
+    InputSplit inputSplit = mock(InputSplit.class);
+    when(inputFormat.createInputSplits(1)).thenReturn(new InputSplit[] {inputSplit});
+    IOException openException = new IOException("expected open failure");
+    HoodieIOException splitCloseException =
+        new HoodieIOException("expected runtime split close failure");
+    doThrow(openException).when(inputFormat).open(inputSplit);
+    doThrow(splitCloseException).when(inputFormat).close();
+
+    HoodieLookupTableReader reader =
+        new HoodieLookupTableReader(() -> inputFormat, new Configuration());
+
+    IOException exception = assertThrows(IOException.class, reader::open);
+    assertSame(openException, exception);
+    assertEquals(1, exception.getSuppressed().length);
+    assertSame(splitCloseException, exception.getSuppressed()[0]);
+    verify(inputFormat).closeInputFormat();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testCloseReleasesInputFormatWhenRuntimeSplitCloseFails() throws Exception {
+    RichInputFormat<RowData, InputSplit> inputFormat = mock(RichInputFormat.class);
+    InputSplit inputSplit = mock(InputSplit.class);
+    when(inputFormat.createInputSplits(1)).thenReturn(new InputSplit[] {inputSplit});
+    HoodieIOException splitCloseException =
+        new HoodieIOException("expected runtime split close failure");
+    IOException formatCloseException = new IOException("expected format close failure");
+    doThrow(splitCloseException).when(inputFormat).close();
+    doThrow(formatCloseException).when(inputFormat).closeInputFormat();
+
+    HoodieLookupTableReader reader =
+        new HoodieLookupTableReader(() -> inputFormat, new Configuration());
+    reader.open();
+
+    HoodieIOException exception = assertThrows(HoodieIOException.class, reader::close);
+    assertSame(splitCloseException, exception);
+    assertEquals(1, exception.getSuppressed().length);
+    assertSame(formatCloseException, exception.getSuppressed()[0]);
+    verify(inputFormat).closeInputFormat();
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flink lookup cache reloads closed the table reader only after a complete, successful read. If opening or reading an input format failed, the retry opened another input format while the previous attempt could still hold file handles or native reader resources.

### Summary and Changelog

- Close the lookup table reader with try-with-resources for every cache reload attempt, preserving cleanup failures as suppressed exceptions.
- Roll back partially opened input formats and make reader cleanup idempotent.
- Attempt rich input-format cleanup even when split cleanup fails, preserving secondary failures as suppressed exceptions.
- Add regression coverage for reload failures, partial-open rollback, and close failures.

No code was copied from another project.

### Impact

No public API, configuration, storage-format, or performance behavior changes. Failed Flink lookup cache reloads no longer accumulate input-format resources across local retries.

### Risk Level

low. The change is limited to lookup reader resource cleanup and is covered by focused success and failure-path tests.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

### Testing

- `mvn -pl hudi-flink-datasource/hudi-flink -am -DskipITs -Dcheckstyle.skip -Drat.skip=true -Dtest=TestHoodieLookupFunction,TestHoodieLookupTableReader -Dsurefire.failIfNoSpecifiedTests=false test` (7 tests passed)
- `mvn -pl hudi-flink-datasource/hudi-flink checkstyle:check -Dcheckstyle.includes='**/table/lookup/*.java'` (0 violations)
