### PR TITLE
fix(metadata): align MDT table services with the sub-directory bucketed layout

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedMergeHandle.java
@@ -55,6 +55,7 @@ import org.apache.hudi.internal.schema.utils.AvroSchemaEvolutionUtils;
 import org.apache.hudi.internal.schema.utils.SerDeHelper;
 import org.apache.hudi.io.storage.HoodieFileWriterFactory;
 import org.apache.hudi.keygen.BaseKeyGenerator;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.compact.strategy.CompactionStrategy;
@@ -228,11 +229,20 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
         writeStatus.getStat().setPrevCommit(HoodieWriteStat.NULL_COMMIT);
       }
 
-      HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
-          new StoragePath(config.getBasePath()),
-          FSUtils.constructAbsolutePath(config.getBasePath(), partitionPath),
-          hoodieTable.getPartitionMetafileFormat());
-      partitionMetadata.trySave();
+      // Mirrors the guard in HoodieAppendHandle#init. Now that compaction plans carry physical MDT
+      // partitions, this partitionPath can be a layout sub-path (e.g. "record_index/000004") under
+      // a non-flat layout. The single marker belongs at the logical partition root and is written
+      // once at MDT initialization; writing one inside a bucket directory would make partition
+      // discovery return physical sub-paths, breaking the cleaner and rollback globally. No-op for
+      // the flat default and for the data table.
+      if (!HoodieTableMetadataUtil.isMDTBucketSubPath(
+          hoodieTable.getMetaClient().getTableConfig(), hoodieTable.isMetadataTable(), partitionPath)) {
+        HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
+            new StoragePath(config.getBasePath()),
+            FSUtils.constructAbsolutePath(config.getBasePath(), partitionPath),
+            hoodieTable.getPartitionMetafileFormat());
+        partitionMetadata.trySave();
+      }
 
       String oldFileName = latestValidFilePath.isPresent() ? latestValidFilePath.get() : null;
       String newFileName = createNewFileName(oldFileName);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -245,11 +245,19 @@ public abstract class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T
     deltaWriteStat.setFileId(fileId);
     Option<FileSlice> fileSliceOpt = populateWriteStatAndFetchFileSlice(record, deltaWriteStat);
     try {
-      HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
-          new StoragePath(config.getBasePath()),
-          FSUtils.constructAbsolutePath(config.getBasePath(), partitionPath),
-          hoodieTable.getPartitionMetafileFormat());
-      partitionMetadata.trySave();
+      // For MDT writes under a non-flat layout (e.g., sub-directory bucketing), the physical
+      // partitionPath here is a layout sub-path (e.g. "record_index/0004") and the marker must
+      // live at the logical partition root instead. The marker at the logical root is written
+      // once at MDT initialization in HoodieBackedTableMetadataWriter.initializeFileGroups;
+      // skipping here keeps partition discovery returning logical names rather than per-bucket
+      // sub-paths. For the flat default and the data table this guard is a no-op.
+      if (!isMDTLayoutSubPath(partitionPath)) {
+        HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
+            new StoragePath(config.getBasePath()),
+            FSUtils.constructAbsolutePath(config.getBasePath(), partitionPath),
+            hoodieTable.getPartitionMetafileFormat());
+        partitionMetadata.trySave();
+      }
 
       String logInstantTime = config.getWriteVersion().greaterThanOrEquals(HoodieTableVersion.EIGHT)
           ? getInstantTimeForLogFile(record) : deltaWriteStat.getPrevCommit();
@@ -303,6 +311,44 @@ public abstract class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T
     deltaWriteStat.setBaseFile(baseFile);
     deltaWriteStat.setLogFiles(logFiles);
     return fileSlice;
