### PR TITLE
chore(ci): trim the CI matrix and reset required checks to unblock PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,6 +3,6 @@
 When updating the pr template, you must consider if updates need to be made to scripts/pr_compliance.py
 
 ## What are the files in workflows?
-- bot.yml: runs the hudi unit tests with various versions of scala, spark, and flink
+- bot.yml: runs the hudi unit tests against the scala, spark, and flink versions in its CI matrix. That matrix is currently cut down to one configuration per area to reduce runner usage; the jobs and matrix entries it dropped are commented out in place and marked `[CI-TRIM]`
 - pr_compliance.yml: checks pr titles and main comment to make sure that everything is filled out and formatted properly
 - update_pr_compliance: runs the pr_compliance tests when scripts/pr_compliance.py is updated

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -32,21 +32,7 @@ env:
   FLINK_IT_FILTER2: -Dit.test=!ITTestHoodieDataSource
 
 jobs:
-  # [CI-TRIM] ASF infra disabled GitHub Actions on this repository over the amount of runner
-  # time the full matrix consumed. To unblock PRs, the matrix below is cut down to one
-  # representative configuration per area - one Spark 3.5 lane on Java 11, one Spark 4.2
-  # lane on Java 17, one Flink 2.1 lane - and the rest is commented out rather than
-  # deleted. Every parked block is marked `[CI-TRIM]` so the coverage can be restored, in
-  # whatever form fits the project's runner budget, once CI is running again.
-
-  # [CI-TRIM] A required status check in .asf.yaml whose job is to invalidate the green
-  # checks a PR collected before the trim. The context is new, so branch protection holds
-  # any such PR until a fresh `pull_request` event runs this workflow again. Note what that
-  # does and does not buy: Actions loads workflow definitions for a `pull_request` from the
-  # merge ref, so re-triggering is enough to satisfy this and a PR is not forced to carry a
-  # rebase. What it does guarantee is that nothing merges on a CI result predating the trim.
-  # Deliberately does nothing and never gates on `changes`, so a docs-only PR can satisfy it
-  # too. Drop it once no pre-trim PR is still open.
+  # [CI-TRIM] to revisit for CI improvement
   validate-ci-baseline:
     runs-on: ubuntu-latest
     steps:
@@ -351,7 +337,7 @@ jobs:
           flags: common-and-other-modules
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  # [CI-TRIM] `test-spark-java-tests-part1` is parked to cut CI usage.
+  # [CI-TRIM] to revisit for CI improvement
 #  test-spark-java-tests-part1:
 #    runs-on: ubuntu-latest
 #    needs: changes
@@ -409,7 +395,7 @@ jobs:
 #          flags: spark-java-tests
 #          token: ${{ secrets.CODECOV_TOKEN }}
 
-  # [CI-TRIM] `test-spark-java-tests-part2` is parked to cut CI usage.
+  # [CI-TRIM] to revisit for CI improvement
 #  test-spark-java-tests-part2:
 #    runs-on: ubuntu-latest
 #    needs: changes
@@ -482,7 +468,7 @@ jobs:
 #          flags: spark-java-tests
 #          token: ${{ secrets.CODECOV_TOKEN }}
 
-  # [CI-TRIM] `test-spark-java-tests-part3` is parked to cut CI usage.
+  # [CI-TRIM] to revisit for CI improvement
 #  test-spark-java-tests-part3:
 #    runs-on: ubuntu-latest
 #    needs: changes
@@ -548,7 +534,7 @@ jobs:
 #          flags: spark-java-tests
 #          token: ${{ secrets.CODECOV_TOKEN }}
 
-  # [CI-TRIM] `test-spark-scala-dml-tests` is parked to cut CI usage.
+  # [CI-TRIM] to revisit for CI improvement
 #  test-spark-scala-dml-tests:
 #    runs-on: ubuntu-latest
 #    needs: changes
@@ -614,7 +600,7 @@ jobs:
 #          flags: spark-scala-tests
 #          token: ${{ secrets.CODECOV_TOKEN }}
 
-  # [CI-TRIM] `test-spark-scala-other-tests` is parked to cut CI usage.
+  # [CI-TRIM] to revisit for CI improvement
 #  test-spark-scala-other-tests:
 #    runs-on: ubuntu-latest
 #    needs: changes
@@ -736,7 +722,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # [CI-TRIM] parked matrix entries:
+          # [CI-TRIM] to revisit for CI improvement
 #          - scalaProfile: "scala-2.13"
 #            sparkProfile: "spark3.5"
 #            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
@@ -795,7 +781,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # [CI-TRIM] parked matrix entries:
+          # [CI-TRIM] to revisit for CI improvement
 #          - scalaProfile: "scala-2.13"
 #            sparkProfile: "spark3.5"
 #            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
@@ -869,7 +855,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # [CI-TRIM] parked matrix entries:
+          # [CI-TRIM] to revisit for CI improvement
 #          - scalaProfile: "scala-2.13"
 #            sparkProfile: "spark3.5"
 #            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
@@ -936,7 +922,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # [CI-TRIM] parked matrix entries:
+          # [CI-TRIM] to revisit for CI improvement
 #          - scalaProfile: "scala-2.13"
 #            sparkProfile: "spark3.5"
 #            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
@@ -1003,7 +989,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # [CI-TRIM] parked matrix entries:
+          # [CI-TRIM] to revisit for CI improvement
 #          - scalaProfile: "scala-2.13"
 #            sparkProfile: "spark3.5"
 #            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
@@ -1070,7 +1056,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # [CI-TRIM] parked matrix entries:
+          # [CI-TRIM] to revisit for CI improvement
 #          - flinkProfile: "flink1.18"
 #            flinkAvroVersion: "1.11.4"
 #            flinkParquetVersion: '1.13.1'
@@ -1188,7 +1174,7 @@ jobs:
           flags: flink-integration-tests
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  # [CI-TRIM] `docker-java17-test` is parked to cut CI usage.
+  # [CI-TRIM] to revisit for CI improvement
 #  docker-java17-test:
 #    runs-on: ubuntu-latest
 #    needs: changes
@@ -1252,7 +1238,7 @@ jobs:
             flinkParquetVersion: '1.13.1'
             sparkProfile: 'spark3.5'
             sparkRuntime: 'spark3.5.1'
-          # [CI-TRIM] parked matrix entries:
+          # [CI-TRIM] to revisit for CI improvement
 #          - scalaProfile: 'scala-2.13'
 #            flinkProfile: 'flink1.19'
 #            flinkAvroVersion: '1.11.4'
@@ -1327,7 +1313,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # [CI-TRIM] parked matrix entries:
+          # [CI-TRIM] to revisit for CI improvement
 #          - scalaProfile: 'scala-2.13'
 #            flinkProfile: 'flink1.20'
 #            flinkAvroVersion: '1.11.4'
