### PR TITLE
docs(schema-evolution): show how to disable hive.metastore.disallow.incompatible.col.type.changes

### DIFF
--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -197,17 +197,18 @@ in the metastore's `hive-site.xml` and restart the service:
 </property>
 ```
 
-or override it for a single Hive or Beeline session with the `metaconf:` prefix, which pushes the value to the metastore
-for that connection:
+or override it for a single Beeline session with the `metaconf:` prefix, which pushes the value to the metastore for
+that connection:
 
 ```sql
 set metaconf:hive.metastore.disallow.incompatible.col.type.changes=false;
 ```
 
 :::note
-Hive's SQL processor handles the `metaconf:` prefix, so this form works from Hive or Beeline only. Spark SQL accepts the
-same statement and echoes the value back, but stores it as an ordinary session property that never reaches the
-metastore. On a remote metastore, use the `hive-site.xml` option above instead.
+Only Hive's SQL processor handles the `metaconf:` prefix, and the override applies over HiveServer2. Spark SQL accepts
+the same statement and echoes the value back, but stores it as an ordinary session property that never reaches the
+metastore. The legacy Hive CLI does send the value to the metastore, but not on the connection that runs the
+`ALTER`. In both cases, use the `hive-site.xml` option above instead.
 :::
 
 ## Schema Evolution in Action 

--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -204,6 +204,12 @@ for that connection:
 set metaconf:hive.metastore.disallow.incompatible.col.type.changes=false;
 ```
 
+:::note
+Hive's SQL processor handles the `metaconf:` prefix, so this form works from Hive or Beeline only. Spark SQL accepts the
+same statement and echoes the value back, but stores it as an ordinary session property that never reaches the
+metastore. On a remote metastore, use the `hive-site.xml` option above instead.
+:::
+
 ## Schema Evolution in Action 
 
 Let us walk through an example to demonstrate the schema evolution support in Hudi. In the below example, we are going to add a new string field and change the datatype of a field from int to long.

--- a/website/docs/schema_evolution.md
+++ b/website/docs/schema_evolution.md
@@ -3,7 +3,7 @@ title: Schema Evolution
 keywords: [hudi, incremental, batch, stream, processing, schema, evolution]
 summary: In this page, we will discuss schema evolution support in Hudi.
 toc: true
-last_modified_at: 2022-04-27T15:59:57-04:00
+last_modified_at: 2026-08-05T22:49:08+05:30
 ---
 
 Schema evolution is an essential aspect of data management, and Hudi supports schema evolution on write out-of-the-box,
@@ -168,10 +168,41 @@ ALTER TABLE tableName RENAME COLUMN old_columnName TO new_columnName
 ALTER TABLE table1 RENAME COLUMN a.b.c TO x
 ```
 
-:::note
-When using hive metastore, please disable  `hive.metastore.disallow.incompatible.col.type.changes` if you encounter this error:
-`The following columns have types incompatible with the existing columns in their respective positions`.
-:::
+### Disabling the Hive metastore column type compatibility check
+
+For tables registered in the Hive metastore, the metastore compares the new column list against the existing one
+position by position and rejects the `ALTER TABLE` when the types in a given position are not compatible. Schema changes
+that alter the type or the position of an existing column, such as adding a column with `FIRST` or `AFTER`, can
+therefore fail with:
+
+`The following columns have types incompatible with the existing columns in their respective positions`
+
+Setting `hive.metastore.disallow.incompatible.col.type.changes` to `false` skips this check. The metastore evaluates the
+check, so where you set the property depends on the metastore the engine talks to.
+
+When Spark runs its own embedded metastore (no `hive.metastore.uris` configured), the metastore shares the Spark JVM, so
+pass the property with Spark's `spark.hadoop.` prefix when you start the job:
+
+```shell
+--conf 'spark.hadoop.hive.metastore.disallow.incompatible.col.type.changes=false'
+```
+
+When the engine talks to a remote Hive metastore service, the property has to take effect on the server. Either set it
+in the metastore's `hive-site.xml` and restart the service:
+
+```xml
+<property>
+  <name>hive.metastore.disallow.incompatible.col.type.changes</name>
+  <value>false</value>
+</property>
+```
+
+or override it for a single Hive or Beeline session with the `metaconf:` prefix, which pushes the value to the metastore
+for that connection:
+
+```sql
+set metaconf:hive.metastore.disallow.incompatible.col.type.changes=false;
+```
 
 ## Schema Evolution in Action 
 

--- a/website/versioned_docs/version-1.2.0/schema_evolution.md
+++ b/website/versioned_docs/version-1.2.0/schema_evolution.md
@@ -197,17 +197,18 @@ in the metastore's `hive-site.xml` and restart the service:
 </property>
 ```
 
