### PR TITLE
fix(hive): read the skeleton file when a bootstrap query projects no columns

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.internal.InternalSchema;
 import org.apache.hudi.common.util.HoodieStorageUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.hadoop.avro.HoodieTimestampAwareParquetInputFormat;
@@ -210,10 +211,10 @@ public class HoodieParquetInputFormat extends HoodieParquetInputFormatBase {
 
     LOG.info("colNameWithTypes ={}, Num Entries ={}", colNameWithTypes, colNameWithTypes.size());
 
-    if (hoodieColsProjected.isEmpty()) {
-      return getRecordReaderInternal(eSplit.getBootstrapFileSplit(), job, reporter);
-    } else if (externalColsProjected.isEmpty()) {
-      return getRecordReaderInternal(split, job, reporter);
+    Option<FileSplit> singleSplit = resolveSingleFileSplit(eSplit, !hoodieColsProjected.isEmpty(),
+        !externalColsProjected.isEmpty());
+    if (singleSplit.isPresent()) {
+      return getRecordReaderInternal(singleSplit.get(), job, reporter);
     } else {
       FileSplit rightSplit = eSplit.getBootstrapFileSplit();
       // Hive PPD works at row-group level and only enabled when hive.optimize.index.filter=true;
@@ -231,6 +232,36 @@ public class HoodieParquetInputFormat extends HoodieParquetInputFormatBase {
           getRecordReaderInternal(rightSplit, jobConfCopy, reporter),
           colNamesWithTypesForExternal.size(),
           true);
+    }
+  }
+
+  /**
+   * The single file backing this read, or empty when both files are needed and have to be stitched.
+   *
+   * <p>A bootstrap split carries two paths: the split itself is the skeleton file, which lives inside the
+   * table root, and {@code getBootstrapFileSplit()} is the external source file, which does not.
+   *
+   * <p>The two "only one file is needed" cases both apply when a query projects no columns at all, as
+   * {@code SELECT COUNT(*)} does, so the order they are tested in decides which file is read. Prefer the
+   * skeleton: it is inside the table root, and bootstrap keeps a one-to-one row correspondence with the
+   * external file, so a count over it is identical. Handing Hive a path outside the table root breaks its
+   * vectorized reader, which derives partition values by looking the split path up in
+   * {@code pathToPartitionInfo} (HUDI-5526).
+   *
+   * @param split                  the bootstrap split.
+   * @param anyHoodieColProjected  whether the query projects any Hudi meta column.
+   * @param anyExternalColProjected whether the query projects any column from the external file.
+   */
+  @VisibleForTesting
+  static Option<FileSplit> resolveSingleFileSplit(BootstrapBaseFileSplit split,
+                                                  boolean anyHoodieColProjected,
+                                                  boolean anyExternalColProjected) {
+    if (!anyExternalColProjected) {
+      return Option.of(split);
+    } else if (!anyHoodieColProjected) {
+      return Option.of(split.getBootstrapFileSplit());
+    } else {
+      return Option.empty();
     }
   }
 }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormat.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.io.ArrayWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
@@ -62,10 +63,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
@@ -77,6 +82,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.COMMIT_METADATA_SER_DE;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
@@ -86,6 +92,7 @@ import static org.apache.hudi.common.testutils.SchemaTestUtil.getSchemaFromResou
 import static org.apache.hudi.hadoop.HoodieColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -837,4 +844,124 @@ public class TestHoodieParquetInputFormat {
       jobConf.set(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key(), "true");
     }
   }