@@ -1377,7 +1363,7 @@ jobs:
           HUDI_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           ./packaging/bundle-validation/ci_run.sh hudi_docker_java17 $HUDI_VERSION openjdk17
 
-  # [CI-TRIM] `validate-bundles-java11` is parked to cut CI usage.
+  # [CI-TRIM] to revisit for CI improvement
 #  # flink 2.0/2.1 only support Java 11 and above version
 #  validate-bundles-java11:
 #    runs-on: ubuntu-latest
@@ -1516,7 +1502,7 @@ jobs:
           flags: integration-tests
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  # [CI-TRIM] `integration-tests-hive-sync` is parked to cut CI usage.
+  # [CI-TRIM] to revisit for CI improvement
 #  integration-tests-hive-sync:
 #    # Testcontainers-based E2E hive sync coverage for Hudi's custom logical types
 #    # (VECTOR, BLOB) and the Spark 4.0+ VARIANT type. Runs the integ2 testcontainers
@@ -1599,7 +1585,7 @@ jobs:
 #            -Dspark.docker.compose.prefix=$COMPOSE_PREFIX \
 #            $MVN_ARGS
 
-  # [CI-TRIM] `build-spark-java17` is parked to cut CI usage.
+  # [CI-TRIM] to revisit for CI improvement
 #  build-spark-java17:
 #    runs-on: ubuntu-latest
 #    needs: changes
@@ -1645,7 +1631,7 @@ jobs:
 #        run:
 #          mvn test -Punit-tests -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -pl hudi-examples/hudi-examples-spark $MVN_ARGS
 
-  # [CI-TRIM] `build-flink-java17` is parked to cut CI usage.
+  # [CI-TRIM] to revisit for CI improvement
 #  build-flink-java17:
 #    runs-on: ubuntu-latest
 #    needs: changes

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -32,6 +32,27 @@ env:
   FLINK_IT_FILTER2: -Dit.test=!ITTestHoodieDataSource
 
 jobs:
+  # [CI-TRIM] ASF infra disabled GitHub Actions on this repository over the amount of runner
+  # time the full matrix consumed. To unblock PRs, the matrix below is cut down to one
+  # representative configuration per area - one Spark 3.5 lane on Java 11, one Spark 4.2
+  # lane on Java 17, one Flink 2.1 lane - and the rest is commented out rather than
+  # deleted. Every parked block is marked `[CI-TRIM]` so the coverage can be restored, in
+  # whatever form fits the project's runner budget, once CI is running again.
+
+  # [CI-TRIM] A required status check in .asf.yaml whose job is to invalidate the green
+  # checks a PR collected before the trim. The context is new, so branch protection holds
+  # any such PR until a fresh `pull_request` event runs this workflow again. Note what that
+  # does and does not buy: Actions loads workflow definitions for a `pull_request` from the
+  # merge ref, so re-triggering is enough to satisfy this and a PR is not forced to carry a
+  # rebase. What it does guarantee is that nothing merges on a CI result predating the trim.
+  # Deliberately does nothing and never gates on `changes`, so a docs-only PR can satisfy it
+  # too. Drop it once no pre-trim PR is still open.
+  validate-ci-baseline:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm CI ran against the reduced matrix
+        run: echo "Ran against the reduced CI matrix."
+
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -330,329 +351,334 @@ jobs:
           flags: common-and-other-modules
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  test-spark-java-tests-part1:
-    runs-on: ubuntu-latest
-    needs: changes
-    strategy:
-      matrix:
-        include:
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.3"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
+  # [CI-TRIM] `test-spark-java-tests-part1` is parked to cut CI usage.
+#  test-spark-java-tests-part1:
+#    runs-on: ubuntu-latest
+#    needs: changes
+#    strategy:
+#      matrix:
+#        include:
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.3"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.4"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.4"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
 
-    steps:
-      - if: needs.changes.outputs.relevant == 'true'
-        uses: actions/checkout@v5
-      - name: Set up JDK 11
-        if: needs.changes.outputs.relevant == 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          architecture: x64
-          cache: maven
-      - name: Build Project
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
-      - name: Java UT 1 - Common & Spark
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DwildcardSuites=skipScalaTests $JAVA_UT_FILTER1 -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
-      - name: Generate merged coverage report
-        if: always() && needs.changes.outputs.relevant == 'true'
-        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
-      - name: Upload coverage to Codecov
-        if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
-        with:
-          files: ./jacoco-report.xml
-          disable_search: true
-          flags: spark-java-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
+#    steps:
+#      - if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/checkout@v5
+#      - name: Set up JDK 11
+#        if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#          architecture: x64
+#          cache: maven
+#      - name: Build Project
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
+#      - name: Java UT 1 - Common & Spark
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DwildcardSuites=skipScalaTests $JAVA_UT_FILTER1 -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+#      - name: Generate merged coverage report
+#        if: always() && needs.changes.outputs.relevant == 'true'
+#        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
+#      - name: Upload coverage to Codecov
+#        if: always() && needs.changes.outputs.relevant == 'true'
+#        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+#        with:
+#          files: ./jacoco-report.xml
+#          disable_search: true
+#          flags: spark-java-tests
+#          token: ${{ secrets.CODECOV_TOKEN }}
 
-  test-spark-java-tests-part2:
-    runs-on: ubuntu-latest
-    needs: changes
-    strategy:
-      matrix:
-        include:
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.3"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
+  # [CI-TRIM] `test-spark-java-tests-part2` is parked to cut CI usage.
+#  test-spark-java-tests-part2:
+#    runs-on: ubuntu-latest
+#    needs: changes
+#    strategy:
+#      matrix:
+#        include:
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.3"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.4"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.4"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
 
-    steps:
-      - if: needs.changes.outputs.relevant == 'true'
-        uses: actions/checkout@v5
-      - name: Set up JDK 11
-        if: needs.changes.outputs.relevant == 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          architecture: x64
-          cache: maven
-      - name: Build Project
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
-      - name: Quickstart Test
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-        run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -pl hudi-examples/hudi-examples-spark $MVN_ARGS -Djacoco.skip=false
-      - name: Java UT 2 - Common & Spark
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DwildcardSuites=skipScalaTests $JAVA_UT_FILTER2 -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
-      - name: Java FTA - Spark
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn test -Pfunctional-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DwildcardSuites=skipScalaTests -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
-      - name: Generate merged coverage report
-        if: always() && needs.changes.outputs.relevant == 'true'
-        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
-      - name: Upload coverage to Codecov
-        if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
-        with:
-          files: ./jacoco-report.xml
-          disable_search: true
-          flags: spark-java-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
+#    steps:
+#      - if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/checkout@v5
+#      - name: Set up JDK 11
+#        if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#          architecture: x64
+#          cache: maven
+#      - name: Build Project
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
+#      - name: Quickstart Test
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#        run:
+#          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -pl hudi-examples/hudi-examples-spark $MVN_ARGS -Djacoco.skip=false
+#      - name: Java UT 2 - Common & Spark
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DwildcardSuites=skipScalaTests $JAVA_UT_FILTER2 -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+#      - name: Java FTA - Spark
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn test -Pfunctional-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DwildcardSuites=skipScalaTests -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+#      - name: Generate merged coverage report
+#        if: always() && needs.changes.outputs.relevant == 'true'
+#        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
+#      - name: Upload coverage to Codecov
+#        if: always() && needs.changes.outputs.relevant == 'true'
+#        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+#        with:
+#          files: ./jacoco-report.xml
+#          disable_search: true
+#          flags: spark-java-tests
+#          token: ${{ secrets.CODECOV_TOKEN }}
 
