### PR TITLE
fix(flink): preserve Avro fixed decimal widths in Parquet writes

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetRowDataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetRowDataWriter.java
@@ -431,7 +431,7 @@ public class ParquetRowDataWriter {
         "Decimal precision %s exceeds max precision %s",
         precision,
         DecimalType.MAX_PRECISION);
-    int numBytes = ParquetSchemaConverter.decimalFixedLen(fieldSchema, precision);
+    int numBytes = ParquetSchemaConverter.resolveDecimalByteLength(fieldSchema, precision);
 
     /*
      * This is optimizer for UnscaledBytesWriter.

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetRowDataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetRowDataWriter.java
@@ -46,7 +46,6 @@ import java.nio.ByteOrder;
 import java.sql.Timestamp;
 import java.util.Arrays;
 
-import static org.apache.flink.formats.parquet.utils.ParquetSchemaConverter.computeMinBytesForDecimalPrecision;
 import static org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader.JULIAN_EPOCH_OFFSET_DAYS;
 import static org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader.MILLIS_IN_DAY;
 import static org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader.NANOS_PER_MILLISECOND;
@@ -116,7 +115,7 @@ public class ParquetRowDataWriter {
         return new BinaryWriter();
       case DECIMAL:
         DecimalType decimalType = (DecimalType) t;
-        return createDecimalWriter(decimalType.getPrecision(), decimalType.getScale());
+        return createDecimalWriter(decimalType.getPrecision(), decimalType.getScale(), fieldSchema);
       case TINYINT:
         return new ByteWriter();
       case SMALLINT:
@@ -426,24 +425,21 @@ public class ParquetRowDataWriter {
     return Binary.fromConstantByteBuffer(buf);
   }
 
-  private FieldWriter createDecimalWriter(int precision, int scale) {
+  private FieldWriter createDecimalWriter(int precision, int scale, HoodieSchema fieldSchema) {
     Preconditions.checkArgument(
         precision <= DecimalType.MAX_PRECISION,
         "Decimal precision %s exceeds max precision %s",
         precision,
         DecimalType.MAX_PRECISION);
+    int numBytes = ParquetSchemaConverter.decimalFixedLen(fieldSchema, precision);
 
     /*
      * This is optimizer for UnscaledBytesWriter.
      */
     class LongUnscaledBytesWriter implements FieldWriter {
-      private final int numBytes;
-      private final int initShift;
       private final byte[] decimalBuffer;
 
       private LongUnscaledBytesWriter() {
-        this.numBytes = computeMinBytesForDecimalPrecision(precision);
-        this.initShift = 8 * (numBytes - 1);
         this.decimalBuffer = new byte[numBytes];
       }
 
@@ -460,12 +456,15 @@ public class ParquetRowDataWriter {
       }
 
       private void doWrite(long unscaled) {
-        int i = 0;
-        int shift = initShift;
-        while (i < numBytes) {
-          decimalBuffer[i] = (byte) (unscaled >> shift);
-          i += 1;
-          shift -= 8;
+        // Parquet encodes FIXED_LEN_BYTE_ARRAY decimals as big-endian two's complement. A compact
+        // Flink decimal provides at most eight value bytes, so pad wider Avro fixed types with the
+        // sign byte to preserve the value.
+        int firstValueByte = Math.max(0, numBytes - Long.BYTES);
+        Arrays.fill(decimalBuffer, 0, firstValueByte, unscaled < 0 ? (byte) -1 : (byte) 0);
+        // Copy from the least-significant byte backwards to produce the big-endian representation.
+        for (int i = numBytes - 1; i >= firstValueByte; i--) {
+          decimalBuffer[i] = (byte) unscaled;
+          unscaled >>= Byte.SIZE;
         }
 
         recordConsumer.addBinary(Binary.fromReusedByteArray(decimalBuffer, 0, numBytes));
@@ -473,11 +472,9 @@ public class ParquetRowDataWriter {
     }
 
     class UnscaledBytesWriter implements FieldWriter {
-      private final int numBytes;
       private final byte[] decimalBuffer;
 
       private UnscaledBytesWriter() {
-        this.numBytes = computeMinBytesForDecimalPrecision(precision);
         this.decimalBuffer = new byte[numBytes];
       }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetSchemaConverter.java
@@ -313,7 +313,7 @@ public class ParquetSchemaConverter {
       case DECIMAL:
         int precision = ((DecimalType) type).getPrecision();
         int scale = ((DecimalType) type).getScale();
-        int numBytes = decimalFixedLen(fieldSchema, precision);
+        int numBytes = resolveDecimalByteLength(fieldSchema, precision);
         return Types.primitive(
                 PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, repetition)
             .as(LogicalTypeAnnotation.decimalType(scale, precision))
@@ -448,7 +448,7 @@ public class ParquetSchemaConverter {
     return numBytes;
   }
 
-  static int decimalFixedLen(HoodieSchema fieldSchema, int precision) {
+  static int resolveDecimalByteLength(HoodieSchema fieldSchema, int precision) {
     if (fieldSchema instanceof HoodieSchema.Decimal) {
       HoodieSchema.Decimal decimalSchema = (HoodieSchema.Decimal) fieldSchema;
       if (decimalSchema.isFixed()) {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetSchemaConverter.java
@@ -313,7 +313,7 @@ public class ParquetSchemaConverter {
       case DECIMAL:
         int precision = ((DecimalType) type).getPrecision();
         int scale = ((DecimalType) type).getScale();
-        int numBytes = computeMinBytesForDecimalPrecision(precision);
+        int numBytes = decimalFixedLen(fieldSchema, precision);
         return Types.primitive(
                 PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, repetition)
             .as(LogicalTypeAnnotation.decimalType(scale, precision))
@@ -446,5 +446,15 @@ public class ParquetSchemaConverter {
       numBytes += 1;
     }
     return numBytes;
+  }
+
+  static int decimalFixedLen(HoodieSchema fieldSchema, int precision) {
+    if (fieldSchema instanceof HoodieSchema.Decimal) {
+      HoodieSchema.Decimal decimalSchema = (HoodieSchema.Decimal) fieldSchema;
+      if (decimalSchema.isFixed()) {
+        return decimalSchema.getFixedSize();
+      }
+    }
+    return computeMinBytesForDecimalPrecision(precision);
   }
 }

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/parquet/TestParquetRowDataWriter.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/parquet/TestParquetRowDataWriter.java
@@ -29,14 +29,18 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -48,6 +52,37 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class TestParquetRowDataWriter {
+
+  @Test
+  void testWriteDecimalWithWidthFromHoodieSchema() {
+    HoodieSchema schema = HoodieSchema.parse(
+        "{\"type\":\"record\",\"name\":\"rec\",\"fields\":["
+            + "{\"name\":\"large_fixed\",\"type\":{\"type\":\"fixed\",\"name\":\"large_fixed_type\","
+            + "\"size\":10,\"logicalType\":\"decimal\",\"precision\":20,\"scale\":2}},"
+            + "{\"name\":\"small_fixed\",\"type\":{\"type\":\"fixed\",\"name\":\"small_fixed_type\","
+            + "\"size\":10,\"logicalType\":\"decimal\",\"precision\":10,\"scale\":2}},"
+            + "{\"name\":\"bytes_decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\","
+            + "\"precision\":20,\"scale\":2}}]}");
+    BigDecimal largeValue = new BigDecimal("123456789.12");
+    BigDecimal smallValue = new BigDecimal("-12.34");
+    BigDecimal bytesValue = new BigDecimal("223456789.34");
+    GenericRowData row = GenericRowData.of(
+        DecimalData.fromBigDecimal(largeValue, 20, 2),
+        DecimalData.fromBigDecimal(smallValue, 10, 2),
+        DecimalData.fromBigDecimal(bytesValue, 20, 2));
+    RecordConsumer consumer = mock(RecordConsumer.class);
+
+    new ParquetRowDataWriter(consumer, true, schema).write(row);
+
+    ArgumentCaptor<Binary> binaryCaptor = ArgumentCaptor.forClass(Binary.class);
+    verify(consumer, times(3)).addBinary(binaryCaptor.capture());
+    assertArrayEquals(signExtend(largeValue.unscaledValue().toByteArray(), 10),
+        binaryCaptor.getAllValues().get(0).getBytes());
+    assertArrayEquals(signExtend(smallValue.unscaledValue().toByteArray(), 10),
+        binaryCaptor.getAllValues().get(1).getBytes());
+    assertArrayEquals(signExtend(bytesValue.unscaledValue().toByteArray(), 9),
+        binaryCaptor.getAllValues().get(2).getBytes());
+  }
 
   @Test
   void testWritePrimitiveNestedArrayMapDecimalAndTimestampValues() {
@@ -172,5 +207,12 @@ class TestParquetRowDataWriter {
     verify(consumer, atLeastOnce()).addFloat(1.5f);
     verify(consumer, atLeastOnce()).addDouble(3.5d);
     verify(consumer, atLeastOnce()).addBinary(any());
+  }
+
+  private static byte[] signExtend(byte[] bytes, int length) {
+    byte[] result = new byte[length];
+    Arrays.fill(result, 0, length - bytes.length, bytes[0] < 0 ? (byte) -1 : (byte) 0);
+    System.arraycopy(bytes, 0, result, length - bytes.length, bytes.length);
+    return result;
   }
 }

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/parquet/TestParquetSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/parquet/TestParquetSchemaConverter.java
@@ -242,6 +242,21 @@ public class TestParquetSchemaConverter {
   }
 
   @Test
+  void testDecimalFixedLenWidthFromHoodieSchema() {
+    HoodieSchema hoodieSchema = HoodieSchema.parse(
+        "{\"type\":\"record\",\"name\":\"rec\",\"fields\":["
+            + "{\"name\":\"fixed_decimal\",\"type\":{\"type\":\"fixed\",\"name\":\"dec_fixed\","
+            + "\"size\":10,\"logicalType\":\"decimal\",\"precision\":20,\"scale\":2}},"
+            + "{\"name\":\"bytes_decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\","
+            + "\"precision\":20,\"scale\":2}}]}");
+
+    MessageType messageType = ParquetSchemaConverter.convertToParquetMessageType("converted", hoodieSchema);
+
+    assertEquals(10, messageType.getType("fixed_decimal").asPrimitiveType().getTypeLength());
+    assertEquals(9, messageType.getType("bytes_decimal").asPrimitiveType().getTypeLength());
+  }
+
+  @Test
   void testUnannotatedFixedLenByteArrayConvertsToBytes() {
     MessageType messageType = new MessageType(
         "test",


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19521.

The Flink `RowData` Parquet writer previously derived the physical width of every decimal from precision alone. This produced a schema and encoded values that were narrower than the authoritative Hudi/Avro schema when a decimal used an over-allocated fixed backing type. The compact-decimal encoding path also relied on shifts that are unsafe when the declared fixed width exceeds eight bytes.

### Summary and Changelog

- Honor the declared Avro fixed size when converting fixed-backed decimals to Parquet `FIXED_LEN_BYTE_ARRAY`, while retaining the precision-based minimum for non-fixed decimal schemas.
- Use the same resolved width in the `RowData` value writer and sign-extend compact positive and negative decimal values when the declared fixed width is greater than eight bytes.
- Add regression coverage for fixed-backed and bytes-backed schemas, including compact negative values and encoded byte widths.

### Impact

Flink Parquet writes now preserve the declared physical width of fixed-backed decimal schemas passed to the writer. There are no public API or configuration changes. Decimal schemas without a fixed backing type retain the existing minimum-width behavior.

### Risk Level

Low. The change is limited to Flink Parquet decimal schema conversion and value encoding. Targeted tests cover schema widths and encoded values for both fixed-backed and fallback decimal representations.

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
