### PR TITLE
fix(spark-sql): reject creating a table that pairs a non partitioned key generator with partition columns

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -219,13 +219,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
 
       val (recordName, namespace) = HoodieSchemaConversionUtils.getRecordNameAndNamespace(table.identifier.table)
       val schema = HoodieSparkSchemaConverters.toHoodieType(dataSchema, nullable = false, recordName, namespace)
-      val partitionColumns = if (SparkConfigUtils.containsConfigProperty(tableConfigs, KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)) {
-        SparkConfigUtils.getStringWithAltKeys(tableConfigs, KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)
-      } else if (table.partitionColumnNames.isEmpty) {
-        null
-      } else {
-        table.partitionColumnNames.mkString(",")
-      }
+      val partitionColumns = resolvePartitionColumns(tableConfigs)
 
       HoodieTableMetaClient.newTableBuilder()
         .fromProperties(properties)
@@ -272,6 +266,9 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
         val schema = table.schema
         val options = extraTableConfig(tableExists = false, globalTableConfigs, sqlOptions) ++
           mapSqlOptionsToTableConfigs(sqlOptions)
+        // Only for a table being created. An existing table already in this state stays readable,
+        // so that registering it in the catalog remains possible.
+        validateKeyGeneratorForPartitionColumns(options)
         (addMetaFields(schema), options)
 
       case (CatalogTableType.MANAGED, true) =>
@@ -288,6 +285,42 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
     verifyDataSchema(table.identifier, table.tableType, dataSchema)
 
     (finalSchema, tableConfigs)