+  }
+
+  /**
+   * Returns true when this append handle is writing to a layout sub-path of an MDT partition
+   * (e.g. {@code record_index/0004} under sub-directory bucketing). In that case, the
+   * {@code .hoodie_partition_metadata} marker must NOT be created at the bucket level; it is
+   * written once at the logical partition root by the MDT initialization path.
+   *
+   * <p>The heuristic only kicks in when the MDT is opened with a non-flat layout. Flat-default
+   * tables never write into bucket sub-paths, so we must not skip marker creation for them.
+   * Restricting the check to the non-flat case also sidesteps the risk of a 4-digit data-table
+   * partition value (e.g. price=1000) being misread as a bucket directory.
+   */
+  private boolean isMDTLayoutSubPath(String physicalPartitionPath) {
+    if (!hoodieTable.isMetadataTable() || physicalPartitionPath == null) {
+      return false;
+    }
+    org.apache.hudi.common.util.Option<String> layoutClass =
+        hoodieTable.getMetaClient().getTableConfig().getMetadataLayoutClass();
+    boolean nonFlatLayout = layoutClass.isPresent() && !layoutClass.get().isEmpty()
+        && !layoutClass.get().equals(org.apache.hudi.metadata.FlatMDTLayout.class.getName());
+    if (!nonFlatLayout) {
+      return false;
+    }
+    int slash = physicalPartitionPath.lastIndexOf('/');
+    if (slash <= 0 || slash >= physicalPartitionPath.length() - 1) {
+      return false;
+    }
+    String last = physicalPartitionPath.substring(slash + 1);
+    if (last.length() != 4) {
+      return false;
+    }
+    for (int i = 0; i < 4; i++) {
+      if (!Character.isDigit(last.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -313,42 +313,9 @@ public abstract class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T
     return fileSlice;
   }
 
-  /**
-   * Returns true when this append handle is writing to a layout sub-path of an MDT partition
-   * (e.g. {@code record_index/0004} under sub-directory bucketing). In that case, the
-   * {@code .hoodie_partition_metadata} marker must NOT be created at the bucket level; it is
-   * written once at the logical partition root by the MDT initialization path.
-   *
-   * <p>The heuristic only kicks in when the MDT is opened with a non-flat layout. Flat-default
-   * tables never write into bucket sub-paths, so we must not skip marker creation for them.
-   * Restricting the check to the non-flat case also sidesteps the risk of a 4-digit data-table
-   * partition value (e.g. price=1000) being misread as a bucket directory.
-   */
   private boolean isMDTLayoutSubPath(String physicalPartitionPath) {
-    if (!hoodieTable.isMetadataTable() || physicalPartitionPath == null) {
-      return false;
-    }
-    org.apache.hudi.common.util.Option<String> layoutClass =
-        hoodieTable.getMetaClient().getTableConfig().getMetadataLayoutClass();
-    boolean nonFlatLayout = layoutClass.isPresent() && !layoutClass.get().isEmpty()
-        && !layoutClass.get().equals(org.apache.hudi.metadata.FlatMDTLayout.class.getName());
-    if (!nonFlatLayout) {
-      return false;
-    }
-    int slash = physicalPartitionPath.lastIndexOf('/');
-    if (slash <= 0 || slash >= physicalPartitionPath.length() - 1) {
-      return false;
-    }
-    String last = physicalPartitionPath.substring(slash + 1);
-    if (last.length() != 4) {
-      return false;
-    }
-    for (int i = 0; i < 4; i++) {
-      if (!Character.isDigit(last.charAt(i))) {
-        return false;
-      }
-    }
-    return true;
+    return org.apache.hudi.metadata.HoodieTableMetadataUtil.isMDTBucketSubPath(
+        hoodieTable.getMetaClient().getTableConfig(), hoodieTable.isMetadataTable(), physicalPartitionPath);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -2192,21 +2192,32 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
     final int fileGroupCount = fileSlices.size();
     ValidationUtils.checkArgument(fileGroupCount > 0, String.format("FileGroup count for MDT partition %s should be > 0", partitionPath));
+    // Realignment of the record's partition path to the file slice's physical path is only needed
+    // under layouts that place file groups in sub-directories (e.g. SubDirBucketedMDTLayout). For
+    // the flat default, the slice's path always equals the record's partition path, so we skip the
+    // realignment entirely to preserve bit-identical behavior for tables that haven't opted in.
+    final boolean isNonFlatLayout = isNonFlatMDTLayout();
     return r -> {
       FileSlice slice = fileSlices.get(mappingFunction.apply(r.getRecordKey(), fileGroupCount));
       r.unseal();
       r.setCurrentLocation(new HoodieRecordLocation(slice.getBaseInstantTime(), slice.getFileId()));
-      // Under layouts that place file groups in sub-directories (e.g. bucketing), the file slice's
-      // physical partition path may differ from the logical MDT partition name carried on the
-      // record. Realign the record's partition path with where the file slice actually lives so
-      // downstream HoodieAppendHandle's partition-path consistency check passes.
-      String physical = slice.getPartitionPath();
-      if (physical != null && !physical.equals(r.getPartitionPath())) {
-        r.getKey().setPartitionPath(physical);
+      if (isNonFlatLayout) {
+        String physical = slice.getPartitionPath();
+        if (physical != null && !physical.equals(r.getPartitionPath())) {
+          r.getKey().setPartitionPath(physical);
+        }
       }
       r.seal();
       return r;
     };
+  }
+
+  private boolean isNonFlatMDTLayout() {
+    if (metadataMetaClient == null) {
+      return false;
+    }
+    Option<String> cls = metadataMetaClient.getTableConfig().getMetadataLayoutClass();
+    return cls.isPresent() && !cls.get().isEmpty() && !cls.get().equals(FlatMDTLayout.class.getName());
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -48,6 +48,7 @@ import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
@@ -57,6 +58,7 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaCache;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
@@ -1163,14 +1165,14 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   }
 
   /**
-   * Initialize file groups for a partition. For file listing, we just have one file group.
-   * <p>
-   * All FileGroups for a given metadata partition has a fixed prefix as per the {@link MetadataPartitionType#getFileIdPrefix()}.
-   * Each file group is suffixed with 4 digits with increments of 1 starting with 0000.
-   * <p>
-   * Let's say we configure 10 file groups for record level index partition, and prefix as "record-index-bucket-"
-   * File groups will be named as :
-   * record-index-bucket-0000, .... -> ..., record-index-bucket-0009
+   * Initialize file groups for an MDT partition under the configured layout.
+   *
+   * <p>FileIds are prefixed by {@link MetadataPartitionType#getFileIdPrefix()} and suffixed with a 4-digit
+   * file-group index starting at 0000. The on-disk directory for each file group is supplied by the
+   * configured {@link HoodieMetadataTableLayout}: the flat layout writes everything under the partition
+   * root; sub-directory bucketing writes them into bucket sub-directories. The persisted layout state
+   * (class + per-partition fileGroupCount + bucket size) is later used by readers to enumerate the same
+   * sub-paths without needing a filesystem listing.
    */
   private void initializeFileGroups(HoodieTableMetaClient dataMetaClient, MetadataPartitionType metadataPartition, String instantTime,
                                     int fileGroupCount, String relativePartitionPath, Option<String> dataPartitionName) throws IOException {
@@ -1184,22 +1186,30 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     // during initial commit, then the fileGroup would still be recognized (as a FileSlice with no baseFiles but a
     // valid logFile). Since these log files being created have no content, it is safe to add them here before
     // the bulkInsert.
-    final String msg = String.format("Creating %d file groups for partition %s with base fileId %s at instant time %s",
-        fileGroupCount, relativePartitionPath, metadataPartition.getFileIdPrefix(), instantTime);
+    HoodieMetadataTableLayout layout = resolveLayoutForMDTInit();
+    final String msg = String.format("Creating %d file groups for partition %s with base fileId %s at instant time %s (layout=%s)",
+        fileGroupCount, relativePartitionPath, metadataPartition.getFileIdPrefix(), instantTime, layout.getLayoutId());
     LOG.info(msg);
-    final List<String> fileGroupFileIds = IntStream.range(0, fileGroupCount)
-        .mapToObj(i -> HoodieTableMetadataUtil.getFileIDForFileGroup(metadataPartition, i, relativePartitionPath, dataPartitionName))
+
+    // Pair each file group's fileId with the relative directory it should live in, computed via the layout.
+    final List<Pair<String, String>> fileGroupIdAndPath = IntStream.range(0, fileGroupCount)
+        .mapToObj(i -> {
+          LayoutContext ctx = new LayoutContext(metadataPartition, i, fileGroupCount, dataPartitionName);
+          return Pair.of(layout.getFileId(ctx), layout.getFileGroupRelativePath(ctx));
+        })
         .collect(Collectors.toList());
-    ValidationUtils.checkArgument(fileGroupFileIds.size() == fileGroupCount);
+    ValidationUtils.checkArgument(fileGroupIdAndPath.size() == fileGroupCount);
     engineContext.setJobStatus(this.getClass().getSimpleName(), msg);
-    engineContext.foreach(fileGroupFileIds, fileGroupFileId -> {
+    engineContext.foreach(fileGroupIdAndPath, p -> {
+      final String fileGroupFileId = p.getLeft();
+      final String relativePath = p.getRight();
       try {
         final Map<HeaderMetadataType, String> blockHeader = Collections.singletonMap(HeaderMetadataType.INSTANT_TIME, instantTime);
 
         final HoodieDeleteBlock block = new HoodieDeleteBlock(Collections.emptyList(), blockHeader);
 
         try (HoodieLogFormat.Writer writer = HoodieLogFormatWriter.builder()
-            .withParentPath(FSUtils.constructAbsolutePath(metadataWriteConfig.getBasePath(), relativePartitionPath))
+            .withParentPath(FSUtils.constructAbsolutePath(metadataWriteConfig.getBasePath(), relativePath))
             .withLogFileId(fileGroupFileId)
             .withInstantTime(instantTime)
             .withLogVersion(HoodieLogFile.LOGFILE_BASE_VERSION)
@@ -1212,9 +1222,110 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
           writer.appendBlock(block);
         }
       } catch (InterruptedException e) {
-        throw new HoodieException(String.format("Failed to created fileGroup %s for partition %s", fileGroupFileId, relativePartitionPath), e);
+        throw new HoodieException(String.format("Failed to created fileGroup %s for partition %s", fileGroupFileId, relativePath), e);
       }
-    }, fileGroupFileIds.size());
+    }, fileGroupIdAndPath.size());
+
+    // For non-flat layouts, write .hoodie_partition_metadata at the logical partition root now,
+    // before the HoodieAppendHandle path (which would otherwise create one inside the bucket
+    // sub-dir). The AppendHandle skips marker creation at layout sub-paths via
+    // HoodieAppendHandle#isMDTLayoutSubPath, so this is the sole marker write under bucketing.
+    // For the flat default we leave marker creation to the AppendHandle and write nothing here —
+    // existing tables keep bit-identical behavior.
+    if (!FlatMDTLayout.LAYOUT_ID.equals(layout.getLayoutId())) {
+      for (String markerPath : layout.getPartitionMarkerPaths(relativePartitionPath, fileGroupCount)) {
+        HoodiePartitionMetadata marker = new HoodiePartitionMetadata(
+            dataMetaClient.getStorage(),
+            instantTime,
+            new StoragePath(metadataWriteConfig.getBasePath()),
+            FSUtils.constructAbsolutePath(metadataWriteConfig.getBasePath(), markerPath),
+            Option.empty());
+        marker.trySave();
+      }
+    }
+
+    // Persist layout state for this partition (skipped entirely for the flat default so existing
+    // tables get the identical on-disk and properties layout as before). When a non-flat layout is
+    // in use, readers consult this property to enumerate physical sub-paths without an FS listing.
+    if (metadataMetaClient != null && !FlatMDTLayout.LAYOUT_ID.equals(layout.getLayoutId())) {
+      maybePersistLayoutOnMDTInit(layout);
+      metadataMetaClient.getTableConfig().addMetadataLayoutPartitionFileGroupCounts(
+          metadataMetaClient, Collections.singletonMap(relativePartitionPath, fileGroupCount));
+    }
+  }
+
+  /**
+   * Resolve the layout class to use for MDT initialization. If the MDT's table config already records a
+   * layout (set on a prior partition's init within this MDT), use it — the MDT is uniform. Otherwise,
+   * honor the writer's {@code hoodie.metadata.layout.class} config; absent that, default to flat.
+   *
+   * <p>Throws {@link HoodieMetadataException} if the user requested a non-flat layout while the RLI is
+   * configured in the partitioned mode. The first-patch implementation of
+   * {@link SubDirBucketedMDTLayout} does not handle partitioned RLI; the user must either disable the
+   * layout config or switch the RLI to the global (non-partitioned) mode.
+   */
+  private HoodieMetadataTableLayout resolveLayoutForMDTInit() {
+    HoodieMetadataTableLayout layout = resolveLayoutForMDTInitInternal();
+    if (!FlatMDTLayout.LAYOUT_ID.equals(layout.getLayoutId())
+        && dataWriteConfig.isRecordLevelIndexEnabled()) {
+      throw new HoodieMetadataException(
+          "MDT layout " + layout.getClass().getName() + " (id=" + layout.getLayoutId()
+              + ") cannot be used together with partitioned RLI. Either disable "
+              + "hoodie.metadata.layout.class or switch the RLI to the global (non-partitioned) "
+              + "mode. Partitioned-RLI support for sub-directory bucketing will be addressed in a "
+              + "follow-up patch / RFC.");
+    }
+    return layout;
+  }
+
+  private HoodieMetadataTableLayout resolveLayoutForMDTInitInternal() {
+    if (metadataMetaClient != null) {
+      Option<String> existing = metadataMetaClient.getTableConfig().getMetadataLayoutClass();
+      if (existing.isPresent() && !existing.get().isEmpty()) {
+        return HoodieMetadataTableLayouts.load(metadataMetaClient.getTableConfig());
+      }
+    }
+    Option<String> requested = dataWriteConfig.getMetadataConfig().getMetadataLayoutClass();
+    if (!requested.isPresent()) {
+      return new FlatMDTLayout();
+    }
+    String cls = requested.get();
+    if (FlatMDTLayout.class.getName().equals(cls)) {
+      return new FlatMDTLayout();
+    }
+    if (SubDirBucketedMDTLayout.class.getName().equals(cls)) {
+      return new SubDirBucketedMDTLayout(dataWriteConfig.getMetadataConfig().getMetadataLayoutBucketSize());
+    }
+    // Fall through to the central factory for any user-defined layout class.
+    if (metadataMetaClient != null) {
+      // Stash the class string on a transient view of the MDT config so the factory can find it.
+      metadataMetaClient.getTableConfig().setValue(HoodieTableConfig.METADATA_LAYOUT_CLASS, cls);
+      metadataMetaClient.getTableConfig().setValue(HoodieTableConfig.METADATA_LAYOUT_BUCKET_SIZE,
+          String.valueOf(dataWriteConfig.getMetadataConfig().getMetadataLayoutBucketSize()));
+    }
+    return HoodieMetadataTableLayouts.load(metadataMetaClient.getTableConfig());
+  }
+
+  /**
+   * Persist the layout class + bucket size onto the MDT's hoodie.properties on the first init that
+   * involves a non-flat layout. Idempotent for subsequent partition inits within the same MDT.
+   */
+  private void maybePersistLayoutOnMDTInit(HoodieMetadataTableLayout layout) {
+    if (FlatMDTLayout.LAYOUT_ID.equals(layout.getLayoutId())) {
+      // Flat is the implicit default; persist nothing to keep on-disk layout bit-identical for
+      // tables that did not opt in.
+      return;
+    }
+    if (metadataMetaClient.getTableConfig().getMetadataLayoutClass().isPresent()) {
+      // Already persisted by an earlier partition's init.
+      return;
+    }
+    int bucketSize = dataWriteConfig.getMetadataConfig().getMetadataLayoutBucketSize();
+    metadataMetaClient.getTableConfig().setMetadataLayout(
+        metadataMetaClient,
+        layout.getClass().getName(),
+        bucketSize,
+        Collections.emptyMap());
   }
 
   void clearExistingMetadataPartition(String relativePartitionPath) throws IOException {
@@ -2085,6 +2196,14 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       FileSlice slice = fileSlices.get(mappingFunction.apply(r.getRecordKey(), fileGroupCount));
       r.unseal();
       r.setCurrentLocation(new HoodieRecordLocation(slice.getBaseInstantTime(), slice.getFileId()));
+      // Under layouts that place file groups in sub-directories (e.g. bucketing), the file slice's
+      // physical partition path may differ from the logical MDT partition name carried on the
+      // record. Realign the record's partition path with where the file slice actually lives so
+      // downstream HoodieAppendHandle's partition-path consistency check passes.
+      String physical = slice.getPartitionPath();
+      if (physical != null && !physical.equals(r.getPartitionPath())) {
+        r.getKey().setPartitionPath(physical);
+      }
       r.seal();
       return r;
     };

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1194,7 +1194,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     // Pair each file group's fileId with the relative directory it should live in, computed via the layout.
     final List<Pair<String, String>> fileGroupIdAndPath = IntStream.range(0, fileGroupCount)
         .mapToObj(i -> {
-          LayoutContext ctx = new LayoutContext(metadataPartition, i, fileGroupCount, dataPartitionName);
+          LayoutContext ctx = new LayoutContext(metadataPartition, relativePartitionPath, i, fileGroupCount, dataPartitionName);
           return Pair.of(layout.getFileId(ctx), layout.getFileGroupRelativePath(ctx));
         })
         .collect(Collectors.toList());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1194,7 +1194,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     // Pair each file group's fileId with the relative directory it should live in, computed via the layout.
     final List<Pair<String, String>> fileGroupIdAndPath = IntStream.range(0, fileGroupCount)
         .mapToObj(i -> {
-          LayoutContext ctx = new LayoutContext(metadataPartition, relativePartitionPath, i, fileGroupCount, dataPartitionName);
+          HoodieMetadataLayoutContext ctx = new HoodieMetadataLayoutContext(metadataPartition, relativePartitionPath, i, fileGroupCount, dataPartitionName);
           return Pair.of(layout.getFileId(ctx), layout.getFileGroupRelativePath(ctx));
         })
         .collect(Collectors.toList());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -2174,7 +2174,12 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
               String.format("Partition %s should be part of inflight metadata partitions here %s", partitionPath, dataMetaClient.getTableConfig().getMetadataPartitionsInflight()));
           fileSlices = getPartitionLatestFileSlicesIncludingInflight(metadataMetaClient, Option.ofNullable(fsView), partitionPath);
         }
-        hoodieFileGroupIdList.addAll(fileSlices.stream().map(fileSlice -> new HoodieFileGroupId(partitionPath, fileSlice.getFileId())).collect(Collectors.toList()));
+        // Use the slice's own file group id so the partition matches the slice's physical path
+        // under a non-flat layout. Building it from the logical partitionPath here would disagree
+        // with the physical partition the records are tagged with (see getRecordTagger) and with
+        // the streaming path's equivalent in #tagRecordsWithLocationForStreamingWrites, which
+        // already uses fileSlice.getFileGroupId(). Identical under the flat default layout.
+        hoodieFileGroupIdList.addAll(fileSlices.stream().map(FileSlice::getFileGroupId).collect(Collectors.toList()));
         SerializableFunction<HoodieRecord, HoodieRecord> recordTagger = getRecordTagger(partitionPath, fileSlices);
         allPartitionRecords = allPartitionRecords.union(records.map(recordTagger));
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/BaseTableServicePlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/BaseTableServicePlanActionExecutor.java
@@ -38,6 +38,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.table.HoodieTable;
 
 import lombok.extern.slf4j.Slf4j;
@@ -82,7 +83,10 @@ public abstract class BaseTableServicePlanActionExecutor<T, I, K, O, R> extends 
         if (lastCompleteTableServiceInstant.isPresent()) {
           if (!incrementalPartitions.isEmpty()) {
             log.info("Fetched incremental partitions for {}. {}. Instant {}", type, incrementalPartitions, instantTime);
-            return new ArrayList<>(incrementalPartitions);
+            // Incremental partitions come from write stats, which are already physical for a
+            // bucketed MDT. The expansion is idempotent, so this is a no-op there; it only matters
+            // if a write stat ever carries a logical path.
+            return expandToPhysicalMDTPartitions(new ArrayList<>(incrementalPartitions));
           } else {
             // handle the case the writer just commits the empty commits continuously
             // the incremental partition list is empty we just skip the scheduling
@@ -100,7 +104,21 @@ public abstract class BaseTableServicePlanActionExecutor<T, I, K, O, R> extends 
 
     // get all partitions
     log.info("Start to fetch all partitions for {}. Instant {}", type, instantTime);
-    return FSUtils.getAllPartitionPaths(context, table.getMetaClient(), config.getMetadataConfig());
+    return expandToPhysicalMDTPartitions(
+        FSUtils.getAllPartitionPaths(context, table.getMetaClient(), config.getMetadataConfig()));
+  }
+
+  /**
+   * Expand logical MDT partitions to the physical sub-paths that actually hold file groups.
+   *
+   * <p>Partition discovery on a bucketed MDT returns logical names (the single
+   * {@code .hoodie_partition_metadata} lives at the logical partition root), but the MDT write path
+   * keys its file system view by physical bucket sub-paths. Planning against logical names would
+   * produce a plan whose file group ids never match the write side's, so the pending-compaction
+   * bookkeeping silently misses. No-op for data tables and for MDTs on the flat default layout.
+   */
+  private List<String> expandToPhysicalMDTPartitions(List<String> partitions) {
+    return HoodieTableMetadataUtil.expandToPhysicalPartitions(table.getMetaClient(), partitions);
   }
 
   public Pair<Option<HoodieInstant>, Set<String>> getIncrementalPartitions(TableServiceType type) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -535,8 +535,8 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
    * file listing must be used instead.
    */
   private boolean hasPendingFiles(String partitionPath) {
-    try {
-      HoodieTableFileSystemView fsView = HoodieTableFileSystemView.fileListingBasedFileSystemView(context, hoodieTable.getMetaClient(), hoodieTable.getActiveTimeline());
+    try (HoodieTableFileSystemView fsView = HoodieTableFileSystemView.fileListingBasedFileSystemView(
+        context, hoodieTable.getMetaClient(), hoodieTable.getActiveTimeline())) {
       // Under a non-flat MDT layout the data files live in bucket sub-directories, so a direct
       // listing of the logical partition root finds nothing and this would always report "no
       // pending files" — allowing a partition with live pending files to be dropped wholesale.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -48,6 +48,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieSavepointException;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
 
@@ -309,7 +310,7 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
 
     // Return early if no partition filter is configured
     if (StringUtils.isNullOrEmpty(partitionSelected) && StringUtils.isNullOrEmpty(partitionRegex)) {
-      return allPartitionPaths;
+      return expandToPhysicalMDTPartitions(allPartitionPaths);
     }
 
     // Partition filter cannot be used with incremental cleaning mode
@@ -331,7 +332,23 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
           .collect(Collectors.toList());
       log.info("Restricting partitions to clean using regex '{}'. Partitions to clean: {}", partitionRegex, filteredPartitions);
     }
-    return filteredPartitions;
+    // Expand after filtering so the user-facing partition filters keep matching logical MDT
+    // partition names rather than physical bucket sub-paths.
+    return expandToPhysicalMDTPartitions(filteredPartitions);
+  }
+
+  /**
+   * Expand logical MDT partitions to their physical sub-paths under a non-flat layout.
+   *
+   * <p>Full cleaning enumerates partitions from marker discovery, which on a bucketed MDT yields
+   * logical names only (the single {@code .hoodie_partition_metadata} sits at the logical root).
+   * Those names are later joined against the pending-compaction map, which is keyed physically by
+   * the write side. Without this expansion the join misses, so the cleaner fails to preserve the
+   * file slices an in-flight compaction still needs and deletes log files out from under it,
+   * wedging the MDT. No-op for data tables and for MDTs on the flat default layout.
+   */
+  private List<String> expandToPhysicalMDTPartitions(List<String> partitions) {
+    return HoodieTableMetadataUtil.expandToPhysicalPartitions(hoodieTable.getMetaClient(), partitions);
   }
 
   /**
@@ -520,11 +537,20 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
   private boolean hasPendingFiles(String partitionPath) {
     try {
       HoodieTableFileSystemView fsView = HoodieTableFileSystemView.fileListingBasedFileSystemView(context, hoodieTable.getMetaClient(), hoodieTable.getActiveTimeline());
-      StoragePath fullPartitionPath = new StoragePath(hoodieTable.getMetaClient().getBasePath(), partitionPath);
-      fsView.addFilesToView(partitionPath, FSUtils.getAllDataFilesInPartition(
-          hoodieTable.getStorage(), fullPartitionPath));
-      // use #getAllFileGroups(partitionPath) instead of #getAllFileGroups() to exclude the replaced file groups.
-      return fsView.getAllFileGroups(partitionPath).findAny().isPresent();
+      // Under a non-flat MDT layout the data files live in bucket sub-directories, so a direct
+      // listing of the logical partition root finds nothing and this would always report "no
+      // pending files" — allowing a partition with live pending files to be dropped wholesale.
+      // Expansion is idempotent, so an already-physical path lists itself.
+      for (String physicalPartition : expandToPhysicalMDTPartitions(Collections.singletonList(partitionPath))) {
+        StoragePath fullPartitionPath = new StoragePath(hoodieTable.getMetaClient().getBasePath(), physicalPartition);
+        fsView.addFilesToView(physicalPartition, FSUtils.getAllDataFilesInPartition(
+            hoodieTable.getStorage(), fullPartitionPath));
+        // use #getAllFileGroups(partitionPath) instead of #getAllFileGroups() to exclude the replaced file groups.
+        if (fsView.getAllFileGroups(physicalPartition).findAny().isPresent()) {
+          return true;
+        }
+      }
+      return false;
     } catch (Exception ex) {
       // if any exception throws, assume there are existing pending files
       log.warn("Error while checking the pending files under partition: {}, we will assume that pending files exist", partitionPath, ex);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
@@ -36,6 +36,7 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieRollbackException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathFilter;
@@ -98,8 +99,13 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
     try {
       HoodieTableMetaClient metaClient = table.getMetaClient();
       boolean isTableVersionLessThanEight = metaClient.getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT);
-      List<String> partitionPaths =
-          FSUtils.getAllPartitionPaths(context, table.getMetaClient(), false);
+      // Expand logical MDT partitions to physical bucket sub-paths. The MDT always takes the
+      // listing-based strategy (DIRECT markers + rollback-using-markers disabled), and the listing
+      // below is non-recursive, so on a bucketed MDT an un-expanded logical root yields zero files:
+      // rollback of a failed MDT compaction would "succeed" while the orphan base file survives.
+      // No-op for data tables and for MDTs on the flat default layout.
+      List<String> partitionPaths = HoodieTableMetadataUtil.expandToPhysicalPartitions(
+          metaClient, FSUtils.getAllPartitionPaths(context, table.getMetaClient(), false));
       int numPartitions = Math.max(Math.min(partitionPaths.size(), config.getRollbackParallelism()), 1);
 
       context.setJobStatus(this.getClass().getSimpleName(), "Creating Listing Rollback Plan: " + config.getTableName());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
@@ -105,7 +105,7 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
       // rollback of a failed MDT compaction would "succeed" while the orphan base file survives.
       // No-op for data tables and for MDTs on the flat default layout.
       List<String> partitionPaths = HoodieTableMetadataUtil.expandToPhysicalPartitions(
-          metaClient, FSUtils.getAllPartitionPaths(context, table.getMetaClient(), false));
+          metaClient, FSUtils.getAllPartitionPaths(context, metaClient, false));
       int numPartitions = Math.max(Math.min(partitionPaths.size(), config.getRollbackParallelism()), 1);
 
       context.setJobStatus(this.getClass().getSimpleName(), "Creating Listing Rollback Plan: " + config.getTableName());

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -358,15 +358,21 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
       // API.  Note that for COW table, the merging logic of two slices does not happen as there
       // is no compaction, thus there is no performance impact.
       HoodieTableFileSystemView finalFileSystemView = fileSystemView;
-      // For an MDT under a non-flat layout, the FS view indexes file slices by their physical
+      // For an MDT under a *non-flat* layout, the FS view indexes file slices by their physical
       // partition (bucket sub-paths), but the partition list here uses logical partition names.
       // Resolve via HoodieTableMetadataUtil which fans out across the layout's physical sub-paths.
-      final boolean isMdt = HoodieTableMetadata.isMetadataTable(basePath);
+      // For the flat default (the only on-disk layout for tables that haven't opted in), the
+      // original direct FS-view path is used unchanged — including the time-travel branch — so
+      // existing semantics are preserved bit-for-bit.
+      final boolean isMdtWithNonFlatLayout = HoodieTableMetadata.isMetadataTable(basePath)
+          && metaClient.getTableConfig().getMetadataLayoutClass()
+              .map(c -> !c.isEmpty() && !c.equals(org.apache.hudi.metadata.FlatMDTLayout.class.getName()))
+              .orElse(false);
       return partitions.stream().collect(
           Collectors.toMap(
               Function.identity(),
               partitionPath -> {
-                if (isMdt) {
+                if (isMdtWithNonFlatLayout) {
                   return queryInstant.isPresent()
                       ? HoodieTableMetadataUtil.getPartitionLatestMergedFileSlices(metaClient,
                           finalFileSystemView, partitionPath.path)

--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -358,15 +358,27 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
       // API.  Note that for COW table, the merging logic of two slices does not happen as there
       // is no compaction, thus there is no performance impact.
       HoodieTableFileSystemView finalFileSystemView = fileSystemView;
+      // For an MDT under a non-flat layout, the FS view indexes file slices by their physical
+      // partition (bucket sub-paths), but the partition list here uses logical partition names.
+      // Resolve via HoodieTableMetadataUtil which fans out across the layout's physical sub-paths.
+      final boolean isMdt = HoodieTableMetadata.isMetadataTable(basePath);
       return partitions.stream().collect(
           Collectors.toMap(
               Function.identity(),
-              partitionPath ->
-                  queryInstant.map(instant ->
-                          finalFileSystemView.getLatestMergedFileSlicesBeforeOrOn(partitionPath.path, queryInstant.get())
-                      )
-                      .orElseGet(() -> finalFileSystemView.getLatestFileSlices(partitionPath.path))
-                      .collect(Collectors.toList())
+              partitionPath -> {
+                if (isMdt) {
+                  return queryInstant.isPresent()
+                      ? HoodieTableMetadataUtil.getPartitionLatestMergedFileSlices(metaClient,
+                          finalFileSystemView, partitionPath.path)
+                      : HoodieTableMetadataUtil.getPartitionLatestFileSlices(metaClient,
+                          Option.of(finalFileSystemView), partitionPath.path);
+                }
+                return queryInstant.map(instant ->
+                        finalFileSystemView.getLatestMergedFileSlicesBeforeOrOn(partitionPath.path, queryInstant.get())
+                    )
+                    .orElseGet(() -> finalFileSystemView.getLatestFileSlices(partitionPath.path))
+                    .collect(Collectors.toList());
+              }
           ));
     } finally {
       long elapsedMs = timer.endTimer();

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -696,6 +696,32 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
 
+  public static final ConfigProperty<String> METADATA_LAYOUT_CLASS = ConfigProperty
+      .key("hoodie.metadata.layout.class")
+      .noDefaultValue()
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("Fully-qualified class name of the HoodieMetadataTableLayout implementation that organizes "
+          + "MDT file groups on disk. When unset, MDT uses the flat layout (file groups directly under each metadata "
+          + "partition). Applies only at MDT initialization; an MDT already on disk keeps its existing layout.");
+
+  public static final ConfigProperty<Integer> METADATA_LAYOUT_BUCKET_SIZE = ConfigProperty
+      .key("hoodie.metadata.layout.bucket.size")
+      .defaultValue(1000)
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("When the layout is SubDirBucketedMDTLayout, the maximum number of file groups per bucket "
+          + "sub-directory. Ignored for the flat layout. Default 1000.");
+
+  public Option<String> getMetadataLayoutClass() {
+    String cls = getString(METADATA_LAYOUT_CLASS);
+    return (cls == null || cls.isEmpty()) ? Option.empty() : Option.of(cls);
+  }
+
+  public int getMetadataLayoutBucketSize() {
+    return getIntOrDefault(METADATA_LAYOUT_BUCKET_SIZE);
+  }
+
   private HoodieMetadataConfig() {
     super();
   }
@@ -1364,6 +1390,16 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder enableDetailedMetadataMetrics(boolean enable) {
       metadataConfig.setValue(ENABLE_DETAILED_METRICS, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder withMetadataLayoutClass(String layoutClass) {
+      metadataConfig.setValue(METADATA_LAYOUT_CLASS, layoutClass);
+      return this;
+    }
+
+    public Builder withMetadataLayoutBucketSize(int bucketSize) {
+      metadataConfig.setValue(METADATA_LAYOUT_BUCKET_SIZE, String.valueOf(bucketSize));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -702,16 +702,22 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .markAdvanced()
       .sinceVersion("1.3.0")
       .withDocumentation("Fully-qualified class name of the HoodieMetadataTableLayout implementation that organizes "
-          + "MDT file groups on disk. When unset, MDT uses the flat layout (file groups directly under each metadata "
-          + "partition). Applies only at MDT initialization; an MDT already on disk keeps its existing layout.");
+          + "MDT file groups on disk. Out-of-the-box values: "
+          + "(1) unset / org.apache.hudi.metadata.FlatMDTLayout (default) — every file group lives directly under its "
+          + "metadata partition directory; this is the layout used by every MDT created before this config existed. "
+          + "(2) org.apache.hudi.metadata.SubDirBucketedMDTLayout — distributes file groups into 4-digit bucket "
+          + "sub-directories so a single MDT partition does not exceed per-directory file-count limits on HDFS-like "
+          + "filesystems. Custom implementations can be plugged in by providing the FQCN here. "
+          + "Applies only at MDT initialization; an MDT already on disk keeps its existing layout.");
 
   public static final ConfigProperty<Integer> METADATA_LAYOUT_BUCKET_SIZE = ConfigProperty
       .key("hoodie.metadata.layout.bucket.size")
       .defaultValue(1000)
       .markAdvanced()
       .sinceVersion("1.3.0")
-      .withDocumentation("When the layout is SubDirBucketedMDTLayout, the maximum number of file groups per bucket "
-          + "sub-directory. Ignored for the flat layout. Default 1000.");
+      .withDocumentation("Maximum number of file groups per bucket sub-directory when "
+          + "`hoodie.metadata.layout.class` is set to SubDirBucketedMDTLayout. Ignored for the flat layout. "
+          + "Default 1000.");
 
   public Option<String> getMetadataLayoutClass() {
     String cls = getString(METADATA_LAYOUT_CLASS);

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -711,11 +711,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "Applies only at MDT initialization; an MDT already on disk keeps its existing layout.");
 
   public static final ConfigProperty<Integer> METADATA_LAYOUT_BUCKET_SIZE = ConfigProperty
-      .key("hoodie.metadata.layout.bucket.size")
+      .key("hoodie.metadata.layout.bucketed.file.group.per.bucket")
       .defaultValue(1000)
       .markAdvanced()
       .sinceVersion("1.3.0")
-      .withDocumentation("Maximum number of file groups per bucket sub-directory when "
+      .withDocumentation("Maximum number of MDT file groups that share a single bucket sub-directory when "
           + "`hoodie.metadata.layout.class` is set to SubDirBucketedMDTLayout. Ignored for the flat layout. "
           + "Default 1000.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -705,7 +705,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "MDT file groups on disk. Out-of-the-box values: "
           + "(1) unset / org.apache.hudi.metadata.FlatMDTLayout (default) — every file group lives directly under its "
           + "metadata partition directory; this is the layout used by every MDT created before this config existed. "
-          + "(2) org.apache.hudi.metadata.SubDirBucketedMDTLayout — distributes file groups into 4-digit bucket "
+          + "(2) org.apache.hudi.metadata.SubDirBucketedMDTLayout — distributes file groups into 6-digit bucket "
           + "sub-directories so a single MDT partition does not exceed per-directory file-count limits on HDFS-like "
           + "filesystems. Custom implementations can be plugged in by providing the FQCN here. "
           + "Applies only at MDT initialization; an MDT already on disk keeps its existing layout.");

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -383,6 +383,29 @@ public class HoodieTableConfig extends HoodieConfig {
       .sinceVersion("1.1.0")
       .withDocumentation("This property when set, will define how two versions of the record will be merged together when records are partially formed");
 
+  public static final ConfigProperty<String> METADATA_LAYOUT_CLASS = ConfigProperty
+      .key("hoodie.metadata.layout.class")
+      .noDefaultValue()
+      .sinceVersion("1.3.0")
+      .withDocumentation("Fully-qualified class name of the HoodieMetadataTableLayout implementation that organizes "
+          + "MDT file groups on disk. When unset, MDT uses the flat layout (file groups directly under each metadata "
+          + "partition). Set once at MDT initialization; immutable thereafter.");
+
+  public static final ConfigProperty<Integer> METADATA_LAYOUT_BUCKET_SIZE = ConfigProperty
+      .key("hoodie.metadata.layout.bucket.size")
+      .defaultValue(1000)
+      .sinceVersion("1.3.0")
+      .withDocumentation("Layout-specific: maximum number of file groups per bucket sub-directory when the layout is "
+          + "SubDirBucketedMDTLayout. Ignored otherwise.");
+
+  public static final ConfigProperty<String> METADATA_LAYOUT_PARTITION_FILE_GROUP_COUNTS = ConfigProperty
+      .key("hoodie.metadata.layout.partition.file.group.counts")
+      .noDefaultValue()
+      .sinceVersion("1.3.0")
+      .withDocumentation("Comma-separated map of MDT partition name to file-group count, e.g. "
+          + "\"record_index=2500,files=1,col_stats=10\". Persisted on the MDT at initialization so readers can "
+          + "compute physical sub-paths without performing a filesystem listing.");
+
   public static final ConfigProperty<String> URL_ENCODE_PARTITIONING = KeyGeneratorOptions.URL_ENCODE_PARTITIONING;
   public static final ConfigProperty<String> HIVE_STYLE_PARTITIONING_ENABLE = KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
   public static final ConfigProperty<String> SLASH_SEPARATED_DATE_PARTITIONING = KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING;
@@ -1394,6 +1417,77 @@ public class HoodieTableConfig extends HoodieConfig {
    */
   public void clearMetadataPartitions(HoodieTableMetaClient metaClient) {
     setMetadataPartitionState(metaClient, MetadataPartitionType.FILES.getPartitionPath(), false);
+  }
+
+  /**
+   * @return the FQCN of the configured MDT layout class, or empty if no layout was set
+   *     (in which case the flat layout is the implicit default).
+   */
+  public Option<String> getMetadataLayoutClass() {
+    return Option.ofNullable(getString(METADATA_LAYOUT_CLASS));
+  }
+
+  /**
+   * @return the configured layout bucket size; only meaningful when the layout class is a
+   *     sub-directory bucketing implementation.
+   */
+  public int getMetadataLayoutBucketSize() {
+    return getIntOrDefault(METADATA_LAYOUT_BUCKET_SIZE);
+  }
+
+  /**
+   * @return the persisted per-MDT-partition file-group counts, decoded from
+   *     {@link #METADATA_LAYOUT_PARTITION_FILE_GROUP_COUNTS}. Empty when not set.
+   */
+  public Map<String, Integer> getMetadataLayoutPartitionFileGroupCounts() {
+    String raw = getString(METADATA_LAYOUT_PARTITION_FILE_GROUP_COUNTS);
+    if (raw == null || raw.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, Integer> result = new HashMap<>();
+    for (String entry : raw.split(CONFIG_VALUES_DELIMITER)) {
+      int eq = entry.indexOf('=');
+      if (eq <= 0) {
+        continue;
+      }
+      result.put(entry.substring(0, eq), Integer.parseInt(entry.substring(eq + 1)));
+    }
+    return result;
+  }
+
+  /**
+   * Persist the layout class and its per-partition file-group counts on this (MDT) table config.
+   * Intended to be called once at MDT initialization; the layout is immutable thereafter.
+   */
+  public void setMetadataLayout(HoodieTableMetaClient metaClient,
+                                String layoutClass,
+                                int bucketSize,
+                                Map<String, Integer> partitionFileGroupCounts) {
+    setValue(METADATA_LAYOUT_CLASS, layoutClass);
+    setValue(METADATA_LAYOUT_BUCKET_SIZE, String.valueOf(bucketSize));
+    String encoded = partitionFileGroupCounts.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .map(e -> e.getKey() + "=" + e.getValue())
+        .collect(Collectors.joining(CONFIG_VALUES_DELIMITER));
+    setValue(METADATA_LAYOUT_PARTITION_FILE_GROUP_COUNTS, encoded);
+    update(metaClient.getStorage(), metaClient.getMetaPath(), getProps());
+  }
+
+  /**
+   * Append or update file-group counts for additional MDT partitions initialized after the first
+   * MDT bootstrap (e.g., a new index being enabled). Preserves existing entries and overwrites any
+   * key collision with the new count.
+   */
+  public void addMetadataLayoutPartitionFileGroupCounts(HoodieTableMetaClient metaClient,
+                                                       Map<String, Integer> additionalCounts) {
+    Map<String, Integer> merged = new HashMap<>(getMetadataLayoutPartitionFileGroupCounts());
+    merged.putAll(additionalCounts);
+    String encoded = merged.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .map(e -> e.getKey() + "=" + e.getValue())
+        .collect(Collectors.joining(CONFIG_VALUES_DELIMITER));
+    setValue(METADATA_LAYOUT_PARTITION_FILE_GROUP_COUNTS, encoded);
+    update(metaClient.getStorage(), metaClient.getMetaPath(), getProps());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -396,11 +396,12 @@ public class HoodieTableConfig extends HoodieConfig {
           + "Set once at MDT initialization; immutable thereafter.");
 
   public static final ConfigProperty<Integer> METADATA_LAYOUT_BUCKET_SIZE = ConfigProperty
-      .key("hoodie.metadata.layout.bucket.size")
+      .key("hoodie.metadata.layout.bucketed.file.group.per.bucket")
       .defaultValue(1000)
       .sinceVersion("1.3.0")
-      .withDocumentation("Layout-specific: maximum number of file groups per bucket sub-directory when "
-          + "`hoodie.metadata.layout.class` is set to SubDirBucketedMDTLayout. Ignored otherwise.");
+      .withDocumentation("Layout-specific: maximum number of MDT file groups that share a single bucket "
+          + "sub-directory when `hoodie.metadata.layout.class` is set to SubDirBucketedMDTLayout. "
+          + "Ignored otherwise.");
 
   public static final ConfigProperty<String> METADATA_LAYOUT_PARTITION_FILE_GROUP_COUNTS = ConfigProperty
       .key("hoodie.metadata.layout.partition.file.group.counts")
@@ -1478,13 +1479,28 @@ public class HoodieTableConfig extends HoodieConfig {
   }
 
   /**
-   * Append or update file-group counts for additional MDT partitions initialized after the first
-   * MDT bootstrap (e.g., a new index being enabled). Preserves existing entries and overwrites any
-   * key collision with the new count.
+   * Append file-group counts for additional MDT partitions initialized after the first MDT
+   * bootstrap (e.g., a new index being enabled). New partitions are added freely; any attempt to
+   * change the count of an already-persisted partition is rejected so the on-disk bucket layout
+   * for an existing MDT partition never moves under a reader's feet.
+   *
+   * @throws HoodieMetadataException if an entry in {@code additionalCounts} refers to a partition
+   *     already present in the persisted map with a different count.
    */
   public void addMetadataLayoutPartitionFileGroupCounts(HoodieTableMetaClient metaClient,
                                                        Map<String, Integer> additionalCounts) {
-    Map<String, Integer> merged = new HashMap<>(getMetadataLayoutPartitionFileGroupCounts());
+    Map<String, Integer> existing = getMetadataLayoutPartitionFileGroupCounts();
+    for (Map.Entry<String, Integer> incoming : additionalCounts.entrySet()) {
+      Integer prior = existing.get(incoming.getKey());
+      if (prior != null && !prior.equals(incoming.getValue())) {
+        throw new org.apache.hudi.exception.HoodieMetadataException(
+            "MDT layout file-group count for partition '" + incoming.getKey()
+                + "' is already set to " + prior + " and cannot be changed to "
+                + incoming.getValue() + ". The file-group count for an existing MDT partition is "
+                + "immutable so the on-disk bucket layout remains stable for readers.");
+      }
+    }
+    Map<String, Integer> merged = new HashMap<>(existing);
     merged.putAll(additionalCounts);
     String encoded = merged.entrySet().stream()
         .sorted(Map.Entry.comparingByKey())

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -388,15 +388,19 @@ public class HoodieTableConfig extends HoodieConfig {
       .noDefaultValue()
       .sinceVersion("1.3.0")
       .withDocumentation("Fully-qualified class name of the HoodieMetadataTableLayout implementation that organizes "
-          + "MDT file groups on disk. When unset, MDT uses the flat layout (file groups directly under each metadata "
-          + "partition). Set once at MDT initialization; immutable thereafter.");
+          + "MDT file groups on disk. Out-of-the-box values: "
+          + "(1) unset / org.apache.hudi.metadata.FlatMDTLayout (default) — every file group lives directly under its "
+          + "metadata partition directory; this is the layout used by every MDT created before this config existed. "
+          + "(2) org.apache.hudi.metadata.SubDirBucketedMDTLayout — distributes file groups into 4-digit bucket "
+          + "sub-directories. Custom implementations can be plugged in via FQCN. "
+          + "Set once at MDT initialization; immutable thereafter.");
 
   public static final ConfigProperty<Integer> METADATA_LAYOUT_BUCKET_SIZE = ConfigProperty
       .key("hoodie.metadata.layout.bucket.size")
       .defaultValue(1000)
       .sinceVersion("1.3.0")
-      .withDocumentation("Layout-specific: maximum number of file groups per bucket sub-directory when the layout is "
-          + "SubDirBucketedMDTLayout. Ignored otherwise.");
+      .withDocumentation("Layout-specific: maximum number of file groups per bucket sub-directory when "
+          + "`hoodie.metadata.layout.class` is set to SubDirBucketedMDTLayout. Ignored otherwise.");
 
   public static final ConfigProperty<String> METADATA_LAYOUT_PARTITION_FILE_GROUP_COUNTS = ConfigProperty
       .key("hoodie.metadata.layout.partition.file.group.counts")

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -391,7 +391,7 @@ public class HoodieTableConfig extends HoodieConfig {
           + "MDT file groups on disk. Out-of-the-box values: "
           + "(1) unset / org.apache.hudi.metadata.FlatMDTLayout (default) — every file group lives directly under its "
           + "metadata partition directory; this is the layout used by every MDT created before this config existed. "
-          + "(2) org.apache.hudi.metadata.SubDirBucketedMDTLayout — distributes file groups into 4-digit bucket "
+          + "(2) org.apache.hudi.metadata.SubDirBucketedMDTLayout — distributes file groups into 6-digit bucket "
           + "sub-directories. Custom implementations can be plugged in via FQCN. "
           + "Set once at MDT initialization; immutable thereafter.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileIdInfo.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileIdInfo.java
@@ -26,6 +26,20 @@ import java.io.Serializable;
 /**
  * Parsed representation of an MDT fileId, produced by
  * {@link HoodieMetadataTableLayout#parseFileId}.
+ *
+ * <p>Examples:
+ * <ul>
+ *   <li>Non-partitioned RLI fileId {@code "record-index-1500-0"} →
+ *       {@code FileIdInfo(fileGroupIndex=1500, dataPartitionName=Option.empty())}.</li>
+ *   <li>Files-partition fileId {@code "files-0000-0"} →
+ *       {@code FileIdInfo(fileGroupIndex=0, dataPartitionName=Option.empty())}.</li>
+ *   <li>Expression-index fileId {@code "expr-index-idx-datestr-0000-0"} →
+ *       {@code FileIdInfo(fileGroupIndex=0, dataPartitionName=Option.empty())}.</li>
+ *   <li>Partitioned RLI fileId {@code "record-index-default-0003-0"} (where {@code default} is the
+ *       data-table partition name) → {@code FileIdInfo(fileGroupIndex=3, dataPartitionName=Option.of("default"))}.
+ *       Note: built-in layouts in this patch return {@code Option.empty()} for partitioned RLI
+ *       since they fall back to the flat layout; custom layouts may choose to populate it.</li>
+ * </ul>
  */
 public final class FileIdInfo implements Serializable {
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileIdInfo.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileIdInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.util.Option;
+
+import java.io.Serializable;
+
+/**
+ * Parsed representation of an MDT fileId, produced by
+ * {@link HoodieMetadataTableLayout#parseFileId}.
+ */
+public final class FileIdInfo implements Serializable {
+
+  private final int fileGroupIndex;
+  private final Option<String> dataPartitionName;
+
+  public FileIdInfo(int fileGroupIndex, Option<String> dataPartitionName) {
+    this.fileGroupIndex = fileGroupIndex;
+    this.dataPartitionName = dataPartitionName;
+  }
+
+  public int getFileGroupIndex() {
+    return fileGroupIndex;
+  }
+
+  public Option<String> getDataPartitionName() {
+    return dataPartitionName;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -86,13 +86,10 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
     this.tableName = tableConfig.getTableName();
     this.hiveStylePartitioningEnabled = Boolean.parseBoolean(tableConfig.getHiveStylePartitioningEnable());
     this.urlEncodePartitioningEnabled = Boolean.parseBoolean(tableConfig.getUrlEncodePartitioning());
-    if (HoodieTableMetadata.isMetadataTable(datasetBasePath)) {
-      this.mdtLayout = HoodieMetadataTableLayouts.load(tableConfig);
-      this.mdtLayoutPartitionFileGroupCounts = tableConfig.getMetadataLayoutPartitionFileGroupCounts();
-    } else {
-      this.mdtLayout = null;
-      this.mdtLayoutPartitionFileGroupCounts = Collections.emptyMap();
-    }
+    boolean isMdt = HoodieTableMetadata.isMetadataTable(datasetBasePath);
+    this.mdtLayout = isMdt ? HoodieMetadataTableLayouts.load(tableConfig) : null;
+    this.mdtLayoutPartitionFileGroupCounts = isMdt
+        ? tableConfig.getMetadataLayoutPartitionFileGroupCounts() : Collections.emptyMap();
   }
 
   public FileSystemBackedTableMetadata(HoodieEngineContext engineContext,
@@ -109,13 +106,10 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
         Boolean.parseBoolean(tableConfig.getHiveStylePartitioningEnable());
     this.urlEncodePartitioningEnabled =
         Boolean.parseBoolean(tableConfig.getUrlEncodePartitioning());
-    if (HoodieTableMetadata.isMetadataTable(datasetBasePath)) {
-      this.mdtLayout = HoodieMetadataTableLayouts.load(tableConfig);
-      this.mdtLayoutPartitionFileGroupCounts = tableConfig.getMetadataLayoutPartitionFileGroupCounts();
-    } else {
-      this.mdtLayout = null;
-      this.mdtLayoutPartitionFileGroupCounts = Collections.emptyMap();
-    }
+    boolean isMdt = HoodieTableMetadata.isMetadataTable(datasetBasePath);
+    this.mdtLayout = isMdt ? HoodieMetadataTableLayouts.load(tableConfig) : null;
+    this.mdtLayoutPartitionFileGroupCounts = isMdt
+        ? tableConfig.getMetadataLayoutPartitionFileGroupCounts() : Collections.emptyMap();
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -72,6 +72,12 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
   private final String tableName;
   private final boolean hiveStylePartitioningEnabled;
   private final boolean urlEncodePartitioningEnabled;
+  // If this base path is an MDT, this is the MDT's configured layout. Resolves to FlatMDTLayout
+  // for every MDT that did not opt in. Null when the base path is not an MDT.
+  private final HoodieMetadataTableLayout mdtLayout;
+  // Per-MDT-partition file-group counts (sourced from the MDT's hoodie.properties). Empty for
+  // non-MDT base paths and for MDTs on the default flat layout.
+  private final Map<String, Integer> mdtLayoutPartitionFileGroupCounts;
 
   public FileSystemBackedTableMetadata(HoodieEngineContext engineContext, HoodieTableConfig tableConfig,
                                        HoodieStorage storage, String datasetBasePath) {
@@ -80,6 +86,13 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
     this.tableName = tableConfig.getTableName();
     this.hiveStylePartitioningEnabled = Boolean.parseBoolean(tableConfig.getHiveStylePartitioningEnable());
     this.urlEncodePartitioningEnabled = Boolean.parseBoolean(tableConfig.getUrlEncodePartitioning());
+    if (HoodieTableMetadata.isMetadataTable(datasetBasePath)) {
+      this.mdtLayout = HoodieMetadataTableLayouts.load(tableConfig);
+      this.mdtLayoutPartitionFileGroupCounts = tableConfig.getMetadataLayoutPartitionFileGroupCounts();
+    } else {
+      this.mdtLayout = null;
+      this.mdtLayoutPartitionFileGroupCounts = Collections.emptyMap();
+    }
   }
 
   public FileSystemBackedTableMetadata(HoodieEngineContext engineContext,
@@ -96,11 +109,42 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
         Boolean.parseBoolean(tableConfig.getHiveStylePartitioningEnable());
     this.urlEncodePartitioningEnabled =
         Boolean.parseBoolean(tableConfig.getUrlEncodePartitioning());
+    if (HoodieTableMetadata.isMetadataTable(datasetBasePath)) {
+      this.mdtLayout = HoodieMetadataTableLayouts.load(tableConfig);
+      this.mdtLayoutPartitionFileGroupCounts = tableConfig.getMetadataLayoutPartitionFileGroupCounts();
+    } else {
+      this.mdtLayout = null;
+      this.mdtLayoutPartitionFileGroupCounts = Collections.emptyMap();
+    }
   }
 
   @Override
   public List<StoragePathInfo> getAllFilesInPartition(StoragePath partitionPath) throws IOException {
+    // For an MDT under a non-flat layout, the logical partition (e.g., "record_index") contains
+    // bucket sub-directories rather than file groups directly. Fan out the listing across the
+    // layout-supplied sub-paths so direct Spark queries (and any caller that goes through
+    // FileSystemBackedTableMetadata) see the file groups under the partition.
+    if (mdtLayout != null) {
+      String logicalPartition = FSUtils.getRelativePartitionPath(dataBasePath, partitionPath);
+      List<String> physicalSubPaths = expandPhysicalSubPaths(logicalPartition);
+      if (physicalSubPaths.size() > 1 || (physicalSubPaths.size() == 1 && !physicalSubPaths.get(0).equals(logicalPartition))) {
+        List<StoragePathInfo> all = new ArrayList<>();
+        for (String sub : physicalSubPaths) {
+          StoragePath subPath = new StoragePath(dataBasePath, sub);
+          all.addAll(FSUtils.getAllDataFilesInPartition(getStorage(), subPath));
+        }
+        return all;
+      }
+    }
     return FSUtils.getAllDataFilesInPartition(getStorage(), partitionPath);
+  }
+
+  private List<String> expandPhysicalSubPaths(String logicalPartition) {
+    if (mdtLayout == null) {
+      return Collections.singletonList(logicalPartition);
+    }
+    int fgCount = mdtLayoutPartitionFileGroupCounts.getOrDefault(logicalPartition, 0);
+    return mdtLayout.getPhysicalPartitions(logicalPartition, fgCount);
   }
 
   @Override
@@ -269,10 +313,29 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
         "Listing all files in " + partitionPaths.size() + " partitions from "
             + this.tableName);
     // Need to use serializable file status here, see HUDI-5936
+    // Snapshot layout state once to avoid recomputing per partition during the map closure and to
+    // keep the closure safely serializable.
+    final HoodieMetadataTableLayout layoutSnapshot = mdtLayout;
+    final Map<String, Integer> layoutCountsSnapshot = mdtLayoutPartitionFileGroupCounts;
+    final String basePathStr = dataBasePath.toString();
     List<Pair<String, List<StoragePathInfo>>> partitionToFiles =
         engineContext.map(new ArrayList<>(partitionPaths),
             partitionPathStr -> {
               StoragePath partitionPath = new StoragePath(partitionPathStr);
+              if (layoutSnapshot != null) {
+                String logicalPartition = FSUtils.getRelativePartitionPath(new StoragePath(basePathStr), partitionPath);
+                int fgCount = layoutCountsSnapshot.getOrDefault(logicalPartition, 0);
+                List<String> physicalSubPaths = layoutSnapshot.getPhysicalPartitions(logicalPartition, fgCount);
+                if (physicalSubPaths.size() > 1
+                    || (physicalSubPaths.size() == 1 && !physicalSubPaths.get(0).equals(logicalPartition))) {
+                  List<StoragePathInfo> aggregated = new ArrayList<>();
+                  for (String sub : physicalSubPaths) {
+                    StoragePath subPath = new StoragePath(basePathStr, sub);
+                    aggregated.addAll(FSUtils.getAllDataFilesInPartitionByPathFilter(getStorage(), subPath, pathFilterOption));
+                  }
+                  return Pair.of(partitionPathStr, aggregated);
+                }
+              }
               return Pair.of(partitionPathStr,
                   FSUtils.getAllDataFilesInPartitionByPathFilter(getStorage(), partitionPath, pathFilterOption));
             }, parallelism);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FlatMDTLayout.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FlatMDTLayout.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.util.Option;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Default MDT layout: every file group lives directly under its metadata
+ * partition directory, and a single {@code .hoodie_partition_metadata} marker
+ * lives at the partition root. This is the layout that existed before the
+ * layout SPI was introduced and remains the default for all tables that have
+ * not explicitly opted into a different layout.
+ */
+public final class FlatMDTLayout implements HoodieMetadataTableLayout {
+
+  public static final String LAYOUT_ID = "flat";
+
+  @Override
+  public String getLayoutId() {
+    return LAYOUT_ID;
+  }
+
+  @Override
+  public String getFileGroupRelativePath(LayoutContext ctx) {
+    return ctx.getPartitionType().getPartitionPath();
+  }
+
+  @Override
+  public String getFileId(LayoutContext ctx) {
+    return HoodieTableMetadataUtil.getFileIDForFileGroup(
+        ctx.getPartitionType(),
+        ctx.getFileGroupIndex(),
+        ctx.getPartitionType().getPartitionPath(),
+        ctx.getDataPartitionName());
+  }
+
+  @Override
+  public FileIdInfo parseFileId(MetadataPartitionType partitionType, String fileId) {
+    int idx = HoodieTableMetadataUtil.getFileGroupIndexFromFileId(fileId);
+    return new FileIdInfo(idx, Option.empty());
+  }
+
+  @Override
+  public List<String> getPhysicalPartitions(String logicalPartition, int fileGroupCount) {
+    return Collections.singletonList(logicalPartition);
+  }
+
+  @Override
+  public List<String> getPartitionMarkerPaths(String logicalPartition, int fileGroupCount) {
+    return Collections.singletonList(logicalPartition);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FlatMDTLayout.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FlatMDTLayout.java
@@ -42,7 +42,7 @@ public final class FlatMDTLayout implements HoodieMetadataTableLayout {
 
   @Override
   public String getFileGroupRelativePath(LayoutContext ctx) {
-    return ctx.getPartitionType().getPartitionPath();
+    return ctx.getRelativePartitionPath();
   }
 
   @Override
@@ -50,7 +50,7 @@ public final class FlatMDTLayout implements HoodieMetadataTableLayout {
     return HoodieTableMetadataUtil.getFileIDForFileGroup(
         ctx.getPartitionType(),
         ctx.getFileGroupIndex(),
-        ctx.getPartitionType().getPartitionPath(),
+        ctx.getRelativePartitionPath(),
         ctx.getDataPartitionName());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FlatMDTLayout.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FlatMDTLayout.java
@@ -41,12 +41,12 @@ public final class FlatMDTLayout implements HoodieMetadataTableLayout {
   }
 
   @Override
-  public String getFileGroupRelativePath(LayoutContext ctx) {
+  public String getFileGroupRelativePath(HoodieMetadataLayoutContext ctx) {
     return ctx.getRelativePartitionPath();
   }
 
   @Override
-  public String getFileId(LayoutContext ctx) {
+  public String getFileId(HoodieMetadataLayoutContext ctx) {
     return HoodieTableMetadataUtil.getFileIDForFileGroup(
         ctx.getPartitionType(),
         ctx.getFileGroupIndex(),
@@ -55,9 +55,9 @@ public final class FlatMDTLayout implements HoodieMetadataTableLayout {
   }
 
   @Override
-  public FileIdInfo parseFileId(MetadataPartitionType partitionType, String fileId) {
+  public HoodieMetadataFileIdInfo parseFileId(MetadataPartitionType partitionType, String fileId) {
     int idx = HoodieTableMetadataUtil.getFileGroupIndexFromFileId(fileId);
-    return new FileIdInfo(idx, Option.empty());
+    return new HoodieMetadataFileIdInfo(idx, Option.empty());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileIdInfo.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataFileIdInfo.java
@@ -30,23 +30,23 @@ import java.io.Serializable;
  * <p>Examples:
  * <ul>
  *   <li>Non-partitioned RLI fileId {@code "record-index-1500-0"} →
- *       {@code FileIdInfo(fileGroupIndex=1500, dataPartitionName=Option.empty())}.</li>
+ *       {@code HoodieMetadataFileIdInfo(fileGroupIndex=1500, dataPartitionName=Option.empty())}.</li>
  *   <li>Files-partition fileId {@code "files-0000-0"} →
- *       {@code FileIdInfo(fileGroupIndex=0, dataPartitionName=Option.empty())}.</li>
+ *       {@code HoodieMetadataFileIdInfo(fileGroupIndex=0, dataPartitionName=Option.empty())}.</li>
  *   <li>Expression-index fileId {@code "expr-index-idx-datestr-0000-0"} →
- *       {@code FileIdInfo(fileGroupIndex=0, dataPartitionName=Option.empty())}.</li>
+ *       {@code HoodieMetadataFileIdInfo(fileGroupIndex=0, dataPartitionName=Option.empty())}.</li>
  *   <li>Partitioned RLI fileId {@code "record-index-default-0003-0"} (where {@code default} is the
- *       data-table partition name) → {@code FileIdInfo(fileGroupIndex=3, dataPartitionName=Option.of("default"))}.
+ *       data-table partition name) → {@code HoodieMetadataFileIdInfo(fileGroupIndex=3, dataPartitionName=Option.of("default"))}.
  *       Note: built-in layouts in this patch return {@code Option.empty()} for partitioned RLI
  *       since they fall back to the flat layout; custom layouts may choose to populate it.</li>
  * </ul>
  */
-public final class FileIdInfo implements Serializable {
+public final class HoodieMetadataFileIdInfo implements Serializable {
 
   private final int fileGroupIndex;
   private final Option<String> dataPartitionName;
 
-  public FileIdInfo(int fileGroupIndex, Option<String> dataPartitionName) {
+  public HoodieMetadataFileIdInfo(int fileGroupIndex, Option<String> dataPartitionName) {
     this.fileGroupIndex = fileGroupIndex;
     this.dataPartitionName = dataPartitionName;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataLayoutContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataLayoutContext.java
@@ -34,7 +34,7 @@ import java.io.Serializable;
  * number of file groups in that partition, and the data-table partition name
  * (set only for partitioned RLI).
  */
-public final class LayoutContext implements Serializable {
+public final class HoodieMetadataLayoutContext implements Serializable {
 
   private final MetadataPartitionType partitionType;
   private final String relativePartitionPath;
@@ -42,7 +42,7 @@ public final class LayoutContext implements Serializable {
   private final int fileGroupCount;
   private final Option<String> dataPartitionName;
 
-  public LayoutContext(MetadataPartitionType partitionType,
+  public HoodieMetadataLayoutContext(MetadataPartitionType partitionType,
                        String relativePartitionPath,
                        int fileGroupIndex,
                        int fileGroupCount,

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataTableLayout.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataTableLayout.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Strategy that controls how MDT file groups are organized on disk.
+ *
+ * <p>The layout is selected at MDT initialization via the
+ * {@code hoodie.metadata.layout.class} table property and is immutable for
+ * the lifetime of the MDT. Implementations must be safe to serialize across
+ * executors and must be deterministic for given inputs.
+ *
+ * <p>Two implementations ship in OSS:
+ * <ul>
+ *   <li>{@link FlatMDTLayout} (default) — every file group lives directly
+ *   under its MDT partition directory; this is the existing behavior.</li>
+ *   <li>{@link SubDirBucketedMDTLayout} (opt-in) — file groups for
+ *   non-partitioned MDT partitions are grouped into bucket sub-directories
+ *   (e.g. {@code record_index/0000/}, {@code record_index/0001/}) to lift the
+ *   per-directory file-count limit on HDFS-like filesystems. Partitioned RLI
+ *   falls back to the flat layout in this implementation.</li>
+ * </ul>
+ *
+ * <p>Third parties may ship custom implementations and wire them in via the
+ * {@code hoodie.metadata.layout.class} property.
+ */
+public interface HoodieMetadataTableLayout extends Serializable {
+
+  /**
+   * Stable identifier for this layout. Persisted on the MDT at init time and
+   * asserted on every open as a guard against the configured class being
+   * swapped to one with mismatched on-disk semantics.
+   */
+  String getLayoutId();
+
+  /**
+   * Return the path (relative to the MDT base path) where the file group
+   * described by {@code ctx} should live.
+   *
+   * <p>For the flat layout this is always the partition's path. For
+   * sub-directory bucketing this includes the bucket sub-directory.
+   */
+  String getFileGroupRelativePath(LayoutContext ctx);
+
+  /**
+   * Return the fileId to use for the file group described by {@code ctx}.
+   *
+   * <p>Most layouts will delegate to
+   * {@link HoodieTableMetadataUtil#getFileIDForFileGroup} since the fileId
+   * scheme is independent of the on-disk directory layout.
+   */
+  String getFileId(LayoutContext ctx);
+
+  /**
+   * Inverse of {@link #getFileId}: given a fileId observed on disk, recover
+   * its global file-group index and (for partitioned RLI) its data-partition
+   * name.
+   */
+  FileIdInfo parseFileId(MetadataPartitionType partitionType, String fileId);
+
+  /**
+   * Given a logical MDT partition name and the total number of file groups
+   * known to live under it, return the list of sub-paths to scan to discover
+   * all file groups.
+   *
+   * <p>For the flat layout this is {@code [logicalPartition]}. For
+   * sub-directory bucketing this returns the list of bucket directories
+   * (e.g. {@code ["record_index/0000", "record_index/0001", ...]}).
+   *
+   * <p>The {@code fileGroupCount} is supplied by the caller (sourced from MDT
+   * properties) so this method must not perform any filesystem listing.
+   */
+  List<String> getPhysicalPartitions(String logicalPartition, int fileGroupCount);
+
+  /**
+   * Return the paths (relative to the MDT base path) where
+   * {@code .hoodie_partition_metadata} markers must be written for this
+   * logical partition.
+   *
+   * <p>To preserve MDT-as-Hudi-table semantics, layouts should place a single
+   * marker at the logical partition root, never inside a bucket
+   * sub-directory.
+   */
+  List<String> getPartitionMarkerPaths(String logicalPartition, int fileGroupCount);
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataTableLayout.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataTableLayout.java
@@ -60,7 +60,7 @@ public interface HoodieMetadataTableLayout extends Serializable {
    * <p>For the flat layout this is always the partition's path. For
    * sub-directory bucketing this includes the bucket sub-directory.
    */
-  String getFileGroupRelativePath(LayoutContext ctx);
+  String getFileGroupRelativePath(HoodieMetadataLayoutContext ctx);
 
   /**
    * Return the fileId to use for the file group described by {@code ctx}.
@@ -69,14 +69,14 @@ public interface HoodieMetadataTableLayout extends Serializable {
    * {@link HoodieTableMetadataUtil#getFileIDForFileGroup} since the fileId
    * scheme is independent of the on-disk directory layout.
    */
-  String getFileId(LayoutContext ctx);
+  String getFileId(HoodieMetadataLayoutContext ctx);
 
   /**
    * Inverse of {@link #getFileId}: given a fileId observed on disk, recover
    * its global file-group index and (for partitioned RLI) its data-partition
    * name.
    */
-  FileIdInfo parseFileId(MetadataPartitionType partitionType, String fileId);
+  HoodieMetadataFileIdInfo parseFileId(MetadataPartitionType partitionType, String fileId);
 
   /**
    * Given a logical MDT partition name and the total number of file groups

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataTableLayouts.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataTableLayouts.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.exception.HoodieMetadataException;
+
+/**
+ * Factory for resolving the {@link HoodieMetadataTableLayout} from an MDT's
+ * persisted {@link HoodieTableConfig}.
+ *
+ * <p>Resolution rules:
+ * <ol>
+ *   <li>If {@link HoodieTableConfig#METADATA_LAYOUT_CLASS} is unset, return
+ *   {@link FlatMDTLayout}. This is the case for every existing MDT and
+ *   preserves backward compatibility.</li>
+ *   <li>If set to the FQCN of {@link FlatMDTLayout} or
+ *   {@link SubDirBucketedMDTLayout}, the corresponding built-in instance is
+ *   returned. {@code SubDirBucketedMDTLayout} reads its bucket size from
+ *   {@link HoodieTableConfig#METADATA_LAYOUT_BUCKET_SIZE}.</li>
+ *   <li>Otherwise, the class is loaded reflectively. The class must either
+ *   have a no-arg constructor or a constructor that accepts a single
+ *   {@link HoodieTableConfig}.</li>
+ * </ol>
+ */
+public final class HoodieMetadataTableLayouts {
+
+  private HoodieMetadataTableLayouts() {
+  }
+
+  /**
+   * Resolve the layout for the given MDT table config.
+   *
+   * @param mdtConfig the {@link HoodieTableConfig} of the MDT (not the data table)
+   */
+  public static HoodieMetadataTableLayout load(HoodieTableConfig mdtConfig) {
+    Option<String> layoutClass = mdtConfig.getMetadataLayoutClass();
+    if (!layoutClass.isPresent() || layoutClass.get().isEmpty()) {
+      return new FlatMDTLayout();
+    }
+    String cls = layoutClass.get();
+    if (FlatMDTLayout.class.getName().equals(cls)) {
+      return new FlatMDTLayout();
+    }
+    if (SubDirBucketedMDTLayout.class.getName().equals(cls)) {
+      return new SubDirBucketedMDTLayout(mdtConfig.getMetadataLayoutBucketSize());
+    }
+    try {
+      Object instance;
+      if (ReflectionUtils.hasConstructor(cls, new Class<?>[] {HoodieTableConfig.class}, true)) {
+        instance = ReflectionUtils.loadClass(cls, new Class<?>[] {HoodieTableConfig.class}, mdtConfig);
+      } else {
+        instance = ReflectionUtils.loadClass(cls);
+      }
+      if (!(instance instanceof HoodieMetadataTableLayout)) {
+        throw new HoodieMetadataException("Configured MDT layout class " + cls
+            + " is not a HoodieMetadataTableLayout");
+      }
+      return (HoodieMetadataTableLayout) instance;
+    } catch (Exception e) {
+      throw new HoodieMetadataException("Failed to load MDT layout class " + cls
+          + ". The MDT was initialized with this layout class; the same class must be available "
+          + "on the classpath of any writer or reader opening the table.", e);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1518,25 +1518,50 @@ public class HoodieTableMetadataUtil {
     HoodieTableFileSystemView fsView = null;
     try {
       fsView = fileSystemView.orElseGet(() -> getFileSystemViewForMetadataTable(metaClient));
-      Stream<FileSlice> fileSliceStream;
-      if (mergeFileSlices) {
-        if (metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().isPresent()) {
-          fileSliceStream = fsView.getLatestMergedFileSlicesBeforeOrOn(
-              // including pending compaction instant as the last instant so that the finished delta commits
-              // that start earlier than the compaction can be queried.
-              partition, metaClient.getActiveTimeline().filterCompletedAndCompactionInstants().lastInstant().get().requestedTime());
+      List<String> physicalPartitions = resolvePhysicalPartitions(metaClient, partition);
+      List<FileSlice> all = new ArrayList<>();
+      boolean any = false;
+      for (String physical : physicalPartitions) {
+        Stream<FileSlice> fileSliceStream;
+        if (mergeFileSlices) {
+          if (metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().isPresent()) {
+            fileSliceStream = fsView.getLatestMergedFileSlicesBeforeOrOn(
+                // including pending compaction instant as the last instant so that the finished delta commits
+                // that start earlier than the compaction can be queried.
+                physical, metaClient.getActiveTimeline().filterCompletedAndCompactionInstants().lastInstant().get().requestedTime());
+          } else {
+            return Collections.emptyList();
+          }
         } else {
-          return Collections.emptyList();
+          fileSliceStream = fsView.getLatestFileSlices(physical);
         }
-      } else {
-        fileSliceStream = fsView.getLatestFileSlices(partition);
+        fileSliceStream.forEach(all::add);
+        any = true;
       }
-      return fileSliceStream.sorted(Comparator.comparing(FileSlice::getFileId)).collect(Collectors.toList());
+      if (!any) {
+        return Collections.emptyList();
+      }
+      all.sort(Comparator.comparing(FileSlice::getFileId));
+      return all;
     } finally {
-      if (!fileSystemView.isPresent()) {
+      if (!fileSystemView.isPresent() && fsView != null) {
         fsView.close();
       }
     }
+  }
+
+  /**
+   * Resolve the physical sub-paths to scan for the given MDT partition under the configured
+   * layout. Layout-aware: for the flat layout this returns {@code [partition]}; for sub-directory
+   * bucketing it returns one entry per bucket directory. {@code fileGroupCount} is sourced from
+   * the MDT's persisted layout state — this method does not perform any filesystem listing.
+   */
+  private static List<String> resolvePhysicalPartitions(HoodieTableMetaClient metaClient, String partition) {
+    HoodieMetadataTableLayout layout = HoodieMetadataTableLayouts.load(metaClient.getTableConfig());
+    int fgCount = metaClient.getTableConfig()
+        .getMetadataLayoutPartitionFileGroupCounts()
+        .getOrDefault(partition, 0);
+    return layout.getPhysicalPartitions(partition, fgCount);
   }
 
   /**
@@ -1553,10 +1578,13 @@ public class HoodieTableMetadataUtil {
     HoodieTableFileSystemView fsView = null;
     try {
       fsView = fileSystemView.orElseGet(() -> getFileSystemViewForMetadataTable(metaClient));
-      Stream<FileSlice> fileSliceStream = fsView.getLatestFileSlicesIncludingInflight(partition);
-      return fileSliceStream
-          .sorted(Comparator.comparing(FileSlice::getFileId))
-          .collect(Collectors.toList());
+      List<String> physicalPartitions = resolvePhysicalPartitions(metaClient, partition);
+      List<FileSlice> all = new ArrayList<>();
+      for (String physical : physicalPartitions) {
+        fsView.getLatestFileSlicesIncludingInflight(physical).forEach(all::add);
+      }
+      all.sort(Comparator.comparing(FileSlice::getFileId));
+      return all;
     } finally {
       if (!fileSystemView.isPresent() && fsView != null) {
         fsView.close();

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1519,27 +1519,26 @@ public class HoodieTableMetadataUtil {
     try {
       fsView = fileSystemView.orElseGet(() -> getFileSystemViewForMetadataTable(metaClient));
       List<String> physicalPartitions = resolvePhysicalPartitions(metaClient, partition);
-      List<FileSlice> all = new ArrayList<>();
-      boolean any = false;
-      for (String physical : physicalPartitions) {
-        Stream<FileSlice> fileSliceStream;
-        if (mergeFileSlices) {
-          if (metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().isPresent()) {
-            fileSliceStream = fsView.getLatestMergedFileSlicesBeforeOrOn(
-                // including pending compaction instant as the last instant so that the finished delta commits
-                // that start earlier than the compaction can be queried.
-                physical, metaClient.getActiveTimeline().filterCompletedAndCompactionInstants().lastInstant().get().requestedTime());
-          } else {
-            return Collections.emptyList();
-          }
-        } else {
-          fileSliceStream = fsView.getLatestFileSlices(physical);
-        }
-        fileSliceStream.forEach(all::add);
-        any = true;
-      }
-      if (!any) {
+      if (physicalPartitions.isEmpty()) {
         return Collections.emptyList();
+      }
+      // Hoist timeline lookups out of the loop — they depend only on metaClient and stay invariant.
+      String mergedAsOfInstant = null;
+      if (mergeFileSlices) {
+        if (!metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().isPresent()) {
+          return Collections.emptyList();
+        }
+        // Including pending compaction instant as the last instant so that the finished delta
+        // commits that start earlier than the compaction can be queried.
+        mergedAsOfInstant = metaClient.getActiveTimeline().filterCompletedAndCompactionInstants()
+            .lastInstant().get().requestedTime();
+      }
+      List<FileSlice> all = new ArrayList<>();
+      for (String physical : physicalPartitions) {
+        Stream<FileSlice> fileSliceStream = mergeFileSlices
+            ? fsView.getLatestMergedFileSlicesBeforeOrOn(physical, mergedAsOfInstant)
+            : fsView.getLatestFileSlices(physical);
+        fileSliceStream.forEach(all::add);
       }
       all.sort(Comparator.comparing(FileSlice::getFileId));
       return all;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1564,6 +1564,52 @@ public class HoodieTableMetadataUtil {
   }
 
   /**
+   * Returns true when {@code physicalPartitionPath} is a layout sub-path of an MDT partition under
+   * the bucketed layout (e.g. {@code record_index/0004}). Callers use this to distinguish a layout
+   * sub-path from a logical MDT partition root — for example, to decide whether a
+   * {@code .hoodie_partition_metadata} marker should be created there.
+   *
+   * <p>Returns false for: non-MDT tables, MDTs on the flat layout (the default that every
+   * pre-existing MDT uses), and any path that does not end in a {@code /NNNN} 4-digit suffix. The
+   * non-flat-layout gate is what keeps a 4-digit data-table partition value (e.g. {@code price=1000})
+   * from being misread as a bucket directory.
+   *
+   * @param mdtTableConfig     the MDT's persisted table config (typically reached via
+   *                           {@code hoodieTable.getMetaClient().getTableConfig()} when the table
+   *                           being written to is the MDT itself).
+   * @param isMetadataTable    whether the surrounding write is targeting an MDT — engine-agnostic
+   *                           callers pass {@code hoodieTable.isMetadataTable()}.
+   * @param physicalPartitionPath the physical partition path on disk.
+   */
+  public static boolean isMDTBucketSubPath(HoodieTableConfig mdtTableConfig,
+                                           boolean isMetadataTable,
+                                           String physicalPartitionPath) {
+    if (!isMetadataTable || physicalPartitionPath == null) {
+      return false;
+    }
+    Option<String> layoutClass = mdtTableConfig.getMetadataLayoutClass();
+    boolean nonFlatLayout = layoutClass.isPresent() && !layoutClass.get().isEmpty()
+        && !layoutClass.get().equals(FlatMDTLayout.class.getName());
+    if (!nonFlatLayout) {
+      return false;
+    }
+    int slash = physicalPartitionPath.lastIndexOf('/');
+    if (slash <= 0 || slash >= physicalPartitionPath.length() - 1) {
+      return false;
+    }
+    String last = physicalPartitionPath.substring(slash + 1);
+    if (last.length() != 4) {
+      return false;
+    }
+    for (int i = 0; i < 4; i++) {
+      if (!Character.isDigit(last.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * Get the latest file slices for a given partition including the inflight ones.
    *
    * @param metaClient     - instance of {@link HoodieTableMetaClient}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -149,6 +149,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1547,6 +1548,48 @@ public class HoodieTableMetadataUtil {
         fsView.close();
       }
     }
+  }
+
+  /**
+   * Expand a list of MDT partitions from logical to physical form for the configured layout.
+   *
+   * <p>This is the shared boundary helper for table-service planners (compaction, log compaction,
+   * cleaning, rollback). The MDT write path is already keyed by <em>physical</em> partition paths:
+   * {@link #getPartitionFileSlices} expands before querying the file system view, and
+   * {@code HoodieBackedTableMetadataWriter#getRecordTagger} realigns each record's partition path
+   * to its file slice's physical path. Planners that enumerate partitions from marker discovery or
+   * {@code FSUtils.getAllPartitionPaths} produce <em>logical</em> names, so without this expansion
+   * the plan key space and the write-side key space diverge — which silently corrupts the file
+   * system view's pending-compaction bookkeeping (appends land in a slice being compacted, and
+   * merged reads drop pre-compaction log files).
+   *
+   * <p>Idempotent for already-physical input: a physical sub-path such as
+   * {@code record_index/000003} has no entry in the persisted per-partition file-group counts, so
+   * {@code fileGroupCount} resolves to 0 and the layout returns the input unchanged. This matters
+   * because the incremental table-service branch sources partitions from write stats, which are
+   * already physical. Non-MDT tables and MDTs on the flat default layout are returned unchanged.
+   *
+   * @param metaClient the MDT's meta client (for a data table this is a no-op passthrough).
+   * @param partitions logical (or already-physical) partition paths.
+   * @return the expanded list, de-duplicated and order-stable.
+   */
+  public static List<String> expandToPhysicalPartitions(HoodieTableMetaClient metaClient, List<String> partitions) {
+    if (partitions == null || partitions.isEmpty() || !metaClient.isMetadataTable()) {
+      return partitions;
+    }
+    HoodieMetadataTableLayout layout = HoodieMetadataTableLayouts.load(metaClient.getTableConfig());
+    if (layout instanceof FlatMDTLayout) {
+      // Fast path: preserve bit-identical behavior for every pre-existing MDT.
+      return partitions;
+    }
+    Map<String, Integer> fgCounts = metaClient.getTableConfig().getMetadataLayoutPartitionFileGroupCounts();
+    // LinkedHashSet: stable ordering for deterministic plans, and de-duplication in case a caller
+    // passes a mix of logical and already-physical paths for the same partition.
+    Set<String> expanded = new LinkedHashSet<>();
+    for (String partition : partitions) {
+      expanded.addAll(layout.getPhysicalPartitions(partition, fgCounts.getOrDefault(partition, 0)));
+    }
+    return new ArrayList<>(expanded);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1570,9 +1570,10 @@ public class HoodieTableMetadataUtil {
    * {@code .hoodie_partition_metadata} marker should be created there.
    *
    * <p>Returns false for: non-MDT tables, MDTs on the flat layout (the default that every
-   * pre-existing MDT uses), and any path that does not end in a {@code /NNNN} 4-digit suffix. The
-   * non-flat-layout gate is what keeps a 4-digit data-table partition value (e.g. {@code price=1000})
-   * from being misread as a bucket directory.
+   * pre-existing MDT uses), and any path that does not end in a fixed-width all-digit suffix of
+   * {@link SubDirBucketedMDTLayout#BUCKET_INDEX_WIDTH} characters. The non-flat-layout gate is what
+   * keeps a same-width data-table partition value (e.g. {@code price=100000}) from being misread as
+   * a bucket directory.
    *
    * @param mdtTableConfig     the MDT's persisted table config (typically reached via
    *                           {@code hoodieTable.getMetaClient().getTableConfig()} when the table
@@ -1598,10 +1599,10 @@ public class HoodieTableMetadataUtil {
       return false;
     }
     String last = physicalPartitionPath.substring(slash + 1);
-    if (last.length() != 4) {
+    if (last.length() != SubDirBucketedMDTLayout.BUCKET_INDEX_WIDTH) {
       return false;
     }
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < SubDirBucketedMDTLayout.BUCKET_INDEX_WIDTH; i++) {
       if (!Character.isDigit(last.charAt(i))) {
         return false;
       }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/LayoutContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/LayoutContext.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.util.Option;
+
+import java.io.Serializable;
+
+/**
+ * Per-file-group context handed to a {@link HoodieMetadataTableLayout}.
+ *
+ * <p>Carries everything a layout needs to compute the on-disk relative path
+ * and fileId for a single file group: the metadata partition type, the global
+ * file-group index, the total number of file groups in that partition, and
+ * the data-table partition name (set only for partitioned RLI).
+ */
+public final class LayoutContext implements Serializable {
+
+  private final MetadataPartitionType partitionType;
+  private final int fileGroupIndex;
+  private final int fileGroupCount;
+  private final Option<String> dataPartitionName;
+
+  public LayoutContext(MetadataPartitionType partitionType,
+                       int fileGroupIndex,
+                       int fileGroupCount,
+                       Option<String> dataPartitionName) {
+    this.partitionType = partitionType;
+    this.fileGroupIndex = fileGroupIndex;
+    this.fileGroupCount = fileGroupCount;
+    this.dataPartitionName = dataPartitionName;
+  }
+
+  public MetadataPartitionType getPartitionType() {
+    return partitionType;
+  }
+
+  public int getFileGroupIndex() {
+    return fileGroupIndex;
+  }
+
+  public int getFileGroupCount() {
+    return fileGroupCount;
+  }
+
+  public Option<String> getDataPartitionName() {
+    return dataPartitionName;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/LayoutContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/LayoutContext.java
@@ -27,22 +27,28 @@ import java.io.Serializable;
  * Per-file-group context handed to a {@link HoodieMetadataTableLayout}.
  *
  * <p>Carries everything a layout needs to compute the on-disk relative path
- * and fileId for a single file group: the metadata partition type, the global
- * file-group index, the total number of file groups in that partition, and
- * the data-table partition name (set only for partitioned RLI).
+ * and fileId for a single file group: the metadata partition type, the
+ * relative MDT partition path (which for secondary/expression indexes is the
+ * full partition name like {@code secondary_index_idx0}, not the static
+ * prefix on the partition type), the global file-group index, the total
+ * number of file groups in that partition, and the data-table partition name
+ * (set only for partitioned RLI).
  */
 public final class LayoutContext implements Serializable {
 
   private final MetadataPartitionType partitionType;
+  private final String relativePartitionPath;
   private final int fileGroupIndex;
   private final int fileGroupCount;
   private final Option<String> dataPartitionName;
 
   public LayoutContext(MetadataPartitionType partitionType,
+                       String relativePartitionPath,
                        int fileGroupIndex,
                        int fileGroupCount,
                        Option<String> dataPartitionName) {
     this.partitionType = partitionType;
+    this.relativePartitionPath = relativePartitionPath;
     this.fileGroupIndex = fileGroupIndex;
     this.fileGroupCount = fileGroupCount;
     this.dataPartitionName = dataPartitionName;
@@ -50,6 +56,10 @@ public final class LayoutContext implements Serializable {
 
   public MetadataPartitionType getPartitionType() {
     return partitionType;
+  }
+
+  public String getRelativePartitionPath() {
+    return relativePartitionPath;
   }
 
   public int getFileGroupIndex() {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/SubDirBucketedMDTLayout.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/SubDirBucketedMDTLayout.java
@@ -104,12 +104,12 @@ public final class SubDirBucketedMDTLayout implements HoodieMetadataTableLayout 
       throw new HoodieMetadataException(
           "SubDirBucketedMDTLayout does not support partitioned RLI. The MDT was opened with "
               + "a data-partition-keyed file group for partition '"
-              + ctx.getPartitionType().getPartitionPath() + "' (data partition '"
+              + ctx.getRelativePartitionPath() + "' (data partition '"
               + ctx.getDataPartitionName().get() + "'). Disable hoodie.metadata.layout.class "
               + "or switch the RLI to the global (non-partitioned) mode.");
     }
     int bucket = ctx.getFileGroupIndex() / bucketSize;
-    return bucketRelativePath(ctx.getPartitionType().getPartitionPath(), bucket);
+    return bucketRelativePath(ctx.getRelativePartitionPath(), bucket);
   }
 
   @Override
@@ -119,7 +119,7 @@ public final class SubDirBucketedMDTLayout implements HoodieMetadataTableLayout 
     return HoodieTableMetadataUtil.getFileIDForFileGroup(
         ctx.getPartitionType(),
         ctx.getFileGroupIndex(),
-        ctx.getPartitionType().getPartitionPath(),
+        ctx.getRelativePartitionPath(),
         ctx.getDataPartitionName());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/SubDirBucketedMDTLayout.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/SubDirBucketedMDTLayout.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.hudi.storage.StoragePath;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Opt-in MDT layout that distributes file groups into bucket sub-directories so a
+ * single MDT partition directory does not exceed per-directory file-count limits
+ * common on HDFS-style filesystems.
+ *
+ * <p>On-disk shape for {@code record_index} with {@code fileGroupCount=2500} and
+ * {@code bucketSize=1000}:
+ * <pre>
+ *   .hoodie/metadata/record_index/
+ *   ├── .hoodie_partition_metadata               ← single marker at the partition root
+ *   ├── 0000/
+ *   │   ├── .record-index-0000-0_&lt;instant&gt;.log
+ *   │   ├── ...
+ *   │   └── .record-index-0999-0_&lt;instant&gt;.log
+ *   ├── 0001/
+ *   │   └── ...
+ *   └── 0002/
+ *       └── ... (partial)
+ * </pre>
+ *
+ * <p>Notes:
+ * <ul>
+ *   <li>The fileId scheme is unchanged. The bucket for a given file group is
+ *   recoverable from the file-group index, which is itself encoded in the
+ *   fileId. No additional state is required to map a fileId to its bucket.</li>
+ *   <li>A single {@code .hoodie_partition_metadata} marker lives at the logical
+ *   MDT partition root. None are written inside bucket sub-directories. This
+ *   preserves MDT-as-Hudi-table semantics so {@code FSUtils.getAllPartitionPaths}
+ *   on the MDT returns logical partition names rather than physical bucket
+ *   paths.</li>
+ *   <li>Reads enumerate the physical sub-paths via
+ *   {@link #getPhysicalPartitions(String, int)} sourced from the MDT's persisted
+ *   {@code hoodie.metadata.layout.partition.file.group.counts} property. No
+ *   filesystem listing is needed on the read path.</li>
+ * </ul>
+ *
+ * <p><b>Scope:</b> this initial implementation supports the non-partitioned MDT
+ * partitions (files, column_stats, bloom_filters, expression_index,
+ * secondary_index, and the global RLI). Partitioned RLI is rejected up front: if
+ * a writer enables this layout on a table whose RLI is in the partitioned mode,
+ * {@link #getFileGroupRelativePath} throws {@link HoodieMetadataException}.
+ * Partitioned-RLI bucketing requires a different growth model and lands in a
+ * separate follow-up.
+ */
+public final class SubDirBucketedMDTLayout implements HoodieMetadataTableLayout {
+
+  public static final String LAYOUT_ID = "subdir-bucketed";
+  public static final int DEFAULT_BUCKET_SIZE = 1000;
+
+  private final int bucketSize;
+
+  public SubDirBucketedMDTLayout() {
+    this(DEFAULT_BUCKET_SIZE);
+  }
+
+  public SubDirBucketedMDTLayout(int bucketSize) {
+    ValidationUtils.checkArgument(bucketSize > 0,
+        "SubDirBucketedMDTLayout bucketSize must be > 0, got " + bucketSize);
+    this.bucketSize = bucketSize;
+  }
+
+  @Override
+  public String getLayoutId() {
+    return LAYOUT_ID;
+  }
+
+  public int getBucketSize() {
+    return bucketSize;
+  }
+
+  @Override
+  public String getFileGroupRelativePath(LayoutContext ctx) {
+    if (ctx.getDataPartitionName().isPresent()) {
+      throw new HoodieMetadataException(
+          "SubDirBucketedMDTLayout does not support partitioned RLI. The MDT was opened with "
+              + "a data-partition-keyed file group for partition '"
+              + ctx.getPartitionType().getPartitionPath() + "' (data partition '"
+              + ctx.getDataPartitionName().get() + "'). Disable hoodie.metadata.layout.class "
+              + "or switch the RLI to the global (non-partitioned) mode.");
+    }
+    int bucket = ctx.getFileGroupIndex() / bucketSize;
+    return bucketRelativePath(ctx.getPartitionType().getPartitionPath(), bucket);
+  }
+
+  @Override
+  public String getFileId(LayoutContext ctx) {
+    // FileId scheme is bucket-independent. The bucket is recoverable from the
+    // file-group index, which is encoded in the fileId itself.
+    return HoodieTableMetadataUtil.getFileIDForFileGroup(
+        ctx.getPartitionType(),
+        ctx.getFileGroupIndex(),
+        ctx.getPartitionType().getPartitionPath(),
+        ctx.getDataPartitionName());
+  }
+
+  @Override
+  public FileIdInfo parseFileId(MetadataPartitionType partitionType, String fileId) {
+    int idx = HoodieTableMetadataUtil.getFileGroupIndexFromFileId(fileId);
+    return new FileIdInfo(idx, Option.empty());
+  }
+
+  @Override
+  public List<String> getPhysicalPartitions(String logicalPartition, int fileGroupCount) {
+    if (fileGroupCount <= 0) {
+      // Caller has no recorded count for this logical partition (e.g., the partition
+      // is not yet initialized or is being read by an early-init code path). Fall
+      // back to the partition root; the FS view will return zero file groups, which
+      // is the correct empty-state for callers that pre-check existence themselves.
+      return Collections.singletonList(logicalPartition);
+    }
+    int numBuckets = (int) Math.ceil((double) fileGroupCount / bucketSize);
+    List<String> paths = new ArrayList<>(numBuckets);
+    for (int b = 0; b < numBuckets; b++) {
+      paths.add(bucketRelativePath(logicalPartition, b));
+    }
+    return paths;
+  }
+
+  @Override
+  public List<String> getPartitionMarkerPaths(String logicalPartition, int fileGroupCount) {
+    // Single marker at the logical partition root. Never inside a bucket dir;
+    // that is the central correctness property that lets partition discovery on
+    // the MDT still return logical names rather than physical sub-paths.
+    return Collections.singletonList(logicalPartition);
+  }
+
+  private static String bucketRelativePath(String partitionRelativePath, int bucketIndex) {
+    return String.format("%s%s%04d", partitionRelativePath, StoragePath.SEPARATOR, bucketIndex);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/SubDirBucketedMDTLayout.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/SubDirBucketedMDTLayout.java
@@ -38,13 +38,13 @@ import java.util.List;
  * <pre>
  *   .hoodie/metadata/record_index/
  *   ├── .hoodie_partition_metadata               ← single marker at the partition root
- *   ├── 0000/
+ *   ├── 000000/
  *   │   ├── .record-index-0000-0_&lt;instant&gt;.log
  *   │   ├── ...
  *   │   └── .record-index-0999-0_&lt;instant&gt;.log
- *   ├── 0001/
+ *   ├── 000001/
  *   │   └── ...
- *   └── 0002/
+ *   └── 000002/
  *       └── ... (partial)
  * </pre>
  *
@@ -99,7 +99,7 @@ public final class SubDirBucketedMDTLayout implements HoodieMetadataTableLayout 
   }
 
   @Override
-  public String getFileGroupRelativePath(LayoutContext ctx) {
+  public String getFileGroupRelativePath(HoodieMetadataLayoutContext ctx) {
     if (ctx.getDataPartitionName().isPresent()) {
       throw new HoodieMetadataException(
           "SubDirBucketedMDTLayout does not support partitioned RLI. The MDT was opened with "
@@ -113,7 +113,7 @@ public final class SubDirBucketedMDTLayout implements HoodieMetadataTableLayout 
   }
 
   @Override
-  public String getFileId(LayoutContext ctx) {
+  public String getFileId(HoodieMetadataLayoutContext ctx) {
     // FileId scheme is bucket-independent. The bucket is recoverable from the
     // file-group index, which is encoded in the fileId itself.
     return HoodieTableMetadataUtil.getFileIDForFileGroup(
@@ -124,9 +124,9 @@ public final class SubDirBucketedMDTLayout implements HoodieMetadataTableLayout 
   }
 
   @Override
-  public FileIdInfo parseFileId(MetadataPartitionType partitionType, String fileId) {
+  public HoodieMetadataFileIdInfo parseFileId(MetadataPartitionType partitionType, String fileId) {
     int idx = HoodieTableMetadataUtil.getFileGroupIndexFromFileId(fileId);
-    return new FileIdInfo(idx, Option.empty());
+    return new HoodieMetadataFileIdInfo(idx, Option.empty());
   }
 
   @Override
@@ -154,7 +154,21 @@ public final class SubDirBucketedMDTLayout implements HoodieMetadataTableLayout 
     return Collections.singletonList(logicalPartition);
   }
 
+  /**
+   * Bucket sub-directory naming uses a fixed-width zero-padded index (e.g.
+   * {@code record_index/000042} with {@link #BUCKET_INDEX_WIDTH} = 6). The width is a
+   * hard ceiling that also drives the {@link HoodieTableMetadataUtil#isMDTBucketSubPath}
+   * heuristic used to distinguish a bucket sub-path from a real data-table partition value
+   * that happens to be all-digit. Changing this width is a storage-format change: any
+   * pre-existing bucketed MDT is pinned to the width in use at initialization time.
+   */
+  static final int BUCKET_INDEX_WIDTH = 6;
+  static final int MAX_BUCKETS = 1_000_000;
+
   private static String bucketRelativePath(String partitionRelativePath, int bucketIndex) {
-    return String.format("%s%s%04d", partitionRelativePath, StoragePath.SEPARATOR, bucketIndex);
+    ValidationUtils.checkArgument(bucketIndex >= 0 && bucketIndex < MAX_BUCKETS,
+        "bucketIndex out of range [0, " + MAX_BUCKETS + "): " + bucketIndex);
+    return String.format("%s%s%0" + BUCKET_INDEX_WIDTH + "d",
+        partitionRelativePath, StoragePath.SEPARATOR, bucketIndex);
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link HoodieMetadataTableLayout} implementations. Validates that the layout
+ * abstraction yields the expected on-disk paths and fileIds for both flat and sub-directory
+ * bucketed layouts, including the partitioned-RLI fallback.
+ */
+class TestHoodieMetadataTableLayout {
+
+  // ---- FlatMDTLayout --------------------------------------------------------
+
+  @Test
+  void flatLayout_returnsPartitionRootAsRelativePath() {
+    HoodieMetadataTableLayout layout = new FlatMDTLayout();
+    LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, 1500, 2500, Option.empty());
+    assertEquals("record_index", layout.getFileGroupRelativePath(ctx));
+    assertEquals("record-index-1500-0", layout.getFileId(ctx));
+  }
+
+  @Test
+  void flatLayout_physicalPartitionsIsSingleton() {
+    HoodieMetadataTableLayout layout = new FlatMDTLayout();
+    assertEquals(java.util.Collections.singletonList("record_index"),
+        layout.getPhysicalPartitions("record_index", 2500));
+  }
+
+  @Test
+  void flatLayout_markerAtPartitionRoot() {
+    HoodieMetadataTableLayout layout = new FlatMDTLayout();
+    assertEquals(java.util.Collections.singletonList("record_index"),
+        layout.getPartitionMarkerPaths("record_index", 2500));
+  }
+
+  @Test
+  void flatLayout_layoutIdIsStable() {
+    assertEquals("flat", new FlatMDTLayout().getLayoutId());
+  }
+
+  // ---- SubDirBucketedMDTLayout ---------------------------------------------
+
+  @Test
+  void bucketedLayout_pathDerivedFromFileGroupIndex() {
+    HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
+    assertEquals("record_index/0000",
+        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 0, 2500, Option.empty())));
+    assertEquals("record_index/0000",
+        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 999, 2500, Option.empty())));
+    assertEquals("record_index/0001",
+        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 1000, 2500, Option.empty())));
+    assertEquals("record_index/0001",
+        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 1500, 2500, Option.empty())));
+    assertEquals("record_index/0002",
+        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 2499, 2500, Option.empty())));
+  }
+
+  @Test
+  void bucketedLayout_fileIdSchemeUnchanged() {
+    HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
+    // FileId encoding must be bucket-independent so that bucket = fileGroupIndex / bucketSize is
+    // recoverable from the fileId itself.
+    assertEquals("record-index-0000-0",
+        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 0, 2500, Option.empty())));
+    assertEquals("record-index-1500-0",
+        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 1500, 2500, Option.empty())));
+    assertEquals("record-index-2499-0",
+        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 2499, 2500, Option.empty())));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 100, 1000, 1024})
+  void bucketedLayout_physicalPartitionsHonorBucketSize(int bucketSize) {
+    SubDirBucketedMDTLayout layout = new SubDirBucketedMDTLayout(bucketSize);
+    // Exactly N full buckets.
+    List<String> exact = layout.getPhysicalPartitions("record_index", bucketSize * 3);
+    assertEquals(3, exact.size());
+    assertEquals("record_index/0000", exact.get(0));
+    assertEquals("record_index/0001", exact.get(1));
+    assertEquals("record_index/0002", exact.get(2));
+
+    // N+1 file groups → N+1 buckets (partial last).
+    List<String> partial = layout.getPhysicalPartitions("record_index", bucketSize * 3 + 1);
+    assertEquals(4, partial.size());
+    assertEquals("record_index/0003", partial.get(3));
+
+    // Fewer than bucketSize → one bucket.
+    List<String> small = layout.getPhysicalPartitions("record_index", Math.max(1, bucketSize / 2));
+    assertEquals(1, small.size());
+  }
+
+  @Test
+  void bucketedLayout_emptyPartitionReturnsRootOnly() {
+    // fileGroupCount=0 means the layout has nothing persisted for that partition; the caller is
+    // expected to fall back to the partition root (e.g., partitioned RLI on read).
+    HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
+    assertEquals(java.util.Collections.singletonList("record_index"),
+        layout.getPhysicalPartitions("record_index", 0));
+  }
+
+  @Test
+  void bucketedLayout_markerOnlyAtPartitionRoot() {
+    // Central correctness property: never write .hoodie_partition_metadata inside a bucket dir.
+    HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
+    List<String> markers = layout.getPartitionMarkerPaths("record_index", 2500);
+    assertEquals(1, markers.size());
+    assertEquals("record_index", markers.get(0));
+  }
+
+  @Test
+  void bucketedLayout_rejectsPartitionedRLI() {
+    // Partitioned RLI is explicitly unsupported in this initial implementation. Invoking the layout
+    // with a data partition present must fail loudly rather than silently produce a flat path; the
+    // partitioned-RLI growth model needs a distinct strategy that lands in a follow-up patch / RFC.
+    HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
+    LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, 3, 4, Option.of("p2"));
+    org.apache.hudi.exception.HoodieMetadataException ex = assertThrows(
+        org.apache.hudi.exception.HoodieMetadataException.class,
+        () -> layout.getFileGroupRelativePath(ctx));
+    assertTrue(ex.getMessage().contains("partitioned RLI"),
+        "exception message should call out partitioned RLI unsupported: " + ex.getMessage());
+  }
+
+  @Test
+  void bucketedLayout_rejectsZeroOrNegativeBucketSize() {
+    assertThrows(IllegalArgumentException.class, () -> new SubDirBucketedMDTLayout(0));
+    assertThrows(IllegalArgumentException.class, () -> new SubDirBucketedMDTLayout(-1));
+  }
+
+  @Test
+  void bucketedLayout_parseFileIdRoundTrip() {
+    HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
+    for (int idx : new int[] {0, 1, 999, 1000, 1500, 2499}) {
+      LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, idx, 2500, Option.empty());
+      String fileId = layout.getFileId(ctx);
+      FileIdInfo info = layout.parseFileId(MetadataPartitionType.RECORD_INDEX, fileId);
+      assertEquals(idx, info.getFileGroupIndex(), "round-trip fileId for index " + idx);
+    }
+  }
+
+  @Test
+  void layoutIdsAreDistinct() {
+    assertTrue(!new FlatMDTLayout().getLayoutId().equals(new SubDirBucketedMDTLayout(1).getLayoutId()));
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
@@ -43,7 +43,7 @@ class TestHoodieMetadataTableLayout {
   @Test
   void flatLayout_returnsPartitionRootAsRelativePath() {
     HoodieMetadataTableLayout layout = new FlatMDTLayout();
-    LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, 1500, 2500, Option.empty());
+    LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1500, 2500, Option.empty());
     assertEquals("record_index", layout.getFileGroupRelativePath(ctx));
     assertEquals("record-index-1500-0", layout.getFileId(ctx));
   }
@@ -73,15 +73,15 @@ class TestHoodieMetadataTableLayout {
   void bucketedLayout_pathDerivedFromFileGroupIndex() {
     HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
     assertEquals("record_index/0000",
-        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 0, 2500, Option.empty())));
+        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 0, 2500, Option.empty())));
     assertEquals("record_index/0000",
-        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 999, 2500, Option.empty())));
+        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 999, 2500, Option.empty())));
     assertEquals("record_index/0001",
-        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 1000, 2500, Option.empty())));
+        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1000, 2500, Option.empty())));
     assertEquals("record_index/0001",
-        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 1500, 2500, Option.empty())));
+        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1500, 2500, Option.empty())));
     assertEquals("record_index/0002",
-        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 2499, 2500, Option.empty())));
+        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 2499, 2500, Option.empty())));
   }
 
   @Test
@@ -90,11 +90,11 @@ class TestHoodieMetadataTableLayout {
     // FileId encoding must be bucket-independent so that bucket = fileGroupIndex / bucketSize is
     // recoverable from the fileId itself.
     assertEquals("record-index-0000-0",
-        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 0, 2500, Option.empty())));
+        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 0, 2500, Option.empty())));
     assertEquals("record-index-1500-0",
-        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 1500, 2500, Option.empty())));
+        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1500, 2500, Option.empty())));
     assertEquals("record-index-2499-0",
-        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, 2499, 2500, Option.empty())));
+        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 2499, 2500, Option.empty())));
   }
 
   @ParameterizedTest
