### PR TITLE
fix(flink): use partition-aware file groups for Flink NBCC bulk inserts

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.sink.bucket;
 
-import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.index.bucket.BucketIdentifier;
@@ -97,8 +96,8 @@ public class BucketBulkInsertWriterHelper extends BulkInsertWriterHelper {
   }
 
   private HoodieRowDataCreateHandle getRowCreateHandle(String partitionPath, String fileId) throws IOException {
-    Object handleKey = isNonBlockingConcurrencyControl
-        ? new HoodieFileGroupId(partitionPath, fileId)
+    String handleKey = isNonBlockingConcurrencyControl
+        ? partitionPath + "/" + fileId
         : fileId;
     if (!handles.containsKey(handleKey)) { // if there is no handle corresponding to the file group
       if (this.isInputSorted) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
@@ -18,7 +18,9 @@
 
 package org.apache.hudi.sink.bucket;
 
+import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
 import org.apache.hudi.io.storage.row.HoodieRowDataCreateHandle;
@@ -46,23 +48,30 @@ import java.util.Map;
 @Slf4j
 public class BucketBulkInsertWriterHelper extends BulkInsertWriterHelper {
   public static final String FILE_GROUP_META_FIELD = "_fg";
+  public static final String PARTITION_PATH_META_FIELD = "_partition_path";
 
   protected final int recordArity;
+  protected final boolean isNonBlockingConcurrencyControl;
 
   private String lastFileId; // for efficient code path
+  private String lastPartitionPath; // only used by NBCC where file IDs repeat across partitions
 
   public BucketBulkInsertWriterHelper(Configuration conf, HoodieTable<?, ?, ?, ?> hoodieTable, HoodieWriteConfig writeConfig,
                                       String instantTime, int taskPartitionId, long taskId, long taskEpochId, RowType rowType) {
     super(conf, hoodieTable, writeConfig, instantTime, taskPartitionId, taskId, taskEpochId, rowType);
     this.recordArity = rowType.getFieldCount();
+    this.isNonBlockingConcurrencyControl = OptionsResolver.isNonBlockingConcurrencyControl(conf);
   }
 
   public void write(RowData tuple) throws IOException {
     try {
-      RowData record = tuple.getRow(1, this.recordArity);
+      int fieldOffset = isNonBlockingConcurrencyControl ? 1 : 0;
+      RowData record = tuple.getRow(fieldOffset + 1, this.recordArity);
       String recordKey = keyGen.getRecordKey(record);
-      String partitionPath = keyGen.getPartitionPath(record);
-      String fileId = tuple.getString(0).toString();
+      String partitionPath = isNonBlockingConcurrencyControl
+          ? tuple.getString(0).toString()
+          : keyGen.getPartitionPath(record);
+      String fileId = tuple.getString(fieldOffset).toString();
       writeRecord(recordKey, partitionPath, fileId, record);
     } catch (Throwable throwable) {
       IOException ioException = new IOException("Exception happened when bulk insert.", throwable);
@@ -76,29 +85,38 @@ public class BucketBulkInsertWriterHelper extends BulkInsertWriterHelper {
       String partitionPath,
       String fileId,
       RowData record) throws IOException {
-    if ((lastFileId == null) || !lastFileId.equals(fileId)) {
+    if ((lastFileId == null)
+        || !lastFileId.equals(fileId)
+        || (isNonBlockingConcurrencyControl && !partitionPath.equals(lastPartitionPath))) {
       log.info("Creating new file for partition path {}", partitionPath);
       handle = getRowCreateHandle(partitionPath, fileId);
       lastFileId = fileId;
+      lastPartitionPath = partitionPath;
     }
     handle.write(recordKey, partitionPath, record);
   }
 
   private HoodieRowDataCreateHandle getRowCreateHandle(String partitionPath, String fileId) throws IOException {
-    if (!handles.containsKey(fileId)) { // if there is no handle corresponding to the fileId
+    Object handleKey = isNonBlockingConcurrencyControl
+        ? new HoodieFileGroupId(partitionPath, fileId)
+        : fileId;
+    if (!handles.containsKey(handleKey)) { // if there is no handle corresponding to the file group
       if (this.isInputSorted) {
         // if records are sorted, we can close all existing handles
         close();
       }
       HoodieRowDataCreateHandle rowCreateHandle = new HoodieRowDataCreateHandle(hoodieTable, writeConfig, partitionPath, fileId,
           instantTime, taskPartitionId, totalSubtaskNum, taskEpochId, writerSchema, preserveHoodieMetadata, isAppendMode && !populateMetaFields);
-      handles.put(fileId, rowCreateHandle);
+      handles.put(handleKey, rowCreateHandle);
     }
-    return handles.get(fileId);
+    return handles.get(handleKey);
   }
 
-  public static SortOperatorGen getFileIdSorterGen(RowType rowType) {
-    return new SortOperatorGen(rowType, new String[] {FILE_GROUP_META_FIELD});
+  public static SortOperatorGen getFileIdSorterGen(
+      RowType rowType, boolean isNonBlockingConcurrencyControl) {
+    return new SortOperatorGen(rowType, isNonBlockingConcurrencyControl
+        ? new String[] {PARTITION_PATH_META_FIELD, FILE_GROUP_META_FIELD}
+        : new String[] {FILE_GROUP_META_FIELD});
   }
 
   static String getFileId(
@@ -125,12 +143,24 @@ public class BucketBulkInsertWriterHelper extends BulkInsertWriterHelper {
         indexKeyFields,
         numBucketsFunction,
         needFixedFileIdSuffix);
-    return GenericRowData.of(StringData.fromString(fileId), record);
+    return needFixedFileIdSuffix
+        ? GenericRowData.of(
+            StringData.fromString(partitionPath), StringData.fromString(fileId), record)
+        : GenericRowData.of(StringData.fromString(fileId), record);
   }
 
-  public static RowType rowTypeWithFileId(RowType rowType) {
-    LogicalType[] types = new LogicalType[] {DataTypes.STRING().getLogicalType(), rowType};
-    String[] names = new String[] {FILE_GROUP_META_FIELD, "record"};
+  public static RowType rowTypeWithFileId(
+      RowType rowType, boolean isNonBlockingConcurrencyControl) {
+    LogicalType[] types;
+    String[] names;
+    if (isNonBlockingConcurrencyControl) {
+      types = new LogicalType[] {
+          DataTypes.STRING().getLogicalType(), DataTypes.STRING().getLogicalType(), rowType};
+      names = new String[] {PARTITION_PATH_META_FIELD, FILE_GROUP_META_FIELD, "record"};
+    } else {
+      types = new LogicalType[] {DataTypes.STRING().getLogicalType(), rowType};
+      names = new String[] {FILE_GROUP_META_FIELD, "record"};
+    }
     return RowType.of(types, names);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/LsmBucketBulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/LsmBucketBulkInsertWriterHelper.java
@@ -39,7 +39,8 @@ import java.util.Map;
 /**
  * Bucket-index bulk-insert writer helper for LSM input rows.
  *
- * <p>The input row contains file ID, encoded record key, and the original table row.
+ * <p>The input row contains file ID, encoded record key, and the original table row. In NBCC mode,
+ * the partition path is prepended because fixed bucket file IDs can repeat across partitions.
  */
 public class LsmBucketBulkInsertWriterHelper extends BucketBulkInsertWriterHelper {
 
@@ -60,10 +61,13 @@ public class LsmBucketBulkInsertWriterHelper extends BucketBulkInsertWriterHelpe
 
   @Override
   public void write(RowData sortRow) throws IOException {
-    String fileId = sortRow.getString(0).toString();
-    String recordKey = sortRow.getString(1).toString();
-    RowData record = sortRow.getRow(2, recordArity);
-    String partitionPath = keyGen.getPartitionPath(record);
+    int fieldOffset = isNonBlockingConcurrencyControl ? 1 : 0;
+    String fileId = sortRow.getString(fieldOffset).toString();
+    String recordKey = sortRow.getString(fieldOffset + 1).toString();
+    RowData record = sortRow.getRow(fieldOffset + 2, recordArity);
+    String partitionPath = isNonBlockingConcurrencyControl
+        ? sortRow.getString(0).toString()
+        : keyGen.getPartitionPath(record);
     writeRecord(recordKey, partitionPath, fileId, record);
   }
 
@@ -83,37 +87,60 @@ public class LsmBucketBulkInsertWriterHelper extends BucketBulkInsertWriterHelpe
         indexKeyFields,
         numBucketsFunction,
         needFixedFileIdSuffix);
-    return GenericRowData.of(
-        StringData.fromString(fileId),
-        StringData.fromString(recordKey),
-        record);
+    return needFixedFileIdSuffix
+        ? GenericRowData.of(
+            StringData.fromString(partitionPath),
+            StringData.fromString(fileId),
+            StringData.fromString(recordKey),
+            record)
+        : GenericRowData.of(
+            StringData.fromString(fileId),
+            StringData.fromString(recordKey),
+            record);
   }
 
   /**
    * Returns the internal row type used to sort LSM bucket bulk-insert records by file ID and
    * record key.
    *
-   * <p>The fields are ordered as file ID, encoded record key, and original table row.
+   * <p>The fields are ordered as file ID, encoded record key, and original table row. In NBCC mode,
+   * the partition path is prepended.
    */
-  public static RowType rowTypeWithFileIdAndKey(RowType rowType) {
-    LogicalType[] types = new LogicalType[] {
-        DataTypes.STRING().getLogicalType(),
-        DataTypes.STRING().getLogicalType(),
-        rowType
-    };
-    String[] names =
-        new String[] {FILE_GROUP_META_FIELD, RECORD_KEY_FIELD, RECORD_FIELD};
+  public static RowType rowTypeWithFileIdAndKey(
+      RowType rowType, boolean isNonBlockingConcurrencyControl) {
+    LogicalType[] types;
+    String[] names;
+    if (isNonBlockingConcurrencyControl) {
+      types = new LogicalType[] {
+          DataTypes.STRING().getLogicalType(),
+          DataTypes.STRING().getLogicalType(),
+          DataTypes.STRING().getLogicalType(),
+          rowType
+      };
+      names = new String[] {
+          PARTITION_PATH_META_FIELD, FILE_GROUP_META_FIELD, RECORD_KEY_FIELD, RECORD_FIELD};
+    } else {
+      types = new LogicalType[] {
+          DataTypes.STRING().getLogicalType(),
+          DataTypes.STRING().getLogicalType(),
+          rowType
+      };
+      names = new String[] {FILE_GROUP_META_FIELD, RECORD_KEY_FIELD, RECORD_FIELD};
+    }
     return RowType.of(types, names);
   }
 
   /**
-   * Creates an external sorter ordered by file ID and encoded record key.
+   * Creates an external sorter ordered by file ID and encoded record key, with partition path as
+   * the leading sort field in NBCC mode.
    *
    * <p>The nested payload is deliberately excluded from the sort keys, so duplicate record keys
    * are retained without comparing or aggregating their payloads.
    */
-  public static SortOperatorGen getFileIdAndKeySorterGen(RowType rowType) {
-    return new SortOperatorGen(
-        rowType, new String[] {FILE_GROUP_META_FIELD, RECORD_KEY_FIELD});
+  public static SortOperatorGen getFileIdAndKeySorterGen(
+      RowType rowType, boolean isNonBlockingConcurrencyControl) {
+    return new SortOperatorGen(rowType, isNonBlockingConcurrencyControl
+        ? new String[] {PARTITION_PATH_META_FIELD, FILE_GROUP_META_FIELD, RECORD_KEY_FIELD}
+        : new String[] {FILE_GROUP_META_FIELD, RECORD_KEY_FIELD});
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
@@ -80,7 +80,8 @@ public class BulkInsertWriterHelper implements AutoCloseable {
   private String lastKnownPartitionPath = null;
   private final String fileIdPrefix;
   private int numFilesWritten = 0;
-  protected final Map<String, HoodieRowDataCreateHandle> handles = new HashMap<>();
+  // String keys are used by existing paths; NBCC bucket writes use HoodieFileGroupId keys.
+  protected final Map<Object, HoodieRowDataCreateHandle> handles = new HashMap<>();
   @Nullable
   protected final RowDataKeyGen keyGen;
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/BulkInsertWriterHelper.java
@@ -80,8 +80,7 @@ public class BulkInsertWriterHelper implements AutoCloseable {
   private String lastKnownPartitionPath = null;
   private final String fileIdPrefix;
   private int numFilesWritten = 0;
-  // String keys are used by existing paths; NBCC bucket writes use HoodieFileGroupId keys.
-  protected final Map<Object, HoodieRowDataCreateHandle> handles = new HashMap<>();
+  protected final Map<String, HoodieRowDataCreateHandle> handles = new HashMap<>();
   @Nullable
   protected final RowDataKeyGen keyGen;
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -191,7 +191,8 @@ public class Pipelines {
 
     if (isLsmTreeStorageLayout) {
       RowType sortRowType =
-          LsmBucketBulkInsertWriterHelper.rowTypeWithFileIdAndKey(rowType);
+          LsmBucketBulkInsertWriterHelper.rowTypeWithFileIdAndKey(
+              rowType, needFixedFileIdSuffix);
       InternalTypeInfo<RowData> sortTypeInfo = InternalTypeInfo.of(sortRowType);
       DataStream<RowData> sortInput = routedDataStream
           .map(record -> LsmBucketBulkInsertWriterHelper.rowWithFileIdAndKey(
@@ -207,12 +208,14 @@ public class Pipelines {
           conf,
           sortInput,
           sortTypeInfo,
-          LsmBucketBulkInsertWriterHelper.getFileIdAndKeySorterGen(sortRowType),
+          LsmBucketBulkInsertWriterHelper.getFileIdAndKeySorterGen(
+              sortRowType, needFixedFileIdSuffix),
           "lsm_sorter:(file_group, record_key)",
           writeTasks);
     }
 
-    RowType rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType);
+    RowType rowTypeWithFileId =
+        BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType, needFixedFileIdSuffix);
     InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(rowTypeWithFileId);
     DataStream<RowData> rowsWithFileId = routedDataStream
         .map(record -> BucketBulkInsertWriterHelper.rowWithFileId(
@@ -232,7 +235,8 @@ public class Pipelines {
         conf,
         rowsWithFileId,
         typeInfo,
-        BucketBulkInsertWriterHelper.getFileIdSorterGen(rowTypeWithFileId),
+        BucketBulkInsertWriterHelper.getFileIdSorterGen(
+            rowTypeWithFileId, needFixedFileIdSuffix),
         "file_sorter",
         writeTasks);
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestBulkInsertWriteHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestBulkInsertWriteHelper.java
@@ -20,7 +20,15 @@ package org.apache.hudi.sink.bulk;
 
 import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.OptionsResolver;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
+import org.apache.hudi.sink.bucket.BucketBulkInsertWriterHelper;
 import org.apache.hudi.table.HoodieFlinkTable;
 import org.apache.hudi.util.DataTypeUtils;
 import org.apache.hudi.util.FlinkTables;
@@ -37,6 +45,8 @@ import org.apache.flink.table.types.logical.RowType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -120,6 +130,53 @@ public class TestBulkInsertWriteHelper {
         TestConfigurations.ROW_TYPE);
 
     assertThrows(IOException.class, () -> writerHelper.write(new GenericRowData(0)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testBucketBulkInsertWithNBCC(boolean sortInput) throws Exception {
+    conf = TestConfigurations.getDefaultConf(
+        new File(tempFile, "nbcc-" + sortInput).getAbsolutePath(),
+        TestConfigurations.ROW_DATA_TYPE);
+    conf.set(FlinkOptions.TABLE_TYPE, HoodieTableType.MERGE_ON_READ.name());
+    conf.set(FlinkOptions.OPERATION, "bulk_insert");
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.set(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS, 1);
+    conf.set(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT, sortInput);
+    conf.setString(
+        HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(),
+        WriteConcurrencyMode.NON_BLOCKING_CONCURRENCY_CONTROL.name());
+    StreamerUtil.initTableIfNotExists(conf);
+
+    HoodieFlinkTable<?> table = FlinkTables.createTable(conf);
+    String instant = WriteClientTestUtils.createNewInstantTime();
+    RowType rowType = TestConfigurations.ROW_TYPE;
+    RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, rowType);
+    NumBucketsFunction numBucketsFunction = new NumBucketsFunction(
+        conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
+        conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE),
+        conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
+    Map<String, String> bucketIdToFileId = new HashMap<>();
+    List<WriteStatus> writeStatuses;
+    try (BucketBulkInsertWriterHelper writerHelper = new BucketBulkInsertWriterHelper(
+        conf, table, table.getConfig(), instant, 1, 1, 0, rowType)) {
+      for (RowData row : TestData.DATA_SET_INSERT) {
+        writerHelper.write(BucketBulkInsertWriterHelper.rowWithFileId(
+            bucketIdToFileId,
+            keyGen,
+            row,
+            OptionsResolver.getIndexKeyFields(conf),
+            numBucketsFunction,
+            true));
+      }
+      writeStatuses = writerHelper.getWriteStatuses(1);
+    }
+
+    assertWriteStatus(writeStatuses);
+    assertThat(writeStatuses.stream()
+        .map(writeStatus -> writeStatus.getStat().getFileId())
+        .distinct()
+        .count(), is(1L));
   }
 
   private void assertWriteStatus(List<WriteStatus> writeStatusList) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
@@ -239,6 +239,8 @@ public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   private void setupSortOperator() throws Exception {
+    boolean isNonBlockingConcurrencyControl =
+        OptionsResolver.isNonBlockingConcurrencyControl(conf);
     MockEnvironment environment = new MockEnvironmentBuilder()
         .setTaskName("mockTask")
         .setManagedMemorySize(12 * MemoryManager.DEFAULT_PAGE_SIZE)
@@ -250,9 +252,9 @@ public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
         .build();
     SortOperatorGen sortOperatorGen = lsmSortInput
         ? LsmBucketBulkInsertWriterHelper.getFileIdAndKeySorterGen(
-            sortInputRowType, OptionsResolver.isNonBlockingConcurrencyControl(conf))
+            sortInputRowType, isNonBlockingConcurrencyControl)
         : BucketBulkInsertWriterHelper.getFileIdSorterGen(
-            rowTypeWithFileId, OptionsResolver.isNonBlockingConcurrencyControl(conf));
+            rowTypeWithFileId, isNonBlockingConcurrencyControl);
     this.sortOperator = (SortOperator) sortOperatorGen.createSortOperator(conf);
     this.sortOperator.setProcessingTimeService(new TestProcessingTimeService());
     this.output = new CollectOutputAdapter<>();

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
@@ -103,10 +103,14 @@ public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
     this.gateway = new MockOperatorEventGateway();
     this.conf = conf;
     this.rowType = (RowType) HoodieSchemaConverter.convertToDataType(StreamerUtil.getSourceSchema(conf)).getLogicalType();
-    this.rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType);
+    boolean isNonBlockingConcurrencyControl =
+        OptionsResolver.isNonBlockingConcurrencyControl(conf);
+    this.rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(
+        rowType, isNonBlockingConcurrencyControl);
     this.lsmSortInput = OptionsResolver.isLsmTreeStorageLayout(conf);
     this.sortInputRowType = lsmSortInput
-        ? LsmBucketBulkInsertWriterHelper.rowTypeWithFileIdAndKey(rowType)
+        ? LsmBucketBulkInsertWriterHelper.rowTypeWithFileIdAndKey(
+            rowType, isNonBlockingConcurrencyControl)
         : rowTypeWithFileId;
     this.coordinatorContext = new MockOperatorCoordinatorContext(new OperatorID(), 1);
     this.coordinator = new StreamWriteOperatorCoordinator(conf, this.coordinatorContext);
@@ -245,8 +249,10 @@ public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
         .setExecutionConfig(new ExecutionConfig().enableObjectReuse())
         .build();
     SortOperatorGen sortOperatorGen = lsmSortInput
-        ? LsmBucketBulkInsertWriterHelper.getFileIdAndKeySorterGen(sortInputRowType)
-        : BucketBulkInsertWriterHelper.getFileIdSorterGen(rowTypeWithFileId);
+        ? LsmBucketBulkInsertWriterHelper.getFileIdAndKeySorterGen(
+            sortInputRowType, OptionsResolver.isNonBlockingConcurrencyControl(conf))
+        : BucketBulkInsertWriterHelper.getFileIdSorterGen(
+            rowTypeWithFileId, OptionsResolver.isNonBlockingConcurrencyControl(conf));
     this.sortOperator = (SortOperator) sortOperatorGen.createSortOperator(conf);
     this.sortOperator.setProcessingTimeService(new TestProcessingTimeService());
     this.output = new CollectOutputAdapter<>();


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19517.

With Flink bucket bulk inserts under non-blocking concurrency control (NBCC), fixed bucket file IDs can repeat across partitions. Sorting and caching write handles only by file ID can therefore mix records from different partitions or reuse the wrong handle.

### Summary and Changelog

- Include the partition path in regular and LSM bucket internal sort rows only when NBCC is enabled, and sort by the partition-aware file group identity.
- Cache NBCC write handles by `HoodieFileGroupId` while retaining the existing file-ID-only path for non-NBCC writes.
- Add regression coverage for both sorted and unsorted NBCC bucket bulk inserts with identical file IDs across partitions.

### Impact

This change affects only Flink bucket bulk inserts using NBCC. It introduces no public API or configuration changes. Non-NBCC row schemas, sort keys, and handle lookup behavior remain unchanged, avoiding additional overhead on existing paths; NBCC sort rows carry one additional partition-path field.

### Risk Level

Low. The behavior change is scoped to NBCC bucket bulk inserts and is covered by a parameterized regression test for sorted and unsorted input.

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
