### PR TITLE
docs(cleaning): document that clean metadata records instant (start) times

### DIFF
--- a/website/docs/cleaning.md
+++ b/website/docs/cleaning.md
@@ -99,9 +99,9 @@ timeline by completion time — see [timeline](timeline.md). The cleaner's own p
 | `lastCompletedCommitTimestamp` | both | Instant time of the last completed write before the clean was planned. Despite the name, this is a start time, not a completion time. |
 | `startCleanTime` | `HoodieCleanMetadata` | Instant time of the clean action itself. |
 
-Incremental clean planning follows the same convention: it selects the commits whose **requested** instant time falls
-between the previous clean's `earliestCommitToRetain` and the current one, and scans only the partitions those commits
-touched.
+Incremental clean planning follows the same convention: it selects the commits whose **requested** instant time is at or
+after the previous clean's `earliestCommitToRetain` and before this clean's, then scans only the partitions those
+commits touched.
 
 ### Configs
 For details about all possible configurations and their default values see the [configuration docs](https://hudi.apache.org/docs/next/configurations/#Clean-Configs).

--- a/website/docs/cleaning.md
+++ b/website/docs/cleaning.md
@@ -3,7 +3,7 @@ title: Cleaning
 toc: true
 toc_min_heading_level: 2
 toc_max_heading_level: 4
-last_modified_at: 2026-05-27T00:00:00-00:00
+last_modified_at: 2026-08-06T15:17:36+05:30
 ---
 ## Background
 Cleaning is a table service employed by Hudi to reclaim space occupied by older versions of data and keep storage costs 
@@ -85,6 +85,23 @@ takes precedence over the regex.
 |---|---|---|
 | `hoodie.clean.partition.filter.regex` | (none) | Java regex pattern; only partitions whose path matches are cleaned. |
 | `hoodie.clean.partition.filter.selected` | (none) | Comma-separated list of partition paths to clean; takes precedence over the regex when both are set. |
+
+### Instant Times in Clean Metadata
+
+Hudi 1.x stamps every action with both a requested instant time and a completion time, and orders actions on the
+timeline by completion time — see [timeline](timeline.md). The cleaner's own plan and metadata, however, record
+**instant (start) times** throughout. Keep this in mind when reading them for debugging.
+
+| Field | Written to | Value |
+|---|---|---|
+| `earliestInstantToRetain.timestamp` | `HoodieCleanerPlan` (the `clean.requested` instant) | Instant time of the oldest commit this clean run retains. |
+| `earliestCommitToRetain` | `HoodieCleanMetadata` (the completed `clean` instant) | Copied from the plan, so also an instant time. |
+| `lastCompletedCommitTimestamp` | both | Instant time of the last completed write before the clean was planned. Despite the name, this is a start time, not a completion time. |
+| `startCleanTime` | `HoodieCleanMetadata` | Instant time of the clean action itself. |
+
+Incremental clean planning follows the same convention: it selects the commits whose **requested** instant time falls
+between the previous clean's `earliestCommitToRetain` and the current one, and scans only the partitions those commits
+touched.
 
 ### Configs
 For details about all possible configurations and their default values see the [configuration docs](https://hudi.apache.org/docs/next/configurations/#Clean-Configs).

--- a/website/docs/cleaning.md
+++ b/website/docs/cleaning.md
@@ -96,8 +96,18 @@ timeline by completion time — see [timeline](timeline.md). The cleaner's own p
 |---|---|---|
 | `earliestInstantToRetain.timestamp` | `HoodieCleanerPlan` (the `clean.requested` instant) | Instant time of the oldest commit this clean run retains. |
 | `earliestCommitToRetain` | `HoodieCleanMetadata` (the completed `clean` instant) | Copied from the plan, so also an instant time. |
-| `lastCompletedCommitTimestamp` | both | Instant time of the last completed write before the clean was planned. Despite the name, this is a start time, not a completion time. |
+| `lastCompletedCommitTimestamp` | both | Instant time of the write that completed most recently before the clean was planned. Despite the name, this is a start time, not a completion time. |
 | `startCleanTime` | `HoodieCleanMetadata` | Instant time of the clean action itself. |
+
+Two details are easy to trip over when reading these values back:
+
+- `lastCompletedCommitTimestamp` mixes the two orderings. The instant is taken from the end of the completed-commits
+  timeline, which is ordered by completion time, but what gets recorded is that instant's start time. Concurrent writers
+  can complete in a different order than they started in, so this is not always the largest instant time among the
+  completed commits.
+- `earliestCommitToRetain` is an empty string under the `KEEP_LATEST_FILE_VERSIONS` policy. That policy retains a fixed
+  number of file versions per file group rather than a range of the timeline, so the plan carries no
+  `earliestInstantToRetain` for the metadata to copy.
 
 Incremental clean planning follows the same convention: it selects the commits whose **requested** instant time is at or
 after the previous clean's `earliestCommitToRetain` and before this clean's, then scans only the partitions those

--- a/website/learn/tech-specs.md
+++ b/website/learn/tech-specs.md
@@ -707,8 +707,8 @@ by completion time. The fields below all hold the requested instant time of the 
 | lastCompletedCommitTimestamp | Instant time of the last completed write before the clean was planned. Despite the name, this is a start time |
 | startCleanTime | Instant time of the clean action itself, in `HoodieCleanMetadata` |
 
-Incremental clean planning selects commits whose requested instant time falls between the previous clean's
-`earliestCommitToRetain` and the current one, and scans only the partitions those commits touched.
+Incremental clean planning selects commits whose requested instant time is at or after the previous clean's
+`earliestCommitToRetain` and before this clean's, and scans only the partitions those commits touched.
 
 
 ### Indexing

--- a/website/learn/tech-specs.md
+++ b/website/learn/tech-specs.md
@@ -703,8 +703,8 @@ by completion time. The fields below all hold the requested instant time of the 
 
 | Field | Description |
 |---|---|
-| earliestInstantToRetain | Instant time, action and state of the oldest commit the clean run retains. Held in `HoodieCleanerPlan`, and copied to `HoodieCleanMetadata` as `earliestCommitToRetain` |
-| lastCompletedCommitTimestamp | Instant time of the last completed write before the clean was planned. Despite the name, this is a start time |
+| earliestInstantToRetain | Instant time, action and state of the oldest commit the clean run retains. Held in `HoodieCleanerPlan`, and copied to `HoodieCleanMetadata` as `earliestCommitToRetain`. Absent under `KEEP_LATEST_FILE_VERSIONS`, which retains a fixed number of file versions per file group rather than a range of the timeline; `earliestCommitToRetain` is then an empty string |
+| lastCompletedCommitTimestamp | Instant time of the write that completed most recently before the clean was planned. Despite the name, this is a start time. The instant is chosen by completion order, so with concurrent writers it is not always the largest instant time among completed commits |
 | startCleanTime | Instant time of the clean action itself, in `HoodieCleanMetadata` |
 
 Incremental clean planning selects commits whose requested instant time is at or after the previous clean's

--- a/website/learn/tech-specs.md
+++ b/website/learn/tech-specs.md
@@ -2,7 +2,7 @@
 
 | **Syntax** | **Description** |
 | ---|-----------------|
-| Last Updated | Jul 2026        |
+| Last Updated | Aug 2026        |
 | [Table Version](https://github.com/apache/hudi/blob/master/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java) | 9               |
 | Reflects release | Hudi 1.2.0 (May 2026) |
 
@@ -697,6 +697,18 @@ For e.g, there are a couple of retention policies supported in Apache Hudi platf
 
 Apache Hudi provides snapshot isolation between writers and readers by managing multiple files with MVCC concurrency. These file versions provide history
 and enable time travel and rollbacks, but it is important to manage how much history you keep to balance your storage costs.
+
+Cleaning is planned and tracked in terms of **instant (start) times**, even though actions on the timeline are ordered
+by completion time. The fields below all hold the requested instant time of the action they refer to.
+
+| Field | Description |
+|---|---|
+| earliestInstantToRetain | Instant time, action and state of the oldest commit the clean run retains. Held in `HoodieCleanerPlan`, and copied to `HoodieCleanMetadata` as `earliestCommitToRetain` |
+| lastCompletedCommitTimestamp | Instant time of the last completed write before the clean was planned. Despite the name, this is a start time |
+| startCleanTime | Instant time of the clean action itself, in `HoodieCleanMetadata` |
+
+Incremental clean planning selects commits whose requested instant time falls between the previous clean's
+`earliestCommitToRetain` and the current one, and scans only the partitions those commits touched.
 
 
 ### Indexing

--- a/website/versioned_docs/version-1.2.0/cleaning.md
+++ b/website/versioned_docs/version-1.2.0/cleaning.md
@@ -99,9 +99,9 @@ timeline by completion time — see [timeline](timeline.md). The cleaner's own p
 | `lastCompletedCommitTimestamp` | both | Instant time of the last completed write before the clean was planned. Despite the name, this is a start time, not a completion time. |
 | `startCleanTime` | `HoodieCleanMetadata` | Instant time of the clean action itself. |
 
-Incremental clean planning follows the same convention: it selects the commits whose **requested** instant time falls
-between the previous clean's `earliestCommitToRetain` and the current one, and scans only the partitions those commits
-touched.
+Incremental clean planning follows the same convention: it selects the commits whose **requested** instant time is at or
+after the previous clean's `earliestCommitToRetain` and before this clean's, then scans only the partitions those
+commits touched.
 
 ### Configs
 For details about all possible configurations and their default values see the [configuration docs](https://hudi.apache.org/docs/next/configurations/#Clean-Configs).

--- a/website/versioned_docs/version-1.2.0/cleaning.md
+++ b/website/versioned_docs/version-1.2.0/cleaning.md
@@ -3,7 +3,7 @@ title: Cleaning
 toc: true
 toc_min_heading_level: 2
 toc_max_heading_level: 4
-last_modified_at: 2026-05-27T00:00:00-00:00
+last_modified_at: 2026-08-06T15:17:36+05:30
 ---
 ## Background
 Cleaning is a table service employed by Hudi to reclaim space occupied by older versions of data and keep storage costs 
@@ -85,6 +85,23 @@ takes precedence over the regex.
 |---|---|---|
 | `hoodie.clean.partition.filter.regex` | (none) | Java regex pattern; only partitions whose path matches are cleaned. |
 | `hoodie.clean.partition.filter.selected` | (none) | Comma-separated list of partition paths to clean; takes precedence over the regex when both are set. |
+
+### Instant Times in Clean Metadata
+
+Hudi 1.x stamps every action with both a requested instant time and a completion time, and orders actions on the
+timeline by completion time — see [timeline](timeline.md). The cleaner's own plan and metadata, however, record
+**instant (start) times** throughout. Keep this in mind when reading them for debugging.
+
+| Field | Written to | Value |
+|---|---|---|
+| `earliestInstantToRetain.timestamp` | `HoodieCleanerPlan` (the `clean.requested` instant) | Instant time of the oldest commit this clean run retains. |
+| `earliestCommitToRetain` | `HoodieCleanMetadata` (the completed `clean` instant) | Copied from the plan, so also an instant time. |
+| `lastCompletedCommitTimestamp` | both | Instant time of the last completed write before the clean was planned. Despite the name, this is a start time, not a completion time. |
+| `startCleanTime` | `HoodieCleanMetadata` | Instant time of the clean action itself. |
+
+Incremental clean planning follows the same convention: it selects the commits whose **requested** instant time falls
+between the previous clean's `earliestCommitToRetain` and the current one, and scans only the partitions those commits
+touched.
 
 ### Configs
 For details about all possible configurations and their default values see the [configuration docs](https://hudi.apache.org/docs/next/configurations/#Clean-Configs).

--- a/website/versioned_docs/version-1.2.0/cleaning.md
+++ b/website/versioned_docs/version-1.2.0/cleaning.md
@@ -96,8 +96,18 @@ timeline by completion time — see [timeline](timeline.md). The cleaner's own p
 |---|---|---|
 | `earliestInstantToRetain.timestamp` | `HoodieCleanerPlan` (the `clean.requested` instant) | Instant time of the oldest commit this clean run retains. |
 | `earliestCommitToRetain` | `HoodieCleanMetadata` (the completed `clean` instant) | Copied from the plan, so also an instant time. |
-| `lastCompletedCommitTimestamp` | both | Instant time of the last completed write before the clean was planned. Despite the name, this is a start time, not a completion time. |
+| `lastCompletedCommitTimestamp` | both | Instant time of the write that completed most recently before the clean was planned. Despite the name, this is a start time, not a completion time. |
 | `startCleanTime` | `HoodieCleanMetadata` | Instant time of the clean action itself. |
+
+Two details are easy to trip over when reading these values back:
+
+- `lastCompletedCommitTimestamp` mixes the two orderings. The instant is taken from the end of the completed-commits
+  timeline, which is ordered by completion time, but what gets recorded is that instant's start time. Concurrent writers
+  can complete in a different order than they started in, so this is not always the largest instant time among the
+  completed commits.
+- `earliestCommitToRetain` is an empty string under the `KEEP_LATEST_FILE_VERSIONS` policy. That policy retains a fixed
+  number of file versions per file group rather than a range of the timeline, so the plan carries no
+  `earliestInstantToRetain` for the metadata to copy.
 
 Incremental clean planning follows the same convention: it selects the commits whose **requested** instant time is at or
 after the previous clean's `earliestCommitToRetain` and before this clean's, then scans only the partitions those


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17274. (JIRA: HUDI-8258, a subtask of HUDI-8894.)

Hudi 1.x stamps every action with both a requested instant time and a completion time, and orders the timeline by
completion time. Nothing in the docs said which of the two the **cleaner** records, so someone reading clean metadata to
debug a retention problem has no way to tell whether `earliestCommitToRetain` is a start time or a completion time — and
picking the wrong interpretation sends them looking at the wrong commit.

It is a start time, on every field. The issue asks for exactly this to be stated on the Cleaning and Tech Spec pages.

### Summary and Changelog

Added an `### Instant Times in Clean Metadata` subsection to the Cleaning page tabulating the four timestamp fields, and
a matching field table to the `Cleaning` section of the 1.0 tech spec:

| Field | Written to | Value |
|---|---|---|
| `earliestInstantToRetain.timestamp` | `HoodieCleanerPlan` (the `clean.requested` instant) | Instant time of the oldest commit this clean run retains |
| `earliestCommitToRetain` | `HoodieCleanMetadata` (the completed `clean` instant) | Copied from the plan, so also an instant time |
| `lastCompletedCommitTimestamp` | both | Instant time of the last completed write before the clean was planned — despite the name, a start time |
| `startCleanTime` | `HoodieCleanMetadata` | Instant time of the clean action itself |

Plus a note that incremental clean planning follows the same convention, ranging over the **requested** instant times of
completed commits.

Files: `website/docs/cleaning.md` (next) and `website/versioned_docs/version-1.2.0/cleaning.md` (current released docs),
per the next-plus-current convention used in #19473 and #19551. `website/learn/tech-specs.md` has no versioned copies —
the `learn` plugin is configured without versioning — so it has a single edit.

### Where this comes from in the code

Checked at both `master` and the `release-1.2.0` tag; the relevant lines are identical in each.

- `CleanPlanActionExecutor.java:111` and `:177` build the plan's `earliestInstantToRetain` from `hoodieInstant.requestedTime()`.
- `CleanPlanner.java:655-657` — `getLastCompletedCommitTimestamp()` returns `getCommitTimeline().lastInstant().requestedTime()`. The source carries the same observation inline at `CleanPlanActionExecutor.java:178`: *"Note: This is the start time of the last completed ingestion before this clean."*
- `CleanActionExecutor.java:172-179` and `:256` copy the plan values into `HoodieCleanMetadata`.
- `CleanPlanner.java:241-245` filters completed commits by `instant.requestedTime()` against `earliestCommitToRetain`.

### Reproduction

Source reading alone felt insufficient here, because the page promises what a user will *see* — and the read path runs
`CleanMetadataMigrator.upgradeToLatest`, which I had not verified leaves these timestamps alone. So the values below were
read back through `CleanerUtils.getCleanerMetadata`, the same call a debugging user would make.

Setup: Spark 3.5.7 with `hudi-spark3.5-bundle_2.12:1.2.0`, a local-filesystem COW table, `hoodie.clean.commits.retained=3`,
`hoodie.clean.incremental.enabled=true`, 8 write batches. Requested and completion times differ on every instant, so no
value can match by coincidence.

Timeline (tail):

| Action | requested | completion |
|---|---|---|
| commit | `20260807112136674` | `20260807112136958` |
| commit | `20260807112137041` | `20260807112137362` |
| commit | `20260807112137452` | `20260807112137746` |
| clean  | `20260807112137760` | `20260807112137796` |

Metadata read back from that last clean:

| Field | Value | Is the... |
|---|---|---|
| `startCleanTime` | `20260807112137760` | clean's **requested** time (not `…137796`) |
| `earliestCommitToRetain` | `20260807112136674` | that commit's **requested** time (not `…136958`) |
| `lastCompletedCommitTimestamp` | `20260807112137452` | last commit's **requested** time (not `…137746`) |
| `HoodieCleanerPlan.earliestInstantToRetain` | `20260807112136674` (action=commit, state=COMPLETED) | identical to the metadata, confirming it is copied from the plan |
| `HoodieCleanerPlan.lastCompletedCommitTimestamp` | `20260807112137452` | same |

**No recorded value appears anywhere in the completion-time column.** Every completion time on that timeline
(`134434, 135308, 135737, 136087, 136511, 136630, 136958, 137008, 137362, 137415, 137746, 137796`) is absent from the
metadata.

Two notes on method. I first ran with `retained=1`, where `earliestCommitToRetain` and `lastCompletedCommitTimestamp`
collapse to the same value and only one field would have been proven; the `retained=3` run above separates them into two
distinct values, both still requested times. And for the incremental-planning sentence, which is not observable in
metadata, I enabled `CleanPlanner` INFO logging:

```
Incremental Cleaning mode is enabled. Looking up partition-paths that have changed since last clean at 20260807112242500.
New Instant to retain Option{val=[20260807112242946__20260807112243250__commit__COMPLETED]}.
```

`20260807112242500` is the **requested** time of `20260807112242500_20260807112242806.commit`, not its completion.

### A note on scope

The parent ticket HUDI-8077, which would have moved clean metadata onto completion time, is resolved *Won't Do* and its
PR #11972 was closed unmerged. This PR therefore documents the behaviour as it actually stands, which matches the
issue's own wording that "the start/instant time is **still** used in the clean metadata".

### Impact

Documentation only. No code, config, or behaviour change.

### Risk Level

none

### Documentation Update

This PR is the documentation update — the Cleaning page (`/docs/cleaning`, `/docs/next/cleaning`) and the technical
specification (`/learn/tech-specs`).

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