+  }
+
+  /**
+   * Resolves the partition fields to persist in the table config, preferring an explicitly configured
+   * partition path field over the columns of the PARTITIONED BY clause.
+   */
+  private def resolvePartitionColumns(tableConfigs: Map[String, String]): String = {
+    if (SparkConfigUtils.containsConfigProperty(tableConfigs, KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)) {
+      SparkConfigUtils.getStringWithAltKeys(tableConfigs, KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)
+    } else if (table.partitionColumnNames.isEmpty) {
+      null
+    } else {
+      table.partitionColumnNames.mkString(",")
+    }
+  }
+
+  /**
+   * A non partitioned key generator never produces a partition path, so pairing one with partition
+   * columns describes a table that cannot exist. Creating it anyway persists a table config that
+   * disagrees with itself, and every subsequent write is rejected for a partition path conflict that
+   * names neither the key generator nor the partition columns. Reject it while the statement that
+   * introduced it is still in hand.
+   */
+  private def validateKeyGeneratorForPartitionColumns(tableConfigs: Map[String, String]): Unit = {
+    val partitionColumns = resolvePartitionColumns(tableConfigs)
+    if (!StringUtils.isNullOrEmpty(partitionColumns)) {
+      val keyGenerator = KeyGeneratorType.getKeyGeneratorClassName(tableConfigs.asJava)
+      if (KeyGeneratorType.NON_PARTITION.getClassName == keyGenerator
+        || KeyGeneratorType.NON_PARTITION_AVRO.getClassName == keyGenerator) {
+        throw new HoodieAnalysisException(
+          s"Cannot create table '$catalogTableName' partitioned by '$partitionColumns' using key generator"
+            + s" '$keyGenerator', which does not generate a partition path. Either drop the partition"
+            + s" columns, or configure a partitioned key generator through"
+            + s" '${HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key}'.")
+      }
+    }
   }
 
   private def extraTableConfig(tableExists: Boolean,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -219,13 +219,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
 
       val (recordName, namespace) = HoodieSchemaConversionUtils.getRecordNameAndNamespace(table.identifier.table)
       val schema = HoodieSparkSchemaConverters.toHoodieType(dataSchema, nullable = false, recordName, namespace)
-      val partitionColumns = if (SparkConfigUtils.containsConfigProperty(tableConfigs, KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)) {
-        SparkConfigUtils.getStringWithAltKeys(tableConfigs, KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)
-      } else if (table.partitionColumnNames.isEmpty) {
-        null
-      } else {
-        table.partitionColumnNames.mkString(",")
-      }
+      val partitionColumns = resolvePartitionColumns(tableConfigs)
 
       HoodieTableMetaClient.newTableBuilder()
         .fromProperties(properties)
@@ -272,6 +266,9 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
         val schema = table.schema
         val options = extraTableConfig(tableExists = false, globalTableConfigs, sqlOptions) ++
           mapSqlOptionsToTableConfigs(sqlOptions)
+        // Only for a table being created. An existing table already in this state stays readable,
+        // so that registering it in the catalog remains possible.
+        validateKeyGeneratorForPartitionColumns(options)
         (addMetaFields(schema), options)
 
       case (CatalogTableType.MANAGED, true) =>
@@ -288,6 +285,42 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
     verifyDataSchema(table.identifier, table.tableType, dataSchema)
 
     (finalSchema, tableConfigs)
+  }
+
+  /**
+   * Resolves the partition fields to persist in the table config, preferring an explicitly configured
+   * partition path field over the columns of the PARTITIONED BY clause.
+   */
+  private def resolvePartitionColumns(tableConfigs: Map[String, String]): String = {
+    if (SparkConfigUtils.containsConfigProperty(tableConfigs, KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)) {
+      SparkConfigUtils.getStringWithAltKeys(tableConfigs, KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)
+    } else if (table.partitionColumnNames.isEmpty) {
+      null
+    } else {
+      table.partitionColumnNames.mkString(",")
+    }
+  }
+
+  /**
+   * A non partitioned key generator never produces a partition path, so pairing one with partition
+   * columns describes a table that cannot exist. Creating it anyway persists a table config that
+   * disagrees with itself, and every subsequent write is rejected for a partition path conflict that
+   * names neither the key generator nor the partition columns. Reject it while the statement that
+   * introduced it is still in hand.
+   */
+  private def validateKeyGeneratorForPartitionColumns(tableConfigs: Map[String, String]): Unit = {
+    val partitionColumns = resolvePartitionColumns(tableConfigs)
+    if (!StringUtils.isNullOrEmpty(partitionColumns)) {
+      val keyGenerator = KeyGeneratorType.getKeyGeneratorClassName(tableConfigs.asJava)
+      if (KeyGeneratorType.NON_PARTITION.getClassName.equals(keyGenerator)
+        || KeyGeneratorType.NON_PARTITION_AVRO.getClassName.equals(keyGenerator)) {
+        throw new HoodieAnalysisException(
+          s"Cannot create table '$catalogTableName' partitioned by '$partitionColumns' using key generator"
+            + s" '$keyGenerator', which does not generate a partition path. Either drop the partition"
+            + s" columns, or configure a partitioned key generator through"
+            + s" '${HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key}'.")
+      }
+    }
   }
 
   private def extraTableConfig(tableExists: Boolean,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -1543,6 +1543,62 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
     spark.sql(s"drop table $tableName")
   }
 