-  test-spark-java-tests-part3:
-    runs-on: ubuntu-latest
-    needs: changes
-    strategy:
-      matrix:
-        include:
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.3"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
+  # [CI-TRIM] `test-spark-java-tests-part3` is parked to cut CI usage.
+#  test-spark-java-tests-part3:
+#    runs-on: ubuntu-latest
+#    needs: changes
+#    strategy:
+#      matrix:
+#        include:
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.3"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.4"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.4"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
 
-    steps:
-      - if: needs.changes.outputs.relevant == 'true'
-        uses: actions/checkout@v5
-      - name: Set up JDK 11
-        if: needs.changes.outputs.relevant == 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          architecture: x64
-          cache: maven
-      - name: Build Project
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
-      - name: Java FTB - Spark
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn test -Pfunctional-tests-b -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DwildcardSuites=skipScalaTests -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
-      - name: Java FTC - Spark
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn test -Pfunctional-tests-c -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DwildcardSuites=skipScalaTests -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
-      - name: Generate merged coverage report
-        if: always() && needs.changes.outputs.relevant == 'true'
-        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
-      - name: Upload coverage to Codecov
-        if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
-        with:
-          files: ./jacoco-report.xml
-          disable_search: true
-          flags: spark-java-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
+#    steps:
+#      - if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/checkout@v5
+#      - name: Set up JDK 11
+#        if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#          architecture: x64
+#          cache: maven
+#      - name: Build Project
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
+#      - name: Java FTB - Spark
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn test -Pfunctional-tests-b -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DwildcardSuites=skipScalaTests -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+#      - name: Java FTC - Spark
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn test -Pfunctional-tests-c -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DwildcardSuites=skipScalaTests -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+#      - name: Generate merged coverage report
+#        if: always() && needs.changes.outputs.relevant == 'true'
+#        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
+#      - name: Upload coverage to Codecov
+#        if: always() && needs.changes.outputs.relevant == 'true'
+#        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+#        with:
+#          files: ./jacoco-report.xml
+#          disable_search: true
+#          flags: spark-java-tests
+#          token: ${{ secrets.CODECOV_TOKEN }}
 
-  test-spark-scala-dml-tests:
-    runs-on: ubuntu-latest
-    needs: changes
-    strategy:
-      matrix:
-        include:
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.3"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
+  # [CI-TRIM] `test-spark-scala-dml-tests` is parked to cut CI usage.
+#  test-spark-scala-dml-tests:
+#    runs-on: ubuntu-latest
+#    needs: changes
+#    strategy:
+#      matrix:
+#        include:
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.3"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.4"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.4"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
 
-    steps:
-      - if: needs.changes.outputs.relevant == 'true'
-        uses: actions/checkout@v5
-      - name: Set up JDK 11
-        if: needs.changes.outputs.relevant == 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          architecture: x64
-          cache: maven
-      - name: Build Project
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
-      - name: Scala UT - Common & Spark
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
-      - name: Scala FT - Spark
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn test -Pfunctional-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
-      - name: Generate merged coverage report
-        if: always() && needs.changes.outputs.relevant == 'true'
-        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
-      - name: Upload coverage to Codecov
-        if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
-        with:
-          files: ./jacoco-report.xml
-          disable_search: true
-          flags: spark-scala-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
+#    steps:
+#      - if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/checkout@v5
+#      - name: Set up JDK 11
+#        if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#          architecture: x64
+#          cache: maven
+#      - name: Build Project
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
+#      - name: Scala UT - Common & Spark
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+#      - name: Scala FT - Spark
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn test -Pfunctional-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+#      - name: Generate merged coverage report
+#        if: always() && needs.changes.outputs.relevant == 'true'
+#        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
+#      - name: Upload coverage to Codecov
+#        if: always() && needs.changes.outputs.relevant == 'true'
+#        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+#        with:
+#          files: ./jacoco-report.xml
+#          disable_search: true
+#          flags: spark-scala-tests
+#          token: ${{ secrets.CODECOV_TOKEN }}
 
-  test-spark-scala-other-tests:
-    runs-on: ubuntu-latest
-    needs: changes
-    strategy:
-      matrix:
-        include:
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.3"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
+  # [CI-TRIM] `test-spark-scala-other-tests` is parked to cut CI usage.
+#  test-spark-scala-other-tests:
+#    runs-on: ubuntu-latest
+#    needs: changes
+#    strategy:
+#      matrix:
+#        include:
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.3"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.4"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.4"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
 
-    steps:
-      - if: needs.changes.outputs.relevant == 'true'
-        uses: actions/checkout@v5
-      - name: Set up JDK 11
-        if: needs.changes.outputs.relevant == 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          architecture: x64
-          cache: maven
-      - name: Build Project
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
-      - name: Scala UT - Common & Spark
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_OTHERS_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
-      - name: Scala FT - Spark
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn test -Pfunctional-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_OTHERS_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
-      - name: Generate merged coverage report
-        if: always() && needs.changes.outputs.relevant == 'true'
-        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
-      - name: Upload coverage to Codecov
-        if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
-        with:
-          files: ./jacoco-report.xml
-          disable_search: true
-          flags: spark-scala-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
+#    steps:
+#      - if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/checkout@v5
+#      - name: Set up JDK 11
+#        if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#          architecture: x64
+#          cache: maven
+#      - name: Build Project
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn clean install -T 2 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
+#      - name: Scala UT - Common & Spark
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn test -Punit-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_OTHERS_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+#      - name: Scala FT - Spark
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn test -Pfunctional-tests -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_OTHERS_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+#      - name: Generate merged coverage report
+#        if: always() && needs.changes.outputs.relevant == 'true'
+#        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
+#      - name: Upload coverage to Codecov
+#        if: always() && needs.changes.outputs.relevant == 'true'
+#        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+#        with:
+#          files: ./jacoco-report.xml
+#          disable_search: true
+#          flags: spark-scala-tests
+#          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-hudi-hadoop-mr-and-hudi-java-client:
     runs-on: ubuntu-latest
