### PR TITLE
test(flink): improve pipeline and utility test coverage

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestCoordinationResponseSerDe.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestCoordinationResponseSerDe.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Constructor;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link CoordinationResponseSerDe}. */
+class TestCoordinationResponseSerDe {
+
+  @Test
+  void testWrapAndUnwrap() {
+    TestResponse expected = new TestResponse("instant-1", 3);
+
+    TestResponse actual = CoordinationResponseSerDe.unwrap(
+        CoordinationResponseSerDe.wrap(expected));
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testUnwrapRejectsUnknownResponseType() {
+    assertThrows(IllegalStateException.class,
+        () -> CoordinationResponseSerDe.unwrap(new TestResponse("instant-1", 3)));
+  }
+
+  @Test
+  void testSerializerContract() throws Exception {
+    TypeSerializer<CoordinationResponse> serializer = serializer();
+    TestResponse response = new TestResponse("instant-2", 5);
+
+    assertTrue(serializer.isImmutableType());
+    assertEquals(-1, serializer.getLength());
+    assertNotSame(serializer, serializer.duplicate());
+    assertTrue(serializer.createInstance() instanceof CoordinationResponse);
+    assertEquals(serializer, serializer.duplicate());
+    assertEquals(serializer.hashCode(), serializer.duplicate().hashCode());
+    assertThrows(UnsupportedOperationException.class, () -> serializer.copy(response));
+    assertThrows(UnsupportedOperationException.class, () -> serializer.copy(response, response));
+
+    ByteArrayOutputStream serializedBytes = new ByteArrayOutputStream();
+    serializer.serialize(response, new DataOutputViewStreamWrapper(serializedBytes));
+    assertEquals(response, serializer.deserialize(
+        response,
+        new DataInputViewStreamWrapper(new ByteArrayInputStream(serializedBytes.toByteArray()))));
+
+    ByteArrayOutputStream copiedBytes = new ByteArrayOutputStream();
+    serializer.copy(
+        new DataInputViewStreamWrapper(new ByteArrayInputStream(serializedBytes.toByteArray())),
+        new DataOutputViewStreamWrapper(copiedBytes));
+    assertEquals(response, serializer.deserialize(
+        new DataInputViewStreamWrapper(new ByteArrayInputStream(copiedBytes.toByteArray()))));
+
+    TypeSerializerSnapshot<CoordinationResponse> snapshot = serializer.snapshotConfiguration();
+    assertEquals(serializer, snapshot.restoreSerializer());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static TypeSerializer<CoordinationResponse> serializer() throws Exception {
+    Class<?> serializerClass = Class.forName(
+        CoordinationResponseSerDe.class.getName() + "$CoordinationResponseSerializer");
+    Constructor<?> constructor = serializerClass.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    return (TypeSerializer<CoordinationResponse>) constructor.newInstance();
+  }
+
+  private static class TestResponse implements CoordinationResponse {
+    private static final long serialVersionUID = 1L;
+
+    private final String instant;
+    private final int taskCount;
+
+    private TestResponse(String instant, int taskCount) {
+      this.instant = instant;
+      this.taskCount = taskCount;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof TestResponse)) {
+        return false;
+      }
+      TestResponse that = (TestResponse) obj;
+      return taskCount == that.taskCount && Objects.equals(instant, that.instant);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(instant, taskCount);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestPipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestPipelines.java
@@ -20,7 +20,10 @@ package org.apache.hudi.sink.utils;
 
 import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.sink.partitioner.GlobalRecordIndexPartitioner;
 import org.apache.hudi.utils.TestConfigurations;
@@ -28,6 +31,8 @@ import org.apache.hudi.utils.TestConfigurations;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.runtime.partitioner.CustomPartitionerWrapper;
@@ -39,8 +44,13 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link Pipelines}.
@@ -67,6 +77,210 @@ public class TestPipelines {
     DataStream<RowData> pipeline = Pipelines.hoodieStreamWrite(conf, TestConfigurations.ROW_TYPE, inputStream);
 
     assertEquals(2, countCustomPartitions(pipeline, GlobalRecordIndexPartitioner.class));
+  }
+
+  @Test
+  void testBootstrapPipelineSelection() {
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_GLOBAL_ENABLED, false);
+    DataStream<RowData> input = rowDataInput();
+
+    DataStream<HoodieFlinkInternalRow> overwrite =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, false, true);
+    assertEquals("row_data_to_hoodie_record", overwrite.getTransformation().getName());
+
+    DataStream<HoodieFlinkInternalRow> bounded =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, true, false);
+    assertEquals("batch_index_bootstrap", bounded.getTransformation().getName());
+
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, true);
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_TASKS, 3);
+    DataStream<HoodieFlinkInternalRow> streaming =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, false, false);
+    assertEquals("index_bootstrap", streaming.getTransformation().getName());
+    assertEquals(3, streaming.getParallelism());
+  }
+
+  @Test
+  void testWritePipelineOperatorGraphs() {
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.BUCKET_ASSIGN_TASKS, 2);
+    conf.set(FlinkOptions.WRITE_TASKS, 3);
+    DataStream<HoodieFlinkInternalRow> input = hoodieRowInput();
+
+    DataStream<RowData> pipeline =
+        Pipelines.hoodieStreamWrite(conf, TestConfigurations.ROW_TYPE, input);
+
+    assertEquals(3, pipeline.getParallelism());
+    assertTrue(transformationNames(pipeline).stream().anyMatch(name -> name.startsWith("bucket_assigner")));
+    assertTrue(transformationNames(pipeline).stream().anyMatch(name -> name.startsWith("stream_write:")));
+  }
+
+  @Test
+  void testSimpleBucketWritePipeline() {
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE,
+        HoodieIndex.BucketIndexEngineType.SIMPLE.name());
+    conf.set(FlinkOptions.WRITE_TASKS, 4);
+
+    DataStream<RowData> pipeline = Pipelines.hoodieStreamWrite(
+        conf, TestConfigurations.ROW_TYPE, hoodieRowInput());
+
+    assertEquals(4, pipeline.getParallelism());
+    assertTrue(pipeline.getTransformation().getName().startsWith("bucket_write:"));
+  }
+
+  @Test
+  void testBulkInsertAndAppendValidation() {
+    Configuration recordIndexConf = defaultConf();
+    recordIndexConf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.RECORD_LEVEL_INDEX.name());
+    assertThrows(HoodieException.class,
+        () -> Pipelines.bulkInsert(recordIndexConf, TestConfigurations.ROW_TYPE, rowDataInput()));
+
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE,
+        HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING.name());
+    Configuration consistentBucketConf = conf;
+    assertThrows(HoodieException.class,
+        () -> Pipelines.bulkInsert(
+            consistentBucketConf, TestConfigurations.ROW_TYPE, rowDataInput()));
+    assertThrows(HoodieNotSupportedException.class,
+        () -> Pipelines.append(
+            consistentBucketConf, TestConfigurations.ROW_TYPE, rowDataInput()));
+  }
+
+  @Test
+  void testBulkInsertGraphForDefaultAndLsmLayouts() {
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.OPERATION, WriteOperationType.BULK_INSERT.value());
+    conf.set(FlinkOptions.WRITE_TASKS, 2);
+    DataStream<RowData> lsmPipeline =
+        Pipelines.bulkInsert(conf, TestConfigurations.ROW_TYPE, rowDataInput());
+    assertEquals(2, lsmPipeline.getParallelism());
+    assertTrue(transformationNames(lsmPipeline).contains("lsm_bulk_insert_sort_keys"));
+    assertTrue(transformationNames(lsmPipeline).contains("lsm_sorter:(partition_path, record_key)"));
+
+    conf = defaultConf();
+    conf.set(FlinkOptions.OPERATION, WriteOperationType.INSERT.value());
+    conf.set(FlinkOptions.WRITE_TASKS, 3);
+    conf.set(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT, true);
+    DataStream<RowData> defaultPipeline =
+        Pipelines.bulkInsert(conf, TestConfigurations.ROW_TYPE, rowDataInput());
+    assertEquals(3, defaultPipeline.getParallelism());
+    assertTrue(transformationNames(defaultPipeline).contains("sorter:(partition_key)"));
+  }
+
+  @Test
+  void testBucketBulkInsertGraphs() {
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE,
+        HoodieIndex.BucketIndexEngineType.SIMPLE.name());
+    conf.set(FlinkOptions.OPERATION, WriteOperationType.INSERT.value());
+    conf.set(FlinkOptions.WRITE_TASKS, 2);
+    conf.set(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT, false);
+
+    DataStream<RowData> unsorted =
+        Pipelines.bulkInsert(conf, TestConfigurations.ROW_TYPE, rowDataInput());
+    assertEquals(2, unsorted.getParallelism());
+    assertTrue(unsorted.getTransformation().getName().startsWith("bucket_bulk_insert"));
+
+    conf.set(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT, true);
+    DataStream<RowData> sorted =
+        Pipelines.bulkInsert(conf, TestConfigurations.ROW_TYPE, rowDataInput());
+    assertTrue(transformationNames(sorted).contains("file_sorter"));
+
+    Configuration lsmConf = defaultConf();
+    lsmConf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    lsmConf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE,
+        HoodieIndex.BucketIndexEngineType.SIMPLE.name());
+    lsmConf.set(FlinkOptions.OPERATION, WriteOperationType.BULK_INSERT.value());
+    lsmConf.set(FlinkOptions.WRITE_TASKS, 3);
+
+    DataStream<RowData> lsm =
+        Pipelines.bulkInsert(lsmConf, TestConfigurations.ROW_TYPE, rowDataInput());
+    assertEquals(3, lsm.getParallelism());
+    assertTrue(transformationNames(lsm).contains("lsm_bulk_insert_sort_keys"));
+    assertTrue(transformationNames(lsm).contains("lsm_sorter:(file_group, record_key)"));
+  }
+
+  @Test
+  void testServiceAndSinkGraphs() {
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.COMPACTION_TASKS, 4);
+    conf.set(FlinkOptions.CLUSTERING_TASKS, 3);
+    DataStream<RowData> input = rowDataInput();
+
+    DataStreamSink<?> compaction = Pipelines.compact(conf, input);
+    assertEquals("compact_commit", compaction.getTransformation().getName());
+    assertEquals(1, compaction.getTransformation().getParallelism());
+    assertEquals(1, compaction.getTransformation().getMaxParallelism());
+
+    DataStreamSink<?> clustering = Pipelines.cluster(conf, TestConfigurations.ROW_TYPE, input);
+    assertEquals("clustering_commit", clustering.getTransformation().getName());
+    assertEquals(1, clustering.getTransformation().getParallelism());
+    assertEquals(1, clustering.getTransformation().getMaxParallelism());
+
+    DataStreamSink<?> clean = Pipelines.clean(conf, input);
+    assertEquals("clean_commits", clean.getTransformation().getName());
+    assertEquals(1, clean.getTransformation().getParallelism());
+    assertEquals(1, clean.getTransformation().getMaxParallelism());
+
+    DataStreamSink<?> dummy = Pipelines.dummySink(rowDataInput(5));
+    assertEquals("dummy", dummy.getTransformation().getName());
+    assertEquals(5, dummy.getTransformation().getParallelism());
+  }
+
+  @Test
+  void testOperatorNamesAndIndexPartitioner() {
+    Configuration conf = defaultConf();
+    assertEquals("write: analytics.orders", Pipelines.opName("write", conf));
+    String firstUid = Pipelines.opUID("unique_test_operator", conf);
+    String secondUid = Pipelines.opUID("unique_test_operator", conf);
+    assertTrue(firstUid.startsWith("uid_unique_test_operator_analytics.orders"));
+    assertTrue(secondUid.startsWith("uid_unique_test_operator_1_analytics.orders"));
+    assertNotEquals(firstUid, secondUid);
+    assertEquals(2, new Pipelines.IndexPartitioner().partition(8, 3));
+  }
+
+  private Configuration defaultConf() {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.set(FlinkOptions.DATABASE_NAME, "analytics");
+    conf.set(FlinkOptions.TABLE_NAME, "orders");
+    return conf;
+  }
+
+  private DataStream<RowData> rowDataInput() {
+    return rowDataInput(1);
+  }
+
+  private DataStream<RowData> rowDataInput(int parallelism) {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    DataStreamSource<RowData> source = env.fromCollection(
+        Collections.<RowData>emptyList(),
+        org.apache.flink.table.runtime.typeutils.InternalTypeInfo.of(TestConfigurations.ROW_TYPE));
+    if (parallelism == 1) {
+      return source;
+    }
+    return source.map(
+        row -> row,
+        org.apache.flink.table.runtime.typeutils.InternalTypeInfo.of(TestConfigurations.ROW_TYPE))
+        .setParallelism(parallelism);
+  }
+
+  private DataStream<HoodieFlinkInternalRow> hoodieRowInput() {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    return env.fromCollection(
+        Collections.<HoodieFlinkInternalRow>emptyList(),
+        new HoodieFlinkInternalRowTypeInfo(TestConfigurations.ROW_TYPE));
+  }
+
+  private List<String> transformationNames(DataStream<?> stream) {
+    return stream.getTransformation().getTransitivePredecessors().stream()
+        .map(Transformation::getName)
+        .collect(Collectors.toList());
   }
 
   private long countCustomPartitions(DataStream<?> stream, Class<?> partitionerClass) throws Exception {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestTimeWait.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestTimeWait.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils;
+
+import org.apache.hudi.exception.HoodieException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link TimeWait}. */
+class TestTimeWait {
+
+  @Test
+  void testBuilderRequiresAction() {
+    assertThrows(NullPointerException.class, () -> TimeWait.builder().build());
+  }
+
+  @Test
+  void testWaitAndTimeout() {
+    TimeWait timeWait = TimeWait.builder()
+        .timeout(1)
+        .interval(2)
+        .action("test action")
+        .build();
+
+    assertDoesNotThrow(timeWait::waitFor);
+    HoodieException exception = assertThrows(HoodieException.class, timeWait::waitFor);
+    assertTrue(exception.getMessage().contains("test action"));
+  }
+
+  @Test
+  void testInterruptedWaitIsWrapped() {
+    TimeWait timeWait = TimeWait.builder()
+        .interval(1)
+        .action("interruptible action")
+        .build();
+
+    Thread.currentThread().interrupt();
+    try {
+      HoodieException exception = assertThrows(HoodieException.class, timeWait::waitFor);
+      assertTrue(exception.getMessage().contains("interruptible action"));
+      assertTrue(exception.getCause() instanceof InterruptedException);
+    } finally {
+      Thread.interrupted();
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestDataTypeUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestDataTypeUtils.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -147,7 +148,7 @@ public class TestDataTypeUtils {
         DataTypeUtils.resolvePartition("2026-08-06T12:30:00", DataTypes.TIMESTAMP()));
     assertEquals(new BigDecimal("12.30"),
         DataTypeUtils.resolvePartition("12.30", DataTypes.DECIMAL(10, 2)));
-    assertEquals(null, DataTypeUtils.resolvePartition(null, DataTypes.STRING()));
+    assertNull(DataTypeUtils.resolvePartition(null, DataTypes.STRING()));
     assertThrows(RuntimeException.class,
         () -> DataTypeUtils.resolvePartition("00:00:00", DataTypes.TIME()));
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestDataTypeUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestDataTypeUtils.java
@@ -21,15 +21,28 @@ package org.apache.hudi.util;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.exception.HoodieCatalogException;
 
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.RowType;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link DataTypeUtils}.
@@ -80,5 +93,127 @@ public class TestDataTypeUtils {
         requiredSchema.getField("payload").get().schema().getNonNullType().getType());
     assertEquals(HoodieSchemaType.STRING,
         requiredSchema.getField("missing").get().schema().getNonNullType().getType());
+  }
+
+  @Test
+  void testTypePredicatesAndPrecision() {
+    assertTrue(DataTypeUtils.isTimestampType(DataTypes.TIMESTAMP(3)));
+    assertFalse(DataTypeUtils.isTimestampType(DataTypes.TIMESTAMP_LTZ(3)));
+    assertTrue(DataTypeUtils.isDateType(DataTypes.DATE()));
+    assertTrue(DataTypeUtils.isDatetimeType(DataTypes.DATE()));
+    assertTrue(DataTypeUtils.isDatetimeType(DataTypes.TIMESTAMP(3)));
+    assertFalse(DataTypeUtils.isDatetimeType(DataTypes.STRING()));
+    assertEquals(3, DataTypeUtils.precision(DataTypes.TIMESTAMP(3).getLogicalType()));
+    assertEquals(6, DataTypeUtils.precision(DataTypes.TIMESTAMP_LTZ(6).getLogicalType()));
+    assertThrows(AssertionError.class,
+        () -> DataTypeUtils.precision(DataTypes.STRING().getLogicalType()));
+    assertTrue(DataTypeUtils.isFamily(
+        DataTypes.INT().getLogicalType(), LogicalTypeFamily.NUMERIC));
+  }
+
+  @Test
+  void testRowTypeProjectionUtilities() {
+    Schema schema = Schema.newBuilder()
+        .column("id", DataTypes.INT())
+        .column("name", DataTypes.STRING())
+        .columnByExpression("computed", "id + 1")
+        .build();
+    RowType rowType = DataTypeUtils.toRowType(schema);
+
+    assertEquals(Arrays.asList("id", "name"), rowType.getFieldNames());
+    RowType projected = (RowType) DataTypes.ROW(
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("id", DataTypes.INT()))
+        .getLogicalType();
+    assertArrayEquals(new int[] {1, 0}, DataTypeUtils.projectOrdinals(rowType, projected));
+    assertEquals(Arrays.asList("name", "id"), Arrays.asList(
+        DataTypeUtils.projectRowFields(rowType, new String[] {"name", "id"})[0].getName(),
+        DataTypeUtils.projectRowFields(rowType, new String[] {"name", "id"})[1].getName()));
+  }
+
+  @Test
+  void testResolvePartitionValues() {
+    assertEquals("value", DataTypeUtils.resolvePartition("value", DataTypes.STRING()));
+    assertEquals(true, DataTypeUtils.resolvePartition("true", DataTypes.BOOLEAN()));
+    assertEquals((byte) 1, DataTypeUtils.resolvePartition("1", DataTypes.TINYINT()));
+    assertEquals((short) 2, DataTypeUtils.resolvePartition("2", DataTypes.SMALLINT()));
+    assertEquals(3, DataTypeUtils.resolvePartition("3", DataTypes.INT()));
+    assertEquals(4L, DataTypeUtils.resolvePartition("4", DataTypes.BIGINT()));
+    assertEquals(1.5F, DataTypeUtils.resolvePartition("1.5", DataTypes.FLOAT()));
+    assertEquals(2.5D, DataTypeUtils.resolvePartition("2.5", DataTypes.DOUBLE()));
+    assertEquals(LocalDate.of(2026, 8, 6),
+        DataTypeUtils.resolvePartition("2026-08-06", DataTypes.DATE()));
+    assertEquals(LocalDateTime.of(2026, 8, 6, 12, 30),
+        DataTypeUtils.resolvePartition("2026-08-06T12:30:00", DataTypes.TIMESTAMP()));
+    assertEquals(new BigDecimal("12.30"),
+        DataTypeUtils.resolvePartition("12.30", DataTypes.DECIMAL(10, 2)));
+    assertEquals(null, DataTypeUtils.resolvePartition(null, DataTypes.STRING()));
+    assertThrows(RuntimeException.class,
+        () -> DataTypeUtils.resolvePartition("00:00:00", DataTypes.TIME()));
+  }
+
+  @Test
+  void testEnsureColumnsAsNonNullable() {
+    DataType row = DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING().notNull()));
+
+    assertSame(row, DataTypeUtils.ensureColumnsAsNonNullable(row, null));
+    assertSame(row, DataTypeUtils.ensureColumnsAsNonNullable(row, Collections.emptyList()));
+    assertSame(row, DataTypeUtils.ensureColumnsAsNonNullable(row, Collections.singletonList("name")));
+
+    DataType converted = DataTypeUtils.ensureColumnsAsNonNullable(
+        row, Collections.singletonList("id"));
+    RowType convertedRowType = (RowType) converted.getLogicalType();
+    assertFalse(convertedRowType.isNullable());
+    assertFalse(convertedRowType.getTypeAt(0).isNullable());
+    assertFalse(convertedRowType.getTypeAt(1).isNullable());
+    assertThrows(RuntimeException.class,
+        () -> DataTypeUtils.ensureColumnsAsNonNullable(
+            DataTypes.STRING(), Collections.singletonList("id")));
+  }
+
+  @Test
+  void testAddMetadataFields() {
+    RowType rowType = (RowType) DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()))
+        .getLogicalType();
+
+    RowType withoutOperation = DataTypeUtils.addMetadataFields(rowType, false);
+    RowType withOperation = DataTypeUtils.addMetadataFields(rowType, true);
+
+    assertEquals(6, withoutOperation.getFieldCount());
+    assertEquals(7, withOperation.getFieldCount());
+    assertEquals("_hoodie_commit_time", withOperation.getFieldNames().get(0));
+    assertEquals("_hoodie_operation", withOperation.getFieldNames().get(5));
+    assertEquals("id", withOperation.getFieldNames().get(6));
+  }
+
+  @Test
+  void testGetMetadataColumnsValidation() {
+    Schema validSchema = Schema.newBuilder()
+        .column("id", DataTypes.INT())
+        .columnByMetadata("_hoodie_commit_time", DataTypes.STRING(), true)
+        .build();
+    assertEquals(Collections.singletonList("_hoodie_commit_time"),
+        DataTypeUtils.getMetadataColumns(validSchema));
+
+    Schema invalidName = Schema.newBuilder()
+        .columnByMetadata("unknown", DataTypes.STRING(), true)
+        .build();
+    assertThrows(HoodieCatalogException.class,
+        () -> DataTypeUtils.getMetadataColumns(invalidName));
+
+    Schema persisted = Schema.newBuilder()
+        .columnByMetadata("_hoodie_commit_time", DataTypes.STRING(), false)
+        .build();
+    assertThrows(HoodieCatalogException.class,
+        () -> DataTypeUtils.getMetadataColumns(persisted));
+
+    Schema withKey = Schema.newBuilder()
+        .columnByMetadata("_hoodie_commit_time", DataTypes.STRING(), "metadata-key", true)
+        .build();
+    assertThrows(HoodieCatalogException.class,
+        () -> DataTypeUtils.getMetadataColumns(withKey));
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestDataTypeUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestDataTypeUtils.java
@@ -127,9 +127,10 @@ public class TestDataTypeUtils {
         DataTypes.FIELD("id", DataTypes.INT()))
         .getLogicalType();
     assertArrayEquals(new int[] {1, 0}, DataTypeUtils.projectOrdinals(rowType, projected));
+    RowType.RowField[] projectedFields =
+        DataTypeUtils.projectRowFields(rowType, new String[] {"name", "id"});
     assertEquals(Arrays.asList("name", "id"), Arrays.asList(
-        DataTypeUtils.projectRowFields(rowType, new String[] {"name", "id"})[0].getName(),
-        DataTypeUtils.projectRowFields(rowType, new String[] {"name", "id"})[1].getName()));
+        projectedFields[0].getName(), projectedFields[1].getName()));
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestHoodiePipeline.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestHoodiePipeline.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.hudi.configuration.FlinkOptions;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link HoodiePipeline}. */
+class TestHoodiePipeline {
+
+  @TempDir
+  File tempDir;
+
+  @Test
+  void testBuildDescriptorFromColumns() {
+    Map<String, String> options = new HashMap<>();
+    options.put(FlinkOptions.PATH.key(), tempDir.toURI().toString());
+    options.put(FlinkOptions.TABLE_TYPE.key(), FlinkOptions.TABLE_TYPE_MERGE_ON_READ);
+
+    HoodiePipeline.TableDescriptor descriptor = HoodiePipeline.builder("orders")
+        .column("id BIGINT NOT NULL")
+        .column("name STRING")
+        .column("dt STRING")
+        .pk("id")
+        .partition("dt")
+        .options(options)
+        .option(FlinkOptions.WRITE_TASKS, 3)
+        .option("custom.option", "custom-value")
+        .getTableDescriptor();
+
+    ResolvedCatalogTable table = descriptor.getResolvedCatalogTable();
+    assertEquals("orders", descriptor.getTableId().getObjectName());
+    assertEquals(Arrays.asList("id", "name", "dt"), table.getResolvedSchema().getColumnNames());
+    assertEquals(Collections.singletonList("id"),
+        table.getResolvedSchema().getPrimaryKey().get().getColumns());
+    assertEquals(Collections.singletonList("dt"), table.getPartitionKeys());
+    assertEquals("3", table.getOptions().get(FlinkOptions.WRITE_TASKS.key()));
+    assertEquals("custom-value", table.getOptions().get("custom.option"));
+  }
+
+  @Test
+  void testBuildDescriptorFromSchema() {
+    Schema schema = Schema.newBuilder()
+        .column("id", DataTypes.INT().notNull())
+        .column("name", DataTypes.STRING())
+        .primaryKey("id")
+        .build();
+
+    HoodiePipeline.TableDescriptor descriptor = HoodiePipeline.builder("schema_table")
+        .schema(schema)
+        .option(FlinkOptions.PATH, tempDir.toURI().toString())
+        .getTableDescriptor();
+
+    ResolvedCatalogTable table = descriptor.getResolvedCatalogTable();
+    assertEquals(Arrays.asList("id", "name"), table.getResolvedSchema().getColumnNames());
+    assertTrue(table.getResolvedSchema().getPrimaryKey().isPresent());
+    assertEquals(Collections.singletonList("id"),
+        table.getResolvedSchema().getPrimaryKey().get().getColumns());
+    assertTrue(table.getPartitionKeys().isEmpty());
+
+    HoodiePipeline.TableDescriptor noPrimaryKey = HoodiePipeline.builder("no_pk_table")
+        .column("payload STRING")
+        .option(FlinkOptions.PATH, tempDir.toURI().toString())
+        .getTableDescriptor();
+    assertTrue(noPrimaryKey.getResolvedCatalogTable().getResolvedSchema().getPrimaryKey().isEmpty());
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
@@ -54,6 +54,7 @@ import java.util.stream.IntStream;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -186,9 +187,17 @@ public class TestCompactionUtil {
   }
 
   @Test
-  void testCompactionSequence() {
+  void testCompactionUtilConstructor() {
     assertNotNull(new CompactionUtil());
-    CompactionUtil.scheduleMetadataCompaction(null, false);
+  }
+
+  @Test
+  void testScheduleMetadataCompactionWhenDisabled() {
+    assertDoesNotThrow(() -> CompactionUtil.scheduleMetadataCompaction(null, false));
+  }
+
+  @Test
+  void testIsLIFOCaseInsensitive() {
     assertTrue(CompactionUtil.isLIFO("lifo"));
     assertTrue(CompactionUtil.isLIFO("LIFO"));
     assertFalse(CompactionUtil.isLIFO("fifo"));

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestCompactionUtil.java
@@ -55,6 +55,8 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -169,6 +171,27 @@ public class TestCompactionUtil {
     CompactionUtil.inferMetadataConf(this.conf, this.metaClient);
     assertThat("Metadata table should be disabled after inference",
         this.conf.get(FlinkOptions.METADATA_ENABLED), is(metadataEnabled));
+  }
+
+  @Test
+  void testInferTableConfiguration() throws Exception {
+    beforeEach();
+    Configuration inferred = new Configuration();
+
+    CompactionUtil.setOrderingFields(inferred, metaClient);
+    CompactionUtil.setPartitionField(inferred, metaClient);
+
+    assertEquals("ts", inferred.get(FlinkOptions.ORDERING_FIELDS));
+    assertEquals("partition", inferred.get(FlinkOptions.PARTITION_PATH_FIELD));
+  }
+
+  @Test
+  void testCompactionSequence() {
+    assertNotNull(new CompactionUtil());
+    CompactionUtil.scheduleMetadataCompaction(null, false);
+    assertTrue(CompactionUtil.isLIFO("lifo"));
+    assertTrue(CompactionUtil.isLIFO("LIFO"));
+    assertFalse(CompactionUtil.isLIFO("fifo"));
   }
 
   /**
@@ -307,4 +330,3 @@ public class TestCompactionUtil {
     return instantTime;
   }
 }
-

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
@@ -351,14 +351,12 @@ class TestStreamerUtil {
   }
 
   @Test
-  void testPartitionExists() throws IOException {
+  void testPartitionExists() {
     Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
     org.apache.hadoop.conf.Configuration hadoopConf = HadoopConfigurations.getHadoopConf(conf);
     assertFalse(StreamerUtil.partitionExists(tempFile.getAbsolutePath(), "dt=2026-08-06", hadoopConf));
 
-    try (FileSystem fs = HadoopFSUtils.getFs(tempFile.getAbsolutePath(), hadoopConf)) {
-      fs.mkdirs(new Path(tempFile.getAbsolutePath(), "dt=2026-08-06"));
-    }
+    assertTrue(new File(tempFile, "dt=2026-08-06").mkdir());
     assertTrue(StreamerUtil.partitionExists(tempFile.getAbsolutePath(), "dt=2026-08-06", hadoopConf));
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
@@ -18,27 +18,43 @@
 
 package org.apache.hudi.utils;
 
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.client.model.CommitTimeFlinkRecordMerger;
+import org.apache.hudi.client.model.EventTimeFlinkRecordMerger;
 import org.apache.hudi.client.model.PartialUpdateFlinkRecordMerger;
 import org.apache.hudi.common.bloom.BloomFilterTypeCode;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Triple;
 import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodiePayloadConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieValidationException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.io.util.FileIOUtils;
+import org.apache.hudi.keygen.ComplexAvroKeyGenerator;
 import org.apache.hudi.keygen.SimpleAvroKeyGenerator;
+import org.apache.hudi.sink.FlinkCheckpointClient;
+import org.apache.hudi.sink.muttley.AthenaIngestionGateway;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.streamer.FlinkStreamerConfig;
 import org.apache.hudi.util.StreamerUtil;
 
 import org.apache.flink.configuration.Configuration;
@@ -46,10 +62,15 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -272,5 +293,264 @@ class TestStreamerUtil {
       fs.create(new Path(new Path(basePath, HoodieTableMetaClient.METAFOLDER_NAME), HoodieTableConfig.HOODIE_PROPERTIES_FILE));
       assertTrue(StreamerUtil.tableExists(basePath, HadoopConfigurations.getHadoopConf(conf)));
     }
+  }
+
+  @Test
+  void testBuildProperties() {
+    TypedProperties properties = StreamerUtil.buildProperties(
+        Arrays.asList("hoodie.test.one=1", "hoodie.test.two=two"));
+
+    assertEquals("1", properties.getString("hoodie.test.one"));
+    assertEquals("two", properties.getString("hoodie.test.two"));
+    assertThrows(IllegalArgumentException.class,
+        () -> StreamerUtil.buildProperties(Collections.singletonList("invalid")));
+  }
+
+  @Test
+  void testSourceSchemaConfiguration() {
+    Configuration conf = new Configuration();
+    String schema = "{\"type\":\"record\",\"name\":\"record\",\"fields\":[{\"name\":\"id\",\"type\":\"long\"}]}";
+    conf.set(FlinkOptions.SOURCE_AVRO_SCHEMA, schema);
+
+    HoodieSchema sourceSchema = StreamerUtil.getSourceSchema(conf);
+
+    assertTrue(sourceSchema.getField("id").isPresent());
+    assertThrows(HoodieException.class,
+        () -> StreamerUtil.getSourceSchema(new Configuration()));
+  }
+
+  @Test
+  void testConfigurationConversions() {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.set(FlinkOptions.COMPACTION_MAX_MEMORY, 256);
+    conf.set(FlinkOptions.ORDERING_FIELDS, "ts");
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BLOOM.name());
+
+    TypedProperties properties = StreamerUtil.flinkConf2TypedProperties(conf);
+
+    assertEquals(conf.get(FlinkOptions.TABLE_TYPE),
+        properties.getString(HoodieTableConfig.TYPE.key()));
+    assertEquals(256L * 1024 * 1024, StreamerUtil.getMaxCompactionMemoryInBytes(conf));
+    assertEquals("ts", StreamerUtil.getPayloadConfig(conf).getString(HoodiePayloadConfig.ORDERING_FIELDS));
+    assertEquals(HoodieIndex.IndexType.BLOOM.name(),
+        StreamerUtil.getIndexConfig(conf).getString(HoodieIndexConfig.INDEX_TYPE));
+  }
+
+  @Test
+  void testSimplePathAndFileUtilities() {
+    assertEquals("partition_file-id", StreamerUtil.generateBucketKey("partition", "file-id"));
+
+    assertFalse(StreamerUtil.isValidFile(pathInfo("file.parquet", 4)));
+    assertTrue(StreamerUtil.isValidFile(pathInfo("file.parquet", 5)));
+    assertFalse(StreamerUtil.isValidFile(pathInfo("file.log", 6)));
+    assertTrue(StreamerUtil.isValidFile(pathInfo("file.log", 7)));
+    assertFalse(StreamerUtil.isValidFile(pathInfo("file.orc", 3)));
+    assertTrue(StreamerUtil.isValidFile(pathInfo("file.orc", 4)));
+    assertFalse(StreamerUtil.isValidFile(pathInfo("file.unknown", 0)));
+    assertTrue(StreamerUtil.isValidFile(pathInfo("file.unknown", 1)));
+  }
+
+  @Test
+  void testPartitionExists() throws IOException {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    org.apache.hadoop.conf.Configuration hadoopConf = HadoopConfigurations.getHadoopConf(conf);
+    assertFalse(StreamerUtil.partitionExists(tempFile.getAbsolutePath(), "dt=2026-08-06", hadoopConf));
+
+    try (FileSystem fs = HadoopFSUtils.getFs(tempFile.getAbsolutePath(), hadoopConf)) {
+      fs.mkdirs(new Path(tempFile.getAbsolutePath(), "dt=2026-08-06"));
+    }
+    assertTrue(StreamerUtil.partitionExists(tempFile.getAbsolutePath(), "dt=2026-08-06", hadoopConf));
+  }
+
+  @Test
+  void testOrderingFieldAndKeyGeneratorValidation() {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.set(FlinkOptions.ORDERING_FIELDS, "missing");
+    assertThrows(HoodieValidationException.class,
+        () -> StreamerUtil.checkOrderingFields(conf, Arrays.asList("id", "ts")));
+
+    conf.set(FlinkOptions.ORDERING_FIELDS, "ts");
+    StreamerUtil.checkOrderingFields(conf, Arrays.asList("id", "ts"));
+    assertEquals("ts", conf.get(FlinkOptions.ORDERING_FIELDS));
+
+    Configuration customPayloadConf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    customPayloadConf.set(FlinkOptions.PAYLOAD_CLASS_NAME, OverwriteWithLatestAvroPayload.class.getName());
+    customPayloadConf.removeConfig(FlinkOptions.ORDERING_FIELDS);
+    StreamerUtil.checkOrderingFields(customPayloadConf, Collections.singletonList("id"));
+    assertEquals(FlinkOptions.NO_PRE_COMBINE, customPayloadConf.get(FlinkOptions.ORDERING_FIELDS));
+
+    Configuration keygenConf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    StreamerUtil.checkKeygenGenerator(true, keygenConf);
+    assertEquals(ComplexAvroKeyGenerator.class.getName(),
+        keygenConf.get(FlinkOptions.KEYGEN_CLASS_NAME));
+  }
+
+  @Test
+  void testKafkaOffsetStringFormatting() {
+    Map<Integer, Long> offsets = new LinkedHashMap<>();
+    offsets.put(2, 200L);
+    offsets.put(0, 100L);
+
+    assertEquals(
+        "kafka_metadata%3Atopic%3A0:100;kafka_metadata%3Atopic%3A2:200;"
+            + "kafka_metadata%3Akafka_cluster%3Atopic%3A:cluster",
+        StreamerUtil.stringFy("topic", "cluster", offsets));
+    assertEquals("kafka_metadata%3Akafka_cluster%3Atopic%3A:cluster",
+        StreamerUtil.stringFy("topic", "cluster", null));
+    assertEquals("", StreamerUtil.stringFy(null, "cluster", offsets));
+  }
+
+  @Test
+  void testOptionalTransformerCreation() throws IOException {
+    assertFalse(StreamerUtil.createTransformer(null).isPresent());
+    assertThrows(IOException.class,
+        () -> StreamerUtil.createTransformer(Collections.singletonList("not.a.Transformer")));
+  }
+
+  @Test
+  void testCheckpointMetadataDisabled() {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.set(FlinkOptions.WRITE_EXTRA_METADATA_ENABLED, false);
+    HashMap<String, String> metadata = new HashMap<>();
+
+    StreamerUtil.addFlinkCheckpointIdIntoMetaData(conf, metadata, 123L);
+    StreamerUtil.addKafkaOffsetMetaData(conf, metadata, 123L);
+
+    assertTrue(metadata.isEmpty());
+  }
+
+  @Test
+  void testStreamerPropertiesAndMergeConfiguration() {
+    FlinkStreamerConfig streamerConfig = new FlinkStreamerConfig();
+    streamerConfig.configs = Arrays.asList("hoodie.test.key=value", "hoodie.test.number=2");
+    streamerConfig.kafkaBootstrapServers = "broker:9092";
+    streamerConfig.kafkaGroupId = "group";
+
+    TypedProperties properties = StreamerUtil.appendKafkaProps(streamerConfig);
+    assertEquals("value", properties.getString("hoodie.test.key"));
+    assertEquals("broker:9092", properties.getString("bootstrap.servers"));
+    assertEquals("group", properties.getString("group.id"));
+
+    streamerConfig.configs = Collections.singletonList("invalid");
+    assertThrows(IllegalArgumentException.class, () -> StreamerUtil.getProps(streamerConfig));
+
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    assertNull(StreamerUtil.getMergeMode(conf));
+    conf.set(FlinkOptions.RECORD_MERGE_MODE, RecordMergeMode.EVENT_TIME_ORDERING.name());
+    assertEquals(RecordMergeMode.EVENT_TIME_ORDERING, StreamerUtil.getMergeMode(conf));
+    assertEquals(EventTimeFlinkRecordMerger.class.getName(),
+        StreamerUtil.getMergerClasses(conf, RecordMergeMode.EVENT_TIME_ORDERING, EventTimeAvroPayload.class.getName()));
+    assertEquals(PartialUpdateFlinkRecordMerger.class.getName(),
+        StreamerUtil.getMergerClasses(conf, RecordMergeMode.EVENT_TIME_ORDERING, PartialUpdateAvroPayload.class.getName()));
+    assertEquals(CommitTimeFlinkRecordMerger.class.getName(),
+        StreamerUtil.getMergerClasses(conf, RecordMergeMode.COMMIT_TIME_ORDERING, OverwriteWithLatestAvroPayload.class.getName()));
+    conf.set(FlinkOptions.RECORD_MERGER_IMPLS, "custom.merger");
+    assertEquals("custom.merger",
+        StreamerUtil.getMergerClasses(conf, RecordMergeMode.CUSTOM, OverwriteWithLatestAvroPayload.class.getName()));
+
+    assertTrue(StreamerUtil.getLockConfig(conf).isPresent());
+    assertEquals(tempFile.getAbsolutePath(), StreamerUtil.getTimeGeneratorConfig(conf).getBasePath());
+  }
+
+  @Test
+  void testLanceAndMetaClientUtilities() throws Exception {
+    org.apache.hadoop.conf.Configuration lanceConf = new org.apache.hadoop.conf.Configuration();
+    lanceConf.set(HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES.key(), "1024");
+    lanceConf.set(HoodieStorageConfig.LANCE_READ_METADATA_ALLOCATOR_SIZE_BYTES.key(), "256");
+    assertEquals("1024", StreamerUtil.getLanceReadConfig(lanceConf)
+        .getString(HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES));
+    assertEquals("256", StreamerUtil.getLanceReadConfig(lanceConf)
+        .getString(HoodieStorageConfig.LANCE_READ_METADATA_ALLOCATOR_SIZE_BYTES));
+
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    org.apache.hadoop.conf.Configuration hadoopConf = HadoopConfigurations.getHadoopConf(conf);
+    assertFalse(StreamerUtil.getTableConfig(tempFile.getAbsolutePath(), hadoopConf).isPresent());
+    assertNull(StreamerUtil.getLatestTableSchema("", hadoopConf));
+
+    Configuration streamingConf = new Configuration(conf);
+    streamingConf.set(FlinkOptions.PATH, new File(tempFile, "missing").getAbsolutePath());
+    streamingConf.set(FlinkOptions.READ_AS_STREAMING, true);
+    assertNull(StreamerUtil.metaClientForReader(streamingConf, hadoopConf));
+
+    StreamerUtil.initTableIfNotExists(conf, hadoopConf);
+    assertTrue(StreamerUtil.getTableConfig(tempFile.getAbsolutePath(), hadoopConf).isPresent());
+    assertNotNull(StreamerUtil.createMetaClient(tempFile.getAbsolutePath(), hadoopConf));
+    assertNotNull(StreamerUtil.createMetaClient(conf));
+    HoodieTableMetaClient metaClient = StreamerUtil.createMetaClient(conf, hadoopConf);
+    assertNotNull(metaClient);
+    assertNotNull(StreamerUtil.metaClientForReader(conf, hadoopConf));
+    assertNull(StreamerUtil.getLatestTableSchema(tempFile.getAbsolutePath(), hadoopConf));
+    assertNull(StreamerUtil.getLastPendingInstant(metaClient));
+    assertNull(StreamerUtil.getLastPendingInstant(metaClient, false));
+    assertNull(StreamerUtil.getLastCompletedInstant(metaClient));
+    assertFalse(StreamerUtil.haveSuccessfulCommits(metaClient));
+    assertFalse(StreamerUtil.getPreviousCommitMetadata(metaClient).isPresent());
+  }
+
+  @Test
+  void testKafkaCheckpointCollectionHappyPath() throws Exception {
+    Configuration conf = kafkaCheckpointConf();
+    Map<Integer, Long> offsetMap = new HashMap<>();
+    offsetMap.put(1, 200L);
+    offsetMap.put(0, 100L);
+    AthenaIngestionGateway.CheckpointKafkaOffsetInfo.KafkaOffsetsInfo.Offsets offsets =
+        new AthenaIngestionGateway.CheckpointKafkaOffsetInfo.KafkaOffsetsInfo.Offsets(offsetMap);
+    AthenaIngestionGateway.CheckpointKafkaOffsetInfo.KafkaOffsetsInfo kafkaOffsetsInfo =
+        new AthenaIngestionGateway.CheckpointKafkaOffsetInfo.KafkaOffsetsInfo("topic-id", "cluster", offsets);
+    AthenaIngestionGateway.CheckpointKafkaOffsetInfo offsetInfo =
+        new AthenaIngestionGateway.CheckpointKafkaOffsetInfo(
+            "123", Collections.singletonList(kafkaOffsetsInfo), "20260806100000", "123");
+    AthenaIngestionGateway gateway = Mockito.mock(AthenaIngestionGateway.class);
+    Mockito.when(gateway.getKafkaCheckpointsInfo(
+        Mockito.anyString(), Mockito.anyString(), Mockito.anyLong(),
+        Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+        Mockito.anyString(), Mockito.anyInt(), Mockito.anyMap(),
+        Mockito.anyString(), Mockito.anyString())).thenReturn(Option.of(offsetInfo));
+
+    String result = StreamerUtil.collectKafkaOffsetCheckpoint(conf, 123L, new FlinkCheckpointClient(gateway));
+
+    assertEquals("kafka_metadata%3Atopic%3A0:100;kafka_metadata%3Atopic%3A1:200;"
+        + "kafka_metadata%3Akafka_cluster%3Atopic%3A:cluster", result);
+
+    HashMap<String, String> metadata = new HashMap<>();
+    Configuration incomplete = new Configuration();
+    incomplete.set(FlinkOptions.WRITE_EXTRA_METADATA_ENABLED, true);
+    incomplete.set(FlinkOptions.KAFKA_TOPIC_NAME, "topic");
+    incomplete.set(FlinkOptions.SOURCE_KAFKA_CLUSTER, "cluster");
+    StreamerUtil.addKafkaOffsetMetaData(incomplete, metadata, 123L);
+    assertEquals("kafka_metadata%3Akafka_cluster%3Atopic%3A:cluster",
+        metadata.get(StreamerUtil.HOODIE_METADATA_KEY));
+  }
+
+  @Test
+  void testWriteStatusFailFastValidation() {
+    WriteStatus writeStatus = new WriteStatus();
+    writeStatus.markFailure("key", "partition", new RuntimeException("failure"));
+    Configuration conf = new Configuration();
+    conf.set(FlinkOptions.WRITE_FAIL_FAST, true);
+
+    assertThrows(HoodieException.class,
+        () -> StreamerUtil.validateWriteStatus(conf, "123", Collections.singletonList(writeStatus)));
+  }
+
+  private Configuration kafkaCheckpointConf() {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.set(FlinkOptions.DC, "dc");
+    conf.set(FlinkOptions.ENV, "production");
+    conf.set(FlinkOptions.JOB_NAME, "job");
+    conf.set(FlinkOptions.HADOOP_USER, "user");
+    conf.set(FlinkOptions.SOURCE_KAFKA_CLUSTER, "cluster");
+    conf.set(FlinkOptions.TARGET_KAFKA_CLUSTER, "target");
+    conf.set(FlinkOptions.ATHENA_SERVICE, "athena");
+    conf.set(FlinkOptions.CALLER_SERVICE_NAME, "caller");
+    conf.set(FlinkOptions.KAFKA_TOPIC_NAME, "topic");
+    conf.set(FlinkOptions.TOPIC_ID, "topic-id");
+    conf.set(FlinkOptions.SERVICE_TIER, "tier");
+    conf.set(FlinkOptions.SERVICE_NAME, "service");
+    return conf;
+  }
+
+  private static StoragePathInfo pathInfo(String path, long length) {
+    return new StoragePathInfo(new StoragePath(path), length, false, (short) 1, 128, 0);
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19538.

The Flink DAG builders and shared utilities lacked focused unit coverage for configuration, data types, serialization, time-wait behavior, compaction helpers, and operator graph assembly. This made regressions in these paths harder to detect without broader job-level tests.

### Summary and Changelog

- Add direct unit tests for `Pipelines`, `HoodiePipeline`, `TimeWait`, `CoordinationResponseSerDe`, `StreamerUtil`, `CompactionUtil`, and `DataTypeUtils`.
- Validate assembled pipeline graphs, including transformation names, parallelism, and bucket bulk-insert variants, without executing full Flink jobs.
- Raise line coverage for every target class to at least 80%.

#### Line coverage

| Class | Before | After |
| --- | ---: | ---: |
| `Pipelines` | 15% | 81.6% |
| `HoodiePipeline` | 0% | 80.2% |
| `StreamerUtil` | 66% | 83.0% |
| `TimeWait` | 0% | 100.0% |
| `CoordinationResponseSerDe` | 44% | 83.7% |
| `CompactionUtil` | 67% | 80.8% |
| `DataTypeUtils` | 72% | 99.1% |

### Impact

Test-only change. There are no public API, configuration, runtime behavior, or performance changes.

### Risk Level

None. Production sources are unchanged, and all targeted unit tests pass.

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