+  test("Test Create Table with a non partitioned key generator and partition columns") {
+    // A non partitioned key generator produces no partition path, so the table config that would be
+    // written disagrees with itself and every later write is rejected for a partition path conflict.
+    // Creating the table has to fail instead. See HUDI-5263.
+    Seq(
+      "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+      "org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator"
+    ).foreach { keyGenClassName =>
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        checkExceptionContain(
+          s"""
+             | create table $tableName (
+             |  id bigint,
+             |  name string,
+             |  ts bigint,
+             |  dt string
+             | ) using hudi
+             | location '${tmp.getCanonicalPath}/$tableName'
+             | tblproperties (
+             |   type = 'cow',
+             |   primaryKey = 'id',
+             |   orderingFields = 'ts',
+             |   hoodie.table.keygenerator.class = '$keyGenClassName'
+             | )
+             | partitioned by (dt)
+       """.stripMargin)("which does not generate a partition path")
+      }
+    }
+  }
+
+  test("Test Create Table with a non partitioned key generator and no partition columns") {
+    // The guard above must not fire when the table really is non partitioned.
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |  id bigint,
+           |  name string,
+           |  ts bigint
+           | ) using hudi
+           | location '${tmp.getCanonicalPath}/$tableName'
+           | tblproperties (
+           |   type = 'cow',
+           |   primaryKey = 'id',
+           |   orderingFields = 'ts',
+           |   hoodie.table.keygenerator.class = 'org.apache.hudi.keygen.NonpartitionedKeyGenerator'
+           | )
+       """.stripMargin)
+      spark.sql(s"insert into $tableName values (1, 'a1', 1000)")
+      checkAnswer(s"select id, name, ts from $tableName")(Seq(1, "a1", 1000))
+      spark.sql(s"drop table $tableName")
+    }
+  }
+
   test("Test CTAS not de-duplicating (by default)") {
     withRecordType() {
       withTempDir { tmp =>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15589 / [HUDI-5263](https://issues.apache.org/jira/browse/HUDI-5263).

Spark SQL accepts a `CREATE TABLE` that declares partition columns and, at the same
time, configures a key generator that never produces a partition path:

```sql
create table hudi_cow_pt_tbl (
  id bigint, name string, ts bigint, dt string
) using hudi
tblproperties (
  type = 'cow',
  primaryKey = 'id',
  hoodie.table.keygenerator.class = 'org.apache.hudi.keygen.NonpartitionedKeyGenerator'
)
partitioned by (dt)
```

The statement succeeds and persists a table config that disagrees with itself. The
partition fields are taken from the partition columns in `initHoodieTable`, while the
key generator is taken from the table properties, which override the value
`extraTableConfig` inferred. Nothing cross checks the two.

The resulting table cannot be written to at all. Running against master, every write
path is rejected identically:

```
create table:                SUCCEEDED (inconsistent config persisted)
sql insert:                  FAILED - Config conflict: PartitionPath: <empty> vs dt
dsWrite(partitionpath=dt):   FAILED - Config conflict: PartitionPath: <empty> vs dt
dsWrite(nonpartitioned):     FAILED - Config conflict: PartitionPath: <empty> vs dt
```

So the behaviour has moved on from the original report: the null partition column is
no longer reachable, because a later guard blocks the write. What remains is that the
broken table is still created, and the eventual failure names neither the key
generator nor the partition columns, which are the two things actually in conflict.

### Summary and Changelog

Creating a table with a non partitioned key generator and partition columns now fails
immediately, with a message that names both, instead of producing a table that cannot
be written to.

- Adds `validateKeyGeneratorForPartitionColumns` to `HoodieCatalogTable`, invoked from
  `parseSchemaAndConfigs` on the path that creates a table.
- Extracts `resolvePartitionColumns` from `initHoodieTable` so the validation and the
  value that gets persisted are derived the same way and cannot drift apart.
- Covers `NonpartitionedKeyGenerator` and `NonpartitionedAvroKeyGenerator`, resolved
  through `KeyGeneratorType.getKeyGeneratorClassName` so the key generator class and
  key generator type properties are both honoured.
- The check is deliberately limited to a table being created. An existing table already
  in this state stays readable and can still be registered in the catalog, so nobody is
  locked out of data they already have.
- Tests added to `TestCreateTable`: the rejection, for both non partitioned key
  generator classes, and a companion test asserting a genuinely non partitioned table
  is still created and still writable, so the guard cannot over fire.

The new error reads:

```
Cannot create table 'spark_catalog.default.hudi_cow_pt_tbl' partitioned by 'dt' using
key generator 'org.apache.hudi.keygen.NonpartitionedKeyGenerator', which does not
generate a partition path. Either drop the partition columns, or configure a
partitioned key generator through 'hoodie.table.keygenerator.class'.
```

### Impact

A `CREATE TABLE` that previously succeeded now fails. This breaks no working workflow:
a table created that way is rejected on every subsequent write, as shown above, so the
statement only ever produced an unusable table. The failure simply moves to the
statement that causes it.

Confined to the Spark SQL table creation path in `HoodieCatalogTable`. No change to the
read path, the write path, or the datasource API. Tables that already exist in this
state are untouched.

### Risk Level

low

The validation runs only while creating a table, and only fires on a combination that
is provably unusable. Verified that no existing test pairs a non partitioned key
generator with partition columns; the whole `org.apache.spark.sql.hudi.ddl` package
passes.

### Documentation Update

None. No new config, no public API change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