@@ -710,15 +736,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark4.0"
-            sparkModules: "hudi-spark-datasource/hudi-spark4.0.x"
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark4.1"
-            sparkModules: "hudi-spark-datasource/hudi-spark4.1.x"
+          # [CI-TRIM] parked matrix entries:
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark4.0"
+#            sparkModules: "hudi-spark-datasource/hudi-spark4.0.x"
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark4.1"
+#            sparkModules: "hudi-spark-datasource/hudi-spark4.1.x"
           - scalaProfile: "scala-2.13"
             sparkProfile: "spark4.2"
             sparkModules: "hudi-spark-datasource/hudi-spark4.2.x"
@@ -768,15 +795,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark4.0"
-            sparkModules: "hudi-spark-datasource/hudi-spark4.0.x"
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark4.1"
-            sparkModules: "hudi-spark-datasource/hudi-spark4.1.x"
+          # [CI-TRIM] parked matrix entries:
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark4.0"
+#            sparkModules: "hudi-spark-datasource/hudi-spark4.0.x"
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark4.1"
+#            sparkModules: "hudi-spark-datasource/hudi-spark4.1.x"
           - scalaProfile: "scala-2.13"
             sparkProfile: "spark4.2"
             sparkModules: "hudi-spark-datasource/hudi-spark4.2.x"
@@ -841,15 +869,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark4.0"
-            sparkModules: "hudi-spark-datasource/hudi-spark4.0.x"
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark4.1"
-            sparkModules: "hudi-spark-datasource/hudi-spark4.1.x"
+          # [CI-TRIM] parked matrix entries:
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark4.0"
+#            sparkModules: "hudi-spark-datasource/hudi-spark4.0.x"
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark4.1"
+#            sparkModules: "hudi-spark-datasource/hudi-spark4.1.x"
           - scalaProfile: "scala-2.13"
             sparkProfile: "spark4.2"
             sparkModules: "hudi-spark-datasource/hudi-spark4.2.x"
@@ -907,15 +936,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark4.0"
-            sparkModules: "hudi-spark-datasource/hudi-spark4.0.x"
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark4.1"
-            sparkModules: "hudi-spark-datasource/hudi-spark4.1.x"
+          # [CI-TRIM] parked matrix entries:
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark4.0"
+#            sparkModules: "hudi-spark-datasource/hudi-spark4.0.x"
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark4.1"
+#            sparkModules: "hudi-spark-datasource/hudi-spark4.1.x"
           - scalaProfile: "scala-2.13"
             sparkProfile: "spark4.2"
             sparkModules: "hudi-spark-datasource/hudi-spark4.2.x"
@@ -973,15 +1003,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark4.0"
-            sparkModules: "hudi-spark-datasource/hudi-spark4.0.x"
-          - scalaProfile: "scala-2.13"
-            sparkProfile: "spark4.1"
-            sparkModules: "hudi-spark-datasource/hudi-spark4.1.x"
+          # [CI-TRIM] parked matrix entries:
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark4.0"
+#            sparkModules: "hudi-spark-datasource/hudi-spark4.0.x"
+#          - scalaProfile: "scala-2.13"
+#            sparkProfile: "spark4.1"
+#            sparkModules: "hudi-spark-datasource/hudi-spark4.1.x"
           - scalaProfile: "scala-2.13"
             sparkProfile: "spark4.2"
             sparkModules: "hudi-spark-datasource/hudi-spark4.2.x"
@@ -1039,18 +1070,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - flinkProfile: "flink1.18"
-            flinkAvroVersion: "1.11.4"
-            flinkParquetVersion: '1.13.1'
-          - flinkProfile: "flink1.19"
-            flinkAvroVersion: "1.11.4"
-            flinkParquetVersion: '1.13.1'
-          - flinkProfile: "flink1.20"
-            flinkAvroVersion: "1.11.4"
-            flinkParquetVersion: '1.13.1'
-          - flinkProfile: "flink2.0"
-            flinkAvroVersion: "1.11.4"
-            flinkParquetVersion: '1.14.4'
+          # [CI-TRIM] parked matrix entries:
+#          - flinkProfile: "flink1.18"
+#            flinkAvroVersion: "1.11.4"
+#            flinkParquetVersion: '1.13.1'
+#          - flinkProfile: "flink1.19"
+#            flinkAvroVersion: "1.11.4"
+#            flinkParquetVersion: '1.13.1'
+#          - flinkProfile: "flink1.20"
+#            flinkAvroVersion: "1.11.4"
+#            flinkParquetVersion: '1.13.1'
+#          - flinkProfile: "flink2.0"
+#            flinkAvroVersion: "1.11.4"
+#            flinkParquetVersion: '1.14.4'
           - flinkProfile: "flink2.1"
             flinkAvroVersion: "1.11.4"
             flinkParquetVersion: '1.15.2'
@@ -1156,56 +1188,57 @@ jobs:
           flags: flink-integration-tests
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  docker-java17-test:
-    runs-on: ubuntu-latest
-    needs: changes
-    strategy:
-      matrix:
-        include:
-          - scalaProfile: 'scala-2.13'
-            flinkProfile: 'flink2.1'
-            sparkProfile: 'spark3.5'
-            sparkRuntime: 'spark3.5.0'
-          - scalaProfile: 'scala-2.12'
-            flinkProfile: 'flink2.1'
-            sparkProfile: 'spark3.5'
-            sparkRuntime: 'spark3.5.0'
-          - scalaProfile: 'scala-2.13'
-            flinkProfile: 'flink2.1'
-            sparkProfile: 'spark4.0'
-            sparkRuntime: 'spark4.0.0'
-          - scalaProfile: 'scala-2.13'
-            flinkProfile: 'flink2.1'
-            sparkProfile: 'spark4.1'
-            sparkRuntime: 'spark4.1.1'
-          - scalaProfile: 'scala-2.13'
-            flinkProfile: 'flink1.20'
-            sparkProfile: 'spark4.2'
-            sparkRuntime: 'spark4.2.0'
+  # [CI-TRIM] `docker-java17-test` is parked to cut CI usage.
+#  docker-java17-test:
+#    runs-on: ubuntu-latest
+#    needs: changes
+#    strategy:
+#      matrix:
+#        include:
+#          - scalaProfile: 'scala-2.13'
+#            flinkProfile: 'flink2.1'
+#            sparkProfile: 'spark3.5'
+#            sparkRuntime: 'spark3.5.0'
+#          - scalaProfile: 'scala-2.12'
+#            flinkProfile: 'flink2.1'
+#            sparkProfile: 'spark3.5'
+#            sparkRuntime: 'spark3.5.0'
+#          - scalaProfile: 'scala-2.13'
+#            flinkProfile: 'flink2.1'
+#            sparkProfile: 'spark4.0'
+#            sparkRuntime: 'spark4.0.0'
+#          - scalaProfile: 'scala-2.13'
+#            flinkProfile: 'flink2.1'
+#            sparkProfile: 'spark4.1'
+#            sparkRuntime: 'spark4.1.1'
+#          - scalaProfile: 'scala-2.13'
+#            flinkProfile: 'flink1.20'
+#            sparkProfile: 'spark4.2'
+#            sparkRuntime: 'spark4.2.0'
 
