### PR TITLE
perf(common): avoid redundant V1 archived timeline loads in incremental queries

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/IncrementalQueryAnalyzer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/IncrementalQueryAnalyzer.java
@@ -202,12 +202,24 @@ public class IncrementalQueryAnalyzer {
     HoodieTimeline archivedReadTimeline = null;
 
     if (startCompletionTime.isEmpty() && endCompletionTime.isPresent()) {
-      // (_, end] returns the last eligible instant at or before end. Check the filtered active
-      // timeline first and only load the archive when there is no active match.
+      // (_, end] returns the last eligible instant at or before end. An old savepointed commit can
+      // remain active before the archive boundary, so only use the active-only shortcut when the
+      // selected active instant is on or after that boundary.
       activeInstants = getLastInstantAtOrBefore(completedTimeline, endCompletionTime.get());
-      if (activeInstants.isEmpty()) {
+      if (activeInstants.isEmpty()
+          || completionTimeQueryView.isArchived(activeInstants.get(0).requestedTime())) {
         archivedReadTimeline = getArchivedReadTimeline(metaClient, "");
         archivedInstants = getLastInstantAtOrBefore(archivedReadTimeline, endCompletionTime.get());
+        if (!archivedInstants.isEmpty()
+            && (activeInstants.isEmpty()
+                || compareTimestamps(
+                    activeInstants.get(0).requestedTime(),
+                    LESSER_THAN_OR_EQUALS,
+                    archivedInstants.get(0).requestedTime()))) {
+          activeInstants = Collections.emptyList();
+        } else {
+          archivedInstants = Collections.emptyList();
+        }
       }
     } else {
       InstantRange instantRange = InstantRange.builder()
@@ -274,6 +286,8 @@ public class IncrementalQueryAnalyzer {
     }
     List<String> instants = Stream.concat(archivedInstants.stream(), activeInstants.stream())
         .map(HoodieInstant::requestedTime)
+        .distinct()
+        .sorted()
         .collect(Collectors.toList());
     if (instants.isEmpty()) {
       // no instants completed within the given time range, returns early.

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/IncrementalQueryAnalyzer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/IncrementalQueryAnalyzer.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.table.timeline.CompletionTimeQueryView;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -42,6 +43,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -49,6 +51,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
+import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 
 /**
  * Analyzer for incremental queries on the timeline, to filter instants based on specified ranges
@@ -167,49 +172,143 @@ public class IncrementalQueryAnalyzer {
         return QueryContext.EMPTY;
       }
       HoodieTimeline filteredTimeline = getFilteredTimeline(this.metaClient);
-      List<String> instantTimeList = completionTimeQueryView.getInstantTimes(filteredTimeline, startCompletionTime, endCompletionTime, rangeType);
-      if (instantTimeList.isEmpty()) {
-        // no instants completed within the give time range, returns early.
-        return QueryContext.EMPTY;
+      if (TimelineLayoutVersion.LAYOUT_VERSION_1.equals(metaClient.getTimelineLayoutVersion())) {
+        return analyzeForV1Timeline(filteredTimeline, completionTimeQueryView);
       }
-      // get hoodie instants
-      Pair<List<String>, List<String>> splitInstantTime = splitInstantByActiveness(instantTimeList, completionTimeQueryView);
-      Set<String> instantTimeSet = new HashSet<>(instantTimeList);
-      List<String> archivedInstantTimes = splitInstantTime.getLeft();
-      List<String> activeInstantTimes = splitInstantTime.getRight();
-      List<HoodieInstant> archivedInstants = new ArrayList<>();
-      List<HoodieInstant> activeInstants = new ArrayList<>();
-      HoodieTimeline archivedReadTimeline = null;
-      if (!activeInstantTimes.isEmpty()) {
-        activeInstants = filteredTimeline.getInstantsAsStream().filter(instant -> instantTimeSet.contains(instant.requestedTime())).collect(Collectors.toList());
-        if (limit > 0 && limit < activeInstants.size()) {
-          // streaming read speed limit, limits the maximum number of commits allowed to read for each run
-          activeInstants = activeInstants.subList(0, limit);
-        }
-      }
-      if (!archivedInstantTimes.isEmpty()) {
-        archivedReadTimeline = getArchivedReadTimeline(metaClient, archivedInstantTimes.get(0));
-        archivedInstants = archivedReadTimeline.getInstantsAsStream().filter(instant -> instantTimeSet.contains(instant.requestedTime())).collect(Collectors.toList());
-      }
-      List<String> instants = Stream.concat(archivedInstants.stream(), activeInstants.stream()).map(HoodieInstant::requestedTime).collect(Collectors.toList());
-      if (instants.isEmpty()) {
-        // no instants completed within the give time range, returns early.
-        return QueryContext.EMPTY;
-      }
-      if (startCompletionTime.isEmpty() && endCompletionTime.isPresent()) {
-        instants = Collections.singletonList(instants.get(instants.size() - 1));
-      }
-      String lastInstant = instants.get(instants.size() - 1);
-      // null => if starting from earliest, if no startCompletionTime is specified, start from the latest instant like usual streaming read semantics.
-      // if startCompletionTime is neither, then use the earliest instant as the start instant.
-      String startInstant = START_COMMIT_EARLIEST.equalsIgnoreCase(startCompletionTime.orElse(null)) ? null :
-          startCompletionTime.isEmpty() ? lastInstant : instants.get(0);
-      String endInstant = endCompletionTime.isEmpty() ? null : lastInstant;
-      return QueryContext.create(startInstant, endInstant, instants, archivedInstants, activeInstants, filteredTimeline, archivedReadTimeline);
+      return analyzeForV2Timeline(filteredTimeline, completionTimeQueryView);
     } catch (Exception ex) {
       log.error("Got exception when generating incremental query info", ex);
       throw new HoodieException(ex);
     }
+  }
+
+  private QueryContext analyzeForV1Timeline(
+      HoodieTimeline filteredTimeline,
+      CompletionTimeQueryView completionTimeQueryView) {
+    final boolean startFromEarliest = START_COMMIT_EARLIEST.equalsIgnoreCase(startCompletionTime.orElse(null));
+    final Option<String> effectiveStart = startFromEarliest ? Option.empty() : startCompletionTime;
+    final HoodieTimeline completedTimeline = filteredTimeline.filterCompletedInstants();
+
+    if (effectiveStart.isEmpty() && endCompletionTime.isEmpty()) {
+      // (_, _) reads the latest completed instant while [earliest, +INF] is a snapshot read.
+      List<HoodieInstant> activeInstants = completedTimeline.lastInstant()
+          .map(Collections::singletonList)
+          .orElse(Collections.emptyList());
+      return createQueryContext(Collections.emptyList(), activeInstants, filteredTimeline, null);
+    }
+
+    List<HoodieInstant> archivedInstants = Collections.emptyList();
+    List<HoodieInstant> activeInstants;
+    HoodieTimeline archivedReadTimeline = null;
+
+    if (startCompletionTime.isEmpty() && endCompletionTime.isPresent()) {
+      // (_, end] returns the last eligible instant at or before end. Check the filtered active
+      // timeline first and only load the archive when there is no active match.
+      activeInstants = getLastInstantAtOrBefore(completedTimeline, endCompletionTime.get());
+      if (activeInstants.isEmpty()) {
+        archivedReadTimeline = getArchivedReadTimeline(metaClient, "");
+        archivedInstants = getLastInstantAtOrBefore(archivedReadTimeline, endCompletionTime.get());
+      }
+    } else {
+      InstantRange instantRange = InstantRange.builder()
+          .rangeType(rangeType)
+          .startInstant(effectiveStart.orElse(null))
+          .endInstant(endCompletionTime.orElse(null))
+          .nullableBoundary(true)
+          .build();
+      activeInstants = getInstantsInRange(completedTimeline, instantRange);
+
+      boolean needsArchivedInstants = startFromEarliest
+          || (effectiveStart.isPresent() && completionTimeQueryView.isArchived(effectiveStart.get()));
+      if (needsArchivedInstants) {
+        archivedReadTimeline = getArchivedReadTimeline(metaClient, effectiveStart.orElse(""));
+        archivedInstants = getInstantsInRange(archivedReadTimeline, instantRange);
+      }
+    }
+
+    return createQueryContext(
+        archivedInstants, activeInstants, filteredTimeline, archivedReadTimeline);
+  }
+
+  private QueryContext analyzeForV2Timeline(
+      HoodieTimeline filteredTimeline,
+      CompletionTimeQueryView completionTimeQueryView) {
+    List<String> instantTimeList = completionTimeQueryView.getInstantTimes(
+        filteredTimeline, startCompletionTime, endCompletionTime, rangeType);
+    if (instantTimeList.isEmpty()) {
+      // no instants completed within the given time range, returns early.
+      return QueryContext.EMPTY;
+    }
+
+    Pair<List<String>, List<String>> splitInstantTime = splitInstantByActiveness(
+        instantTimeList, completionTimeQueryView);
+    Set<String> instantTimeSet = new HashSet<>(instantTimeList);
+    List<String> archivedInstantTimes = splitInstantTime.getLeft();
+    List<String> activeInstantTimes = splitInstantTime.getRight();
+    List<HoodieInstant> archivedInstants = new ArrayList<>();
+    List<HoodieInstant> activeInstants = new ArrayList<>();
+    HoodieTimeline archivedReadTimeline = null;
+    if (!activeInstantTimes.isEmpty()) {
+      activeInstants = filteredTimeline.getInstantsAsStream()
+          .filter(instant -> instantTimeSet.contains(instant.requestedTime()))
+          .collect(Collectors.toList());
+    }
+    if (!archivedInstantTimes.isEmpty()) {
+      archivedReadTimeline = getArchivedReadTimeline(metaClient, archivedInstantTimes.get(0));
+      archivedInstants = archivedReadTimeline.getInstantsAsStream()
+          .filter(instant -> instantTimeSet.contains(instant.requestedTime()))
+          .collect(Collectors.toList());
+    }
+    return createQueryContext(
+        archivedInstants, activeInstants, filteredTimeline, archivedReadTimeline);
+  }
+
+  private QueryContext createQueryContext(
+      List<HoodieInstant> archivedInstants,
+      List<HoodieInstant> activeInstants,
+      HoodieTimeline filteredTimeline,
+      @Nullable HoodieTimeline archivedReadTimeline) {
+    if (limit > 0 && limit < activeInstants.size()) {
+      // streaming read speed limit, limits the maximum number of active commits allowed per run
+      activeInstants = activeInstants.subList(0, limit);
+    }
+    List<String> instants = Stream.concat(archivedInstants.stream(), activeInstants.stream())
+        .map(HoodieInstant::requestedTime)
+        .collect(Collectors.toList());
+    if (instants.isEmpty()) {
+      // no instants completed within the given time range, returns early.
+      return QueryContext.EMPTY;
+    }
+    if (startCompletionTime.isEmpty() && endCompletionTime.isPresent()) {
+      instants = Collections.singletonList(instants.get(instants.size() - 1));
+    }
+    String lastInstant = instants.get(instants.size() - 1);
+    // null => if starting from earliest. If no startCompletionTime is specified, start from the
+    // latest instant like usual streaming read semantics. Otherwise use the earliest selected instant.
+    String startInstant = START_COMMIT_EARLIEST.equalsIgnoreCase(startCompletionTime.orElse(null)) ? null :
+        startCompletionTime.isEmpty() ? lastInstant : instants.get(0);
+    String endInstant = endCompletionTime.isEmpty() ? null : lastInstant;
+    return QueryContext.create(
+        startInstant, endInstant, instants, archivedInstants, activeInstants,
+        filteredTimeline, archivedReadTimeline);
+  }
+
+  private static List<HoodieInstant> getInstantsInRange(
+      HoodieTimeline timeline, InstantRange instantRange) {
+    return timeline.getInstantsAsStream()
+        .filter(instant -> instantRange.isInRange(instant.requestedTime()))
+        .sorted(Comparator.comparing(HoodieInstant::requestedTime))
+        .collect(Collectors.toList());
+  }
+
+  private static List<HoodieInstant> getLastInstantAtOrBefore(
+      HoodieTimeline timeline, String endInstant) {
+    return timeline.getInstantsAsStream()
+        .filter(instant -> compareTimestamps(
+            instant.requestedTime(), LESSER_THAN_OR_EQUALS, endInstant))
+        .max(Comparator.comparing(HoodieInstant::requestedTime))
+        .map(Collections::singletonList)
+        .orElse(Collections.emptyList());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/IncrementalQueryAnalyzer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/IncrementalQueryAnalyzer.java
@@ -182,6 +182,11 @@ public class IncrementalQueryAnalyzer {
     }
   }
 
+  /**
+   * Analyzes a layout V1 timeline by applying the completion-time range directly to requested time,
+   * since V1 does not persist a separate completion time. This path filters active instants first
+   * and loads the archived timeline at most once, only when the range may overlap it.
+   */
   private QueryContext analyzeForV1Timeline(
       HoodieTimeline filteredTimeline,
       CompletionTimeQueryView completionTimeQueryView) {
@@ -242,6 +247,11 @@ public class IncrementalQueryAnalyzer {
         archivedInstants, activeInstants, filteredTimeline, archivedReadTimeline);
   }
 
+  /**
+   * Analyzes a layout V2 timeline through {@link CompletionTimeQueryView}, since completion time can
+   * differ from requested time. The query view resolves requested-time candidates before they are
+   * materialized from the active and archived timelines.
+   */
   private QueryContext analyzeForV2Timeline(
       HoodieTimeline filteredTimeline,
       CompletionTimeQueryView completionTimeQueryView) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestIncrementalQueryAnalyzer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestIncrementalQueryAnalyzer.java
@@ -19,26 +19,47 @@
 
 package org.apache.hudi.common.table.read;
 
+import org.apache.hudi.common.HoodieTableFormat;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.InstantRange;
+import org.apache.hudi.common.table.timeline.CompletionTimeQueryView;
+import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineFactory;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
+import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TestIncrementalQueryAnalyzer {
+
+  private static final String T1 = "20240101010001000";
+  private static final String T2 = "20240101010002000";
+  private static final String T3 = "20240101010003000";
+  private static final String T4 = "20240101010004000";
 
   @Test
   void testQueryContextRangeEdges() {
@@ -85,5 +106,210 @@ class TestIncrementalQueryAnalyzer {
     assertThrows(NullPointerException.class, () -> IncrementalQueryAnalyzer.builder()
         .metaClient(mock(HoodieTableMetaClient.class))
         .build());
+  }
+
+  @Test
+  void testV1LoadsArchivedTimelineOnceAndReusesIt() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T3), instant(T4)),
+        Arrays.asList(instant(T1), instant(T2)));
+    when(fixture.completionTimeQueryView.isArchived(T2)).thenReturn(true);
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer(T2, T4).analyze();
+
+    assertEquals(Arrays.asList(T2, T3, T4), queryContext.getInstantTimeList());
+    assertEquals(Collections.singletonList(T2), requestedTimes(queryContext.getArchivedInstants()));
+    assertEquals(Arrays.asList(T3, T4), requestedTimes(queryContext.getActiveInstants()));
+    assertSame(fixture.archivedCommitsTimeline, queryContext.getArchivedTimeline());
+    verify(fixture.metaClient, times(1)).getArchivedTimeline(T2, false);
+    verify(fixture.completionTimeQueryView, never()).getInstantTimes(
+        any(HoodieTimeline.class), any(), any(), any(InstantRange.RangeType.class));
+  }
+
+  @Test
+  void testV1EndOnlyLoadsArchiveOnceAndSelectsLastEligibleInstant() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T3), instant(T4)),
+        Arrays.asList(instant(T1), instant(T2)));
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer(null, T2).analyze();
+
+    assertEquals(Collections.singletonList(T2), queryContext.getInstantTimeList());
+    assertEquals(Collections.singletonList(T2), requestedTimes(queryContext.getArchivedInstants()));
+    assertTrue(queryContext.getActiveInstants().isEmpty());
+    assertSame(fixture.archivedCommitsTimeline, queryContext.getArchivedTimeline());
+    verify(fixture.metaClient, times(1)).getArchivedTimeline("", false);
+  }
+
+  @Test
+  void testV1ActiveOnlyAndSnapshotRangesDoNotLoadArchive() {
+    AnalyzerFixture activeFixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T3), instant(T4)),
+        Arrays.asList(instant(T1), instant(T2)));
+    when(activeFixture.completionTimeQueryView.isArchived(T3)).thenReturn(false);
+
+    IncrementalQueryAnalyzer.QueryContext activeContext = activeFixture.analyzer(T3, T4).analyze();
+
+    assertEquals(Arrays.asList(T3, T4), activeContext.getInstantTimeList());
+    assertNull(activeContext.getArchivedTimeline());
+    verify(activeFixture.metaClient, never()).getArchivedTimeline(anyString(), eq(false));
+
+    AnalyzerFixture snapshotFixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T3), instant(T4)),
+        Arrays.asList(instant(T1), instant(T2)));
+
+    IncrementalQueryAnalyzer.QueryContext snapshotContext = snapshotFixture.analyzer("earliest", null).analyze();
+
+    assertEquals(Collections.singletonList(T4), snapshotContext.getInstantTimeList());
+    assertTrue(snapshotContext.getInstantRange().isEmpty());
+    verify(snapshotFixture.metaClient, never()).getArchivedTimeline(anyString(), eq(false));
+  }
+
+  @Test
+  void testV1PreservesActiveSideLimitForMixedRange() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T3), instant(T4)),
+        Arrays.asList(instant(T1), instant(T2)));
+    when(fixture.completionTimeQueryView.isArchived(T2)).thenReturn(true);
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzerBuilder(T2, T4)
+        .limit(1)
+        .build()
+        .analyze();
+
+    assertEquals(Arrays.asList(T2, T3), queryContext.getInstantTimeList());
+    assertEquals(Collections.singletonList(T2), requestedTimes(queryContext.getArchivedInstants()));
+    assertEquals(Collections.singletonList(T3), requestedTimes(queryContext.getActiveInstants()));
+    verify(fixture.metaClient, times(1)).getArchivedTimeline(T2, false);
+  }
+
+  @Test
+  void testV1AppliesOpenClosedRangeDirectlyToRequestedTime() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T3), instant(T4)),
+        Arrays.asList(instant(T1), instant(T2)));
+    when(fixture.completionTimeQueryView.isArchived(T1)).thenReturn(true);
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzerBuilder(T1, T4)
+        .rangeType(InstantRange.RangeType.OPEN_CLOSED)
+        .build()
+        .analyze();
+
+    assertEquals(Arrays.asList(T2, T3, T4), queryContext.getInstantTimeList());
+    assertEquals(Collections.singletonList(T2), requestedTimes(queryContext.getArchivedInstants()));
+    verify(fixture.metaClient, times(1)).getArchivedTimeline(T1, false);
+  }
+
+  @Test
+  void testV1EarliestBoundedRangeLoadsArchiveOnce() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T3), instant(T4)),
+        Arrays.asList(instant(T1), instant(T2)));
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer("earliest", T3).analyze();
+
+    assertEquals(Arrays.asList(T1, T2, T3), queryContext.getInstantTimeList());
+    assertTrue(queryContext.isConsumingFromEarliest());
+    assertEquals(Arrays.asList(T1, T2), requestedTimes(queryContext.getArchivedInstants()));
+    verify(fixture.metaClient, times(1)).getArchivedTimeline("", false);
+  }
+
+  @Test
+  void testV2ContinuesToUseCompletionTimeQueryView() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_2,
+        Arrays.asList(instant(T3), instant(T4)),
+        Collections.emptyList());
+    when(fixture.completionTimeQueryView.getInstantTimes(
+        any(HoodieTimeline.class), any(), any(), any(InstantRange.RangeType.class)))
+        .thenReturn(Arrays.asList(T3, T4));
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer(T3, T4).analyze();
+
+    assertEquals(Arrays.asList(T3, T4), queryContext.getInstantTimeList());
+    verify(fixture.completionTimeQueryView, times(1)).getInstantTimes(
+        any(HoodieTimeline.class), any(), any(), eq(InstantRange.RangeType.CLOSED_CLOSED));
+    verify(fixture.metaClient, never()).getArchivedTimeline(anyString(), eq(false));
+  }
+
+  private static HoodieInstant instant(String requestedTime) {
+    HoodieInstant instant = mock(HoodieInstant.class);
+    when(instant.requestedTime()).thenReturn(requestedTime);
+    return instant;
+  }
+
+  private static HoodieTimeline timeline(List<HoodieInstant> instants) {
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    when(timeline.filterCompletedAndCompactionInstants()).thenReturn(timeline);
+    when(timeline.filterCompletedInstants()).thenReturn(timeline);
+    when(timeline.getInstantsAsStream()).thenAnswer(invocation -> instants.stream());
+    when(timeline.lastInstant()).thenReturn(instants.isEmpty()
+        ? Option.empty()
+        : Option.of(instants.get(instants.size() - 1)));
+    return timeline;
+  }
+
+  private static List<String> requestedTimes(List<HoodieInstant> instants) {
+    return instants.stream().map(HoodieInstant::requestedTime).collect(Collectors.toList());
+  }
+
+  private static AnalyzerFixture analyzerFixture(
+      TimelineLayoutVersion layoutVersion,
+      List<HoodieInstant> activeInstants,
+      List<HoodieInstant> archivedInstants) {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableFormat tableFormat = mock(HoodieTableFormat.class);
+    TimelineFactory timelineFactory = mock(TimelineFactory.class);
+    CompletionTimeQueryView completionTimeQueryView = mock(CompletionTimeQueryView.class);
+    HoodieTimeline activeTimeline = timeline(activeInstants);
+    HoodieTimeline archivedCommitsTimeline = timeline(archivedInstants);
+    HoodieArchivedTimeline archivedTimeline = mock(HoodieArchivedTimeline.class);
+
+    when(metaClient.getTimelineLayoutVersion()).thenReturn(layoutVersion);
+    when(metaClient.getTableFormat()).thenReturn(tableFormat);
+    when(metaClient.getTableType()).thenReturn(HoodieTableType.COPY_ON_WRITE);
+    when(metaClient.getCommitsAndCompactionTimeline()).thenReturn(activeTimeline);
+    when(metaClient.getArchivedTimeline(anyString(), eq(false))).thenReturn(archivedTimeline);
+    when(tableFormat.getTimelineFactory()).thenReturn(timelineFactory);
+    when(timelineFactory.createCompletionTimeQueryView(metaClient)).thenReturn(completionTimeQueryView);
+    when(completionTimeQueryView.isEmptyTable()).thenReturn(false);
+    when(archivedTimeline.getCommitsTimeline()).thenReturn(archivedCommitsTimeline);
+
+    return new AnalyzerFixture(
+        metaClient, completionTimeQueryView, archivedCommitsTimeline);
+  }
+
+  private static class AnalyzerFixture {
+    private final HoodieTableMetaClient metaClient;
+    private final CompletionTimeQueryView completionTimeQueryView;
+    private final HoodieTimeline archivedCommitsTimeline;
+
+    private AnalyzerFixture(
+        HoodieTableMetaClient metaClient,
+        CompletionTimeQueryView completionTimeQueryView,
+        HoodieTimeline archivedCommitsTimeline) {
+      this.metaClient = metaClient;
+      this.completionTimeQueryView = completionTimeQueryView;
+      this.archivedCommitsTimeline = archivedCommitsTimeline;
+    }
+
+    private IncrementalQueryAnalyzer analyzer(String start, String end) {
+      return analyzerBuilder(start, end).build();
+    }
+
+    private IncrementalQueryAnalyzer.Builder analyzerBuilder(String start, String end) {
+      return IncrementalQueryAnalyzer.builder()
+          .metaClient(metaClient)
+          .startCompletionTime(start)
+          .endCompletionTime(end)
+          .rangeType(InstantRange.RangeType.CLOSED_CLOSED);
+    }
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestIncrementalQueryAnalyzer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestIncrementalQueryAnalyzer.java
@@ -60,6 +60,7 @@ class TestIncrementalQueryAnalyzer {
   private static final String T2 = "20240101010002000";
   private static final String T3 = "20240101010003000";
   private static final String T4 = "20240101010004000";
+  private static final String T5 = "20240101010005000";
 
   @Test
   void testQueryContextRangeEdges() {
@@ -144,29 +145,112 @@ class TestIncrementalQueryAnalyzer {
   }
 
   @Test
-  void testV1ActiveOnlyAndSnapshotRangesDoNotLoadArchive() {
-    AnalyzerFixture activeFixture = analyzerFixture(
+  void testV1EndOnlyComparesCandidatesAcrossSavepointHole() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T1), instant(T5)),
+        Arrays.asList(instant(T2), instant(T3), instant(T4)));
+    when(fixture.completionTimeQueryView.isArchived(T1)).thenReturn(true);
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer(null, T4).analyze();
+
+    assertEquals(Collections.singletonList(T4), queryContext.getInstantTimeList());
+    assertEquals(Collections.singletonList(T4), requestedTimes(queryContext.getArchivedInstants()));
+    assertTrue(queryContext.getActiveInstants().isEmpty());
+    assertSame(fixture.archivedCommitsTimeline, queryContext.getArchivedTimeline());
+    verify(fixture.metaClient, times(1)).getArchivedTimeline("", false);
+  }
+
+  @Test
+  void testV1EndOnlyRetainsNewerActiveCandidateAcrossSavepointHole() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T4), instant(T5)),
+        Arrays.asList(instant(T1), instant(T2), instant(T3)));
+    when(fixture.completionTimeQueryView.isArchived(T4)).thenReturn(true);
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer(null, T4).analyze();
+
+    assertEquals(Collections.singletonList(T4), queryContext.getInstantTimeList());
+    assertEquals(Collections.singletonList(T4), requestedTimes(queryContext.getActiveInstants()));
+    assertTrue(queryContext.getArchivedInstants().isEmpty());
+    assertSame(fixture.archivedCommitsTimeline, queryContext.getArchivedTimeline());
+    verify(fixture.metaClient, times(1)).getArchivedTimeline("", false);
+  }
+
+  @Test
+  void testV1EndOnlyActiveCandidateAfterArchiveBoundaryDoesNotLoadArchive() {
+    AnalyzerFixture fixture = analyzerFixture(
         TimelineLayoutVersion.LAYOUT_VERSION_1,
         Arrays.asList(instant(T3), instant(T4)),
         Arrays.asList(instant(T1), instant(T2)));
-    when(activeFixture.completionTimeQueryView.isArchived(T3)).thenReturn(false);
+    when(fixture.completionTimeQueryView.isArchived(T3)).thenReturn(false);
 
-    IncrementalQueryAnalyzer.QueryContext activeContext = activeFixture.analyzer(T3, T4).analyze();
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer(null, T3).analyze();
 
-    assertEquals(Arrays.asList(T3, T4), activeContext.getInstantTimeList());
-    assertNull(activeContext.getArchivedTimeline());
-    verify(activeFixture.metaClient, never()).getArchivedTimeline(anyString(), eq(false));
+    assertEquals(Collections.singletonList(T3), queryContext.getInstantTimeList());
+    assertEquals(Collections.singletonList(T3), requestedTimes(queryContext.getActiveInstants()));
+    assertTrue(queryContext.getArchivedInstants().isEmpty());
+    assertNull(queryContext.getArchivedTimeline());
+    verify(fixture.metaClient, never()).getArchivedTimeline(anyString(), eq(false));
+  }
 