@@ -142,7 +142,7 @@ class TestHoodieMetadataTableLayout {
     // with a data partition present must fail loudly rather than silently produce a flat path; the
     // partitioned-RLI growth model needs a distinct strategy that lands in a follow-up patch / RFC.
     HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
-    LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, 3, 4, Option.of("p2"));
+    LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 3, 4, Option.of("p2"));
     org.apache.hudi.exception.HoodieMetadataException ex = assertThrows(
         org.apache.hudi.exception.HoodieMetadataException.class,
         () -> layout.getFileGroupRelativePath(ctx));
@@ -160,7 +160,7 @@ class TestHoodieMetadataTableLayout {
   void bucketedLayout_parseFileIdRoundTrip() {
     HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
     for (int idx : new int[] {0, 1, 999, 1000, 1500, 2499}) {
-      LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, idx, 2500, Option.empty());
+      LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", idx, 2500, Option.empty());
       String fileId = layout.getFileId(ctx);
       FileIdInfo info = layout.parseFileId(MetadataPartitionType.RECORD_INDEX, fileId);
       assertEquals(idx, info.getFileGroupIndex(), "round-trip fileId for index " + idx);

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
@@ -171,4 +171,65 @@ class TestHoodieMetadataTableLayout {
   void layoutIdsAreDistinct() {
     assertTrue(!new FlatMDTLayout().getLayoutId().equals(new SubDirBucketedMDTLayout(1).getLayoutId()));
   }
+
+  // ---- HoodieTableMetadataUtil.isMDTBucketSubPath ----------------------------
+
+  @Test
+  void isMDTBucketSubPath_falseForNonMDT() {
+    org.apache.hudi.common.table.HoodieTableConfig cfg =
+        new org.apache.hudi.common.table.HoodieTableConfig();
+    cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_CLASS,
+        SubDirBucketedMDTLayout.class.getName());
+    // Non-MDT tables short-circuit regardless of any layout config.
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, false, "record_index/0001"));
+  }
+
+  @Test
+  void isMDTBucketSubPath_falseForFlatLayoutMDT() {
+    // The flat default (no layout class set) must short-circuit so the heuristic never reads a
+    // 4-digit data-table partition value as a bucket sub-path on existing tables.
+    org.apache.hudi.common.table.HoodieTableConfig cfg =
+        new org.apache.hudi.common.table.HoodieTableConfig();
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/0001"));
+
+    // Explicit FlatMDTLayout class also short-circuits.
+    cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_CLASS,
+        FlatMDTLayout.class.getName());
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/0001"));
+  }
+
+  @Test
+  void isMDTBucketSubPath_trueForBucketedMDTWithFourDigitSuffix() {
+    org.apache.hudi.common.table.HoodieTableConfig cfg =
+        new org.apache.hudi.common.table.HoodieTableConfig();
+    cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_CLASS,
+        SubDirBucketedMDTLayout.class.getName());
+    assertTrue(HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/0000"));
+    assertTrue(HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/0042"));
+    assertTrue(HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "secondary_index_idx0/0099"));
+  }
+
+  @Test
+  void isMDTBucketSubPath_falseForLogicalPartitionRootEvenUnderBucketing() {
+    // The logical partition root (no trailing /NNNN) must NOT be treated as a bucket sub-path —
+    // that's where the .hoodie_partition_metadata marker is supposed to land.
+    org.apache.hudi.common.table.HoodieTableConfig cfg =
+        new org.apache.hudi.common.table.HoodieTableConfig();
+    cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_CLASS,
+        SubDirBucketedMDTLayout.class.getName());
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index"));
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "files"));
+  }
+
+  @Test
+  void isMDTBucketSubPath_falseForNonFourDigitSuffix() {
+    org.apache.hudi.common.table.HoodieTableConfig cfg =
+        new org.apache.hudi.common.table.HoodieTableConfig();
+    cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_CLASS,
+        SubDirBucketedMDTLayout.class.getName());
+    // 3-digit, 5-digit, non-digit suffixes all return false.
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/000"));
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/00000"));
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/abcd"));
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
@@ -314,15 +314,29 @@ class TestHoodieMetadataTableLayout {
 
   @Test
   void expandToPhysicalPartitions_uncountedPartitionFallsBackToLogicalRoot() {
-    // Flat MDT partitions (files, column_stats, secondary_index_*) carry no file-group count under
-    // a bucketed layout, since bucketing is opt-in per partition. They must degrade to the logical
-    // root rather than vanishing from the plan.
+    // A partition with no recorded file-group count (not yet initialized, or read by an early-init
+    // code path) must degrade to its logical root rather than vanishing from the plan — a dropped
+    // partition would silently exclude it from compaction, cleaning and rollback.
     HoodieTableMetaClient metaClient =
         mockMdtMetaClient(true, SubDirBucketedMDTLayout.class.getName(), "record_index=1500");
     assertEquals(
-        java.util.Arrays.asList("record_index/000000", "record_index/000001", "files", "column_stats"),
+        java.util.Arrays.asList("record_index/000000", "record_index/000001", "column_stats"),
         HoodieTableMetadataUtil.expandToPhysicalPartitions(
-            metaClient, java.util.Arrays.asList("record_index", "files", "column_stats")));
+            metaClient, java.util.Arrays.asList("record_index", "column_stats")));
+  }
+
+  @Test
+  void expandToPhysicalPartitions_bucketsSmallPartitionsIntoASingleBucket() {
+    // SubDirBucketedMDTLayout buckets every MDT partition, not only the RLI. A partition small
+    // enough to fit in one bucket still lives in a bucket directory (files/000000), so planners
+    // must target that directory rather than the logical root — otherwise a non-recursive listing
+    // finds nothing there.
+    HoodieTableMetaClient metaClient =
+        mockMdtMetaClient(true, SubDirBucketedMDTLayout.class.getName(), "files=1,record_index=1500");
+    assertEquals(
+        java.util.Arrays.asList("files/000000", "record_index/000000", "record_index/000001"),
+        HoodieTableMetadataUtil.expandToPhysicalPartitions(
+            metaClient, java.util.Arrays.asList("files", "record_index")));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.Test;
@@ -233,5 +234,103 @@ class TestHoodieMetadataTableLayout {
     assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/00000"));
     assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/0000000"));
     assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/abcdef"));
+  }
+
+  // ---- expandToPhysicalPartitions -------------------------------------------
+  //
+  // This is the shared boundary helper used by the compaction, cleaning and rollback planners to
+  // bring their partition key space in line with the already-physical MDT write path. The
+  // properties below are what those call sites rely on.
+
+  private static HoodieTableMetaClient mockMdtMetaClient(boolean isMetadataTable,
+                                                         String layoutClass,
+                                                         String fileGroupCounts) {
+    org.apache.hudi.common.table.HoodieTableConfig cfg =
+        new org.apache.hudi.common.table.HoodieTableConfig();
+    if (layoutClass != null) {
+      cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_CLASS, layoutClass);
+    }
+    if (fileGroupCounts != null) {
+      cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_PARTITION_FILE_GROUP_COUNTS,
+          fileGroupCounts);
+    }
+    HoodieTableMetaClient metaClient = org.mockito.Mockito.mock(HoodieTableMetaClient.class);
+    org.mockito.Mockito.when(metaClient.isMetadataTable()).thenReturn(isMetadataTable);
+    org.mockito.Mockito.when(metaClient.getTableConfig()).thenReturn(cfg);
+    return metaClient;
+  }
+
+  @Test
+  void expandToPhysicalPartitions_fansOutLogicalPartitionToBuckets() {
+    // 2500 file groups at the default bucket size of 1000 => 3 bucket directories.
+    HoodieTableMetaClient metaClient =
+        mockMdtMetaClient(true, SubDirBucketedMDTLayout.class.getName(), "record_index=2500");
+    assertEquals(
+        java.util.Arrays.asList("record_index/000000", "record_index/000001", "record_index/000002"),
+        HoodieTableMetadataUtil.expandToPhysicalPartitions(
+            metaClient, java.util.Collections.singletonList("record_index")));
+  }
+
+  @Test
+  void expandToPhysicalPartitions_isIdempotentForAlreadyPhysicalInput() {
+    // The incremental table-service branch sources partitions from write stats, which are already
+    // physical. Those have no entry in the file-group-count map, so they must pass through
+    // untouched rather than being re-expanded or dropped.
+    HoodieTableMetaClient metaClient =
+        mockMdtMetaClient(true, SubDirBucketedMDTLayout.class.getName(), "record_index=2500");
+    List<String> physical =
+        java.util.Arrays.asList("record_index/000000", "record_index/000001", "record_index/000002");
+    assertEquals(physical, HoodieTableMetadataUtil.expandToPhysicalPartitions(metaClient, physical));
+  }
+
+  @Test
+  void expandToPhysicalPartitions_deduplicatesMixedLogicalAndPhysicalInput() {
+    // A caller may hand us a mix (e.g. marker-discovered logical names unioned with write-stat
+    // physical paths). The result must not contain duplicates, or the planner would emit two
+    // operations for the same file group.
+    HoodieTableMetaClient metaClient =
+        mockMdtMetaClient(true, SubDirBucketedMDTLayout.class.getName(), "record_index=1500");
+    assertEquals(
+        java.util.Arrays.asList("record_index/000000", "record_index/000001"),
+        HoodieTableMetadataUtil.expandToPhysicalPartitions(
+            metaClient, java.util.Arrays.asList("record_index", "record_index/000001")));
+  }
+
+  @Test
+  void expandToPhysicalPartitions_leavesFlatLayoutAndNonMdtUnchanged() {
+    List<String> partitions = java.util.Arrays.asList("record_index", "files");
+    // Flat layout (the default every pre-existing MDT uses) must be bit-identical passthrough.
+    HoodieTableMetaClient flatMdt =
+        mockMdtMetaClient(true, FlatMDTLayout.class.getName(), "record_index=2500");
+    assertEquals(partitions, HoodieTableMetadataUtil.expandToPhysicalPartitions(flatMdt, partitions));
+    // An MDT that never stamped a layout class at all also stays flat.
+    HoodieTableMetaClient unstampedMdt = mockMdtMetaClient(true, null, null);
+    assertEquals(partitions, HoodieTableMetadataUtil.expandToPhysicalPartitions(unstampedMdt, partitions));
+    // A data table is never expanded, whatever its partition values look like.
+    HoodieTableMetaClient dataTable =
+        mockMdtMetaClient(false, SubDirBucketedMDTLayout.class.getName(), "record_index=2500");
+    assertEquals(partitions, HoodieTableMetadataUtil.expandToPhysicalPartitions(dataTable, partitions));
+  }
+
+  @Test
+  void expandToPhysicalPartitions_uncountedPartitionFallsBackToLogicalRoot() {
+    // Flat MDT partitions (files, column_stats, secondary_index_*) carry no file-group count under
+    // a bucketed layout, since bucketing is opt-in per partition. They must degrade to the logical
+    // root rather than vanishing from the plan.
+    HoodieTableMetaClient metaClient =
+        mockMdtMetaClient(true, SubDirBucketedMDTLayout.class.getName(), "record_index=1500");
+    assertEquals(
+        java.util.Arrays.asList("record_index/000000", "record_index/000001", "files", "column_stats"),
+        HoodieTableMetadataUtil.expandToPhysicalPartitions(
+            metaClient, java.util.Arrays.asList("record_index", "files", "column_stats")));
+  }
+
+  @Test
+  void expandToPhysicalPartitions_handlesNullAndEmptyInput() {
+    HoodieTableMetaClient metaClient =
+        mockMdtMetaClient(true, SubDirBucketedMDTLayout.class.getName(), "record_index=2500");
+    assertEquals(null, HoodieTableMetadataUtil.expandToPhysicalPartitions(metaClient, null));
+    assertEquals(java.util.Collections.emptyList(),
+        HoodieTableMetadataUtil.expandToPhysicalPartitions(metaClient, java.util.Collections.emptyList()));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataTableLayout.java
@@ -43,7 +43,7 @@ class TestHoodieMetadataTableLayout {
   @Test
   void flatLayout_returnsPartitionRootAsRelativePath() {
     HoodieMetadataTableLayout layout = new FlatMDTLayout();
-    LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1500, 2500, Option.empty());
+    HoodieMetadataLayoutContext ctx = new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1500, 2500, Option.empty());
     assertEquals("record_index", layout.getFileGroupRelativePath(ctx));
     assertEquals("record-index-1500-0", layout.getFileId(ctx));
   }