-    steps:
-      - if: needs.changes.outputs.relevant == 'true'
-        uses: actions/checkout@v5
-      - name: Set up JDK 17
-        if: needs.changes.outputs.relevant == 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          architecture: x64
-          # No `cache: maven` on purpose. This job runs no Maven on the host: run_docker_java17.sh
-          # builds inside the container and never mounts $HOME/.m2. Caching here seals a near-empty
-          # repo under the key all jobs share, which every later job then discards and re-downloads.
-      - name: UT/FT - Docker Test - OpenJDK 17
-        env:
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_RUNTIME: ${{ matrix.sparkRuntime }}
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-        # Only support Spark 3.4 for now
-        if: ${{ env.SPARK_PROFILE >= 'spark3.4' && needs.changes.outputs.relevant == 'true' }}
-        run: |
-          ./packaging/bundle-validation/run_docker_java17.sh
+#    steps:
+#      - if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/checkout@v5
+#      - name: Set up JDK 17
+#        if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '17'
+#          distribution: 'temurin'
+#          architecture: x64
+#          # No `cache: maven` on purpose. This job runs no Maven on the host: run_docker_java17.sh
+#          # builds inside the container and never mounts $HOME/.m2. Caching here seals a near-empty
+#          # repo under the key all jobs share, which every later job then discards and re-downloads.
+#      - name: UT/FT - Docker Test - OpenJDK 17
+#        env:
+#          FLINK_PROFILE: ${{ matrix.flinkProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_RUNTIME: ${{ matrix.sparkRuntime }}
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#        # Only support Spark 3.4 for now
+#        if: ${{ env.SPARK_PROFILE >= 'spark3.4' && needs.changes.outputs.relevant == 'true' }}
+#        run: |
+#          ./packaging/bundle-validation/run_docker_java17.sh
 
   validate-bundles:
     runs-on: ubuntu-latest
@@ -1219,24 +1252,25 @@ jobs:
             flinkParquetVersion: '1.13.1'
             sparkProfile: 'spark3.5'
             sparkRuntime: 'spark3.5.1'
-          - scalaProfile: 'scala-2.13'
-            flinkProfile: 'flink1.19'
-            flinkAvroVersion: '1.11.4'
-            flinkParquetVersion: '1.13.1'
-            sparkProfile: 'spark3.5'
-            sparkRuntime: 'spark3.5.1'
-          - scalaProfile: 'scala-2.12'
-            flinkProfile: 'flink1.18'
-            flinkAvroVersion: '1.11.4'
-            flinkParquetVersion: '1.13.1'
-            sparkProfile: 'spark3.4'
-            sparkRuntime: 'spark3.4.3'
-          - scalaProfile: 'scala-2.12'
-            flinkProfile: 'flink1.18'
-            flinkAvroVersion: '1.11.4'
-            flinkParquetVersion: '1.13.1'
-            sparkProfile: 'spark3.3'
-            sparkRuntime: 'spark3.3.4'
+          # [CI-TRIM] parked matrix entries:
+#          - scalaProfile: 'scala-2.13'
+#            flinkProfile: 'flink1.19'
+#            flinkAvroVersion: '1.11.4'
+#            flinkParquetVersion: '1.13.1'
+#            sparkProfile: 'spark3.5'
+#            sparkRuntime: 'spark3.5.1'
+#          - scalaProfile: 'scala-2.12'
+#            flinkProfile: 'flink1.18'
+#            flinkAvroVersion: '1.11.4'
+#            flinkParquetVersion: '1.13.1'
+#            sparkProfile: 'spark3.4'
+#            sparkRuntime: 'spark3.4.3'
+#          - scalaProfile: 'scala-2.12'
+#            flinkProfile: 'flink1.18'
+#            flinkAvroVersion: '1.11.4'
+#            flinkParquetVersion: '1.13.1'
+#            sparkProfile: 'spark3.3'
+#            sparkRuntime: 'spark3.3.4'
 
     steps:
       - if: needs.changes.outputs.relevant == 'true'
@@ -1293,18 +1327,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - scalaProfile: 'scala-2.13'
-            flinkProfile: 'flink1.20'
-            flinkAvroVersion: '1.11.4'
-            flinkParquetVersion: '1.13.1'
-            sparkProfile: 'spark4.0'
-            sparkRuntime: 'spark4.0.0'
-          - scalaProfile: 'scala-2.13'
-            flinkProfile: 'flink1.20'
-            flinkAvroVersion: '1.11.4'
-            flinkParquetVersion: '1.13.1'
-            sparkProfile: 'spark4.1'
-            sparkRuntime: 'spark4.1.1'
+          # [CI-TRIM] parked matrix entries:
+#          - scalaProfile: 'scala-2.13'
+#            flinkProfile: 'flink1.20'
+#            flinkAvroVersion: '1.11.4'
+#            flinkParquetVersion: '1.13.1'
+#            sparkProfile: 'spark4.0'
+#            sparkRuntime: 'spark4.0.0'
+#          - scalaProfile: 'scala-2.13'
+#            flinkProfile: 'flink1.20'
+#            flinkAvroVersion: '1.11.4'
+#            flinkParquetVersion: '1.13.1'
+#            sparkProfile: 'spark4.1'
+#            sparkRuntime: 'spark4.1.1'
           - scalaProfile: 'scala-2.13'
             flinkProfile: 'flink1.20'
             flinkAvroVersion: '1.11.4'
@@ -1342,67 +1377,68 @@ jobs:
           HUDI_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           ./packaging/bundle-validation/ci_run.sh hudi_docker_java17 $HUDI_VERSION openjdk17
 
