### PR TITLE
chore(ci): stop requiring GitHub checks on master to unblock PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -51,6 +51,7 @@ github:
           # is what made every change to the CI matrix in .github/workflows/bot.yml a
           # two-sided edit, and a context left without a job to report it blocks merges
           # indefinitely. Reviewers gate on the checks the PR shows.
+          - validate-ci-baseline
           - validate-source
           - validate-pr
           - validate-pr-title

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -47,75 +47,14 @@ github:
       required_status_checks:
         strict: false
         contexts:
+          # The per-job test contexts are no longer required individually. Listing them here
+          # is what made every change to the CI matrix in .github/workflows/bot.yml a
+          # two-sided edit, and a context left without a job to report it blocks merges
+          # indefinitely. Reviewers gate on the checks the PR shows.
           - validate-source
           - validate-pr
           - validate-pr-title
           - validate-commit-coauthor
-          - test-hudi-trino-plugin
-          - test-spark-client-and-hadoop-common (scala-2.12, spark3.5, flink2.1)
-          - test-utilities (scala-2.12, spark3.5, flink2.1)
-          - test-common-and-other-modules (scala-2.12, spark3.5, flink2.1)
-          - test-hudi-hadoop-mr-and-hudi-java-client (scala-2.12, spark3.5, flink2.1)
-          - test-spark-java-tests-part1 (scala-2.12, spark3.3, hudi-spark-datasource/hudi-spark3.3.x)
-          - test-spark-java-tests-part1 (scala-2.12, spark3.4, hudi-spark-datasource/hudi-spark3.4.x)
-          - test-spark-java-tests-part1 (scala-2.12, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - test-spark-java-tests-part2 (scala-2.12, spark3.3, hudi-spark-datasource/hudi-spark3.3.x)
-          - test-spark-java-tests-part2 (scala-2.12, spark3.4, hudi-spark-datasource/hudi-spark3.4.x)
-          - test-spark-java-tests-part2 (scala-2.12, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - test-spark-java-tests-part3 (scala-2.12, spark3.3, hudi-spark-datasource/hudi-spark3.3.x)
-          - test-spark-java-tests-part3 (scala-2.12, spark3.4, hudi-spark-datasource/hudi-spark3.4.x)
-          - test-spark-java-tests-part3 (scala-2.12, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - test-spark-scala-dml-tests (scala-2.12, spark3.3, hudi-spark-datasource/hudi-spark3.3.x)
-          - test-spark-scala-dml-tests (scala-2.12, spark3.4, hudi-spark-datasource/hudi-spark3.4.x)
-          - test-spark-scala-dml-tests (scala-2.12, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - test-spark-scala-other-tests (scala-2.12, spark3.3, hudi-spark-datasource/hudi-spark3.3.x)
-          - test-spark-scala-other-tests (scala-2.12, spark3.4, hudi-spark-datasource/hudi-spark3.4.x)
-          - test-spark-scala-other-tests (scala-2.12, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - test-spark-java17-java-tests-part1 (scala-2.13, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - test-spark-java17-java-tests-part1 (scala-2.13, spark4.0, hudi-spark-datasource/hudi-spark4.0.x)
-          - test-spark-java17-java-tests-part1 (scala-2.13, spark4.1, hudi-spark-datasource/hudi-spark4.1.x)
-          - test-spark-java17-java-tests-part1 (scala-2.13, spark4.2, hudi-spark-datasource/hudi-spark4.2.x)
-          - test-spark-java17-java-tests-part2 (scala-2.13, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - test-spark-java17-java-tests-part2 (scala-2.13, spark4.0, hudi-spark-datasource/hudi-spark4.0.x)
-          - test-spark-java17-java-tests-part2 (scala-2.13, spark4.1, hudi-spark-datasource/hudi-spark4.1.x)
-          - test-spark-java17-java-tests-part2 (scala-2.13, spark4.2, hudi-spark-datasource/hudi-spark4.2.x)
-          - test-spark-java17-java-tests-part3 (scala-2.13, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - test-spark-java17-java-tests-part3 (scala-2.13, spark4.0, hudi-spark-datasource/hudi-spark4.0.x)
-          - test-spark-java17-java-tests-part3 (scala-2.13, spark4.1, hudi-spark-datasource/hudi-spark4.1.x)
-          - test-spark-java17-java-tests-part3 (scala-2.13, spark4.2, hudi-spark-datasource/hudi-spark4.2.x)
-          - test-spark-java17-scala-dml-tests (scala-2.13, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - test-spark-java17-scala-dml-tests (scala-2.13, spark4.0, hudi-spark-datasource/hudi-spark4.0.x)
-          - test-spark-java17-scala-dml-tests (scala-2.13, spark4.1, hudi-spark-datasource/hudi-spark4.1.x)
-          - test-spark-java17-scala-dml-tests (scala-2.13, spark4.2, hudi-spark-datasource/hudi-spark4.2.x)
-          - test-spark-java17-scala-other-tests (scala-2.13, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - test-spark-java17-scala-other-tests (scala-2.13, spark4.0, hudi-spark-datasource/hudi-spark4.0.x)
-          - test-spark-java17-scala-other-tests (scala-2.13, spark4.1, hudi-spark-datasource/hudi-spark4.1.x)
-          - test-spark-java17-scala-other-tests (scala-2.13, spark4.2, hudi-spark-datasource/hudi-spark4.2.x)
-          - test-flink-1 (flink1.18, 1.11.4, 1.13.1)
-          - test-flink-1 (flink1.19, 1.11.4, 1.13.1)
-          - test-flink-1 (flink1.20, 1.11.4, 1.13.1)
-          - test-flink-1 (flink2.0, 1.11.4, 1.14.4)
-          - test-flink-1 (flink2.1, 1.11.4, 1.15.2)
-          - test-flink-2 (flink2.1, 1.11.4, 1.15.2)
-          - build-spark-java17 (scala-2.12, spark3.3, hudi-spark-datasource/hudi-spark3.3.x)
-          - build-spark-java17 (scala-2.12, spark3.4, hudi-spark-datasource/hudi-spark3.4.x)
-          - build-spark-java17 (scala-2.12, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - build-flink-java17 (scala-2.12, flink2.1, 1.11.4, 1.15.2)
-          - validate-bundles (scala-2.12, flink1.18, 1.11.4, 1.13.1, spark3.3, spark3.3.4)
-          - validate-bundles (scala-2.12, flink1.18, 1.11.4, 1.13.1, spark3.4, spark3.4.3)
-          - validate-bundles (scala-2.13, flink1.19, 1.11.4, 1.13.1, spark3.5, spark3.5.1)
-          - validate-bundles (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark3.5, spark3.5.1)
-          - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.0, spark4.0.0)
-          - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.1, spark4.1.1)
-          - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.2, spark4.2.0)
-          - validate-bundles-java11 (scala-2.12, flink2.0, 1.11.4, 1.14.4, spark3.5, spark3.5.1)
-          - validate-bundles-java11 (scala-2.12, flink2.1, 1.11.4, 1.15.2, spark3.5, spark3.5.1)
-          - docker-java17-test (scala-2.12, flink2.1, spark3.5, spark3.5.0)
-          - docker-java17-test (scala-2.13, flink2.1, spark3.5, spark3.5.0)
-          - docker-java17-test (scala-2.13, flink2.1, spark4.0, spark4.0.0)
-          - docker-java17-test (scala-2.13, flink2.1, spark4.1, spark4.1.1)
-          - docker-java17-test (scala-2.13, flink1.20, spark4.2, spark4.2.0)
-          - integration-tests (spark3.5, flink2.1, spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz)
   collaborators:
     - ad1happy2go
     - rangareddy


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

closes #19525, part of the CI improvement epic #19524.

### Summary and Changelog

Drops the per-job test contexts from `required_status_checks` and adds `validate-ci-baseline` (job added in #19514) alongside the four cheap gates: `validate-source`, `validate-pr`, `validate-pr-title`, `validate-commit-coauthor`.

`validate-ci-baseline` only enforces once this merges, so no currently open PR is affected. Merge #19514 right after this so the gap where the context has no job to report it stays short.

### Impact

No product code changes, no change to which jobs run.

### Risk Level

low. `.asf.yaml` only, reversible by restoring the list.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