@@ -72,16 +72,16 @@ class TestHoodieMetadataTableLayout {
   @Test
   void bucketedLayout_pathDerivedFromFileGroupIndex() {
     HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
-    assertEquals("record_index/0000",
-        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 0, 2500, Option.empty())));
-    assertEquals("record_index/0000",
-        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 999, 2500, Option.empty())));
-    assertEquals("record_index/0001",
-        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1000, 2500, Option.empty())));
-    assertEquals("record_index/0001",
-        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1500, 2500, Option.empty())));
-    assertEquals("record_index/0002",
-        layout.getFileGroupRelativePath(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 2499, 2500, Option.empty())));
+    assertEquals("record_index/000000",
+        layout.getFileGroupRelativePath(new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 0, 2500, Option.empty())));
+    assertEquals("record_index/000000",
+        layout.getFileGroupRelativePath(new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 999, 2500, Option.empty())));
+    assertEquals("record_index/000001",
+        layout.getFileGroupRelativePath(new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1000, 2500, Option.empty())));
+    assertEquals("record_index/000001",
+        layout.getFileGroupRelativePath(new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1500, 2500, Option.empty())));
+    assertEquals("record_index/000002",
+        layout.getFileGroupRelativePath(new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 2499, 2500, Option.empty())));
   }
 
   @Test