-  # flink 2.0/2.1 only support Java 11 and above version
-  validate-bundles-java11:
-    runs-on: ubuntu-latest
-    needs: changes
-    strategy:
-      matrix:
-        include:
-          - scalaProfile: 'scala-2.12'
-            flinkProfile: 'flink2.0'
-            flinkAvroVersion: '1.11.4'
-            flinkParquetVersion: '1.14.4'
-            sparkProfile: 'spark3.5'
-            sparkRuntime: 'spark3.5.1'
-          - scalaProfile: 'scala-2.12'
-            flinkProfile: 'flink2.1'
-            flinkAvroVersion: '1.11.4'
-            flinkParquetVersion: '1.15.2'
-            sparkProfile: 'spark3.5'
-            sparkRuntime: 'spark3.5.1'
+  # [CI-TRIM] `validate-bundles-java11` is parked to cut CI usage.
+#  # flink 2.0/2.1 only support Java 11 and above version
+#  validate-bundles-java11:
+#    runs-on: ubuntu-latest
+#    needs: changes
+#    strategy:
+#      matrix:
+#        include:
+#          - scalaProfile: 'scala-2.12'
+#            flinkProfile: 'flink2.0'
+#            flinkAvroVersion: '1.11.4'
+#            flinkParquetVersion: '1.14.4'
+#            sparkProfile: 'spark3.5'
+#            sparkRuntime: 'spark3.5.1'
+#          - scalaProfile: 'scala-2.12'
+#            flinkProfile: 'flink2.1'
+#            flinkAvroVersion: '1.11.4'
+#            flinkParquetVersion: '1.15.2'
+#            sparkProfile: 'spark3.5'
+#            sparkRuntime: 'spark3.5.1'
 