-or override it for a single Hive or Beeline session with the `metaconf:` prefix, which pushes the value to the metastore
-for that connection:
+or override it for a single Beeline session with the `metaconf:` prefix, which pushes the value to the metastore for
+that connection:
 
 ```sql
 set metaconf:hive.metastore.disallow.incompatible.col.type.changes=false;
 ```
 
 :::note
-Hive's SQL processor handles the `metaconf:` prefix, so this form works from Hive or Beeline only. Spark SQL accepts the
-same statement and echoes the value back, but stores it as an ordinary session property that never reaches the
-metastore. On a remote metastore, use the `hive-site.xml` option above instead.
+Only Hive's SQL processor handles the `metaconf:` prefix, and the override applies over HiveServer2. Spark SQL accepts
+the same statement and echoes the value back, but stores it as an ordinary session property that never reaches the
+metastore. The legacy Hive CLI does send the value to the metastore, but not on the connection that runs the
+`ALTER`. In both cases, use the `hive-site.xml` option above instead.
 :::
 
 ## Schema Evolution in Action 

--- a/website/versioned_docs/version-1.2.0/schema_evolution.md
+++ b/website/versioned_docs/version-1.2.0/schema_evolution.md
@@ -204,6 +204,12 @@ for that connection:
 set metaconf:hive.metastore.disallow.incompatible.col.type.changes=false;
 ```
 
+:::note
+Hive's SQL processor handles the `metaconf:` prefix, so this form works from Hive or Beeline only. Spark SQL accepts the
+same statement and echoes the value back, but stores it as an ordinary session property that never reaches the
+metastore. On a remote metastore, use the `hive-site.xml` option above instead.
+:::
+
 ## Schema Evolution in Action 
 
 Let us walk through an example to demonstrate the schema evolution support in Hudi. In the below example, we are going to add a new string field and change the datatype of a field from int to long.

--- a/website/versioned_docs/version-1.2.0/schema_evolution.md
+++ b/website/versioned_docs/version-1.2.0/schema_evolution.md
@@ -3,7 +3,7 @@ title: Schema Evolution
 keywords: [hudi, incremental, batch, stream, processing, schema, evolution]
 summary: In this page, we will discuss schema evolution support in Hudi.
 toc: true
-last_modified_at: 2022-04-27T15:59:57-04:00
+last_modified_at: 2026-08-05T22:49:08+05:30
 ---
 
 Schema evolution is an essential aspect of data management, and Hudi supports schema evolution on write out-of-the-box,
@@ -168,10 +168,41 @@ ALTER TABLE tableName RENAME COLUMN old_columnName TO new_columnName
 ALTER TABLE table1 RENAME COLUMN a.b.c TO x
 ```
 
-:::note
-When using hive metastore, please disable  `hive.metastore.disallow.incompatible.col.type.changes` if you encounter this error:
-`The following columns have types incompatible with the existing columns in their respective positions`.
-:::
+### Disabling the Hive metastore column type compatibility check
+
+For tables registered in the Hive metastore, the metastore compares the new column list against the existing one
+position by position and rejects the `ALTER TABLE` when the types in a given position are not compatible. Schema changes
+that alter the type or the position of an existing column, such as adding a column with `FIRST` or `AFTER`, can
+therefore fail with:
+
+`The following columns have types incompatible with the existing columns in their respective positions`
+
+Setting `hive.metastore.disallow.incompatible.col.type.changes` to `false` skips this check. The metastore evaluates the
+check, so where you set the property depends on the metastore the engine talks to.
+
+When Spark runs its own embedded metastore (no `hive.metastore.uris` configured), the metastore shares the Spark JVM, so
+pass the property with Spark's `spark.hadoop.` prefix when you start the job:
+
+```shell
+--conf 'spark.hadoop.hive.metastore.disallow.incompatible.col.type.changes=false'
+```
+
+When the engine talks to a remote Hive metastore service, the property has to take effect on the server. Either set it
+in the metastore's `hive-site.xml` and restart the service:
+
+```xml
+<property>
+  <name>hive.metastore.disallow.incompatible.col.type.changes</name>
+  <value>false</value>
+</property>
+```
+
+or override it for a single Hive or Beeline session with the `metaconf:` prefix, which pushes the value to the metastore
+for that connection:
+
+```sql
+set metaconf:hive.metastore.disallow.incompatible.col.type.changes=false;
+```
 
 ## Schema Evolution in Action 
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15648.