+
+  /**
+   * A bootstrap split carries two files: the split's own path is the skeleton, inside the table root, and
+   * {@code getBootstrapFileSplit()} is the external source file, which is not. A query projecting no columns
+   * at all - {@code SELECT COUNT(*)} - satisfies both "only one file is needed" conditions at once, so the
+   * order they are tested in decides which file Hive is handed.
+   *
+   * <p>Handing Hive a path outside the table root breaks its vectorized reader, which derives partition
+   * values by looking the split path up in {@code pathToPartitionInfo} (HUDI-5526, #15676). Hive 2.3 ships
+   * the same reader but defaults {@code hive.vectorized.execution.enabled} to false where Hive 3 defaults it
+   * to true, so this is gated by that config rather than by the Hive version.
+   *
+   * <p>Only the no-projection case is new behaviour: TestBootstrap and TestOrcBootstrap drive the other
+   * three branches end to end, they have just been disabled (HUDI-7353) since #10551.
+   */
+  @Test
+  public void testCountStarReadsSkeletonSoSplitPathStaysInsideTable() throws IOException {
+    BootstrapBaseFileSplit split = bootstrapSplit();
+
+    Option<FileSplit> resolved = HoodieParquetInputFormat.resolveSingleFileSplit(split, false, false);
+
+    assertTrue(resolved.isPresent(), "a query projecting no columns must resolve to a single file");
+    assertSame(split, resolved.get(),
+        "it must be the skeleton, whose path is inside the table root");
+  }
+
+  /**
+   * The remaining three combinations, which behave the same before and after the reorder: only meta columns
+   * needs the skeleton, only data columns needs the external file, and both needs them stitched.
+   */
+  @ParameterizedTest
+  @MethodSource("singleFileSplitCases")
+  public void testSingleFileSplitSelection(boolean anyHoodieCol, boolean anyExternalCol,
+                                           String expected) throws IOException {
+    BootstrapBaseFileSplit split = bootstrapSplit();
+
+    Option<FileSplit> resolved =
+        HoodieParquetInputFormat.resolveSingleFileSplit(split, anyHoodieCol, anyExternalCol);
+
+    if ("stitch".equals(expected)) {
+      assertFalse(resolved.isPresent(), "both files are needed, so the caller must stitch them");
+    } else {
+      assertTrue(resolved.isPresent(), "a single file should have been resolved");
+      assertSame("skeleton".equals(expected) ? split : split.getBootstrapFileSplit(), resolved.get(),
+          "wrong file chosen for (anyHoodieCol=" + anyHoodieCol + ", anyExternalCol=" + anyExternalCol + ")");
+    }
+  }
+
+  private static Stream<Arguments> singleFileSplitCases() {
+    return Stream.of(
+        Arguments.of(true, false, "skeleton"),
+        Arguments.of(false, true, "external"),
+        Arguments.of(true, true, "stitch"));
+  }
+
+  private static BootstrapBaseFileSplit bootstrapSplit() throws IOException {
+    return new BootstrapBaseFileSplit(
+        new FileSplit(new Path("/tbl/event_type=two/skeleton.parquet"), 0, 100, (String[]) null),
+        new FileSplit(new Path("/src/event_type=two/part-0.parquet"), 0, 100, (String[]) null));
+  }
+
+  /**
+   * The end-to-end shape of HUDI-5526: a bootstrap split whose skeleton and external file hold a different
+   * number of rows, read through {@link HoodieParquetInputFormat#getRecordReader} with nothing projected.
+   * The reader must yield the skeleton's row count. On master it yields the external file's.
+   *
+   * <p>No Hudi table is needed: {@code shouldUseFilegroupReader} excludes {@code BootstrapBaseFileSplit}, so
+   * this falls straight through to {@code createBootstrappingRecordReader}.
+   */
+  @Test
+  public void testNoProjectionReaderReadsSkeletonRowCount() throws Exception {
+    HoodieSchema schema = SchemaTestUtil.getSchemaFromResource(getClass(), "/test_timetype.avsc");
+    java.nio.file.Path skeletonFile = basePath.resolve("skeleton.parquet");
+    java.nio.file.Path externalFile = basePath.resolve("external.parquet");
+    int skeletonRows = 3;
+    int externalRows = 7;
+    writeParquet(skeletonFile, schema, skeletonRows);
+    writeParquet(externalFile, schema, externalRows);
+
+    jobConf.set(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key(), "false");
+    jobConf.set(IOConstants.COLUMNS, "test_timestamp,test_long,test_date,_hoodie_commit_time,_hoodie_commit_seqno");
+    jobConf.set(IOConstants.COLUMNS_TYPES, "timestamp,bigint,date,string,string");
+    // SELECT COUNT(*): Hive projects no columns at all.
+    jobConf.set(READ_COLUMN_NAMES_CONF_STR, "");
+    jobConf.set(HoodieColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, "");
+
+    BootstrapBaseFileSplit split = new BootstrapBaseFileSplit(
+        new FileSplit(new Path(skeletonFile.toString()), 0, Files.size(skeletonFile), (String[]) null),
+        new FileSplit(new Path(externalFile.toString()), 0, Files.size(externalFile), (String[]) null));
+
+    RecordReader<NullWritable, ArrayWritable> reader = inputFormat.getRecordReader(split, jobConf, null);
+    try {
+      NullWritable key = reader.createKey();
+      ArrayWritable value = reader.createValue();
+      int rows = 0;
+      while (reader.next(key, value)) {
+        rows++;
+      }
+      assertEquals(skeletonRows, rows,
+          "a no-projection read must come from the skeleton file, whose path is inside the table root");
+    } finally {
+      reader.close();
+    }
+  }
+
+  private static void writeParquet(java.nio.file.Path file, HoodieSchema schema, int numRows) throws IOException {
+    try (AvroParquetWriter parquetWriter =
+             new AvroParquetWriter(new Path(file.toString()), schema.toAvroSchema())) {
+      for (int i = 0; i < numRows; i++) {
+        GenericData.Record record = new GenericData.Record(schema.toAvroSchema());
+        record.put("test_timestamp", (long) i);
+        record.put("test_long", (long) i);
+        record.put("test_date", i);
+        record.put("_hoodie_commit_time", "20160628071126");
+        record.put("_hoodie_commit_seqno", "20160628071126_" + i);
+        parquetWriter.write(record);
+      }
+    }
+  }
+
 }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormatBootstrapSplitSelection.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestHoodieParquetInputFormatBootstrapSplitSelection.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hadoop;
