### PR TITLE
fix(bulk-insert): add write config constructors to all sort mode partitioners

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/BulkInsertPartitioner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/BulkInsertPartitioner.java
@@ -19,9 +19,13 @@
 package org.apache.hudi.table;
 
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode;
 import org.apache.hudi.io.WriteHandleFactory;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
 import java.io.Serializable;
 
@@ -70,5 +74,33 @@ public interface BulkInsertPartitioner<I> extends Serializable {
    */
   default Option<WriteHandleFactory> getWriteHandleFactory(int partitionId) {
     return Option.empty();
+  }
+
+  /**
+   * Whether the records being written carry a partition path, derived from the write config alone.
+   * <p>
+   * A partitioner named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME} is instantiated by
+   * reflection with only the write config, so an implementation that otherwise takes the flag from
+   * the {@link HoodieTable} has nothing else to derive it from.
+   * <p>
+   * The factory path takes the flag from {@link HoodieTable#isPartitioned()}, which reads
+   * {@link HoodieTableConfig#PARTITION_FIELDS}. This prefers that same property, evaluated by
+   * {@link HoodieTableConfig#getPartitionFields}, so a user defined use of these partitioners
+   * repartitions the way the built in sort mode does whenever the table properties reached the
+   * write config. Only when that property is absent does it fall back to the write side partition
+   * path field, which is the best available signal for whether records will carry a non-empty
+   * partition path.
+   *
+   * @param config Write config.
+   * @return {@code true} if the table is partitioned; {@code false} otherwise.
+   */
+  static boolean isTablePartitioned(HoodieWriteConfig config) {
+    Option<String[]> partitionFields = HoodieTableConfig.getPartitionFields(config);
+    if (partitionFields.isPresent()) {
+      return partitionFields.get().length > 0;
+    }
+    return !StringUtils.isNullOrEmpty(
+        config.getProps().getProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()));
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/BulkInsertPartitioner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/BulkInsertPartitioner.java
@@ -20,8 +20,11 @@ package org.apache.hudi.table;
 
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode;
 import org.apache.hudi.io.WriteHandleFactory;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
 import java.io.Serializable;
 
@@ -70,5 +73,23 @@ public interface BulkInsertPartitioner<I> extends Serializable {
    */
   default Option<WriteHandleFactory> getWriteHandleFactory(int partitionId) {
     return Option.empty();
+  }
+
+  /**
+   * Whether the records being written carry a partition path, derived from the write config alone.
+   * <p>
+   * A partitioner named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME} is instantiated by
+   * reflection with only the write config, so an implementation that otherwise takes the flag from
+   * the {@link HoodieTable} has nothing else to derive it from. The write side partition path field
+   * governs whether records end up with a non-empty partition path, which is what those
+   * implementations branch on.
+   *
+   * @param config Write config.
+   * @return {@code true} if a partition path field is configured; {@code false} otherwise.
+   */
+  static boolean isTablePartitioned(HoodieWriteConfig config) {
+    return !StringUtils.isNullOrEmpty(
+        config.getProps().getProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()));
   }
 }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaGlobalSortPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaGlobalSortPartitioner.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import java.util.Comparator;
