### PR TITLE
fix(spark): fetch schema from HMS when it is not found in FileSystem

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -174,10 +174,16 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
     } getOrElse {
       Try(schemaResolver.getTableSchema) match {
         case Success(schema) => schema
-        case Failure(_) =>
+        case Failure(e) =>
           // Schema not found on the dataset, so fetching schema from HMS.
           logWarning(s"Schema not found on the dataset for $tableName, so fetching schema from HMS.")
-          val catalogTable = sparkSession.sessionState.catalog.externalCatalog.getTable(metaClient.getDbName, metaClient.getTableName)
+          val databaseName = metaClient.getTableConfig.getDatabaseName
+          val externalCatalog = sparkSession.sessionState.catalog.externalCatalog
+          if (!externalCatalog.tableExists(databaseName, tableName)) {
+            throw new HoodieException(s"Failed to resolve schema for table $tableName: schema was not found on " +
+              s"the dataset and no such table exists in the catalog (database: $databaseName)", e)
+          }
+          val catalogTable = externalCatalog.getTable(databaseName, tableName)
           convertToHoodieSchema(catalogTable.schema, tableName)
       }
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -174,7 +174,11 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
     } getOrElse {
       Try(schemaResolver.getTableSchema) match {
         case Success(schema) => schema
-        case Failure(e) => throw e
+        case Failure(_) =>
+          // Schema not found on the dataset, so fetching schema from HMS.
+          logWarning(s"Schema not found on the dataset for $tableName, so fetching schema from HMS.")
+          val catalogTable = sparkSession.sessionState.catalog.externalCatalog.getTable(metaClient.getDbName, metaClient.getTableName)
+          convertToHoodieSchema(catalogTable.schema, tableName)
       }
     }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -102,6 +102,28 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
     spark.sql("use default")
   }
 
+  test("Test Select On Empty Table Falls Back To HMS Schema") {
+    val tableName = generateTableName
+    spark.sql(
+      s"""
+         | create table $tableName (
+         |  id int,
+         |  name string,
+         |  price double,
+         |  ts long
+         | ) using hudi
+         | tblproperties (
+         |   primaryKey = 'id',
+         |   orderingFields = 'ts'
+         | )
+       """.stripMargin)
+
+    // No data has been written to the table yet, so TableSchemaResolver cannot resolve
+    // a schema from commit metadata or data files on the file system. The read path
+    // should fall back to the table's schema in the catalog (HMS) rather than throwing.
+    checkAnswer(s"select id, name, price, ts from $tableName")()
+  }
+
   test("Test Create Hoodie Table With Options") {
     val tableName = generateTableName
     spark.sql(


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

  In HoodieBaseRelation, schema is assumed to always be resolvable from the table's commit metadata or data files. For datasets that contain no hudi partitions (only non-hudi partitions), or that have no data written yet, schema cannot be
  resolved that way. Fall back to fetching the schema from HMS in that case instead of throwing.

  Adds a unit test covering select on a freshly created, empty table.
  
  ### Summary and Changelog
  
  Reads on a Hudi table would throw when `TableSchemaResolver` could not resolve a schema from commit metadata or data files on the file system — e.g. a table with no hudi partitions (only non-hudi partitions), or one with no data written yet.
  `HoodieBaseRelation` now catches that failure and falls back to reading the table's schema from the Hive Metastore (HMS) catalog entry instead of throwing.

  - `HoodieBaseRelation.scala`: on `TableSchemaResolver.getTableSchema` failure, fetch the catalog table via `sparkSession.sessionState.catalog.externalCatalog.getTable(...)` and convert its schema instead of propagating the exception.
  - `TestCreateTable.scala`: added `Test Select On Empty Table Falls Back To HMS Schema`, which creates a table with no data written and verifies a `select` on it succeeds (schema resolved from HMS) rather than throwing.
  
  ### Impact
  
  No public API changes. Read behavior change: a `select` on a table whose schema can't be resolved from the file system (e.g. empty table, or non-hudi-only partitions) now succeeds using the HMS-registered schema instead of throwing.
  
  ### Risk Level
  
  low
  
  ### Documentation Update
  
  none
  
  ### Contributor's checklist
  
  - [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
  - [x] Enough context is provided in the sections above
  - [x] Adequate tests were added if applicable