+
+import org.apache.hudi.common.util.Option;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileSplit;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Which of a bootstrap split's two files backs the read, per projection.
+ *
+ * <p>A bootstrap split carries the skeleton file as its own path - inside the table root - and the external
+ * source file separately, outside it. Handing Hive a path outside the table root breaks its vectorized
+ * parquet reader, which derives partition values by looking the split path up in {@code pathToPartitionInfo}
+ * and fails with {@code cannot find dir = [...] in pathToPartitionInfo: [...]} (HUDI-5526, #15676). Hive 2
+ * never vectorized this path, which is why the same query worked there.
+ *
+ * <p>This is the first coverage of that selection: nothing in the tree referenced
+ * {@code BootstrapBaseFileSplit} or the reader built from it.
+ */
+class TestHoodieParquetInputFormatBootstrapSplitSelection {
+
+  private static final Path SKELETON = new Path("s3://bucket/hudi-table/tbl/event_type=two/skeleton.parquet");
+  private static final Path EXTERNAL = new Path("s3://bucket/source-tables/tbl/event_type=two/part-0.parquet");
+
+  private static BootstrapBaseFileSplit split() throws IOException {
+    return new BootstrapBaseFileSplit(
+        new FileSplit(SKELETON, 0, 100, (String[]) null),
+        new FileSplit(EXTERNAL, 0, 100, (String[]) null));
+  }
+
+  /**
+   * {@code SELECT COUNT(*)} projects nothing, so both "only one file is needed" cases apply at once and the
+   * order they are tested in decides the answer. It has to be the skeleton: it is inside the table root, and
+   * bootstrap keeps a one-to-one row correspondence, so the count is the same either way.
+   */
+  @Test
+  void testCountStarReadsSkeletonSoSplitPathStaysInsideTable() throws IOException {
+    BootstrapBaseFileSplit split = split();
+
+    Option<FileSplit> resolved = HoodieParquetInputFormat.resolveSingleFileSplit(split, false, false);
+
+    assertSame(split, resolved.get(),
+        "a query projecting no columns must read the skeleton, whose path is inside the table root");
+    assertEquals(SKELETON, resolved.get().getPath());
+  }
+
+  /** Only meta columns projected: the external file is not needed. */
+  @Test
+  void testMetaColumnsOnlyReadsTheSkeleton() throws IOException {
+    BootstrapBaseFileSplit split = split();
+
+    Option<FileSplit> resolved = HoodieParquetInputFormat.resolveSingleFileSplit(split, true, false);
+
+    assertEquals(SKELETON, resolved.get().getPath());
+  }
+
+  /** Only external columns projected: the data lives there, so the external file is required. */
+  @Test
+  void testDataColumnsOnlyReadsTheExternalFile() throws IOException {
+    BootstrapBaseFileSplit split = split();
+
+    Option<FileSplit> resolved = HoodieParquetInputFormat.resolveSingleFileSplit(split, false, true);
+
+    assertEquals(EXTERNAL, resolved.get().getPath(),
+        "data columns exist only in the external file, so it must still be read");
+  }
+
+  /** Both projected: neither file alone will do, and the caller stitches them. */
+  @Test
+  void testBothProjectedNeedsStitching() throws IOException {
+    Option<FileSplit> resolved = HoodieParquetInputFormat.resolveSingleFileSplit(split(), true, true);
+
+    assertFalse(resolved.isPresent(),
+        "when both files are needed the caller must stitch them rather than pick one");
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15676 (HUDI-5526).

A `BootstrapBaseFileSplit` carries two files: the split's own path is the **skeleton**, inside the table root,
and `getBootstrapFileSplit()` is the **external source file**, which is not.
`createBootstrappingRecordReader` opens one of them when only one is needed, and it tested "no Hudi meta column
projected" first — which resolves to the external file.

`SELECT COUNT(*)` projects no columns at all, so both single-file conditions hold and that branch won: Hive was
handed a path outside the table root. Its vectorized reader resolves partition values by looking the split path
up in `pathToPartitionInfo`, which only holds the table's own partition directories, so on a partitioned
bootstrap table the query failed with:

```
java.io.IOException: cannot find dir = s3://.../parquet-source-tables/<tbl>/event_type=two/part-....parquet
  in pathToPartitionInfo: [s3://.../<tbl>/event_type=one, .../event_type=two]
```

### Summary and Changelog

- Test the external-column condition first, so a projection of no columns reads the skeleton. Bootstrap keeps a
  one-to-one row correspondence between the two files, so the count is unchanged, and the skeleton is inside
  the table root and much smaller.
- Derive the two booleans from the projected column **names** alone, deleting the id/name zip (see Verification).
- Tests in `TestHoodieParquetInputFormat`: a reader-level test through `getRecordReader`, plus a parameterised
  truth table for the other three combinations.

### Scope — what this does and does not fix

**Only the no-projection shape.** Projecting data columns still opens the external split, and so does the stitch
branch, so a partitioned bootstrap table still fails for those. Filed as **#19643**, with the
`set hive.vectorized.execution.enabled=false` workaround.

**Not Hive-3 specific.** `hive-exec` 2.3.10 ships the same vectorized reader; what differs is the default of
`hive.vectorized.execution.enabled` — `false` in `hive-common` 2.3.10, `true` in 3.1.3 (`javap` on
`HiveConf$ConfVars`: `iconst_0` vs `iconst_1`). A Hive 2 deployment with vectorization enabled hits it too.

**MOR is reached only for a bootstrap file slice with no log files.** When a
`HoodieRealtimeBootstrapBaseFileSplit` has delta logs, `addVirtualKeysProjection` injects the meta columns
through the 3-arg `addProjectionField`, which does not consult `LIST_COLUMNS` and so always succeeds — leaving
this branch unreachable on that path.

### Verification

The test that matters goes through `getRecordReader`: a bootstrap split whose skeleton holds 3 rows and whose
external file holds 7, read with nothing projected, must yield **3**.

```
without the fix: expected: <3> but was: <7>
with the fix:    25 tests, 0 failures
```

`hudi-hadoop-mr`: 195 tests pass, checkstyle 0, apache-rat 0.

**Why the id/name zip went.** The previous code paired `getReadColumnIDs` with `getReadColumnNames` — the exact
pairing `HoodieColumnProjectionUtils` warns about in `getReadColumnIDs` itself ("some code uses this list to
correlate with column names, and yet these lists may contain duplicates, which this call will remove and the
other won't"). The id list is de-duplicated and parsed with `Integer.parseInt` while the name list is neither,
so a blank id (the HIVE-22438 shape) threw `NumberFormatException` and a duplicated name misaligned the zip.
The `Integer` half was never read.

**Existing coverage.** `TestBootstrap` and `TestOrcBootstrap` drive the other three branches end to end, but
both are `@Disabled("HUDI-7353")` since #10551 — so only the no-projection case is genuinely uncovered
behaviour today.

### Impact

A no-column projection on a bootstrap table (`SELECT COUNT(*)`, and any projection naming no column from either
file) now reads the skeleton, whose path is inside the table root, instead of failing. It also reads less: the
skeleton holds 5 meta columns against the external file's full row.

No public API, config or on-disk change.

### Risk Level

low — one branch order in the bootstrap reader selection, plus deleting an unused id/name correlation. Row
counts are unaffected because skeleton and external file hold the same rows in the same order, the invariant
`BootstrapColumnStichingRecordReader` already relies on.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