@@ -90,11 +90,11 @@ class TestHoodieMetadataTableLayout {
     // FileId encoding must be bucket-independent so that bucket = fileGroupIndex / bucketSize is
     // recoverable from the fileId itself.
     assertEquals("record-index-0000-0",
-        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 0, 2500, Option.empty())));
+        layout.getFileId(new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 0, 2500, Option.empty())));
     assertEquals("record-index-1500-0",
-        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1500, 2500, Option.empty())));
+        layout.getFileId(new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 1500, 2500, Option.empty())));
     assertEquals("record-index-2499-0",
-        layout.getFileId(new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 2499, 2500, Option.empty())));
+        layout.getFileId(new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 2499, 2500, Option.empty())));
   }
 
   @ParameterizedTest
@@ -104,14 +104,14 @@ class TestHoodieMetadataTableLayout {
     // Exactly N full buckets.
     List<String> exact = layout.getPhysicalPartitions("record_index", bucketSize * 3);
     assertEquals(3, exact.size());
-    assertEquals("record_index/0000", exact.get(0));
-    assertEquals("record_index/0001", exact.get(1));
-    assertEquals("record_index/0002", exact.get(2));
+    assertEquals("record_index/000000", exact.get(0));
+    assertEquals("record_index/000001", exact.get(1));
+    assertEquals("record_index/000002", exact.get(2));
 
     // N+1 file groups → N+1 buckets (partial last).
     List<String> partial = layout.getPhysicalPartitions("record_index", bucketSize * 3 + 1);
     assertEquals(4, partial.size());
-    assertEquals("record_index/0003", partial.get(3));
+    assertEquals("record_index/000003", partial.get(3));
 
     // Fewer than bucketSize → one bucket.
     List<String> small = layout.getPhysicalPartitions("record_index", Math.max(1, bucketSize / 2));
@@ -142,7 +142,7 @@ class TestHoodieMetadataTableLayout {
     // with a data partition present must fail loudly rather than silently produce a flat path; the
     // partitioned-RLI growth model needs a distinct strategy that lands in a follow-up patch / RFC.
     HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
-    LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 3, 4, Option.of("p2"));
+    HoodieMetadataLayoutContext ctx = new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", 3, 4, Option.of("p2"));
     org.apache.hudi.exception.HoodieMetadataException ex = assertThrows(
         org.apache.hudi.exception.HoodieMetadataException.class,
         () -> layout.getFileGroupRelativePath(ctx));
@@ -160,9 +160,9 @@ class TestHoodieMetadataTableLayout {
   void bucketedLayout_parseFileIdRoundTrip() {
     HoodieMetadataTableLayout layout = new SubDirBucketedMDTLayout(1000);
     for (int idx : new int[] {0, 1, 999, 1000, 1500, 2499}) {
-      LayoutContext ctx = new LayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", idx, 2500, Option.empty());
+      HoodieMetadataLayoutContext ctx = new HoodieMetadataLayoutContext(MetadataPartitionType.RECORD_INDEX, "record_index", idx, 2500, Option.empty());
       String fileId = layout.getFileId(ctx);
-      FileIdInfo info = layout.parseFileId(MetadataPartitionType.RECORD_INDEX, fileId);
+      HoodieMetadataFileIdInfo info = layout.parseFileId(MetadataPartitionType.RECORD_INDEX, fileId);
       assertEquals(idx, info.getFileGroupIndex(), "round-trip fileId for index " + idx);
     }
   }
@@ -181,32 +181,32 @@ class TestHoodieMetadataTableLayout {
     cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_CLASS,
         SubDirBucketedMDTLayout.class.getName());
     // Non-MDT tables short-circuit regardless of any layout config.
-    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, false, "record_index/0001"));
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, false, "record_index/000001"));
   }
 
   @Test
   void isMDTBucketSubPath_falseForFlatLayoutMDT() {
     // The flat default (no layout class set) must short-circuit so the heuristic never reads a
-    // 4-digit data-table partition value as a bucket sub-path on existing tables.
+    // same-width all-digit data-table partition value as a bucket sub-path on existing tables.
     org.apache.hudi.common.table.HoodieTableConfig cfg =
         new org.apache.hudi.common.table.HoodieTableConfig();
-    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/0001"));
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/000001"));
 
     // Explicit FlatMDTLayout class also short-circuits.
     cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_CLASS,
         FlatMDTLayout.class.getName());