@@ -33,6 +34,19 @@ import java.util.List;
  */
 public class JavaGlobalSortPartitioner<T>
     implements BulkInsertPartitioner<List<HoodieRecord<T>>> {
+
+  public JavaGlobalSortPartitioner() {
+  }
+
+  /**
+   * Constructor taking the write config, so this partitioner can also be named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}, which is
+   * instantiated by reflection with only the write config. Nothing here is configurable.
+   *
+   * @param config Write config, unused.
+   */
+  public JavaGlobalSortPartitioner(HoodieWriteConfig config) {
+  }
 
   @Override
   public List<HoodieRecord<T>> repartitionRecords(List<HoodieRecord<T>> records,

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaGlobalSortPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaGlobalSortPartitioner.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import java.util.Comparator;
@@ -33,6 +34,18 @@ import java.util.List;
  */
 public class JavaGlobalSortPartitioner<T>
     implements BulkInsertPartitioner<List<HoodieRecord<T>>> {
+
+  public JavaGlobalSortPartitioner() {
+  }
+
+  /**
+   * Constructor for reflection-based instantiation via
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}.
+   *
+   * @param config Write config, unused.
+   */
+  public JavaGlobalSortPartitioner(HoodieWriteConfig config) {
+  }
 
   @Override
   public List<HoodieRecord<T>> repartitionRecords(List<HoodieRecord<T>> records,

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaNonSortPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaNonSortPartitioner.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import java.util.List;
@@ -31,6 +32,18 @@ import java.util.List;
  */
 public class JavaNonSortPartitioner<T>
     implements BulkInsertPartitioner<List<HoodieRecord<T>>> {
+
+  public JavaNonSortPartitioner() {
+  }
+
+  /**
+   * Constructor for reflection-based instantiation via
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}.
+   *
+   * @param config Write config, unused.
+   */
+  public JavaNonSortPartitioner(HoodieWriteConfig config) {
+  }
 
   @Override
   public List<HoodieRecord<T>> repartitionRecords(List<HoodieRecord<T>> records,

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaNonSortPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/execution/bulkinsert/JavaNonSortPartitioner.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import java.util.List;
@@ -31,6 +32,19 @@ import java.util.List;
  */
 public class JavaNonSortPartitioner<T>
     implements BulkInsertPartitioner<List<HoodieRecord<T>>> {
+
+  public JavaNonSortPartitioner() {
+  }
+
+  /**
+   * Constructor taking the write config, so this partitioner can also be named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}, which is
+   * instantiated by reflection with only the write config. Nothing here is configurable.
+   *
+   * @param config Write config, unused.
+   */
+  public JavaNonSortPartitioner(HoodieWriteConfig config) {
+  }
 
   @Override
   public List<HoodieRecord<T>> repartitionRecords(List<HoodieRecord<T>> records,

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestJavaBulkInsertInternalPartitionerFactory.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestJavaBulkInsertInternalPartitionerFactory.java
@@ -18,10 +18,14 @@
 
 package org.apache.hudi.execution.bulkinsert;
 
+import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -41,6 +45,29 @@ public class TestJavaBulkInsertInternalPartitionerFactory {
   void globalSortModeReturnsGlobalSortPartitioner() {
     BulkInsertPartitioner partitioner = JavaBulkInsertInternalPartitionerFactory.get(BulkInsertSortMode.GLOBAL_SORT);
     assertInstanceOf(JavaGlobalSortPartitioner.class, partitioner);
+  }
+
+  /**
+   * A partitioner named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME} is instantiated by
+   * reflection with only the write config, so every partitioner backing an out of the box sort
+   * mode has to expose a constructor taking only one. See HUDI-7526.
+   */
+  @ParameterizedTest
+  @ValueSource(classes = {JavaNonSortPartitioner.class, JavaGlobalSortPartitioner.class})
+  void sortModePartitionersTakeWriteConfig(Class<?> partitionerClass) {
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath("/").build();
+    Object partitioner = ReflectionUtils.loadClass(partitionerClass.getName(), config);
+    assertInstanceOf(BulkInsertPartitioner.class, partitioner);
+  }
+
+  /**
+   * Declaring the write config constructor drops the implicit no-arg one, which the factory uses.
+   */
+  @ParameterizedTest
+  @ValueSource(classes = {JavaNonSortPartitioner.class, JavaGlobalSortPartitioner.class})
+  void sortModePartitionersKeepNoArgConstructor(Class<?> partitionerClass) {
+    assertInstanceOf(BulkInsertPartitioner.class, ReflectionUtils.loadClass(partitionerClass.getName()));
   }
 
   @Test

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/NonSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/NonSortPartitioner.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.api.java.JavaRDD;
@@ -44,6 +45,18 @@ public class NonSortPartitioner<T>
    * Default constructor without enforcing the number of output partitions.
    */
   public NonSortPartitioner() {
+    this(false);
+  }
+
+  /**
+   * Constructor taking the write config, so this partitioner can also be named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}, which is
+   * instantiated by reflection with only the write config. Nothing here is configurable, so
+   * this behaves as the default constructor does.
+   *
+   * @param config Write config, unused.
+   */
+  public NonSortPartitioner(HoodieWriteConfig config) {
     this(false);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/NonSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/NonSortPartitioner.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.execution.bulkinsert;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.api.java.JavaRDD;
@@ -44,6 +45,16 @@ public class NonSortPartitioner<T>
    * Default constructor without enforcing the number of output partitions.
    */
   public NonSortPartitioner() {
+    this(false);
+  }
+
+  /**
+   * Constructor for reflection-based instantiation via
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}.
+   *
+   * @param config Write config, unused.
+   */
+  public NonSortPartitioner(HoodieWriteConfig config) {
     this(false);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/NonSortPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/NonSortPartitionerWithRows.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.execution.bulkinsert;
 
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.sql.Dataset;
@@ -41,6 +42,16 @@ public class NonSortPartitionerWithRows implements BulkInsertPartitioner<Dataset
    * Default constructor without enforcing the number of output partitions.
    */
   public NonSortPartitionerWithRows() {
+    this(false);
+  }
+
+  /**
+   * Constructor for reflection-based instantiation via
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}.
+   *
+   * @param config Write config, unused.
+   */
+  public NonSortPartitionerWithRows(HoodieWriteConfig config) {
     this(false);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/NonSortPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/NonSortPartitionerWithRows.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.execution.bulkinsert;
 
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import org.apache.spark.sql.Dataset;
@@ -41,6 +42,18 @@ public class NonSortPartitionerWithRows implements BulkInsertPartitioner<Dataset
    * Default constructor without enforcing the number of output partitions.
    */
   public NonSortPartitionerWithRows() {
+    this(false);
+  }
+
+  /**
+   * Constructor taking the write config, so this partitioner can also be named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}, which is
+   * instantiated by reflection with only the write config. Nothing here is configurable, so
+   * this behaves as the default constructor does.
+   *
+   * @param config Write config, unused.
+   */
+  public NonSortPartitionerWithRows(HoodieWriteConfig config) {
     this(false);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitioner.java
@@ -51,6 +51,16 @@ public class PartitionPathRepartitionAndSortPartitioner<T extends HoodieRecordPa
   private final boolean isTablePartitioned;
   private final boolean shouldPopulateMetaFields;
 
+  /**
+   * Constructor for reflection-based instantiation via
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}.
+   *
+   * @param config Write config.
+   */
+  public PartitionPathRepartitionAndSortPartitioner(HoodieWriteConfig config) {
+    this(BulkInsertPartitioner.isTablePartitioned(config), config);
+  }
+
   public PartitionPathRepartitionAndSortPartitioner(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
     this.shouldPopulateMetaFields = config.populateMetaFields();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitioner.java
@@ -51,6 +51,17 @@ public class PartitionPathRepartitionAndSortPartitioner<T extends HoodieRecordPa
   private final boolean isTablePartitioned;
   private final boolean shouldPopulateMetaFields;
 
+  /**
+   * Constructor taking only the write config, so this partitioner can also be named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}, which is
+   * instantiated by reflection with only the write config.
+   *
+   * @param config Write config.
+   */
+  public PartitionPathRepartitionAndSortPartitioner(HoodieWriteConfig config) {
+    this(BulkInsertPartitioner.isTablePartitioned(config), config);
+  }
+
   public PartitionPathRepartitionAndSortPartitioner(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
     this.shouldPopulateMetaFields = config.populateMetaFields();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitionerWithRows.java
@@ -47,6 +47,17 @@ public class PartitionPathRepartitionAndSortPartitionerWithRows implements BulkI
   private final boolean isTablePartitioned;
   private final boolean shouldPopulateMetaFields;
 
+  /**
+   * Constructor taking only the write config, so this partitioner can also be named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}, which is
+   * instantiated by reflection with only the write config.
+   *
+   * @param config Write config.
+   */
+  public PartitionPathRepartitionAndSortPartitionerWithRows(HoodieWriteConfig config) {
+    this(BulkInsertPartitioner.isTablePartitioned(config), config);
+  }
+
   public PartitionPathRepartitionAndSortPartitionerWithRows(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
     this.shouldPopulateMetaFields = config.populateMetaFields();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionAndSortPartitionerWithRows.java
@@ -47,6 +47,16 @@ public class PartitionPathRepartitionAndSortPartitionerWithRows implements BulkI
   private final boolean isTablePartitioned;
   private final boolean shouldPopulateMetaFields;
 
+  /**
+   * Constructor for reflection-based instantiation via
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}.
+   *
+   * @param config Write config.
+   */
+  public PartitionPathRepartitionAndSortPartitionerWithRows(HoodieWriteConfig config) {
+    this(BulkInsertPartitioner.isTablePartitioned(config), config);
+  }
+
   public PartitionPathRepartitionAndSortPartitionerWithRows(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
     this.shouldPopulateMetaFields = config.populateMetaFields();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitioner.java
@@ -50,6 +50,17 @@ public class PartitionPathRepartitionPartitioner<T extends HoodieRecordPayload>
   private final boolean isTablePartitioned;
   private final boolean shouldPopulateMetaFields;
 
+  /**
+   * Constructor taking only the write config, so this partitioner can also be named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}, which is
+   * instantiated by reflection with only the write config.
+   *
+   * @param config Write config.
+   */
+  public PartitionPathRepartitionPartitioner(HoodieWriteConfig config) {
+    this(BulkInsertPartitioner.isTablePartitioned(config), config);
+  }
+
   public PartitionPathRepartitionPartitioner(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
     this.shouldPopulateMetaFields = config.populateMetaFields();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitioner.java
@@ -50,6 +50,16 @@ public class PartitionPathRepartitionPartitioner<T extends HoodieRecordPayload>
   private final boolean isTablePartitioned;
   private final boolean shouldPopulateMetaFields;
 
+  /**
+   * Constructor for reflection-based instantiation via
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}.
+   *
+   * @param config Write config.
+   */
+  public PartitionPathRepartitionPartitioner(HoodieWriteConfig config) {
+    this(BulkInsertPartitioner.isTablePartitioned(config), config);
+  }
+
   public PartitionPathRepartitionPartitioner(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
     this.shouldPopulateMetaFields = config.populateMetaFields();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitionerWithRows.java
@@ -46,6 +46,16 @@ public class PartitionPathRepartitionPartitionerWithRows implements BulkInsertPa
   private final boolean isTablePartitioned;
   private final boolean shouldPopulateMetaFields;
 
+  /**
+   * Constructor for reflection-based instantiation via
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}.
+   *
+   * @param config Write config.
+   */
+  public PartitionPathRepartitionPartitionerWithRows(HoodieWriteConfig config) {
+    this(BulkInsertPartitioner.isTablePartitioned(config), config);
+  }
+
   public PartitionPathRepartitionPartitionerWithRows(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
     this.shouldPopulateMetaFields = config.populateMetaFields();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRepartitionPartitionerWithRows.java
@@ -46,6 +46,17 @@ public class PartitionPathRepartitionPartitionerWithRows implements BulkInsertPa
   private final boolean isTablePartitioned;
   private final boolean shouldPopulateMetaFields;
 
+  /**
+   * Constructor taking only the write config, so this partitioner can also be named through
+   * {@code HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_CLASS_NAME}, which is
+   * instantiated by reflection with only the write config.
+   *
+   * @param config Write config.
+   */
+  public PartitionPathRepartitionPartitionerWithRows(HoodieWriteConfig config) {
+    this(BulkInsertPartitioner.isTablePartitioned(config), config);
+  }
+
   public PartitionPathRepartitionPartitionerWithRows(boolean isTablePartitioned, HoodieWriteConfig config) {
     this.isTablePartitioned = isTablePartitioned;
     this.shouldPopulateMetaFields = config.populateMetaFields();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceUtils.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.SerializationUtils;
 import org.apache.hudi.common.util.StringUtils;
@@ -35,7 +36,20 @@ import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.execution.bulkinsert.GlobalSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.GlobalSortPartitionerWithRows;
+import org.apache.hudi.execution.bulkinsert.NonSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.NonSortPartitionerWithRows;
+import org.apache.hudi.execution.bulkinsert.PartitionPathRepartitionAndSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.PartitionPathRepartitionAndSortPartitionerWithRows;
+import org.apache.hudi.execution.bulkinsert.PartitionPathRepartitionPartitioner;
+import org.apache.hudi.execution.bulkinsert.PartitionPathRepartitionPartitionerWithRows;
+import org.apache.hudi.execution.bulkinsert.PartitionSortPartitionerWithRows;
 import org.apache.hudi.execution.bulkinsert.RDDCustomColumnsSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.RDDPartitionSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.RowCustomColumnsSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.RowSpatialCurveSortPartitioner;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.metadata.stats.ValueMetadata;
@@ -54,6 +68,8 @@ import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -245,6 +261,95 @@ public class TestDataSourceUtils extends HoodieClientTestBase {
 
     Option<BulkInsertPartitioner<Dataset<Row>>> partitioner = DataSourceUtils.createUserDefinedBulkInsertPartitionerWithRows(config);
     assertThat(partitioner.isPresent(), is(true));
+  }
+
+  /**
+   * Every out of the box bulk insert partitioner has to be usable as a user defined partitioner.
+   * One is instantiated by reflection with only the write config, so each has to expose a
+   * constructor taking only a {@link HoodieWriteConfig}. See HUDI-7526.
+   */
+  @ParameterizedTest
+  @ValueSource(classes = {
+      NonSortPartitioner.class,
+      GlobalSortPartitioner.class,
+      RDDPartitionSortPartitioner.class,
+      RDDCustomColumnsSortPartitioner.class,
+      PartitionPathRepartitionPartitioner.class,
+      PartitionPathRepartitionAndSortPartitioner.class,
+      NonSortPartitionerWithRows.class,
+      GlobalSortPartitionerWithRows.class,
+      PartitionSortPartitionerWithRows.class,
+      RowCustomColumnsSortPartitioner.class,
+      RowSpatialCurveSortPartitioner.class,
+      PartitionPathRepartitionPartitionerWithRows.class,
+      PartitionPathRepartitionAndSortPartitionerWithRows.class
+  })
+  public void testBuiltInPartitionersAreUsableAsUserDefinedPartitioners(Class<?> partitionerClass) {
+    Map<String, String> props = new HashMap<>();
+    // required by the spatial curve partitioner, ignored by the rest
+    props.put(HoodieClusteringConfig.PLAN_STRATEGY_SORT_COLUMNS.key(), "column1,column2");
+    config = HoodieWriteConfig.newBuilder()
+        .withPath("/")
+        .withUserDefinedBulkInsertPartitionerClass(partitionerClass.getName())
+        .withUserDefinedBulkInsertPartitionerSortColumns("column1,column2")
+        .withSchema(avroSchemaString)
+        .withProps(props)
+        .build();
+
+    assertThat(DataSourceUtils.createUserDefinedBulkInsertPartitioner(config).isPresent(), is(true));
+    assertThat(DataSourceUtils.createUserDefinedBulkInsertPartitionerWithRows(config).isPresent(), is(true));
+  }
+
+  /**
+   * The partition path partitioners take the flag from the table when built by the factory, so
+   * check the write config only path agrees with the table config the factory path reads.
+   */
+  @Test
+  public void testIsTablePartitionedPrefersTableConfigOverPartitionPathField() {
+    // hoodie.table.partition.fields is what HoodieTable#isPartitioned reads, so it wins when present.
+    HoodieWriteConfig fromTableConfig = HoodieWriteConfig.newBuilder().withPath("/")
+        .withProps(Collections.singletonMap(
+            HoodieTableConfig.PARTITION_FIELDS.key(), "partition_path"))
+        .build();
+    assertThat(BulkInsertPartitioner.isTablePartitioned(fromTableConfig), is(true));
+
+    // Present but empty means a non partitioned table, even with a write side field configured.
+    Map<String, String> emptyTableConfig = new HashMap<>();
+    emptyTableConfig.put(HoodieTableConfig.PARTITION_FIELDS.key(), "");
+    emptyTableConfig.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition_path");
+    HoodieWriteConfig emptyWins = HoodieWriteConfig.newBuilder().withPath("/")
+        .withProps(emptyTableConfig).build();
+    assertThat(BulkInsertPartitioner.isTablePartitioned(emptyWins), is(false));
+
+    // The two sources disagreeing resolves to the table config, matching the factory path.
+    Map<String, String> disagreeing = new HashMap<>();
+    disagreeing.put(HoodieTableConfig.PARTITION_FIELDS.key(), "partition_path");
+    disagreeing.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "");
+    HoodieWriteConfig tableConfigWins = HoodieWriteConfig.newBuilder().withPath("/")
+        .withProps(disagreeing).build();
+    assertThat(BulkInsertPartitioner.isTablePartitioned(tableConfigWins), is(true));
+  }
+
+  /**
+   * Without the table property, which is the case for a write config assembled without the table's
+   * properties, the write side partition path field is the only signal left.
+   */
+  @Test
+  public void testIsTablePartitionedFallsBackToPartitionPathField() {
+    HoodieWriteConfig partitioned = HoodieWriteConfig.newBuilder().withPath("/")
+        .withProps(Collections.singletonMap(
+            KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition_path"))
+        .build();
+    assertThat(BulkInsertPartitioner.isTablePartitioned(partitioned), is(true));
+
+    HoodieWriteConfig nonPartitioned = HoodieWriteConfig.newBuilder().withPath("/")
+        .withProps(Collections.singletonMap(
+            KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), ""))
+        .build();
+    assertThat(BulkInsertPartitioner.isTablePartitioned(nonPartitioned), is(false));
+
+    HoodieWriteConfig unset = HoodieWriteConfig.newBuilder().withPath("/").build();
+    assertThat(BulkInsertPartitioner.isTablePartitioned(unset), is(false));
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceUtils.java
@@ -33,7 +33,20 @@ import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.execution.bulkinsert.GlobalSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.GlobalSortPartitionerWithRows;
+import org.apache.hudi.execution.bulkinsert.NonSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.NonSortPartitionerWithRows;
+import org.apache.hudi.execution.bulkinsert.PartitionPathRepartitionAndSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.PartitionPathRepartitionAndSortPartitionerWithRows;
+import org.apache.hudi.execution.bulkinsert.PartitionPathRepartitionPartitioner;
+import org.apache.hudi.execution.bulkinsert.PartitionPathRepartitionPartitionerWithRows;
+import org.apache.hudi.execution.bulkinsert.PartitionSortPartitionerWithRows;
 import org.apache.hudi.execution.bulkinsert.RDDCustomColumnsSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.RDDPartitionSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.RowCustomColumnsSortPartitioner;
+import org.apache.hudi.execution.bulkinsert.RowSpatialCurveSortPartitioner;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.metadata.stats.ValueMetadata;
@@ -52,6 +65,8 @@ import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -219,6 +234,65 @@ public class TestDataSourceUtils extends HoodieClientTestBase {
 
     Option<BulkInsertPartitioner<Dataset<Row>>> partitioner = DataSourceUtils.createUserDefinedBulkInsertPartitionerWithRows(config);
     assertThat(partitioner.isPresent(), is(true));
+  }
+
+  /**
+   * Every out of the box bulk insert partitioner has to be usable as a user defined partitioner.
+   * One is instantiated by reflection with only the write config, so each has to expose a
+   * constructor taking only a {@link HoodieWriteConfig}. See HUDI-7526.
+   */
+  @ParameterizedTest
+  @ValueSource(classes = {
+      NonSortPartitioner.class,
+      GlobalSortPartitioner.class,
+      RDDPartitionSortPartitioner.class,
+      RDDCustomColumnsSortPartitioner.class,
+      PartitionPathRepartitionPartitioner.class,
+      PartitionPathRepartitionAndSortPartitioner.class,
+      NonSortPartitionerWithRows.class,
+      GlobalSortPartitionerWithRows.class,
+      PartitionSortPartitionerWithRows.class,
+      RowCustomColumnsSortPartitioner.class,
+      RowSpatialCurveSortPartitioner.class,
+      PartitionPathRepartitionPartitionerWithRows.class,
+      PartitionPathRepartitionAndSortPartitionerWithRows.class
+  })
+  public void testBuiltInPartitionersAreUsableAsUserDefinedPartitioners(Class<?> partitionerClass) {
+    Map<String, String> props = new HashMap<>();
+    // required by the spatial curve partitioner, ignored by the rest
+    props.put(HoodieClusteringConfig.PLAN_STRATEGY_SORT_COLUMNS.key(), "column1,column2");
+    config = HoodieWriteConfig.newBuilder()
+        .withPath("/")
+        .withUserDefinedBulkInsertPartitionerClass(partitionerClass.getName())
+        .withUserDefinedBulkInsertPartitionerSortColumns("column1,column2")
+        .withSchema(avroSchemaString)
+        .withProps(props)
+        .build();
+
+    assertThat(DataSourceUtils.createUserDefinedBulkInsertPartitioner(config).isPresent(), is(true));
+    assertThat(DataSourceUtils.createUserDefinedBulkInsertPartitionerWithRows(config).isPresent(), is(true));
+  }
+
+  /**
+   * The partition path partitioners take the flag from the table when built by the factory, so
+   * check the write config only constructor derives it from the configured partition path field.
+   */
+  @Test
+  public void testPartitionPathRepartitionPartitionerDerivesIsTablePartitioned() {
+    HoodieWriteConfig partitioned = HoodieWriteConfig.newBuilder().withPath("/")
+        .withProps(Collections.singletonMap(
+            KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition_path"))
+        .build();
+    assertThat(BulkInsertPartitioner.isTablePartitioned(partitioned), is(true));
+
+    HoodieWriteConfig nonPartitioned = HoodieWriteConfig.newBuilder().withPath("/")
+        .withProps(Collections.singletonMap(
+            KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), ""))
+        .build();
+    assertThat(BulkInsertPartitioner.isTablePartitioned(nonPartitioned), is(false));
+
+    HoodieWriteConfig unset = HoodieWriteConfig.newBuilder().withPath("/").build();
+    assertThat(BulkInsertPartitioner.isTablePartitioned(unset), is(false));
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #16423 / [HUDI-7526](https://issues.apache.org/jira/browse/HUDI-7526).

A partitioner named through `hoodie.bulkinsert.user.defined.partitioner.class` is
instantiated by reflection:

```java
// DataSourceUtils#createUserDefinedBulkInsertPartitioner
Option.of((BulkInsertPartitioner) ReflectionUtils.loadClass(bulkInsertPartitionerClass, config));
```

`ReflectionUtils.loadClass(clazz, Object...)` infers the constructor argument types from
the instances it is handed, so it resolves `getConstructor(HoodieWriteConfig.class)`. A
class is therefore usable as a user defined partitioner only if it exposes a public
constructor taking exactly one `HoodieWriteConfig`.

Twelve partitioners back an out of the box `BulkInsertSortMode`. Eight of them did not
have such a constructor, and failed with `Unable to instantiate class ...`:

| Sort mode | Spark RDD | Spark row writer | Java client |
| --- | --- | --- | --- |
| `NONE` | `NonSortPartitioner` (fixed) | `NonSortPartitionerWithRows` (fixed) | `JavaNonSortPartitioner` (fixed) |
| `GLOBAL_SORT` | `GlobalSortPartitioner` | `GlobalSortPartitionerWithRows` | `JavaGlobalSortPartitioner` (fixed) |
| `PARTITION_SORT` | `RDDPartitionSortPartitioner` | `PartitionSortPartitionerWithRows` | not supported |
| `PARTITION_PATH_REPARTITION` | `PartitionPathRepartitionPartitioner` (fixed) | `PartitionPathRepartitionPartitionerWithRows` (fixed) | not supported |
| `PARTITION_PATH_REPARTITION_AND_SORT` | `PartitionPathRepartitionAndSortPartitioner` (fixed) | `PartitionPathRepartitionAndSortPartitionerWithRows` (fixed) | not supported |

`NonSortPartitioner`, backing `BulkInsertSortMode.NONE`, is the example named in the
ticket.

### Summary and Changelog

Every partitioner that an out of the box bulk insert sort mode maps to can now be named
through `hoodie.bulkinsert.user.defined.partitioner.class`.

- Adds a public `(HoodieWriteConfig)` constructor to the eight partitioners marked above.
- `NonSortPartitioner`, `NonSortPartitionerWithRows`, `JavaNonSortPartitioner` and
  `JavaGlobalSortPartitioner` have nothing configurable, so the new constructor behaves
  as the default one does. The value used for `enforceNumOutputPartitions` is `false`,
  matching what `BulkInsertInternalPartitionerFactory.get(table, config)` and
  `BulkInsertInternalPartitionerWithRowsFactory.get(config, isTablePartitioned)` pass on
  the bulk insert write path.
- The two java client partitioners relied on the implicit no-arg constructor. Declaring
  any constructor removes it, and `JavaBulkInsertInternalPartitionerFactory` calls it, so
  the no-arg constructor is now declared explicitly alongside the new one.
- The partition path repartition partitioners take the table partitioned flag from the
  `HoodieTable` when built by the factory, which reflection cannot supply. The new
  constructor derives it from the configured partition path field, added as
  `BulkInsertPartitioner.isTablePartitioned`. Those partitioners branch on whether
  records carry a non-empty partition path, and the write side partition path field is
  what governs that.
- Purely additive. No existing constructor is changed or removed, so no existing caller
  is affected.

Left alone, because no sort mode maps to them:

- `RDDSpatialCurveSortPartitioner` and `RowSpatialCurveSortPartitioner` are clustering
  layout partitioners, not sort mode partitioners. The RDD one also needs a
  `HoodieSparkEngineContext` that cannot be derived from a write config.
- `JavaCustomColumnsSortPartitioner` is not selected by any sort mode.

Tests:

- `TestDataSourceUtils` gains a parameterized test over all thirteen constructible spark
  partitioners, asserting each loads through both
  `createUserDefinedBulkInsertPartitioner` and
  `createUserDefinedBulkInsertPartitionerWithRows`. It covers the ones that already
  worked, so the whole contract is pinned rather than only the classes being fixed. It
  also gains a test pinning `isTablePartitioned` for a configured partition path field,
  an explicitly empty one, and an unset one.
- `TestJavaBulkInsertInternalPartitionerFactory` gains a test that both java client sort
  mode partitioners load from a write config, and a test that both still expose a no-arg
  constructor, which guards the implicit constructor removal described above.

Reverting only the new constructors makes those tests fail for exactly the classes
concerned and nothing else.

### Impact

None for existing users. The change only adds constructors, so every current call site
resolves as before, and the factories are unaffected. What changes is that eight built in
partitioners can now be named as a user defined partitioner where that previously failed
at instantiation.

### Risk Level

low

Additive only, with no signature changed or removed. The one piece of new logic,
`isTablePartitioned`, is used solely by the new constructors; the existing
`(boolean, HoodieWriteConfig)` constructors still take the flag from the caller. Verified
end to end by running a bulk insert with each fixed partitioner named as the user defined
partitioner, over both the RDD and row writer paths, and on both a partitioned and a non
partitioned table so both branches of the derived flag are exercised.

### Documentation Update

None. No new config, and no change to an existing config's meaning or default.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