The Schema Evolution page told users to disable `hive.metastore.disallow.incompatible.col.type.changes`
when an `ALTER TABLE` fails, but never showed **how**:

> :::note
> When using hive metastore, please disable  `hive.metastore.disallow.incompatible.col.type.changes` if you encounter this error:
> `The following columns have types incompatible with the existing columns in their respective positions`.
> :::

That matters because the same page documents adding a column at an arbitrary position (`FIRST` / `AFTER`),
which is exactly what trips the check. As HUDI-5459 notes, the way to disable it differs depending on which
metastore the engine talks to, and the note covered neither variant.

### Summary and Changelog

The metastore evaluates this check against **its own** configuration — `HiveAlterHandler#alterTable` reads
`handler.getConf()` — so where the property has to be set depends on the metastore in play. Replaced the bare
note with a `### Disabling the Hive metastore column type compatibility check` subsection covering all three
mechanisms:

| Deployment | How to disable |
|---|---|
| Spark with its own embedded metastore (no `hive.metastore.uris`) | `--conf 'spark.hadoop.hive.metastore.disallow.incompatible.col.type.changes=false'` — the metastore shares the Spark JVM, so the client conf *is* the handler conf |
| Remote Hive metastore service | Set the property in the metastore's `hive-site.xml` and restart the service |
| Remote HMS, single session | `set metaconf:hive.metastore.disallow.incompatible.col.type.changes=false;` — routes through `SetProcessor` to `IMetaStoreClient#setMetaConf`; the property is a `metaConfVars` entry, so the server accepts the override |

Applied to `website/docs/schema_evolution.md` (next) and
`website/versioned_docs/version-1.2.0/schema_evolution.md` (the current released docs), per the
next-plus-current convention used in #19473. The nine older versioned copies carry the same bare note and were
left alone — happy to widen if preferred.

### Verification

Every claim was first checked against Hive `rel/release-3.1.3` and Spark `v3.5.1` sources, then reproduced on a
Spark 3.5.7 + Hive 3.1.3 (standalone HMS) + MinIO stack using `hudi-spark3.5-bundle_2.12:1.2.0`.

Reproducer: a Hudi table `(id int, name string, ts bigint)` with `hoodie.schema.on.read.enable=true` set at
session level, then `ALTER TABLE t ADD COLUMNS (age int AFTER id)` — which shifts an `int` into a position a
`string` occupied, incompatible per `ColumnType#areColTypesCompatible`.

| Scenario | `hive.metastore.uris` | Property set | Result |
|---|---|---|---|
| Embedded metastore, default | *(unset)* | — | :x: `...types incompatible with the existing columns in their respective positions : age` |
| Embedded + `spark.hadoop.…=false` | *(unset)* | client | :white_check_mark: succeeds; `describe` → `id, age, name, ts` |
| Remote HMS, default | `thrift://…:9083` | — | :x: same error |
| Remote HMS + `spark.hadoop.…=false` | `thrift://…:9083` | client | :x: **still fails** |
| Remote HMS + property in the HMS's `hive-site.xml` | `thrift://…:9083` | server | :white_check_mark: succeeds |
| Remote HMS + `setMetaConf` | `thrift://…:9083` | pushed to server | :white_check_mark: succeeds |

Rows 2 and 4 are why the section is split by deployment: the same property, set the same way, works against an
embedded metastore and is silently ignored against a remote one. Also confirmed that a standalone metastore does
read `hive-site.xml` (`MetastoreConf` adds it ahead of `metastore-site.xml`), so the middle remedy is correct
for that deployment.

Site build: `npm run build` passes, with the warning set byte-identical to a baseline build of the same base
commit (no new broken links or anchors). Both `/docs/schema_evolution` and `/docs/next/schema_evolution` were
loaded from `npm run serve` and render the new section, with all pre-existing anchors on the page preserved.

### Impact

Documentation only. No code, config, or behaviour change.

### Risk Level

none

### Documentation Update

This PR is the documentation update — the Schema Evolution page, `/docs/schema_evolution` and
`/docs/next/schema_evolution`.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