-    AnalyzerFixture snapshotFixture = analyzerFixture(
+  @Test
+  void testV1ActiveOnlyRangeDoesNotLoadArchive() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T3), instant(T4)),
+        Arrays.asList(instant(T1), instant(T2)));
+    when(fixture.completionTimeQueryView.isArchived(T3)).thenReturn(false);
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer(T3, T4).analyze();
+
+    assertEquals(Arrays.asList(T3, T4), queryContext.getInstantTimeList());
+    assertNull(queryContext.getArchivedTimeline());
+    verify(fixture.metaClient, never()).getArchivedTimeline(anyString(), eq(false));
+  }
+
+  @Test
+  void testV1EarliestSnapshotDoesNotLoadArchive() {
+    AnalyzerFixture fixture = analyzerFixture(
         TimelineLayoutVersion.LAYOUT_VERSION_1,
         Arrays.asList(instant(T3), instant(T4)),
         Arrays.asList(instant(T1), instant(T2)));
 
-    IncrementalQueryAnalyzer.QueryContext snapshotContext = snapshotFixture.analyzer("earliest", null).analyze();
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer("earliest", null).analyze();
 
-    assertEquals(Collections.singletonList(T4), snapshotContext.getInstantTimeList());
-    assertTrue(snapshotContext.getInstantRange().isEmpty());
-    verify(snapshotFixture.metaClient, never()).getArchivedTimeline(anyString(), eq(false));
+    assertEquals(Collections.singletonList(T4), queryContext.getInstantTimeList());
+    assertTrue(queryContext.getInstantRange().isEmpty());
+    verify(fixture.metaClient, never()).getArchivedTimeline(anyString(), eq(false));
+  }
+
+  @Test
+  void testV1GloballySortsInstantsAcrossSavepointHole() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T1), instant(T5)),
+        Arrays.asList(instant(T2), instant(T3), instant(T4)));
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer("earliest", T4).analyze();
+
+    assertEquals(Arrays.asList(T1, T2, T3, T4), queryContext.getInstantTimeList());
+    assertEquals(T4, queryContext.getLastInstant());
+    assertTrue(queryContext.getInstantRange().get().isInRange(T4));
+    verify(fixture.metaClient, times(1)).getArchivedTimeline("", false);
+  }
+
+  @Test
+  void testV1DeduplicatesInstantsAcrossConcurrentArchival() {
+    AnalyzerFixture fixture = analyzerFixture(
+        TimelineLayoutVersion.LAYOUT_VERSION_1,
+        Arrays.asList(instant(T1), instant(T4), instant(T5)),
+        Arrays.asList(instant(T2), instant(T3), instant(T4)));
+
+    IncrementalQueryAnalyzer.QueryContext queryContext = fixture.analyzer("earliest", T4).analyze();
+
+    assertEquals(Arrays.asList(T1, T2, T3, T4), queryContext.getInstantTimeList());
+    assertEquals(T4, queryContext.getLastInstant());
+    verify(fixture.metaClient, times(1)).getArchivedTimeline("", false);
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

  This is a follow-up to #19338 and addresses the archived-timeline optimization suggested in https://github.com/apache/hudi/pull/19338#issuecomment-5211158987.

  For timeline layout V1, `CompletionTimeQueryViewV1` loaded archived instants to identify candidate requested times, after which `IncrementalQueryAnalyzer` discarded that timeline and loaded the archive again to construct `QueryContext`. Since V1 completion time is equivalent to requested time, the second scan is redundant.

### Summary and Changelog

  - Add a dedicated V1 analysis path in `IncrementalQueryAnalyzer`.
  - Load the filtered archived timeline at most once when the requested range overlaps archived instants.
  - Apply `InstantRange` directly to `HoodieInstant.requestedTime()` and reuse the same archived timeline in `QueryContext`.
  - Avoid archive loading for active-only and snapshot ranges; for end-only ranges, check the filtered active timeline before loading the archive.
  - Keep the V2 completion-time query path unchanged.
  - Add tests covering single archive loading, timeline reuse, range boundaries, active-only and snapshot paths, limits, and V2 behavior.

### Impact

  Improves incremental-query performance for timeline layout V1 (table versions 5–7) by eliminating a redundant archived-timeline scan. There are no public API, configuration, storage-format, or V2 semantic changes. Query results and existing range semantics remain unchanged.

### Risk Level

  low

  The change touches V1 incremental range selection but keeps V2 on the existing path. It is covered by `TestIncrementalQueryAnalyzer` and `TestCompletionTimeQueryViewV1`: 16 tests passed with no failures or errors. Reactor compilation, Checkstyle, RAT, and `git diff --check` also passed.

### Documentation Update

  none. This is an internal performance optimization with no new user-facing behavior or configuration.

### Contributor's checklist

  - [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
  - [x] Enough context is provided in the sections above
  - [x] Adequate tests were added if applicable