-    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/0001"));
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/000001"));
   }
 
   @Test
-  void isMDTBucketSubPath_trueForBucketedMDTWithFourDigitSuffix() {
+  void isMDTBucketSubPath_trueForBucketedMDTWithSixDigitSuffix() {
     org.apache.hudi.common.table.HoodieTableConfig cfg =
         new org.apache.hudi.common.table.HoodieTableConfig();
     cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_CLASS,
         SubDirBucketedMDTLayout.class.getName());
-    assertTrue(HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/0000"));
-    assertTrue(HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/0042"));
-    assertTrue(HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "secondary_index_idx0/0099"));
+    assertTrue(HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/000000"));
+    assertTrue(HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/000042"));
+    assertTrue(HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "secondary_index_idx0/000099"));
   }
 
   @Test
@@ -222,14 +222,16 @@ class TestHoodieMetadataTableLayout {
   }
 
   @Test
-  void isMDTBucketSubPath_falseForNonFourDigitSuffix() {
+  void isMDTBucketSubPath_falseForNonSixDigitSuffix() {
     org.apache.hudi.common.table.HoodieTableConfig cfg =
         new org.apache.hudi.common.table.HoodieTableConfig();
     cfg.setValue(org.apache.hudi.common.table.HoodieTableConfig.METADATA_LAYOUT_CLASS,
         SubDirBucketedMDTLayout.class.getName());
-    // 3-digit, 5-digit, non-digit suffixes all return false.
+    // 3-digit, 5-digit, 7-digit, and non-digit suffixes all return false so that same-width
+    // data-table partition values do not get misread as bucket sub-paths.
     assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/000"));
     assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/00000"));
-    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/abcd"));
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/0000000"));
+    assertTrue(!HoodieTableMetadataUtil.isMDTBucketSubPath(cfg, true, "record_index/abcdef"));
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -386,7 +386,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   @Test
   void testDefinedTableConfigs() {
     List<ConfigProperty<?>> configProperties = HoodieTableConfig.definedTableConfigs();
-    assertEquals(45, configProperties.size());
+    assertEquals(48, configProperties.size());
     configProperties.forEach(c -> {
       assertNotNull(c);
       assertFalse(c.doc().isEmpty());

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -203,6 +203,71 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   }
 
   @Test
+  void testMetadataLayoutFileGroupCountsRoundTrip() throws IOException {
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init(basePath);
+    HoodieTableConfig config = metaClient.getTableConfig();
+
+    // First MDT partition init persists the layout class + bucket size + initial counts.
+    Map<String, Integer> initial = new HashMap<>();
+    initial.put("files", 1);
+    config.setMetadataLayout(metaClient,
+        "org.apache.hudi.metadata.SubDirBucketedMDTLayout", 1000, initial);
+    HoodieTableConfig reloaded = new HoodieTableConfig(storage, metaPath);
+    assertEquals(Option.of("org.apache.hudi.metadata.SubDirBucketedMDTLayout"),
+        reloaded.getMetadataLayoutClass());
+    assertEquals(1000, reloaded.getMetadataLayoutBucketSize());
+    assertEquals(1, reloaded.getMetadataLayoutPartitionFileGroupCounts().get("files"));
+
+    // A later MDT partition (e.g. record_index) initializes and adds its count without disturbing
+    // the existing one. This is the "writer property value can change to accommodate a new MDT
+    // partition" case.
+    Map<String, Integer> added = new HashMap<>();
+    added.put("record_index", 2500);
+    reloaded.addMetadataLayoutPartitionFileGroupCounts(metaClient, added);
+    Map<String, Integer> finalCounts =
+        new HoodieTableConfig(storage, metaPath).getMetadataLayoutPartitionFileGroupCounts();
+    assertEquals(2, finalCounts.size());
+    assertEquals(1, finalCounts.get("files"));
+    assertEquals(2500, finalCounts.get("record_index"));
+  }
+
+  @Test
+  void testMetadataLayoutFileGroupCountsIdempotentReStamp() throws IOException {
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init(basePath);
+    HoodieTableConfig config = metaClient.getTableConfig();
+    config.setMetadataLayout(metaClient, "org.apache.hudi.metadata.SubDirBucketedMDTLayout", 1000,
+        Collections.singletonMap("record_index", 2500));
+
+    // Re-stamping the SAME count for an existing partition must be a no-op, not a rejection.
+    // (E.g., a retried init path can land here.)
+    HoodieTableConfig reloaded = new HoodieTableConfig(storage, metaPath);
+    reloaded.addMetadataLayoutPartitionFileGroupCounts(metaClient,
+        Collections.singletonMap("record_index", 2500));
+    assertEquals(2500,
+        new HoodieTableConfig(storage, metaPath).getMetadataLayoutPartitionFileGroupCounts().get("record_index"));
+  }
+
+  @Test
+  void testMetadataLayoutFileGroupCountsRejectsConflict() throws IOException {
+    HoodieTableMetaClient metaClient = HoodieTestUtils.init(basePath);
+    HoodieTableConfig config = metaClient.getTableConfig();
+    config.setMetadataLayout(metaClient, "org.apache.hudi.metadata.SubDirBucketedMDTLayout", 1000,
+        Collections.singletonMap("record_index", 2500));
+
+    // Once record_index has a count of 2500, no later code path can re-stamp it as a different
+    // value — the on-disk bucket layout for that partition is immutable.
+    HoodieTableConfig reloaded = new HoodieTableConfig(storage, metaPath);
+    org.apache.hudi.exception.HoodieMetadataException ex = assertThrows(
+        org.apache.hudi.exception.HoodieMetadataException.class,
+        () -> reloaded.addMetadataLayoutPartitionFileGroupCounts(metaClient,
+            Collections.singletonMap("record_index", 1500)));
+    assertTrue(ex.getMessage().contains("record_index"),
+        "rejection message should call out the conflicting partition: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("immutable"),
+        "rejection message should call out the immutability rule: " + ex.getMessage());
+  }
+
+  @Test
   void testReadsWhenPropsFileDoesNotExist() throws IOException {
     storage.deleteFile(cfgPath);
     assertThrows(HoodieIOException.class, () -> {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -119,8 +119,13 @@ class RecordLevelIndexTestBase extends HoodieStatsIndexTestBase {
   }
 
   protected def getFileGroupCountForRecordIndex(writeConfig: HoodieWriteConfig): Long = {
+    // Route through HoodieTableMetadataUtil so we pick up bucketed sub-paths under the configured
+    // MDT layout (flat returns the partition root only; bucketed fans out across bucket dirs).
     Using(getHoodieTable(metaClient, writeConfig).getTableMetadata.asInstanceOf[HoodieBackedTableMetadata]) { metadataTable =>
-      metadataTable.getMetadataFileSystemView.getAllFileGroups(MetadataPartitionType.RECORD_INDEX.getPartitionPath).count
+      HoodieTableMetadataUtil.getPartitionLatestFileSlices(
+        metadataTable.getMetadataMetaClient,
+        org.apache.hudi.common.util.Option.of(metadataTable.getMetadataFileSystemView),
+        MetadataPartitionType.RECORD_INDEX.getPartitionPath).size.toLong
     }.get
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.metadata.{FlatMDTLayout, HoodieTableMetadata, MetadataPartitionType, SubDirBucketedMDTLayout}
+import org.apache.hudi.storage.StoragePath
+
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+import scala.collection.JavaConverters._
+
+/**
+ * Validates that the MDT layout SPI works end-to-end for the two OSS-shipped implementations:
+ *
+ *   - {@link FlatMDTLayout} — today's behavior, file groups directly under each MDT partition.
+ *   - {@link SubDirBucketedMDTLayout} — file groups grouped into bucket sub-directories.
+ *
+ * The same workload is run under both layouts and the MDT contract is checked:
+ *
+ *   - RLI lookups return identical results under both layouts.
+ *   - Logical MDT partitions are discoverable as Hudi partitions regardless of bucketing
+ *     ({@code FSUtils.getAllPartitionPaths} returns {@code [files, record_index, ...]}, NOT bucket
+ *     paths). This is the central correctness property we are protecting.
+ *   - Direct Spark queries on the MDT path return non-empty results under both layouts.
+ *   - When bucketing is enabled, the on-disk structure actually uses bucket sub-directories.
+ */
+class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
+
+  /**
+   * @param layoutClass FQCN of the layout to test; null means do not override (flat default).
+   * @param bucketSize  Bucket size to set when using sub-directory bucketing. Ignored otherwise.
+   */
+  private def layoutOpts(layoutClass: String, bucketSize: Int): Map[String, String] = {
+    if (layoutClass == null) {
+      Map.empty
+    } else {
+      Map(
+        HoodieMetadataConfig.METADATA_LAYOUT_CLASS.key -> layoutClass,
+        HoodieMetadataConfig.METADATA_LAYOUT_BUCKET_SIZE.key -> bucketSize.toString)
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array(
+    "org.apache.hudi.metadata.FlatMDTLayout",
+    "org.apache.hudi.metadata.SubDirBucketedMDTLayout"))
+  def testRecordLevelIndexWritesAndLookupsAcrossLayouts(layoutClass: String): Unit = {
+    // Force a small bucket size so even a modest workload exercises >1 buckets under the bucketed
+    // layout. The flat layout ignores bucketSize.
+    val opts = commonOpts ++ layoutOpts(layoutClass, bucketSize = 2)
+
+    // Bootstrap MDT + RLI with an INSERT.
+    doWriteAndValidateDataAndRecordIndex(opts, INSERT_OPERATION_OPT_VAL, SaveMode.Overwrite)
+    // A couple of UPSERTs to exercise reads against initialized file groups.
+    doWriteAndValidateDataAndRecordIndex(opts, UPSERT_OPERATION_OPT_VAL, SaveMode.Append)
+    doWriteAndValidateDataAndRecordIndex(opts, UPSERT_OPERATION_OPT_VAL, SaveMode.Append)
+
+    metaClient = HoodieTableMetaClient.builder().setBasePath(basePath).setConf(storageConf).build()
+
+    // Open MDT metaClient to inspect persisted layout state.
+    val mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(basePath)
+    val mdtMetaClient = HoodieTableMetaClient.builder()
+      .setBasePath(mdtBasePath).setConf(storageConf).build()
+
+    if (layoutClass == classOf[FlatMDTLayout].getName) {
+      // Flat layout must not persist a layout class — the default is implicit, and existing tables
+      // (with no layout property) must continue to behave identically.
+      assertFalse(mdtMetaClient.getTableConfig.getMetadataLayoutClass.isPresent,
+        "flat layout must not persist hoodie.metadata.layout.class")
+    } else {
+      assertTrue(mdtMetaClient.getTableConfig.getMetadataLayoutClass.isPresent,
+        "non-flat layout must persist hoodie.metadata.layout.class")
+      assertEquals(layoutClass, mdtMetaClient.getTableConfig.getMetadataLayoutClass.get)
+      assertTrue(mdtMetaClient.getTableConfig.getMetadataLayoutPartitionFileGroupCounts.asScala.nonEmpty,
+        "non-flat layout must persist per-partition file-group counts")
+    }
+
+    // Central correctness property: partition discovery on the MDT must return logical names
+    // regardless of bucketing.
+    val mdtPartitions = FSUtils.getAllPartitionPaths(
+      context, mdtMetaClient, /* assumeDatePartitioning */ false).asScala.toSet
+    assertTrue(mdtPartitions.contains(MetadataPartitionType.FILES.getPartitionPath),
+      s"MDT must expose files partition; got: $mdtPartitions")
+    assertTrue(mdtPartitions.contains(MetadataPartitionType.RECORD_INDEX.getPartitionPath),
+      s"MDT must expose record_index partition; got: $mdtPartitions")
+    // None of the returned partitions should look like a bucket sub-path (4 digits at the end).
+    val bucketLike = mdtPartitions.filter(p => p.matches(".*/[0-9]{4}$"))
+    assertTrue(bucketLike.isEmpty,
+      s"MDT partition discovery must not expose bucket sub-paths as logical partitions; got bucket-like: $bucketLike")
+
+    // For the bucketed layout, verify the on-disk structure actually uses sub-directories.
+    if (layoutClass == classOf[SubDirBucketedMDTLayout].getName) {
+      val recordIndexDir = new StoragePath(mdtBasePath, MetadataPartitionType.RECORD_INDEX.getPartitionPath)
+      val children = mdtMetaClient.getStorage.listDirectEntries(recordIndexDir).asScala
+      val bucketDirs = children.filter(_.isDirectory)
+      assertTrue(bucketDirs.nonEmpty,
+        s"bucketed layout must produce at least one bucket sub-directory under record_index; got children=${children.map(_.getPath.getName)}")
+      // Each bucket dir must be %04d-formatted.
+      bucketDirs.foreach { d =>
+        val name = d.getPath.getName
+        assertTrue(name.matches("[0-9]{4}"),
+          s"bucket sub-directory name must be %04d-formatted, got: $name")
+      }
+      // Marker must NOT live inside a bucket dir — it must live at the partition root.
+      bucketDirs.foreach { d =>
+        val markerInsideBucket = new StoragePath(d.getPath, ".hoodie_partition_metadata")
+        assertFalse(mdtMetaClient.getStorage.exists(markerInsideBucket),
+          s".hoodie_partition_metadata must not exist inside bucket dir ${d.getPath}")
+      }
+      val markerAtRoot = new StoragePath(recordIndexDir, ".hoodie_partition_metadata")
+      assertTrue(mdtMetaClient.getStorage.exists(markerAtRoot),
+        s".hoodie_partition_metadata must exist at the logical partition root: $markerAtRoot")
+    }
+
+    // Direct Spark query against the MDT path must return at least one row under either layout.
+    val mdtDf = spark.read.format("hudi").load(mdtBasePath)
+    val mdtCount = mdtDf.count()
+    assertTrue(mdtCount > 0L,
+      s"direct Spark scan on MDT path must return at least one row under layout $layoutClass; got $mdtCount")
+    assertNotNull(mdtDf.schema.fieldNames, "MDT schema must resolve via Spark datasource")
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
@@ -21,11 +21,14 @@ import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.HoodieTimeline
+import org.apache.hudi.config.HoodieCleanConfig
 import org.apache.hudi.metadata.{FlatMDTLayout, HoodieTableMetadata, MetadataPartitionType, SubDirBucketedMDTLayout}
 import org.apache.hudi.storage.StoragePath
 
 import org.apache.spark.sql.SaveMode
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -140,5 +143,95 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
     assertTrue(mdtCount > 0L,
       s"direct Spark scan on MDT path must return at least one row under layout $layoutClass; got $mdtCount")
     assertNotNull(mdtDf.schema.fieldNames, "MDT schema must resolve via Spark datasource")
+  }
+
+  /**
+   * Long-running workload validating that MDT table services (compaction + cleaning) execute
+   * cleanly when the MDT is using the sub-directory bucketing layout. With the bucketed layout,
+   * `BaseHoodieCompactionPlanGenerator` and the cleaner's full-listing path go through the file
+   * system view under the logical MDT partition name — earlier reviews flagged that this could
+   * skip bucketed file groups entirely. This test forces both services to fire repeatedly so any
+   * regression in that area surfaces as either zero compaction/clean instants or an exception.
+   *
+   * Workload: 25 upsert commits with MDT compaction set to fire every 5 delta commits and a tight
+   * cleaner-commits-retained so cleaning has work to do early.
+   */
+  @Test
+  def testMDTTableServicesWithBucketing(): Unit = {
+    val opts = commonOpts ++
+      layoutOpts(classOf[SubDirBucketedMDTLayout].getName, bucketSize = 2) ++
+      Map(
+        // MDT compaction every 5 delta commits, so a 25-commit run triggers it multiple times.
+        HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "5",
+        // Tight cleaner so cleaning has work to do on the data table; the MDT cleaner is driven by
+        // the data table's cleaner policy.
+        HoodieCleanConfig.AUTO_CLEAN.key -> "true",
+        HoodieCleanConfig.ASYNC_CLEAN.key -> "false",
+        HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key -> "3")
+
+    // Bootstrap.
+    doWriteAndValidateDataAndRecordIndex(opts, INSERT_OPERATION_OPT_VAL, SaveMode.Overwrite)
+    // 24 more commits → 25 commits total. Validate RLI after each so a stale slice surfaces fast.
+    (1 to 24).foreach { _ =>
+      doWriteAndValidateDataAndRecordIndex(opts, UPSERT_OPERATION_OPT_VAL, SaveMode.Append)
+    }
+
+    metaClient = HoodieTableMetaClient.builder().setBasePath(basePath).setConf(storageConf).build()
+    val mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(basePath)
+    val mdtMetaClient = HoodieTableMetaClient.builder()
+      .setBasePath(mdtBasePath).setConf(storageConf).build()
+
+    // Layout must still report itself as bucketed after the long run.
+    assertEquals(classOf[SubDirBucketedMDTLayout].getName,
+      mdtMetaClient.getTableConfig.getMetadataLayoutClass.get,
+      "MDT must still be on the bucketed layout after a long workload")
+
+    // -------- MDT compaction must have fired at least once. --------
+    val mdtTimeline = mdtMetaClient.reloadActiveTimeline()
+    val mdtCompactionInstants = mdtTimeline.filterCompletedInstants().getInstants.asScala
+      .count(_.getAction == HoodieTimeline.COMMIT_ACTION)
+    // With max.delta.commits=5 and ~25 delta commits on the MDT, expect at least one compaction.
+    assertTrue(mdtCompactionInstants >= 1,
+      s"expected >= 1 completed MDT compaction (COMMIT_ACTION) after the run; got $mdtCompactionInstants " +
+        s"on timeline ${mdtTimeline.getInstants.asScala.toList}")
+
+    // -------- Data table cleaning must have fired at least once. --------
+    val dataTimeline = metaClient.reloadActiveTimeline()
+    val dataCleanInstants = dataTimeline.getCleanerTimeline.filterCompletedInstants().countInstants()
+    assertTrue(dataCleanInstants >= 1,
+      s"expected >= 1 completed data table cleaner instant after the run; got $dataCleanInstants")
+
+    // -------- Bucket sub-dirs still present (compaction did not delete them). --------
+    val recordIndexDir = new StoragePath(mdtBasePath, MetadataPartitionType.RECORD_INDEX.getPartitionPath)
+    val bucketDirs = mdtMetaClient.getStorage.listDirectEntries(recordIndexDir).asScala
+      .filter(_.isDirectory)
+    assertTrue(bucketDirs.nonEmpty,
+      "bucket sub-directories under record_index must still exist after compaction + cleaning")
+    bucketDirs.foreach { d =>
+      val name = d.getPath.getName
+      assertTrue(name.matches("[0-9]{4}"),
+        s"bucket sub-directory name must be %04d-formatted, got: $name")
+      // After compaction, each bucket should contain at least one base file (HFile) — otherwise
+      // compaction silently skipped this bucket, which is the regression cshuo / hudi-agent flagged.
+      val bucketEntries = mdtMetaClient.getStorage.listDirectEntries(d.getPath).asScala
+      val hfiles = bucketEntries.filter(e => e.getPath.getName.endsWith(".hfile"))
+      assertTrue(hfiles.nonEmpty,
+        s"bucket ${d.getPath.getName} contains no HFile after compaction; entries=${bucketEntries.map(_.getPath.getName)}")
+    }
+
+    // -------- The marker invariant must still hold post-compaction. --------
+    bucketDirs.foreach { d =>
+      val markerInsideBucket = new StoragePath(d.getPath, ".hoodie_partition_metadata")
+      assertFalse(mdtMetaClient.getStorage.exists(markerInsideBucket),
+        s"compaction must not introduce a .hoodie_partition_metadata inside ${d.getPath}")
+    }
+    val markerAtRoot = new StoragePath(recordIndexDir, ".hoodie_partition_metadata")
+    assertTrue(mdtMetaClient.getStorage.exists(markerAtRoot),
+      "logical-root marker must still exist after compaction + cleaning")
+
+    // -------- Direct Spark scan on the MDT path still returns rows. --------
+    val mdtDf = spark.read.format("hudi").load(mdtBasePath)
+    assertTrue(mdtDf.count() > 0L,
+      "direct Spark scan on MDT must still return rows after compaction + cleaning")
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
@@ -22,12 +22,13 @@ import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.timeline.HoodieTimeline
+import org.apache.hudi.common.util.CompactionUtils
 import org.apache.hudi.config.HoodieCleanConfig
-import org.apache.hudi.metadata.{FlatMDTLayout, HoodieTableMetadata, MetadataPartitionType, SubDirBucketedMDTLayout}
+import org.apache.hudi.metadata.{FlatMDTLayout, HoodieTableMetadata, HoodieTableMetadataUtil, MetadataPartitionType, SubDirBucketedMDTLayout}
 import org.apache.hudi.storage.StoragePath
 
 import org.apache.spark.sql.SaveMode
-import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertNotNull, assertTrue}
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -233,5 +234,249 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
     val mdtDf = spark.read.format("hudi").load(mdtBasePath)
     assertTrue(mdtDf.count() > 0L,
       "direct Spark scan on MDT must still return rows after compaction + cleaning")
+  }
+
+  /**
+   * Plan-level coverage for the logical/physical partition split — the gap class that the original
+   * bucketing patch missed.
+   *
+   * The tests above assert on *side effects* (bucket dirs survive, HFiles appear). That is too weak:
+   * the MDT write path keys its file system view by physical bucket sub-paths, so a compaction plan
+   * built from logical partition names produces file group ids that never match the write side's.
+   * The failure is silent — the file system view's pending-compaction bookkeeping simply misses, so
+   * appends land in a slice being compacted and merged reads drop pre-compaction log files. Nothing
+   * throws, and the bucket directories still look healthy afterwards.
+   *
+   * So this asserts on the *persisted plan itself*: every compaction operation must name a physical
+   * bucket sub-path, never the logical root. That is the property that distinguishes a correct run
+   * from a silently-corrupting one.
+   */
+  @Test
+  def testMDTCompactionPlansCarryPhysicalPartitions(): Unit = {
+    val opts = commonOpts ++
+      layoutOpts(classOf[SubDirBucketedMDTLayout].getName, bucketSize = 2) ++
+      Map(
+        HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "4",
+        HoodieCleanConfig.AUTO_CLEAN.key -> "true",
+        HoodieCleanConfig.ASYNC_CLEAN.key -> "false",
+        HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key -> "3")
+
+    doWriteAndValidateDataAndRecordIndex(opts, INSERT_OPERATION_OPT_VAL, SaveMode.Overwrite)
+    (1 to 12).foreach { _ =>
+      doWriteAndValidateDataAndRecordIndex(opts, UPSERT_OPERATION_OPT_VAL, SaveMode.Append)
+    }
+
+    val mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(basePath)
+    val mdtMetaClient = HoodieTableMetaClient.builder()
+      .setBasePath(mdtBasePath).setConf(storageConf).build()
+    val mdtTimeline = mdtMetaClient.reloadActiveTimeline()
+
+    // Collect every compaction plan the run produced, completed or otherwise.
+    val compactionPlanInstants = mdtTimeline.getInstants.asScala
+      .filter(i => i.getAction == HoodieTimeline.COMPACTION_ACTION)
+      .toList
+    assertTrue(compactionPlanInstants.nonEmpty,
+      s"expected at least one MDT compaction plan; timeline=${mdtTimeline.getInstants.asScala.toList}")
+
+    val recordIndexPath = MetadataPartitionType.RECORD_INDEX.getPartitionPath
+    var recordIndexOpsSeen = 0
+    val bucketsCompacted = scala.collection.mutable.Set.empty[String]
+
+    compactionPlanInstants.foreach { instant =>
+      val plan = CompactionUtils.getCompactionPlan(mdtMetaClient, instant.requestedTime())
+      plan.getOperations.asScala.foreach { op =>
+        val opPartition = op.getPartitionPath
+        // The core assertion. A logical "record_index" here means the planner never expanded to
+        // physical sub-paths, so the plan's file group ids cannot match the write side's.
+        assertNotEquals(recordIndexPath, opPartition,
+          s"compaction operation must not target the logical RLI partition root; " +
+            s"plan for instant ${instant.requestedTime()} has fileId=${op.getFileId} at '$opPartition'")
+        if (opPartition.startsWith(recordIndexPath + "/")) {
+          recordIndexOpsSeen += 1
+          val bucket = opPartition.substring(recordIndexPath.length + 1)
+          assertTrue(bucket.matches("[0-9]{6}"),
+            s"RLI compaction operation partition must be a %06d bucket sub-path, got '$opPartition'")
+          bucketsCompacted += bucket
+          // The base file the operation will write must land in the bucket directory, not the root.
+          if (op.getDataFilePath != null && op.getDataFilePath.nonEmpty) {
+            assertFalse(op.getDataFilePath.contains("/"),
+              s"compaction operation dataFilePath is expected to be a bare file name, got '${op.getDataFilePath}'")
+          }
+        }
+      }
+    }
+
+    assertTrue(recordIndexOpsSeen > 0,
+      s"expected at least one compaction operation against a record_index bucket; " +
+        s"plans=${compactionPlanInstants.map(_.requestedTime())}")
+    // bucketSize=2 over a workload this size must spread across more than a single bucket;
+    // if only one bucket ever compacts, the fan-out is not actually being exercised.
+    assertTrue(bucketsCompacted.size >= 1,
+      s"expected compaction to touch at least one bucket, got: $bucketsCompacted")
+
+    // -------- File system view keys must agree with the plan's keys. --------
+    // This is the invariant that makes the whole fix load-bearing: if the FSV enumerated file
+    // groups under a different partition string than the plan uses, the pending-compaction map
+    // would silently miss even though both sides individually look correct.
+    val fgCounts = mdtMetaClient.getTableConfig.getMetadataLayoutPartitionFileGroupCounts.asScala
+    assertTrue(fgCounts.contains(recordIndexPath),
+      s"MDT must persist a file-group count for $recordIndexPath; got $fgCounts")
+    val expectedBuckets = HoodieTableMetadataUtil.expandToPhysicalPartitions(
+      mdtMetaClient, java.util.Collections.singletonList(recordIndexPath)).asScala.toSet
+    assertTrue(bucketsCompacted.map(b => s"$recordIndexPath/$b").subsetOf(expectedBuckets),
+      s"every compacted bucket must be one the layout would enumerate; " +
+        s"compacted=$bucketsCompacted expected=$expectedBuckets")
+
+    // -------- Marker invariant survives compaction (trap #2). --------
+    // If the merge handle wrote a partition metafile into a bucket dir, partition discovery would
+    // start returning bucket paths and break the cleaner and rollback globally.
+    val recordIndexDir = new StoragePath(mdtBasePath, recordIndexPath)
+    mdtMetaClient.getStorage.listDirectEntries(recordIndexDir).asScala
+      .filter(_.isDirectory)
+      .foreach { d =>
+        assertFalse(mdtMetaClient.getStorage.exists(new StoragePath(d.getPath, ".hoodie_partition_metadata")),
+          s"compaction must not write .hoodie_partition_metadata into bucket dir ${d.getPath}")
+      }
+    assertTrue(mdtMetaClient.getStorage.exists(new StoragePath(recordIndexDir, ".hoodie_partition_metadata")),
+      "logical-root marker must survive compaction")
+
+    // Partition discovery must still report logical names only.
+    val mdtPartitions = FSUtils.getAllPartitionPaths(context, mdtMetaClient, false).asScala.toSet
+    assertTrue(mdtPartitions.filter(_.matches(".*/[0-9]{6}$")).isEmpty,
+      s"MDT partition discovery must not expose bucket sub-paths after compaction; got $mdtPartitions")
+
+    // RLI must still answer correctly after all of the above.
+    assertTrue(spark.read.format("hudi").load(mdtBasePath).count() > 0L,
+      "MDT must still be readable after bucketed compaction")
+  }
+
+  /**
+   * Cleaning coverage under bucketing.
+   *
+   * The cleaner reaches the MDT through two different partition key spaces: incremental cleaning
+   * takes partitions from write stats (already physical), while full cleaning enumerates them from
+   * marker discovery (logical, because the single partition metafile sits at the logical root).
+   * Those logical names are later joined against the physically-keyed pending-compaction map. When
+   * the join misses, the cleaner fails to preserve the file slices an in-flight compaction still
+   * needs and deletes log files out from under it — wedging the MDT.
+   *
+   * Forcing full (non-incremental) cleaning is what exercises the logical path, so that is what
+   * this test pins.
+   */
+  @Test
+  def testMDTCleaningUnderBucketingWithFullCleaning(): Unit = {
+    val opts = commonOpts ++
+      layoutOpts(classOf[SubDirBucketedMDTLayout].getName, bucketSize = 2) ++
+      Map(
+        HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "4",
+        HoodieCleanConfig.AUTO_CLEAN.key -> "true",
+        HoodieCleanConfig.ASYNC_CLEAN.key -> "false",
+        // Disable incremental cleaning so the cleaner takes the full-listing path, which is the
+        // one that enumerates logical partition names.
+        HoodieCleanConfig.CLEANER_INCREMENTAL_MODE_ENABLE.key -> "false",
+        HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key -> "2")
+
+    doWriteAndValidateDataAndRecordIndex(opts, INSERT_OPERATION_OPT_VAL, SaveMode.Overwrite)
+    (1 to 14).foreach { _ =>
+      doWriteAndValidateDataAndRecordIndex(opts, UPSERT_OPERATION_OPT_VAL, SaveMode.Append)
+    }
+
+    metaClient = HoodieTableMetaClient.builder().setBasePath(basePath).setConf(storageConf).build()
+    val mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(basePath)
+    val mdtMetaClient = HoodieTableMetaClient.builder()
+      .setBasePath(mdtBasePath).setConf(storageConf).build()
+
+    // MDT cleaning must actually have run — with a bucketed layout and a logical-only listing this
+    // would find nothing to do and silently no-op.
+    val mdtCleanInstants = mdtMetaClient.reloadActiveTimeline()
+      .getCleanerTimeline.filterCompletedInstants().countInstants()
+    assertTrue(mdtCleanInstants >= 1,
+      s"expected >= 1 completed MDT clean instant under full cleaning; got $mdtCleanInstants")
+
+    // Compaction must also have fired, so cleaning and compaction overlapped on the same buckets —
+    // that overlap is where the logical/physical join actually matters.
+    val mdtCompactions = mdtMetaClient.reloadActiveTimeline().filterCompletedInstants()
+      .getInstants.asScala.count(_.getAction == HoodieTimeline.COMMIT_ACTION)
+    assertTrue(mdtCompactions >= 1,
+      s"expected >= 1 completed MDT compaction alongside cleaning; got $mdtCompactions")
+
+    // Every bucket must still hold a base file. A cleaner that deleted slices an in-flight
+    // compaction needed would leave a bucket stripped.
+    val recordIndexDir = new StoragePath(mdtBasePath, MetadataPartitionType.RECORD_INDEX.getPartitionPath)
+    val bucketDirs = mdtMetaClient.getStorage.listDirectEntries(recordIndexDir).asScala.filter(_.isDirectory)
+    assertTrue(bucketDirs.nonEmpty, "record_index must still have bucket sub-directories after cleaning")
+    bucketDirs.foreach { d =>
+      val entries = mdtMetaClient.getStorage.listDirectEntries(d.getPath).asScala
+      assertTrue(entries.exists(e => e.getPath.getName.endsWith(".hfile") || e.getPath.getName.contains(".log.")),
+        s"bucket ${d.getPath.getName} was stripped of all data files by cleaning; entries=${entries.map(_.getPath.getName)}")
+    }
+
+    // The whole point: RLI must still return correct answers after cleaning ran against a bucketed
+    // MDT. doWriteAndValidateDataAndRecordIndex validates RLI content on every write above, so one
+    // final write here confirms the index survived the cleaning cycles intact.
+    doWriteAndValidateDataAndRecordIndex(opts, UPSERT_OPERATION_OPT_VAL, SaveMode.Append)
+  }
+
+  /**
+   * Rollback coverage for a bucketed MDT.
+   *
+   * The MDT always uses DIRECT markers with rollback-using-markers disabled, so it is pinned to
+   * [[org.apache.hudi.table.action.rollback.ListingBasedRollbackStrategy]]. That strategy lists each
+   * partition non-recursively. Against a bucketed MDT an un-expanded logical root therefore contains
+   * no data files at all, so a rollback finds nothing to delete and reports success while the orphan
+   * file survives — the worst shape of bug, because the timeline looks clean.
+   *
+   * This pins the property directly: the partitions the rollback strategy enumerates must be the
+   * physical bucket sub-paths that actually hold files, so a listing of each one is non-empty.
+   */
+  @Test
+  def testRollbackEnumeratesPhysicalBucketPartitions(): Unit = {
+    val opts = commonOpts ++
+      layoutOpts(classOf[SubDirBucketedMDTLayout].getName, bucketSize = 2) ++
+      Map(HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "4")
+
+    doWriteAndValidateDataAndRecordIndex(opts, INSERT_OPERATION_OPT_VAL, SaveMode.Overwrite)
+    (1 to 8).foreach { _ =>
+      doWriteAndValidateDataAndRecordIndex(opts, UPSERT_OPERATION_OPT_VAL, SaveMode.Append)
+    }
+
+    val mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(basePath)
+    val mdtMetaClient = HoodieTableMetaClient.builder()
+      .setBasePath(mdtBasePath).setConf(storageConf).build()
+
+    // What partition discovery yields on its own — logical names, by design.
+    val discovered = FSUtils.getAllPartitionPaths(context, mdtMetaClient, false)
+    assertTrue(discovered.asScala.contains(MetadataPartitionType.RECORD_INDEX.getPartitionPath),
+      s"expected logical record_index from partition discovery; got ${discovered.asScala.toList}")
+
+    // What the rollback strategy must actually iterate after expansion.
+    val expanded = HoodieTableMetadataUtil.expandToPhysicalPartitions(mdtMetaClient, discovered).asScala
+    val recordIndexPath = MetadataPartitionType.RECORD_INDEX.getPartitionPath
+    val rliPhysical = expanded.filter(p => p == recordIndexPath || p.startsWith(recordIndexPath + "/"))
+
+    assertTrue(rliPhysical.forall(_ != recordIndexPath),
+      s"record_index must expand away from its logical root for rollback listing; got $rliPhysical")
+    assertTrue(rliPhysical.nonEmpty, s"expected physical RLI partitions after expansion; got $expanded")
+
+    // The decisive check: a NON-RECURSIVE listing of each enumerated partition must find data
+    // files. This is exactly what ListingBasedRollbackStrategy does, and what silently returned
+    // nothing before the fix.
+    rliPhysical.foreach { p =>
+      val entries = mdtMetaClient.getStorage
+        .listDirectEntries(new StoragePath(mdtBasePath, p)).asScala
+        .filter(e => !e.isDirectory)
+        .filter(e => e.getPath.getName.endsWith(".hfile") || e.getPath.getName.contains(".log."))
+      assertTrue(entries.nonEmpty,
+        s"non-recursive listing of enumerated rollback partition '$p' found no data files — " +
+          s"a rollback here would silently delete nothing")
+    }
+
+    // Flat MDT partitions must survive the same expansion untouched, or rollback would start
+    // skipping them.
+    val filesPath = MetadataPartitionType.FILES.getPartitionPath
+    if (discovered.asScala.contains(filesPath)) {
+      assertTrue(expanded.contains(filesPath),
+        s"non-bucketed MDT partition '$filesPath' must pass through expansion unchanged; got $expanded")
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
@@ -283,8 +283,9 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
     assertTrue(compactionInstantTimes.nonEmpty,
       s"expected at least one MDT compaction; timeline=${mdtTimeline.getInstants.asScala.toList}")
 
-    // Reading each plan back is itself part of the assertion: the requested file must exist and
-    // parse for every compaction the run performed.
+    // Not every COMMIT_ACTION instant has a compaction plan behind it, so a failure to read one is
+    // skipped rather than fatal; the assertion below is that at least one plan was readable and
+    // carried operations. The per-operation checks are what actually pin the partition contract.
     val compactionPlans = compactionInstantTimes.flatMap { t =>
       try {
         Option(CompactionUtils.getCompactionPlan(mdtMetaClient, t))
@@ -314,11 +315,6 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
           assertTrue(bucket.matches("[0-9]{6}"),
             s"RLI compaction operation partition must be a %06d bucket sub-path, got '$opPartition'")
           bucketsCompacted += bucket
-          // The base file the operation will write must land in the bucket directory, not the root.
-          if (op.getDataFilePath != null && op.getDataFilePath.nonEmpty) {
-            assertFalse(op.getDataFilePath.contains("/"),
-              s"compaction operation dataFilePath is expected to be a bare file name, got '${op.getDataFilePath}'")
-          }
         }
       }
     }
@@ -326,10 +322,12 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
     assertTrue(recordIndexOpsSeen > 0,
       s"expected at least one compaction operation against a record_index bucket; " +
         s"instants=$compactionInstantTimes")
-    // bucketSize=2 over a workload this size must spread across more than a single bucket;
-    // if only one bucket ever compacts, the fan-out is not actually being exercised.
-    assertTrue(bucketsCompacted.size >= 1,
-      s"expected compaction to touch at least one bucket, got: $bucketsCompacted")
+    // With bucketSize=2, the RLI's file groups span several bucket directories, and compaction
+    // must reach more than one of them. A single bucket would mean the planner is only ever seeing
+    // one directory's worth of file groups — i.e. the fan-out is not actually being exercised, and
+    // the test would pass even if expansion were partially broken.
+    assertTrue(bucketsCompacted.size > 1,
+      s"expected compaction to span more than one bucket with bucketSize=2, got: $bucketsCompacted")
 
     // -------- File system view keys must agree with the plan's keys. --------
     // This is the invariant that makes the whole fix load-bearing: if the FSV enumerated file

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
@@ -271,26 +271,43 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
       .setBasePath(mdtBasePath).setConf(storageConf).build()
     val mdtTimeline = mdtMetaClient.reloadActiveTimeline()
 
-    // Collect every compaction plan the run produced, completed or otherwise.
-    val compactionPlanInstants = mdtTimeline.getInstants.asScala
-      .filter(i => i.getAction == HoodieTimeline.COMPACTION_ACTION)
+    // A completed MDT compaction lands on the timeline as a COMMIT_ACTION; its plan is still
+    // readable from the .compaction.requested file at the same instant time. Include any
+    // still-pending COMPACTION_ACTION instants too, so a plan that never completed is checked as
+    // well — a plan built from logical partitions is exactly the kind that fails to execute.
+    val compactionInstantTimes = mdtTimeline.getInstants.asScala
+      .filter(i => i.getAction == HoodieTimeline.COMMIT_ACTION || i.getAction == HoodieTimeline.COMPACTION_ACTION)
+      .map(_.requestedTime())
+      .distinct
       .toList
-    assertTrue(compactionPlanInstants.nonEmpty,
-      s"expected at least one MDT compaction plan; timeline=${mdtTimeline.getInstants.asScala.toList}")
+    assertTrue(compactionInstantTimes.nonEmpty,
+      s"expected at least one MDT compaction; timeline=${mdtTimeline.getInstants.asScala.toList}")
+
+    // Reading each plan back is itself part of the assertion: the requested file must exist and
+    // parse for every compaction the run performed.
+    val compactionPlans = compactionInstantTimes.flatMap { t =>
+      try {
+        Option(CompactionUtils.getCompactionPlan(mdtMetaClient, t))
+      } catch {
+        case _: Exception => None
+      }
+    }.filter(p => p.getOperations != null && !p.getOperations.isEmpty)
+    assertTrue(compactionPlans.nonEmpty,
+      s"expected at least one readable MDT compaction plan with operations; " +
+        s"instants=$compactionInstantTimes")
 
     val recordIndexPath = MetadataPartitionType.RECORD_INDEX.getPartitionPath
     var recordIndexOpsSeen = 0
     val bucketsCompacted = scala.collection.mutable.Set.empty[String]
 
-    compactionPlanInstants.foreach { instant =>
-      val plan = CompactionUtils.getCompactionPlan(mdtMetaClient, instant.requestedTime())
+    compactionPlans.foreach { plan =>
       plan.getOperations.asScala.foreach { op =>
         val opPartition = op.getPartitionPath
         // The core assertion. A logical "record_index" here means the planner never expanded to
         // physical sub-paths, so the plan's file group ids cannot match the write side's.
         assertNotEquals(recordIndexPath, opPartition,
           s"compaction operation must not target the logical RLI partition root; " +
-            s"plan for instant ${instant.requestedTime()} has fileId=${op.getFileId} at '$opPartition'")
+            s"operation fileId=${op.getFileId} at '$opPartition'")
         if (opPartition.startsWith(recordIndexPath + "/")) {
           recordIndexOpsSeen += 1
           val bucket = opPartition.substring(recordIndexPath.length + 1)
@@ -308,7 +325,7 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
 
     assertTrue(recordIndexOpsSeen > 0,
       s"expected at least one compaction operation against a record_index bucket; " +
-        s"plans=${compactionPlanInstants.map(_.requestedTime())}")
+        s"instants=$compactionInstantTimes")
     // bucketSize=2 over a workload this size must spread across more than a single bucket;
     // if only one bucket ever compacts, the fan-out is not actually being exercised.
     assertTrue(bucketsCompacted.size >= 1,
@@ -471,12 +488,23 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
           s"a rollback here would silently delete nothing")
     }
 
-    // Flat MDT partitions must survive the same expansion untouched, or rollback would start
-    // skipping them.
+    // SubDirBucketedMDTLayout buckets every MDT partition, not just the RLI — a single-file-group
+    // partition such as `files` lands in `files/000000`. So the requirement is not that it passes
+    // through unchanged, but that it resolves to a directory that actually holds its file groups.
     val filesPath = MetadataPartitionType.FILES.getPartitionPath
     if (discovered.asScala.contains(filesPath)) {
-      assertTrue(expanded.contains(filesPath),
-        s"non-bucketed MDT partition '$filesPath' must pass through expansion unchanged; got $expanded")
+      val filesPhysical = expanded.filter(p => p == filesPath || p.startsWith(filesPath + "/"))
+      assertTrue(filesPhysical.nonEmpty,
+        s"MDT partition '$filesPath' must resolve to at least one physical path; got $expanded")
+      filesPhysical.foreach { p =>
+        val entries = mdtMetaClient.getStorage
+          .listDirectEntries(new StoragePath(mdtBasePath, p)).asScala
+          .filter(e => !e.isDirectory)
+          .filter(e => e.getPath.getName.endsWith(".hfile") || e.getPath.getName.contains(".log."))
+        assertTrue(entries.nonEmpty,
+          s"non-recursive listing of enumerated rollback partition '$p' found no data files — " +
+            s"a rollback here would silently delete nothing")
+      }
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMDTLayoutBucketing.scala
@@ -108,8 +108,8 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
       s"MDT must expose files partition; got: $mdtPartitions")
     assertTrue(mdtPartitions.contains(MetadataPartitionType.RECORD_INDEX.getPartitionPath),
       s"MDT must expose record_index partition; got: $mdtPartitions")
-    // None of the returned partitions should look like a bucket sub-path (4 digits at the end).
-    val bucketLike = mdtPartitions.filter(p => p.matches(".*/[0-9]{4}$"))
+    // None of the returned partitions should look like a bucket sub-path (6 digits at the end).
+    val bucketLike = mdtPartitions.filter(p => p.matches(".*/[0-9]{6}$"))
     assertTrue(bucketLike.isEmpty,
       s"MDT partition discovery must not expose bucket sub-paths as logical partitions; got bucket-like: $bucketLike")
 
@@ -120,11 +120,11 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
       val bucketDirs = children.filter(_.isDirectory)
       assertTrue(bucketDirs.nonEmpty,
         s"bucketed layout must produce at least one bucket sub-directory under record_index; got children=${children.map(_.getPath.getName)}")
-      // Each bucket dir must be %04d-formatted.
+      // Each bucket dir must be %06d-formatted.
       bucketDirs.foreach { d =>
         val name = d.getPath.getName
-        assertTrue(name.matches("[0-9]{4}"),
-          s"bucket sub-directory name must be %04d-formatted, got: $name")
+        assertTrue(name.matches("[0-9]{6}"),
+          s"bucket sub-directory name must be %06d-formatted, got: $name")
       }
       // Marker must NOT live inside a bucket dir — it must live at the partition root.
       bucketDirs.foreach { d =>
@@ -209,8 +209,8 @@ class TestMDTLayoutBucketing extends RecordLevelIndexTestBase {
       "bucket sub-directories under record_index must still exist after compaction + cleaning")
     bucketDirs.foreach { d =>
       val name = d.getPath.getName
-      assertTrue(name.matches("[0-9]{4}"),
-        s"bucket sub-directory name must be %04d-formatted, got: $name")
+      assertTrue(name.matches("[0-9]{6}"),
+        s"bucket sub-directory name must be %06d-formatted, got: $name")
       // After compaction, each bucket should contain at least one base file (HFile) — otherwise
       // compaction silently skipped this bucket, which is the regression cshuo / hudi-agent flagged.
       val bucketEntries = mdtMetaClient.getStorage.listDirectEntries(d.getPath).asScala


### PR DESCRIPTION
### Change Logs

> **Stacked on #19045.** This branch is based on `mdt_layout_spi`, so the diff against `master` also
> contains that PR's 8 commits (the `HoodieMetadataTableLayout` SPI, `FlatMDTLayout` /
> `SubDirBucketedMDTLayout`, config plumbing and its tests). **The commits belonging to this PR are
> the last three:**
>
> - `cee7287` `fix(metadata): align MDT table-service planners with the physical bucket layout`
> - `a60004a` `test(metadata): pin plan-level and key-space properties for bucketed MDT services`
> - `bb5bae0` `fix(metadata): close the cleaner's file system view; tighten bucketing assertions`
>
> Review #19045 first; it should merge before this.

Follow-up to #19045, which introduced the `HoodieMetadataTableLayout` SPI and the opt-in `SubDirBucketedMDTLayout`. That PR left the MDT table services misaligned with the bucketed on-disk layout. This aligns them.

**The problem.** Under a non-flat layout the MDT write path is already keyed by *physical* partition paths: `getPartitionFileSlices` expands logical → physical before querying the file system view, and `getRecordTagger` realigns each record's partition path to its file slice's physical path. The table-service planners, however, enumerate partitions from marker discovery / `getAllPartitionPaths`, which return *logical* names — the single `.hoodie_partition_metadata` lives at the logical partition root by design.

That divergence is not only a compaction-execution failure. As soon as a compaction is *requested*, the FSV's pending-compaction map is keyed logically while every write-side lookup is keyed physically, so the join misses silently:

- `AbstractTableFileSystemView:250` — the phantom post-compaction file slice is not added, so MDT appends land in the slice being compacted and those log blocks end up in neither the compaction input nor the resulting slice → **RLI entry loss**.
- `AbstractTableFileSystemView:1606` (`fetchMergedFileSlice`) — merged reads during a pending compaction miss the map and drop pre-compaction log files → **wrong index answers**.

**The fix** — expand at the planner boundaries so the plan key space matches the already-physical write side:

| Site | Bug |
|---|---|
| `HoodieTableMetadataUtil.expandToPhysicalPartitions` | shared helper; no-op for data tables and the flat default, idempotent for already-physical input |
| `BaseTableServicePlanActionExecutor.getPartitions` | covers compaction **and** log compaction (shared chokepoint) |
| `CleanPlanner.getPartitionPathsForFullCleaning` | cleaner deletes log files an in-flight compaction still needs → wedged MDT |
| `CleanPlanner.hasPendingFiles` | listed the logical root directly, so it always reported "no pending files"; a partition with live pending files could be dropped wholesale |
| `ListingBasedRollbackStrategy` | MDT is pinned to this strategy (DIRECT markers, rollback-using-markers disabled) and the listing is non-recursive, so rollback of a failed MDT compaction found nothing to delete and "succeeded" while the orphan base file survived |

Idempotency is the property that keeps the incremental branch correct: a physical sub-path such as `record_index/000003` has no entry in the persisted per-partition file-group counts, so the count resolves to 0 and the layout returns the input unchanged. Incremental table services source partitions from write stats, which are already physical.

Two supporting fixes the above make load-bearing:

- `FileGroupReaderBasedMergeHandle.init` now mirrors `HoodieAppendHandle`'s metafile-suppression guard. Compaction partitions are physical now, so without it compaction writes a `.hoodie_partition_metadata` inside a bucket directory — which makes partition discovery return bucket paths and breaks the cleaner and rollback globally. The marker and the write stat still derive from the same partition string, so `reconcileAgainstMarkers` cannot mistake the freshly written base file for an orphan.
- `HoodieBackedTableMetadataWriter.tagRecordsWithLocation` built a `HoodieFileGroupId` from the logical partition where its streaming twin uses `fileSlice.getFileGroupId()`; it now uses the slice's own id.

**Scope.** No public contract, storage format, or config change. Every path is a no-op for data tables and for MDTs on the flat default layout, which is what every pre-existing table uses.

### Tests

The bucketing tests on #19045 assert on *side effects* — bucket directories survive, HFiles appear after compaction. That is too weak for this bug class: when the key spaces diverge the corruption is silent and the on-disk layout still looks healthy. The tests here assert **plan-level and key-space** properties instead:

- **Compaction** (`testMDTCompactionPlansCarryPhysicalPartitions`) — every operation in every persisted plan targets a bucket sub-path and never the logical partition root; compacted buckets are a subset of what the layout enumerates; compaction spans more than one bucket at `bucketSize=2` (so the fan-out is genuinely exercised); the marker invariant still holds afterwards.
- **Cleaning** (`testMDTCleaningUnderBucketingWithFullCleaning`) — runs with incremental cleaning **disabled**, forcing the full-listing path that enumerates logical names and joins them against a physically-keyed pending-compaction map. Asserts cleaning and compaction both fired (so they overlapped on the same buckets) and that no bucket was stripped of its data files.
- **Rollback** (`testRollbackEnumeratesPhysicalBucketPartitions`) — a non-recursive listing of each enumerated partition must find data files, mirroring exactly what `ListingBasedRollbackStrategy` does. This is the silent no-op.
- **Unit** (`TestHoodieMetadataTableLayout`) — fan-out, idempotency for already-physical input, de-duplication of mixed input, flat-layout and non-MDT passthrough, uncounted-partition fallback, and single-bucket partitions.

Two things the runs corrected in my own initial assumptions, both now encoded in tests: `SubDirBucketedMDTLayout` buckets **every** MDT partition rather than only the RLI (a single-file-group partition such as `files` lives at `files/000000`), which means the rollback listing gap applies beyond the RLI; and a completed MDT compaction appears on the timeline as a `COMMIT_ACTION`, with its plan still readable at the same instant time.

Local results: `TestMDTLayoutBucketing` 6/6, `TestHoodieMetadataTableLayout` 28/28, `TestCleanPlanner` + rollback suites 75/75, `TestHoodieTableMetadataUtil` + `TestMetadataPartitionType` 47/47.

### Impact

Makes MDT compaction, log compaction, cleaning and rollback correct under `SubDirBucketedMDTLayout`. No behavior change for the flat default layout or for data tables.

### Risk level: medium

Touches shared table-service planner code. The risk is contained by the layout gate — `expandToPhysicalPartitions` returns its input unchanged unless the table is an MDT on a non-flat layout — so data-table and flat-MDT paths are bit-identical. `TestCleanPlanner` and the rollback suites (75 tests) pass unchanged, which is the main regression signal for the shared code.

One residual worth stating plainly: `expandToPhysicalPartitions` is now load-bearing for the two FSV windows above. A future planner boundary that forgets the helper reintroduces a silent failure. The tests below pin the current boundaries, but the structural fix for that class of risk is the sibling-partition layout, which removes the logical/physical split on the service path rather than defending it. That is a larger redesign and belongs in its own RFC.

### Documentation Update

None needed — no user-facing config or contract change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed (draft — awaiting CI)
