### PR TITLE
fix(spark): preserve the Avro fixed-size decimal width in the Spark row write support

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -486,7 +486,7 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
    * Fixed-length byte width for a decimal column: honor the declared Avro {@code fixed} size when
    * present (it may be wider than the precision-minimal width), otherwise the precision-minimal width.
    */
-  static int decimalFixedLen(HoodieSchema resolvedSchema, int precision) {
+  static int resolveDecimalByteLength(HoodieSchema resolvedSchema, int precision) {
     if (resolvedSchema instanceof HoodieSchema.Decimal) {
       HoodieSchema.Decimal decimalSchema = (HoodieSchema.Decimal) resolvedSchema;
       if (decimalSchema.isFixed()) {
@@ -584,7 +584,7 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
       int scale = ((DecimalType) dataType).scale();
       // Honor the declared Avro `fixed` size so the row/bulk-insert/clustering/compaction write
       // path preserves the schema width instead of narrowing to the precision-minimal one.
-      int numBytes = decimalFixedLen(resolvedSchema, precision);
+      int numBytes = resolveDecimalByteLength(resolvedSchema, precision);
       // Padding buffer resolved once per column, not per record: reuse the shared decimalBuffer when
       // it is wide enough, otherwise allocate one dedicated buffer here (an over-allocated Avro fixed
       // size can exceed the shared buffer's capacity).
@@ -851,7 +851,7 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
       return Types
           .primitive(FIXED_LEN_BYTE_ARRAY, repetition)
           .as(LogicalTypeAnnotation.decimalType(scale, precision))
-          .length(decimalFixedLen(resolvedSchema, precision))
+          .length(resolveDecimalByteLength(resolvedSchema, precision))
           .named(structField.name());
     } else if (dataType instanceof ArrayType
             && resolvedSchema != null

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -483,15 +483,8 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
   }
 
   /**
-   * Fixed-length byte width for a decimal column. A Spark {@link DecimalType} carries only
-   * precision/scale, so on its own it yields the precision-minimal width. When the resolved schema
-   * is a {@link HoodieSchema.Decimal} backed by an Avro {@code fixed} type it declares the width
-   * explicitly (which may be wider than the minimum), and that declared size is honored so the
-   * Spark write path matches the Avro write path and stays consistent with base files written on
-   * insert. Falls back to the precision-minimal width otherwise.
-   *
-   * <p>Package-private so it can be unit-tested directly (constructing the full write support
-   * from this module is not possible: it needs a Spark adapter that lives in a sibling module).
+   * Fixed-length byte width for a decimal column: honor the declared Avro {@code fixed} size when
+   * present (it may be wider than the precision-minimal width), otherwise the precision-minimal width.
    */
   static int decimalFixedLen(HoodieSchema resolvedSchema, int precision) {
     if (resolvedSchema instanceof HoodieSchema.Decimal) {
@@ -507,14 +500,6 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     return Decimal.minBytesForPrecision()[precision];
   }
 
-  /**
-   * Left-pads the unscaled decimal bytes with sign-extension bytes to exactly {@code numBytes},
-   * writing into {@code paddingBuffer} when a copy is needed and returning {@code unscaledBytes}
-   * directly when it already spans the full width (Avro validates the fixed size covers the
-   * precision, so the unscaled magnitude always fits).
-   *
-   * <p>Package-private so it can be unit-tested directly (see {@link #decimalFixedLen}).
-   */
   static byte[] padDecimalToFixedLength(byte[] unscaledBytes, int numBytes, byte[] paddingBuffer) {
     if (unscaledBytes.length == numBytes) {
       return unscaledBytes;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -482,6 +482,16 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     }
   }
 
+  private static int decimalFixedLen(HoodieSchema resolvedSchema, int precision) {
+    if (resolvedSchema instanceof HoodieSchema.Decimal) {
+      HoodieSchema.Decimal decimalSchema = (HoodieSchema.Decimal) resolvedSchema;
+      if (decimalSchema.isFixed()) {
+        return decimalSchema.getFixedSize();
+      }
+    }
+    return Decimal.minBytesForPrecision()[precision];
+  }
+
   private ValueWriter makeWriter(HoodieSchema schema, DataType dataType) {
     HoodieSchema resolvedSchema = schema == null ? null : schema.getNonNullType();
 
@@ -550,26 +560,31 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
         consumeGroup(() -> variantWriter.accept(row, ordinal));
       };
     } else if (dataType instanceof DecimalType) {
+      int precision = ((DecimalType) dataType).precision();
+      ValidationUtils.checkArgument(precision <= DecimalType.MAX_PRECISION(),
+          () -> String.format("Decimal precision %s exceeds max precision %s", precision, DecimalType.MAX_PRECISION()));
+      int scale = ((DecimalType) dataType).scale();
+      // Honor the declared Avro `fixed` size so the row/bulk-insert/clustering/compaction write
+      // path preserves the schema width instead of narrowing to the precision-minimal one.
+      int numBytes = decimalFixedLen(resolvedSchema, precision);
+      // Padding buffer resolved once per column, not per record: reuse the shared decimalBuffer when
+      // it is wide enough, otherwise allocate one dedicated buffer here (an over-allocated Avro fixed
+      // size can exceed the shared buffer's capacity).
+      byte[] paddingBuffer = numBytes <= decimalBuffer.length ? decimalBuffer : new byte[numBytes];
       return (row, ordinal) -> {
-        int precision = ((DecimalType) dataType).precision();
-        ValidationUtils.checkArgument(precision <= DecimalType.MAX_PRECISION(),
-            () -> String.format("Decimal precision %s exceeds max precision %s", precision, DecimalType.MAX_PRECISION()));
-        int scale = ((DecimalType) dataType).scale();
         byte[] bytes = row.getDecimal(ordinal, precision, scale).toJavaBigDecimal().unscaledValue().toByteArray();
-        int numBytes = Decimal.minBytesForPrecision()[precision];
         byte[] fixedLengthBytes;
         if (bytes.length == numBytes) {
           // If the length of the underlying byte array of the unscaled `BigInteger` happens to be
-          // `numBytes`, just reuse it, so that we don't bother copying it to `decimalBuffer`.
+          // `numBytes`, just reuse it, so that we don't bother copying it to a buffer.
           fixedLengthBytes = bytes;
         } else {
-          // Otherwise, the length must be less than `numBytes`.  In this case we copy contents of
-          // the underlying bytes with padding sign bytes to `decimalBuffer` to form the result
-          // fixed-length byte array.
+          // Otherwise left-pad the unscaled bytes with sign bytes to reach `numBytes` (Avro validates
+          // the fixed size covers the precision, so the unscaled magnitude always fits).
           byte signByte = (bytes[0] < 0) ? (byte) -1 : (byte) 0;
-          Arrays.fill(decimalBuffer, 0, numBytes - bytes.length, signByte);
-          System.arraycopy(bytes, 0, decimalBuffer, numBytes - bytes.length, bytes.length);
-          fixedLengthBytes = decimalBuffer;
+          Arrays.fill(paddingBuffer, 0, numBytes - bytes.length, signByte);
+          System.arraycopy(bytes, 0, paddingBuffer, numBytes - bytes.length, bytes.length);
+          fixedLengthBytes = paddingBuffer;
         }
         recordConsumer.addBinary(Binary.fromReusedByteArray(fixedLengthBytes, 0, numBytes));
       };
@@ -830,7 +845,7 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
       return Types
           .primitive(FIXED_LEN_BYTE_ARRAY, repetition)
           .as(LogicalTypeAnnotation.decimalType(scale, precision))
-          .length(Decimal.minBytesForPrecision()[precision])
+          .length(decimalFixedLen(resolvedSchema, precision))
           .named(structField.name());
     } else if (dataType instanceof ArrayType
             && resolvedSchema != null

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -507,6 +507,24 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     return Decimal.minBytesForPrecision()[precision];
   }
 
+  /**
+   * Left-pads the unscaled decimal bytes with sign-extension bytes to exactly {@code numBytes},
+   * writing into {@code paddingBuffer} when a copy is needed and returning {@code unscaledBytes}
+   * directly when it already spans the full width (Avro validates the fixed size covers the
+   * precision, so the unscaled magnitude always fits).
+   *
+   * <p>Package-private so it can be unit-tested directly (see {@link #decimalFixedLen}).
+   */
+  static byte[] padDecimalToFixedLength(byte[] unscaledBytes, int numBytes, byte[] paddingBuffer) {
+    if (unscaledBytes.length == numBytes) {
+      return unscaledBytes;
+    }
+    byte signByte = (unscaledBytes[0] < 0) ? (byte) -1 : (byte) 0;
+    Arrays.fill(paddingBuffer, 0, numBytes - unscaledBytes.length, signByte);
+    System.arraycopy(unscaledBytes, 0, paddingBuffer, numBytes - unscaledBytes.length, unscaledBytes.length);
+    return paddingBuffer;
+  }
+
   private ValueWriter makeWriter(HoodieSchema schema, DataType dataType) {
     HoodieSchema resolvedSchema = schema == null ? null : schema.getNonNullType();
 
@@ -588,20 +606,8 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
       byte[] paddingBuffer = numBytes <= decimalBuffer.length ? decimalBuffer : new byte[numBytes];
       return (row, ordinal) -> {
         byte[] bytes = row.getDecimal(ordinal, precision, scale).toJavaBigDecimal().unscaledValue().toByteArray();
-        byte[] fixedLengthBytes;
-        if (bytes.length == numBytes) {
-          // If the length of the underlying byte array of the unscaled `BigInteger` happens to be
-          // `numBytes`, just reuse it, so that we don't bother copying it to a buffer.
-          fixedLengthBytes = bytes;
-        } else {
-          // Otherwise left-pad the unscaled bytes with sign bytes to reach `numBytes` (Avro validates
-          // the fixed size covers the precision, so the unscaled magnitude always fits).
-          byte signByte = (bytes[0] < 0) ? (byte) -1 : (byte) 0;
-          Arrays.fill(paddingBuffer, 0, numBytes - bytes.length, signByte);
-          System.arraycopy(bytes, 0, paddingBuffer, numBytes - bytes.length, bytes.length);
-          fixedLengthBytes = paddingBuffer;
-        }
-        recordConsumer.addBinary(Binary.fromReusedByteArray(fixedLengthBytes, 0, numBytes));
+        recordConsumer.addBinary(Binary.fromReusedByteArray(
+            padDecimalToFixedLength(bytes, numBytes, paddingBuffer), 0, numBytes));
       };
     } else if (dataType instanceof ArrayType
             && resolvedSchema != null

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -482,7 +482,18 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     }
   }
 
-  private static int decimalFixedLen(HoodieSchema resolvedSchema, int precision) {
+  /**
+   * Fixed-length byte width for a decimal column. A Spark {@link DecimalType} carries only
+   * precision/scale, so on its own it yields the precision-minimal width. When the resolved schema
+   * is a {@link HoodieSchema.Decimal} backed by an Avro {@code fixed} type it declares the width
+   * explicitly (which may be wider than the minimum), and that declared size is honored so the
+   * Spark write path matches the Avro write path and stays consistent with base files written on
+   * insert. Falls back to the precision-minimal width otherwise.
+   *
+   * <p>Package-private so it can be unit-tested directly (constructing the full write support
+   * from this module is not possible: it needs a Spark adapter that lives in a sibling module).
+   */
+  static int decimalFixedLen(HoodieSchema resolvedSchema, int precision) {
     if (resolvedSchema instanceof HoodieSchema.Decimal) {
       HoodieSchema.Decimal decimalSchema = (HoodieSchema.Decimal) resolvedSchema;
       if (decimalSchema.isFixed()) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -486,7 +486,11 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     if (resolvedSchema instanceof HoodieSchema.Decimal) {
       HoodieSchema.Decimal decimalSchema = (HoodieSchema.Decimal) resolvedSchema;
       if (decimalSchema.isFixed()) {
-        return decimalSchema.getFixedSize();
+        int fixedSize = decimalSchema.getFixedSize();
+        ValidationUtils.checkArgument(fixedSize >= Decimal.minBytesForPrecision()[precision],
+            () -> String.format("Avro fixed size %s is too small for decimal precision %s (need >= %s bytes)",
+                fixedSize, precision, Decimal.minBytesForPrecision()[precision]));
+        return fixedSize;
       }
     }
     return Decimal.minBytesForPrecision()[precision];

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
@@ -18,8 +18,11 @@
 
 package org.apache.hudi.io.storage.row;
 
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.testutils.HoodieClientTestBase;
 
+import org.apache.spark.sql.types.Decimal;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -41,6 +44,21 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
 
   private static final String SESSION_LOCAL_TIME_ZONE_KEY = "spark.sql.session.timeZone";
+
+  @Test
+  void testDecimalFixedLen() {
+    int minWidth = Decimal.minBytesForPrecision()[20];
+    // A non-decimal schema falls back to the precision-minimal width.
+    assertEquals(minWidth,
+        HoodieRowParquetWriteSupport.decimalFixedLen(HoodieSchema.create(HoodieSchemaType.STRING), 20));
+    // A bytes-backed decimal (no declared fixed size) also falls back to the minimum.
+    assertEquals(minWidth,
+        HoodieRowParquetWriteSupport.decimalFixedLen(HoodieSchema.createDecimal(20, 2), 20));
+    // An Avro fixed decimal wider than the minimum is honored.
+    assertEquals(10,
+        HoodieRowParquetWriteSupport.decimalFixedLen(
+            HoodieSchema.createDecimal("dec", null, null, 20, 2, 10), 20));
+  }
 
   @Test
   void testResolveSessionLocalTimeZoneWithoutOverride() {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
@@ -48,17 +48,17 @@ class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
   private static final String SESSION_LOCAL_TIME_ZONE_KEY = "spark.sql.session.timeZone";
 
   @Test
-  void testDecimalFixedLen() {
+  void testResolveDecimalByteLength() {
     int minWidth = Decimal.minBytesForPrecision()[20];
     // A non-decimal schema falls back to the precision-minimal width.
     assertEquals(minWidth,
-        HoodieRowParquetWriteSupport.decimalFixedLen(HoodieSchema.create(HoodieSchemaType.STRING), 20));
+        HoodieRowParquetWriteSupport.resolveDecimalByteLength(HoodieSchema.create(HoodieSchemaType.STRING), 20));
     // A bytes-backed decimal (no declared fixed size) also falls back to the minimum.
     assertEquals(minWidth,
-        HoodieRowParquetWriteSupport.decimalFixedLen(HoodieSchema.createDecimal(20, 2), 20));
+        HoodieRowParquetWriteSupport.resolveDecimalByteLength(HoodieSchema.createDecimal(20, 2), 20));
     // An Avro fixed decimal wider than the minimum is honored.
     assertEquals(10,
-        HoodieRowParquetWriteSupport.decimalFixedLen(
+        HoodieRowParquetWriteSupport.resolveDecimalByteLength(
             HoodieSchema.createDecimal("dec", null, null, 20, 2, 10), 20));
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
@@ -29,8 +29,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.TimeZone;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Coverage for {@link HoodieRowParquetWriteSupport#resolveSessionLocalTimeZone()}.
@@ -58,6 +60,21 @@ class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
     assertEquals(10,
         HoodieRowParquetWriteSupport.decimalFixedLen(
             HoodieSchema.createDecimal("dec", null, null, 20, 2, 10), 20));
+  }
+
+  @Test
+  void testPadDecimalToFixedLength() {
+    byte[] buffer = new byte[16];
+    // Already the full width: returned as-is, no copy into the buffer.
+    byte[] exact = new byte[] {1, 2, 3, 4};
+    assertSame(exact, HoodieRowParquetWriteSupport.padDecimalToFixedLength(exact, 4, buffer));
+    // Positive magnitude: left-padded with zero sign bytes.
+    byte[] positive = HoodieRowParquetWriteSupport.padDecimalToFixedLength(new byte[] {0x12, 0x34}, 4, buffer);
+    assertArrayEquals(new byte[] {0, 0, 0x12, 0x34}, Arrays.copyOf(positive, 4));
+    // Negative magnitude: left-padded with 0xFF sign bytes.
+    byte[] negative = HoodieRowParquetWriteSupport.padDecimalToFixedLength(
+        new byte[] {(byte) 0xFF, (byte) 0x80}, 4, buffer);
+    assertArrayEquals(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0x80}, Arrays.copyOf(negative, 4));
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieInternalRowParquetWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieInternalRowParquetWriter.java
@@ -36,12 +36,16 @@ import org.apache.hudi.testutils.SparkDatasetTestUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -124,6 +128,38 @@ public class TestHoodieInternalRowParquetWriter extends HoodieSparkClientTestHar
     recordKeys.forEach(recordKey -> {
       assertTrue(bloomFilter.mightContain(recordKey));
     });
+  }
+
+  @Test
+  void testDecimalFixedLenWidthFromAvroSchema() {
+    // The row-writer sizes decimal FIXED_LEN columns from the Avro schema: an Avro fixed(10) for
+    // decimal(20,2) keeps its declared width (10, wider than the precision-minimal 9), while a bytes
+    // decimal keeps the precision-minimal width (9).
+    assertEquals(10, decimalParquetTypeLength(decimalRecordSchema(
+        "{\"type\":\"fixed\",\"name\":\"dec_fixed\",\"size\":10,\"logicalType\":\"decimal\",\"precision\":20,\"scale\":2}")),
+        "Avro fixed(10) decimal must stay FIXED_LEN_BYTE_ARRAY(10)");
+    assertEquals(9, decimalParquetTypeLength(decimalRecordSchema(
+        "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":2}")),
+        "bytes decimal keeps the precision-minimal FIXED_LEN width (9)");
+  }
+
+  private static String decimalRecordSchema(String decType) {
+    return "{\"type\":\"record\",\"name\":\"rec\",\"fields\":[{\"name\":\"dec\",\"type\":" + decType + "}]}";
+  }
+
+  private int decimalParquetTypeLength(String avroSchemaJson) {
+    StructType structType = new StructType().add("dec", DataTypes.createDecimalType(20, 2), false);
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withSchema(avroSchemaJson)
+        .build();
+    HoodieRowParquetWriteSupport writeSupport = HoodieRowParquetWriteSupport.getHoodieRowParquetWriteSupport(
+        storageConf.unwrap(), structType, Option.empty(), config);
+    MessageType parquetSchema = writeSupport.init(writeSupport.getHadoopConf()).getSchema();
+    PrimitiveType dec = parquetSchema.getType("dec").asPrimitiveType();
+    assertEquals(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, dec.getPrimitiveTypeName(),
+        "decimal must be encoded as FIXED_LEN_BYTE_ARRAY");
+    return dec.getTypeLength();
   }
 
   private HoodieRowParquetWriteSupport getWriteSupport(HoodieWriteConfig.Builder writeConfigBuilder, Configuration hadoopConf, boolean parquetWriteLegacyFormatEnabled) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
@@ -28,19 +28,27 @@ import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.config.HoodieCleanConfig;
+import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieLayoutConfig;
@@ -52,6 +60,8 @@ import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.table.HoodieSparkTable;
+import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.table.action.commit.SparkBucketIndexPartitioner;
 import org.apache.hudi.table.action.rollback.RollbackUtils;
@@ -59,17 +69,28 @@ import org.apache.hudi.table.storage.HoodieStorageLayout;
 import org.apache.hudi.testutils.HoodieMergeOnReadTestUtils;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
+import org.apache.avro.Conversions;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -441,5 +462,138 @@ public class TestHoodieSparkMergeOnReadTableCompaction extends SparkClientFuncti
     boolean committed =
         client.commitStats(instant, writeStats, Option.empty(), metaClient.getCommitActionType());
     assertTrue(committed);
+  }
+
+  // Avro fixed(10) decimal(20,2). 10 is wider than the precision-minimal width (9 for precision
+  // 20), so Spark's own DecimalType->Avro conversion would emit fixed(9); the declared 10 only
+  // survives if the write path honors the Avro fixed size. Do not derive this schema from a
+  // DataFrame, which would drop the fixed size.
+  private static final String FIXED10_DECIMAL_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"decimalRec\",\"fields\":["
+          + "{\"name\":\"_row_key\",\"type\":\"string\"},"
+          + "{\"name\":\"partition_path\",\"type\":\"string\"},"
+          + "{\"name\":\"ts\",\"type\":\"long\"},"
+          + "{\"name\":\"dec\",\"type\":{\"type\":\"fixed\",\"name\":\"decFixed\",\"size\":10,"
+          + "\"logicalType\":\"decimal\",\"precision\":20,\"scale\":2}}]}";
+
+  private static final String DECIMAL_PARTITION = "p1";
+  private static final int EXPECTED_DECIMAL_FIXED_LEN = 10;
+
+  @Test
+  void testDecimalFixedWidthPreservedAfterCompactionAndClustering() throws Exception {
+    Properties props = getPropertiesForKeyGen(true);
+    Properties rowWriterProps = new Properties();
+    rowWriterProps.put("hoodie.datasource.write.row.writer.enable", "true");
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
+        .forTable("test-decimal-fixed")
+        .withPath(basePath())
+        .withSchema(FIXED10_DECIMAL_SCHEMA)
+        .withParallelism(2, 2)
+        .withPreCombineField("ts")
+        .withProperties(rowWriterProps)
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .withMaxNumDeltaCommitsBeforeCompaction(1)
+            .compactionSmallFileSize(0)
+            .withInlineCompaction(false)
+            .build())
+        .withClusteringConfig(HoodieClusteringConfig.newBuilder()
+            .withClusteringMaxNumGroups(10)
+            .withClusteringTargetPartitions(0)
+            .withInlineClustering(false)
+            .withInlineClusteringNumCommits(1)
+            .build())
+        .build();
+    props.putAll(config.getProps());
+
+    metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, props);
+    client = getHoodieWriteClient(config);
+
+    // two insert commits (small-file size 0 forces a fresh file group each) create two base-file
+    // groups, both written via the Avro path at fixed(10)
+    String instant1 = WriteClientTestUtils.createNewInstantTime();
+    writeData(instant1, buildDecimalRecords(0, 10, 1L, new BigDecimal("123456789.12")), true);
+    String instant2 = WriteClientTestUtils.createNewInstantTime();
+    writeData(instant2, buildDecimalRecords(10, 10, 1L, new BigDecimal("223456789.34")), true);
+    // update every key so both groups accumulate log files for compaction to merge
+    String instant3 = WriteClientTestUtils.createNewInstantTime();
+    writeData(instant3, buildDecimalRecords(0, 20, 2L, new BigDecimal("323456789.56")), true);
+
+    // precondition: both file groups must carry log files, else compaction is a no-op and would not
+    // exercise the row-writer merge path
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieTable hoodieTable = HoodieSparkTable.create(config, context(), metaClient);
+    hoodieTable.getHoodieView().sync();
+    List<FileSlice> latestSlices =
+        hoodieTable.getHoodieView().getLatestFileSlices(DECIMAL_PARTITION).collect(Collectors.toList());
+    assertEquals(2, latestSlices.size(), "expected two file groups before compaction");
+    assertTrue(latestSlices.stream().allMatch(slice -> slice.getLogFiles().findAny().isPresent()),
+        "each file group must have log files for compaction to merge");
+    HoodieSchema tableSchema = new TableSchemaResolver(metaClient).getTableSchema(false);
+
+    // compaction rewrites both base files through the Spark record type
+    String compactionInstant = (String) client.scheduleCompaction(Option.empty()).get();
+    HoodieWriteMetadata compactionResult = client.compact(compactionInstant);
+    client.commitCompaction(compactionInstant, compactionResult, Option.empty());
+    assertTrue(metaClient.reloadActiveTimeline().filterCompletedInstants().containsInstant(compactionInstant));
+    List<StoragePath> compactedBaseFiles = latestBaseFilePaths(config, DECIMAL_PARTITION);
+    assertEquals(2, compactedBaseFiles.size(), "expected two compacted base files");
+    for (StoragePath path : compactedBaseFiles) {
+      assertDecimalFixedLen(path, EXPECTED_DECIMAL_FIXED_LEN);
+    }
+    assertEquals(tableSchema,
+        new TableSchemaResolver(HoodieTableMetaClient.reload(metaClient)).getTableSchema(false),
+        "table schema in commit metadata must not change after compaction");
+
+    // clustering rewrites the two compacted groups through the same Spark row-writer path
+    String clusteringInstant = (String) client.scheduleClustering(Option.empty()).get();
+    HoodieWriteMetadata<JavaRDD<WriteStatus>> clusterMetadata = client.cluster(clusteringInstant, true);
+    List<HoodieWriteStat> clusterStats = clusterMetadata.getWriteStats().get();
+    assertTrue(!clusterStats.isEmpty(), "clustering should write at least one base file");
+    for (HoodieWriteStat stat : clusterStats) {
+      assertDecimalFixedLen(new StoragePath(metaClient.getBasePath(), stat.getPath()),
+          EXPECTED_DECIMAL_FIXED_LEN);
+    }
+    assertEquals(tableSchema,
+        new TableSchemaResolver(HoodieTableMetaClient.reload(metaClient)).getTableSchema(false),
+        "table schema in commit metadata must not change after clustering");
+  }
+
+  private List<HoodieRecord> buildDecimalRecords(int startKey, int count, long ts, BigDecimal decValue) {
+    Schema schema = new Schema.Parser().parse(FIXED10_DECIMAL_SCHEMA);
+    Schema decSchema = schema.getField("dec").schema();
+    Conversions.DecimalConversion decimalConversion = new Conversions.DecimalConversion();
+    LogicalTypes.Decimal decimalType = LogicalTypes.decimal(20, 2);
+    BigDecimal scaledValue = decValue.setScale(2);
+    List<HoodieRecord> records = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      String key = "key_" + (startKey + i);
+      GenericRecord rec = new GenericData.Record(schema);
+      rec.put("_row_key", key);
+      rec.put("partition_path", DECIMAL_PARTITION);
+      rec.put("ts", ts);
+      GenericFixed fixed = decimalConversion.toFixed(scaledValue, decSchema, decimalType);
+      rec.put("dec", fixed);
+      records.add(new HoodieAvroRecord<>(new HoodieKey(key, DECIMAL_PARTITION),
+          new OverwriteWithLatestAvroPayload(rec, ts)));
+    }
+    return records;
+  }
+
+  private List<StoragePath> latestBaseFilePaths(HoodieWriteConfig config, String partition) {
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieTable hoodieTable = HoodieSparkTable.create(config, context(), metaClient);
+    hoodieTable.getHoodieView().sync();
+    return hoodieTable.getBaseFileOnlyView().getLatestBaseFiles(partition)
+        .map(HoodieBaseFile::getStoragePath).collect(Collectors.toList());
+  }
+
+  private void assertDecimalFixedLen(StoragePath baseFilePath, int expectedLen) {
+    MessageType parquetSchema = ParquetUtils.readMetadata(hoodieStorage(), baseFilePath)
+        .getFileMetaData().getSchema();
+    PrimitiveType decType = parquetSchema.getType("dec").asPrimitiveType();
+    assertEquals(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, decType.getPrimitiveTypeName(),
+        "decimal must be encoded as FIXED_LEN_BYTE_ARRAY");
+    assertEquals(expectedLen, decType.getTypeLength(),
+        "Avro fixed(10) decimal(20,2) must stay FIXED_LEN_BYTE_ARRAY(10), not narrow to 9");
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
@@ -102,6 +102,7 @@ import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -548,7 +549,7 @@ public class TestHoodieSparkMergeOnReadTableCompaction extends SparkClientFuncti
     String clusteringInstant = (String) client.scheduleClustering(Option.empty()).get();
     HoodieWriteMetadata<JavaRDD<WriteStatus>> clusterMetadata = client.cluster(clusteringInstant, true);
     List<HoodieWriteStat> clusterStats = clusterMetadata.getWriteStats().get();
-    assertTrue(!clusterStats.isEmpty(), "clustering should write at least one base file");
+    assertFalse(clusterStats.isEmpty(), "clustering should write at least one base file");
     for (HoodieWriteStat stat : clusterStats) {
       assertDecimalFixedLen(new StoragePath(metaClient.getBasePath(), stat.getPath()),
           EXPECTED_DECIMAL_FIXED_LEN);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`HoodieRowParquetWriteSupport`, the Spark row write support used by bulk insert, clustering, and file-group-reader-based MOR compaction, sizes decimal `FIXED_LEN_BYTE_ARRAY` columns from `Decimal.minBytesForPrecision()[precision]` and discards the declared Avro `fixed` size. A Spark `DecimalType` carries only precision and scale, so an Avro `fixed(N)` decimal whose declared size is wider than the precision-minimal width (for example a `fixed(10)` decimal(20,2), whose minimal width is 9) is written as `FIXED_LEN_BYTE_ARRAY(9)`. This diverges from the Avro write path (inserts), which preserves the declared 10. Mixing the two paths (insert then compaction, or upsert then clustering) leaves a table with mixed-width decimal columns under one logical schema.

### Summary and Changelog

Add a helper `decimalFixedLen(HoodieSchema resolvedSchema, int precision)`: when the resolved schema is a `HoodieSchema.Decimal` backed by an Avro `fixed` type (`isFixed()`), use its `getFixedSize()`; otherwise fall back to `Decimal.minBytesForPrecision()[precision]`. It is applied at both decimal branches that already receive the resolved `HoodieSchema`:

- the output Parquet type in the schema converter (`convertField`), so the column is declared `FIXED_LEN_BYTE_ARRAY(N)`, and
- the value writer (`makeWriter`), so the written value bytes are padded to the same `N`.

The padding buffer is now resolved once per column instead of once per record. The shared `decimalBuffer` is only sized for the precision-minimal maximum, so a declared `fixed(N)` wider than that gets its own per-column buffer, which also closes a latent overflow when honoring a wide fixed size.

No code copied.

### Impact

Behavior change on the Spark row write path: a decimal declared as an Avro `fixed(N)` is now written as `FIXED_LEN_BYTE_ARRAY(N)`, matching the table schema and the Avro write path, instead of the precision-minimal width. Existing narrower files still read correctly (Spark decodes decimals by precision). The scope is limited to decimals backed by an Avro `fixed` type; `bytes`-backed decimals and pure-Spark tables (no Avro fixed size) are unaffected.

### Risk Level

low

The change is confined to the decimal branch and only diverges from prior behavior when the resolved schema is a `fixed`-backed decimal. A new unit test asserts an Avro `fixed(10)` decimal(20,2) is declared `FIXED_LEN(10)` and a `bytes` decimal(20,2) stays `FIXED_LEN(9)`. A new functional MOR test builds a table whose Avro schema declares a `fixed(10)` decimal, runs compaction and row-writer clustering over two file groups, asserts the rewritten base files stay `FIXED_LEN_BYTE_ARRAY(10)`, and asserts the commit-metadata table schema is unchanged after both operations. Both fixed-width assertions fail (expected 10 but was 9) when the fix is reverted.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