-    steps:
-      - if: needs.changes.outputs.relevant == 'true'
-        uses: actions/checkout@v5
-      - name: Set up JDK 11
-        if: needs.changes.outputs.relevant == 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          architecture: x64
-          cache: maven
-      - name: Build Project
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
-          FLINK_PARQUET_VERSION: ${{ matrix.flinkParquetVersion }}
-        run: |
-          mvn clean package -T 2 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -DskipTests=true $MVN_ARGS -pl packaging/hudi-flink-bundle -am -Davro.version="$FLINK_AVRO_VERSION" -Dparquet.version="$FLINK_PARQUET_VERSION"
-      - name: IT - Bundle Validation - OpenJDK 11
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_RUNTIME: ${{ matrix.sparkRuntime }}
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-        run: |
-          HUDI_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          ./packaging/bundle-validation/ci_run.sh hudi_docker_java11 $HUDI_VERSION openjdk11
-      - name: IT - Bundle Validation - OpenJDK 17
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_RUNTIME: ${{ matrix.sparkRuntime }}
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-        run: |
-          HUDI_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          ./packaging/bundle-validation/ci_run.sh hudi_docker_java17 $HUDI_VERSION openjdk17
+#    steps:
+#      - if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/checkout@v5
+#      - name: Set up JDK 11
+#        if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#          architecture: x64
+#          cache: maven
+#      - name: Build Project
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          FLINK_PROFILE: ${{ matrix.flinkProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
+#          FLINK_PARQUET_VERSION: ${{ matrix.flinkParquetVersion }}
+#        run: |
+#          mvn clean package -T 2 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -DskipTests=true $MVN_ARGS -pl packaging/hudi-flink-bundle -am -Davro.version="$FLINK_AVRO_VERSION" -Dparquet.version="$FLINK_PARQUET_VERSION"
+#      - name: IT - Bundle Validation - OpenJDK 11
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          FLINK_PROFILE: ${{ matrix.flinkProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_RUNTIME: ${{ matrix.sparkRuntime }}
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#        run: |
+#          HUDI_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+#          ./packaging/bundle-validation/ci_run.sh hudi_docker_java11 $HUDI_VERSION openjdk11
+#      - name: IT - Bundle Validation - OpenJDK 17
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          FLINK_PROFILE: ${{ matrix.flinkProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_RUNTIME: ${{ matrix.sparkRuntime }}
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#        run: |
+#          HUDI_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+#          ./packaging/bundle-validation/ci_run.sh hudi_docker_java17 $HUDI_VERSION openjdk17
 
   integration-tests:
     runs-on: ubuntu-latest
@@ -1480,168 +1516,171 @@ jobs:
           flags: integration-tests
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  integration-tests-hive-sync:
-    # Testcontainers-based E2E hive sync coverage for Hudi's custom logical types
-    # (VECTOR, BLOB) and the Spark 4.0+ VARIANT type. Runs the integ2 testcontainers
-    # suite (ITTestCustomTypeHiveSync) against a real Hive metastore on Spark 3.5.3,
-    # 4.0.2, and 4.1.1 stacks.
-    runs-on: ubuntu-latest
-    needs: changes
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - sparkProfile: 'spark3.5'
-            scalaProfile: '-Dscala-2.12 -Dscala.binary.version=2.12'
-            flinkProfile: 'flink1.20'
-            jdkVersion: '11'
-            composePrefix: 'docker-compose_hadoop284_hive2310_spark353'
-            sparkAdhocImage: 'apachehudi/hudi-hadoop_2.8.4-hive_2.3.10-sparkadhoc_3.5.3:latest'
-          - sparkProfile: 'spark4.0'
-            scalaProfile: '-Dscala-2.13 -Dscala.binary.version=2.13'
-            flinkProfile: 'flink1.20'
-            jdkVersion: '17'
-            composePrefix: 'docker-compose_hadoop340_hive2310_spark402'
-            sparkAdhocImage: 'apachehudi/hudi-hadoop_3.4.0-hive_2.3.10-sparkadhoc_4.0.2:latest'
-          - sparkProfile: 'spark4.1'
-            scalaProfile: '-Dscala-2.13 -Dscala.binary.version=2.13'
-            flinkProfile: 'flink1.20'
-            jdkVersion: '17'
-            composePrefix: 'docker-compose_hadoop340_hive2310_spark411'
-            sparkAdhocImage: 'apachehudi/hudi-hadoop_3.4.0-hive_2.3.10-sparkadhoc_4.1.1:latest'
-    steps:
-      - if: needs.changes.outputs.relevant == 'true'
-        uses: actions/checkout@v5
-      - name: Set up JDK ${{ matrix.jdkVersion }}
-        if: needs.changes.outputs.relevant == 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ matrix.jdkVersion }}
-          distribution: 'temurin'
-          architecture: x64
-          cache: maven
-      - name: Free disk space
-        if: needs.changes.outputs.relevant == 'true'
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          docker system prune --all --force --volumes
-      - name: Pre-pull compose images (fails fast if not published)
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SPARK_ADHOC_IMAGE: ${{ matrix.sparkAdhocImage }}
-        run: |
-          # Surface missing Spark 4.0.2 images before the 15-minute Maven install.
-          # The remaining images in the compose stack are pulled by docker-compose at
-          # test time.
-          docker pull "$SPARK_ADHOC_IMAGE"
-      - name: Build and install Hudi artifacts
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-        run:
-          mvn clean install -T 2 $SCALA_PROFILE -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" -Pintegration-tests -DskipTests=true -Ddocker.compose.skip=true $MVN_ARGS
-      - name: Run integ2 testcontainers suite
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          COMPOSE_PREFIX: ${{ matrix.composePrefix }}
-        run: |
-          # -DskipITs=false overrides the spark4.0 profile's skipITs=true default
-          # (see root pom.xml). Without it, failsafe skips all ITs on the spark4.0 matrix row.
-          mvn verify $SCALA_PROFILE -D"$SPARK_PROFILE" -Pintegration-tests \
-            -pl hudi-integ-test \
-            -DskipITs=false \
-            -Ddocker.compose.skip=true \
-            -Dit.test='ITTestCustomTypeHiveSync' \
-            -Dspark.docker.compose.prefix=$COMPOSE_PREFIX \
-            $MVN_ARGS
+  # [CI-TRIM] `integration-tests-hive-sync` is parked to cut CI usage.
+#  integration-tests-hive-sync:
+#    # Testcontainers-based E2E hive sync coverage for Hudi's custom logical types
+#    # (VECTOR, BLOB) and the Spark 4.0+ VARIANT type. Runs the integ2 testcontainers
+#    # suite (ITTestCustomTypeHiveSync) against a real Hive metastore on Spark 3.5.3,
+#    # 4.0.2, and 4.1.1 stacks.
+#    runs-on: ubuntu-latest
+#    needs: changes
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          - sparkProfile: 'spark3.5'
+#            scalaProfile: '-Dscala-2.12 -Dscala.binary.version=2.12'
+#            flinkProfile: 'flink1.20'
+#            jdkVersion: '11'
+#            composePrefix: 'docker-compose_hadoop284_hive2310_spark353'
+#            sparkAdhocImage: 'apachehudi/hudi-hadoop_2.8.4-hive_2.3.10-sparkadhoc_3.5.3:latest'
+#          - sparkProfile: 'spark4.0'
+#            scalaProfile: '-Dscala-2.13 -Dscala.binary.version=2.13'
+#            flinkProfile: 'flink1.20'
+#            jdkVersion: '17'
+#            composePrefix: 'docker-compose_hadoop340_hive2310_spark402'
+#            sparkAdhocImage: 'apachehudi/hudi-hadoop_3.4.0-hive_2.3.10-sparkadhoc_4.0.2:latest'
+#          - sparkProfile: 'spark4.1'
+#            scalaProfile: '-Dscala-2.13 -Dscala.binary.version=2.13'
+#            flinkProfile: 'flink1.20'
+#            jdkVersion: '17'
+#            composePrefix: 'docker-compose_hadoop340_hive2310_spark411'
+#            sparkAdhocImage: 'apachehudi/hudi-hadoop_3.4.0-hive_2.3.10-sparkadhoc_4.1.1:latest'
+#    steps:
+#      - if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/checkout@v5
+#      - name: Set up JDK ${{ matrix.jdkVersion }}
+#        if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: ${{ matrix.jdkVersion }}
+#          distribution: 'temurin'
+#          architecture: x64
+#          cache: maven
+#      - name: Free disk space
+#        if: needs.changes.outputs.relevant == 'true'
+#        run: |
+#          sudo rm -rf /usr/share/dotnet
+#          sudo rm -rf /usr/local/lib/android
+#          sudo rm -rf /opt/ghc
+#          sudo rm -rf /usr/local/share/boost
+#          docker system prune --all --force --volumes
+#      - name: Pre-pull compose images (fails fast if not published)
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SPARK_ADHOC_IMAGE: ${{ matrix.sparkAdhocImage }}
+#        run: |
+#          # Surface missing Spark 4.0.2 images before the 15-minute Maven install.
+#          # The remaining images in the compose stack are pulled by docker-compose at
+#          # test time.
+#          docker pull "$SPARK_ADHOC_IMAGE"
+#      - name: Build and install Hudi artifacts
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          FLINK_PROFILE: ${{ matrix.flinkProfile }}
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#        run:
+#          mvn clean install -T 2 $SCALA_PROFILE -D"$SPARK_PROFILE" -D"$FLINK_PROFILE" -Pintegration-tests -DskipTests=true -Ddocker.compose.skip=true $MVN_ARGS
+#      - name: Run integ2 testcontainers suite
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          COMPOSE_PREFIX: ${{ matrix.composePrefix }}
+#        run: |
+#          # -DskipITs=false overrides the spark4.0 profile's skipITs=true default
+#          # (see root pom.xml). Without it, failsafe skips all ITs on the spark4.0 matrix row.
+#          mvn verify $SCALA_PROFILE -D"$SPARK_PROFILE" -Pintegration-tests \
+#            -pl hudi-integ-test \
+#            -DskipITs=false \
+#            -Ddocker.compose.skip=true \
+#            -Dit.test='ITTestCustomTypeHiveSync' \
+#            -Dspark.docker.compose.prefix=$COMPOSE_PREFIX \
+#            $MVN_ARGS
 
-  build-spark-java17:
-    runs-on: ubuntu-latest
-    needs: changes
-    strategy:
-      matrix:
-        include:
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.3"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
+  # [CI-TRIM] `build-spark-java17` is parked to cut CI usage.
+#  build-spark-java17:
+#    runs-on: ubuntu-latest
+#    needs: changes
+#    strategy:
+#      matrix:
+#        include:
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.3"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.3.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.4"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.4"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.4.x"
 
-          - scalaProfile: "scala-2.12"
-            sparkProfile: "spark3.5"
-            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
+#          - scalaProfile: "scala-2.12"
+#            sparkProfile: "spark3.5"
+#            sparkModules: "hudi-spark-datasource/hudi-spark3.5.x"
 
-    steps:
-      - if: needs.changes.outputs.relevant == 'true'
-        uses: actions/checkout@v5
-      - name: Set up JDK 17
-        if: needs.changes.outputs.relevant == 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          architecture: x64
-          cache: maven
-      - name: Build Project
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-          SPARK_MODULES: ${{ matrix.sparkModules }}
-        run:
-          mvn clean install -T 2 -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
-      - name: Quickstart Test
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          SPARK_PROFILE: ${{ matrix.sparkProfile }}
-        run:
-          mvn test -Punit-tests -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -pl hudi-examples/hudi-examples-spark $MVN_ARGS
+#    steps:
+#      - if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/checkout@v5
+#      - name: Set up JDK 17
+#        if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '17'
+#          distribution: 'temurin'
+#          architecture: x64
+#          cache: maven
+#      - name: Build Project
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#          SPARK_MODULES: ${{ matrix.sparkModules }}
+#        run:
+#          mvn clean install -T 2 -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,$SPARK_COMMON_MODULES,$SPARK_MODULES"
+#      - name: Quickstart Test
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          SPARK_PROFILE: ${{ matrix.sparkProfile }}
+#        run:
+#          mvn test -Punit-tests -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -pl hudi-examples/hudi-examples-spark $MVN_ARGS
 
-  build-flink-java17:
-    runs-on: ubuntu-latest
-    needs: changes
-    strategy:
-      matrix:
-        include:
-          - scalaProfile: "scala-2.12"
-            flinkProfile: "flink2.1"
-            flinkAvroVersion: '1.11.4'
-            flinkParquetVersion: '1.15.2'
-    steps:
-      - if: needs.changes.outputs.relevant == 'true'
-        uses: actions/checkout@v5
-      - name: Set up JDK 17
-        if: needs.changes.outputs.relevant == 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          architecture: x64
-          cache: maven
-      - name: Build Project
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
-          FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
-          FLINK_PARQUET_VERSION: ${{ matrix.flinkParquetVersion }}
-        run:
-          mvn clean install -T 2 -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink -am -Davro.version="$FLINK_AVRO_VERSION" -Dparquet.version="$FLINK_PARQUET_VERSION" -DskipTests=true $MVN_ARGS
-      - name: Quickstart Test
-        if: needs.changes.outputs.relevant == 'true'
-        env:
-          SCALA_PROFILE: ${{ matrix.scalaProfile }}
-          FLINK_PROFILE: ${{ matrix.flinkProfile }}
-        run:
-          mvn test -Punit-tests -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink $MVN_ARGS
+  # [CI-TRIM] `build-flink-java17` is parked to cut CI usage.
+#  build-flink-java17:
+#    runs-on: ubuntu-latest
+#    needs: changes
+#    strategy:
+#      matrix:
+#        include:
+#          - scalaProfile: "scala-2.12"
+#            flinkProfile: "flink2.1"
+#            flinkAvroVersion: '1.11.4'
+#            flinkParquetVersion: '1.15.2'
+#    steps:
+#      - if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/checkout@v5
+#      - name: Set up JDK 17
+#        if: needs.changes.outputs.relevant == 'true'
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '17'
+#          distribution: 'temurin'
+#          architecture: x64
+#          cache: maven
+#      - name: Build Project
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          FLINK_PROFILE: ${{ matrix.flinkProfile }}
+#          FLINK_AVRO_VERSION: ${{ matrix.flinkAvroVersion }}
+#          FLINK_PARQUET_VERSION: ${{ matrix.flinkParquetVersion }}
+#        run:
+#          mvn clean install -T 2 -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink -am -Davro.version="$FLINK_AVRO_VERSION" -Dparquet.version="$FLINK_PARQUET_VERSION" -DskipTests=true $MVN_ARGS
+#      - name: Quickstart Test
+#        if: needs.changes.outputs.relevant == 'true'
+#        env:
+#          SCALA_PROFILE: ${{ matrix.scalaProfile }}
+#          FLINK_PROFILE: ${{ matrix.flinkProfile }}
+#        run:
+#          mvn test -Punit-tests -Djava17 -Djava.version=17 -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-examples/hudi-examples-flink $MVN_ARGS
 

--- a/.github/workflows/hudi_trino_ci.yml
+++ b/.github/workflows/hudi_trino_ci.yml
@@ -23,10 +23,12 @@ on:
       - 'hudi-client/hudi-java-client/**'
       - 'hudi-sync/hudi-sync-common/**'
       - 'hudi-sync/hudi-hive-sync/**'
-  # No `paths:` filter here on purpose. test-hudi-trino-plugin is a required status check
-  # in .asf.yaml, and a path-filtered workflow is never instantiated on PRs that miss the
-  # filter, leaving the required context permanently pending. Run on every PR instead and
-  # skip the expensive steps via the detect-trino-changes job below.
+  # No `paths:` filter here on purpose. A path-filtered workflow is never instantiated on
+  # PRs that miss the filter, so any run of this workflow that a reviewer or a required
+  # status check expects to see would sit permanently pending. Run on every PR instead and
+  # skip the expensive steps via the detect-trino-changes job below. (test-hudi-trino-plugin
+  # is no longer a required check: the .asf.yaml contexts list was reset when the CI matrix
+  # was trimmed. Restoring the filter here is an option if runner time gets tight again.)
   pull_request:
     branches:
       - master

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -540,6 +540,8 @@
         its own docker-compose demo in the same job, which collides on host ports
         (e.g. zookeeper 2181). Exclude the integ2 package here so only the
         dedicated `integration-tests-hive-sync` stage runs them (via -Dit.test=).
+        That stage is currently parked in .github/workflows/bot.yml to cut CI
+        usage, so nothing runs the integ2 suite until it is restored.
       -->
       <build>
         <plugins>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

closes #19526, part of the CI improvement epic #19524.

ASF Infra has disabled GitHub Actions on apache/hudi over how much runner time our CI consumes, so nothing can be verified or merged right now. This brings us back within the [ASF GitHub Actions policy](https://infra.apache.org/github-actions-policy.html) on both job concurrency and total usage.

The reset of `required_status_checks` moved to #19523, which should merge first: dropping the per-job contexts is what lets anything merge again, including this PR.

### Summary and Changelog

Java CI now runs one configuration per area: a Spark lane on Java 11, a Spark lane on Java 17, a Flink lane, bundle validation, and integration tests. The jobs and matrix entries this takes out are commented out in place and marked `[CI-TRIM]`, so any lane can be restored as our runner budget allows.

The one `.asf.yaml` line left here adds `validate-ci-baseline`, a new do-nothing job defined in this PR, as a required context, so that a PR holding checks from the old matrix cannot merge on them. The context and the job that reports it stay in the same commit. Both should be removed once no pre-trim PR is open.

This is an interim measure to get back to green, not a statement about which versions we support. Coverage comes back properly in #19082, which runs a curated core test suite on every Spark version and reserves the full suites for the latest 3.x and 4.x. That gives us broader version coverage than this PR at a fraction of the cost of the old matrix.

### Impact

No product code changes. Two coverage gaps worth being explicit about while this is in place:

- The Spark 3.3/3.4/4.0/4.1 and Flink 1.18 through 2.0 datasource modules are no longer compiled by any job, so a change to shared code that updates only the surviving lanes can break them on master.
- Bundle validation now covers the Spark bundles only, not the Flink, Kafka Connect or metaserver bundles.

Both are temporary. #19082 restores the Spark side with core tests per version; a cheap compile-only lane could do the same for the Flink modules and bundles.

### Risk Level

low

Mechanical and reversible: every removed line has an exact commented-out counterpart. Verified that both workflows parse, that `actionlint` is clean, and that every surviving job renders the same check name as before, since a mismatch would leave a required context pending forever.

One sequencing note: `validate-ci-baseline` can only report once Actions is enabled again, so this should merge alongside or after the re-enable.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

