### PR TITLE
fix(spark): read shredded variants through internal write-side parquet reads

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -163,10 +163,16 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     // PushVariantIntoScan does for user queries. Requesting native VariantType against a
     // SHREDDED parquet base file clips the file group to {metadata, value} and reads
     // value=null; write-side callers (compaction, clustering, merge) would then persist the
-    // nulls, silently losing the variant data (#19556). Request the full-variant projection
-    // shape instead and restore native VariantType after the scan. User-facing reads pass
-    // sparkRequiredSchema and are overlaid above; Spark < 4.1 has no shredded read support
-    // and the adapter returns None (shredded files cannot be written there either).
+    // nulls, silently losing the variant data (#19556). Query paths that build this context
+    // without sparkRequiredSchema (MOR incremental relation, streaming, CDC) hit the same
+    // null reads and take the same rewrite. Request the full-variant projection shape
+    // instead and restore native VariantType after the scan. User-facing reads pass
+    // sparkRequiredSchema and are overlaid above. Only top-level variant fields are
+    // rewritten: no production write path shreds a nested variant today (a nested shredded
+    // write schema needs the test-only force config until shredding-schema inference
+    // lands), so the nested leg is deferred until such files can exist. Spark < 4.1 cannot
+    // reconstruct shredded values on read (SPARK-54410) and the adapter returns None;
+    // Spark 4.0 does write shredded files, so its pre-existing read-side gap stays as is.
     val isParquetBaseFile = !isInlineLog && !FSUtils.isLogFile(filePath) &&
       HoodieFileFormat.fromFileExtension(filePath.getFileExtension) == HoodieFileFormat.PARQUET
     val (readStructTypeForScan, variantOrdinals) =

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -37,7 +37,7 @@ import org.apache.hudi.util.CloseableInternalRowIterator
 import org.apache.parquet.avro.HoodieAvroParquetSchemaConverter.getAvroSchemaConverter
 import org.apache.spark.sql.HoodieInternalRowUtils
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{JoinedRow, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.{BoundReference, Expression, GetStructField, JoinedRow, UnsafeProjection}
 import org.apache.spark.sql.execution.datasources.{PartitionedFile, SparkColumnarFileReader}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.internal.SQLConf
@@ -159,7 +159,31 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
       structType
     }
 
-    val (readSchema, readFilters) = getSchemaAndFiltersForRead(parquetReadStructType, hasRowIndexField)
+    // Internal reads have no catalyst plan, so nothing rewrites VariantType fields the way
+    // PushVariantIntoScan does for user queries. Requesting native VariantType against a
+    // SHREDDED parquet base file clips the file group to {metadata, value} and reads
+    // value=null; write-side callers (compaction, clustering, merge) would then persist the
+    // nulls, silently losing the variant data (#19556). Request the full-variant projection
+    // shape instead and restore native VariantType after the scan. User-facing reads pass
+    // sparkRequiredSchema and are overlaid above; Spark < 4.1 has no shredded read support
+    // and the adapter returns None (shredded files cannot be written there either).
+    val isParquetBaseFile = !isInlineLog && !FSUtils.isLogFile(filePath) &&
+      HoodieFileFormat.fromFileExtension(filePath.getFileExtension) == HoodieFileFormat.PARQUET
+    val (readStructTypeForScan, variantOrdinals) =
+      if (sparkRequiredSchema.isEmpty && isParquetBaseFile) {
+        sparkAdapter.buildFullVariantReadSchema(parquetReadStructType) match {
+          case Some(rewritten) =>
+            val ordinals = rewritten.fields.indices
+              .filter(i => rewritten.fields(i).dataType != parquetReadStructType.fields(i).dataType)
+              .toSet
+            (rewritten, ordinals)
+          case None => (parquetReadStructType, Set.empty[Int])
+        }
+      } else {
+        (parquetReadStructType, Set.empty[Int])
+      }
+
+    val (readSchema, readFilters) = getSchemaAndFiltersForRead(readStructTypeForScan, hasRowIndexField)
     if (FSUtils.isLogFile(filePath)) {
       // NOTE: now only primary key based filtering is supported for log files
       // Position-based merging pairs log records with the RECORD_POSITIONS bitmap by index (see
@@ -205,11 +229,21 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
         readSchema, StructType(Seq.empty), getSchemaHandler.getInternalSchemaOpt,
         readFilters, storage.getConf.asInstanceOf[StorageConfiguration[Configuration]], tableSchemaOpt))
 
-      // Post-process: convert binary VECTOR columns back to typed arrays
-      if (vectorColumnInfo.nonEmpty) {
-        SparkFileFormatInternalRowReaderContext.wrapWithVectorConversion(rawIterator, vectorColumnInfo, readSchema)
+      // Post-process: restore native VariantType from the full-variant projection shape
+      // (child 0 of each rewritten field), then convert binary VECTOR columns back to arrays.
+      val (variantRestoredIterator, variantRestoredSchema) = if (variantOrdinals.nonEmpty) {
+        val restoredSchema = StructType(readSchema.fields.zipWithIndex.map { case (f, i) =>
+          if (variantOrdinals.contains(i)) f.copy(dataType = structType.fields(i).dataType) else f
+        })
+        (SparkFileFormatInternalRowReaderContext.wrapWithVariantRestore(rawIterator, readSchema, variantOrdinals),
+          restoredSchema)
       } else {
-        rawIterator
+        (rawIterator, readSchema)
+      }
+      if (vectorColumnInfo.nonEmpty) {
+        SparkFileFormatInternalRowReaderContext.wrapWithVectorConversion(variantRestoredIterator, vectorColumnInfo, variantRestoredSchema)
+      } else {
+        variantRestoredIterator
       }
     }
   }
@@ -433,6 +467,32 @@ object SparkFileFormatInternalRowReaderContext {
   def replaceVectorColumnsWithBinary(structType: StructType, vectorColumns: Map[Int, HoodieSchema.Vector]): StructType = {
     val javaMap = vectorColumns.map { case (k, v) => (Integer.valueOf(k), v.asInstanceOf[AnyRef]) }.asJava
     VectorConversionUtils.replaceVectorColumnsWithBinary(structType, javaMap)
+  }
+
+  /**
+   * Restores native VariantType columns from the full-variant projection shape requested for
+   * internal reads of parquet base files (see SparkAdapter.buildFullVariantReadSchema): each
+   * rewritten column is a struct with a single child "0" holding the reconstructed variant,
+   * so restoring is a projection of that child.
+   */
+  private[hudi] def wrapWithVariantRestore(
+      iterator: ClosableIterator[InternalRow],
+      readSchema: StructType,
+      variantOrdinals: Set[Int]): ClosableIterator[InternalRow] = {
+    val exprs: Seq[Expression] = readSchema.fields.zipWithIndex.map { case (field, i) =>
+      val ref = BoundReference(i, field.dataType, field.nullable)
+      if (variantOrdinals.contains(i)) {
+        GetStructField(ref, 0, Some("0"))
+      } else {
+        ref: Expression
+      }
+    }.toSeq
+    val projection = UnsafeProjection.create(exprs)
+    new ClosableIterator[InternalRow] {
+      override def hasNext: Boolean = iterator.hasNext
+      override def next(): InternalRow = projection(iterator.next())
+      override def close(): Unit = iterator.close()
+    }
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -164,8 +164,11 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     // SHREDDED parquet base file clips the file group to {metadata, value} and reads
     // value=null; write-side callers (compaction, clustering, merge) would then persist the
     // nulls, silently losing the variant data (#19556). Query paths that build this context
-    // without sparkRequiredSchema (MOR incremental relation, streaming, CDC) hit the same
-    // null reads and take the same rewrite. Request the full-variant projection shape
+    // without sparkRequiredSchema hit the same null reads and take the same rewrite: CDC
+    // (CDCFileGroupIterator) under default configs, plus the legacy RDD paths (streaming
+    // source, MergeOnRead relations) only when hoodie.file.group.reader.enabled=false;
+    // batch incremental always scans through the file format with a catalyst schema.
+    // Request the full-variant projection shape
     // instead and restore native VariantType after the scan. User-facing reads pass
     // sparkRequiredSchema and are overlaid above. Only top-level variant fields are
     // rewritten: no production write path shreds a nested variant today (a nested shredded

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -519,6 +519,23 @@ trait SparkAdapter extends Serializable {
                             sparkRequiredSchema: StructType): Option[InternalRow => InternalRow] = None
 
   /**
+   * Rewrites each top-level VariantType field of `schema` into the full-variant projection
+   * struct that PushVariantIntoScan would request for whole-variant access: a single child
+   * field "0" of VariantType carrying `VariantMetadata` for path "$". Requesting that shape
+   * makes the parquet reader reconstruct shredded variants by field name; requesting native
+   * VariantType instead clips a shredded file group down to {metadata, value} and reads
+   * value=null (#19556).
+   *
+   * Used by internal (non-catalyst) reads of parquet base files, which have no
+   * PushVariantIntoScan to do this for them. The caller restores the native VariantType
+   * shape by projecting child 0 of each rewritten field.
+   *
+   * Returns None when the schema has no top-level VariantType field or the Spark version has
+   * no shredded-read support (Spark 3.x / 4.0).
+   */
+  def buildFullVariantReadSchema(schema: StructType): Option[StructType] = None
+
+  /**
    * Generates a shredded Variant schema and marks it with write shredding metadata.
    *
    * For Spark 4.x, this uses SparkShreddingUtils to generate the schema and add metadata.

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -19,7 +19,7 @@
 
 package org.apache.spark.sql.hudi.dml.schema
 
-import org.apache.hudi.HoodieSparkUtils
+import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.schema.internal.HoodieSchemaException
 import org.apache.hudi.common.testutils.HoodieTestUtils
@@ -281,6 +281,24 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
         Seq(3, "{\"key\":\"value3\"}", 1000),
         Seq(4, "{\"key\":\"value4\"}", 1000)
       )
+
+      // Incremental round trip over the shredded table: batch incremental reads the
+      // shredded base file through the file-group-reader file format with a catalyst
+      // schema, a stack nothing else in this suite pins for variant columns. The
+      // no-catalyst-schema legs of the incremental relation (streaming source, CDC)
+      // are tracked in #19578.
+      val incRows = spark.read.format("hudi")
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+        .option(DataSourceReadOptions.START_COMMIT.key, "000")
+        .load(tablePath)
+        .selectExpr("id", "cast(v as string) as v", "ts")
+        .orderBy("id")
+        .collect()
+      assertResult(4)(incRows.length)
+      assertResult("{\"key\":\"v1-r3\"}")(incRows(0).getString(1))
+      assertResult("{\"key\":\"v2-r3\"}")(incRows(1).getString(1))
+      assertResult("{\"key\":\"value3\"}")(incRows(2).getString(1))
+      assertResult("{\"key\":\"value4\"}")(incRows(3).getString(1))
     })
   }
 
@@ -399,6 +417,19 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
       spark.sql(s"insert into $tableName values " +
         "(1, parse_json('{\"key\":\"value1\"}'), 1000), " +
         "(2, parse_json('{\"key\":\"value2\"}'), 1000)")
+
+      // Pin the layout: these files must NOT carry typed_value, or this twin silently
+      // becomes a copy of the shredded test above and the unshredded leg of the rewrite
+      // goes uncovered.
+      val preClusteringFiles = listDataParquetFiles(tablePath)
+      assert(preClusteringFiles.nonEmpty, "Should have at least one data parquet file before clustering")
+      preClusteringFiles.foreach { filePath =>
+        val parquetSchema = readParquetSchema(filePath)
+        val variantGroup = getFieldAsGroup(parquetSchema, "v")
+        assert(!variantGroup.containsField("typed_value"),
+          s"Unshredded base file must not carry typed_value. Schema:\n$variantGroup")
+      }
+
       spark.sql(s"insert into $tableName values " +
         "(3, parse_json('{\"key\":\"value3\"}'), 1000), " +
         "(4, parse_json('{\"key\":\"value4\"}'), 1000)")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -285,8 +285,8 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
       // Incremental round trip over the shredded table: batch incremental reads the
       // shredded base file through the file-group-reader file format with a catalyst
       // schema, a stack nothing else in this suite pins for variant columns. The
-      // no-catalyst-schema legs of the incremental relation (streaming source, CDC)
-      // are tracked in #19578.
+      // no-catalyst-schema legs (CDC, and streaming with
+      // hoodie.file.group.reader.enabled=false) are tracked in #19578.
       val incRows = spark.read.format("hudi")
         .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
         .option(DataSourceReadOptions.START_COMMIT.key, "000")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -253,6 +253,201 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
     })
   }
 
+  test("Test COW clustering preserves VARIANT values") {
+    // Same Spark 4.1 gate as the compaction test above: clustering reads the shredded
+    // base files back through the native reader, which rejects the 3-field shredded
+    // layout before SPARK-54410 (Spark 4.1+).
+    assume(HoodieSparkUtils.gteqSpark4_1, "Shredded variant base-file read requires Spark 4.1 or higher")
+
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath
+      // Clustering rewrites ALL rows of the clustered file groups through the internal
+      // write-side reader context (SparkReaderContextFactory ->
+      // SparkFileFormatInternalRowReaderContext), the stack whose blob handling silently
+      // lost bytes in #19232. Nothing pinned its VARIANT behavior: this is the first
+      // clustering coverage for the type. Shredding is forced so the rewrite reads and
+      // rewrites the shredded layout, the default in production.
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  v variant,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  preCombineField = 'ts',
+           |  hoodie.parquet.variant.write.shredding.enabled = 'true',
+           |  hoodie.parquet.variant.force.shredding.schema.for.test = 'key string',
+           |  hoodie.index.type = 'INMEMORY',
+           |  hoodie.parquet.small.file.limit = '0',
+           |  hoodie.clustering.inline = 'true',
+           |  hoodie.clustering.inline.max.commits = '2'
+           | )
+       """.stripMargin)
+
+      // small.file.limit = 0 keeps the second insert in its own file group. Otherwise the
+      // second commit bin-packs into the first file group and rewrites it through the CoW
+      // small-file MERGE (a different internal read stack), conflating that path's variant
+      // handling with the clustering rewrite this test isolates.
+      spark.sql(s"insert into $tableName values " +
+        "(1, parse_json('{\"key\":\"value1\"}'), 1000), " +
+        "(2, parse_json('{\"key\":\"value2\"}'), 1000)")
+      // Second commit trips inline clustering (max.commits = 2), which rewrites the rows
+      // of the first commit too.
+      spark.sql(s"insert into $tableName values " +
+        "(3, parse_json('{\"key\":\"value3\"}'), 1000), " +
+        "(4, parse_json('{\"key\":\"value4\"}'), 1000)")
+
+      // getLastClusteringInstant filters by action only, so a REQUESTED/INFLIGHT instant
+      // satisfies isPresent; isCompleted confirms the rewrite finished.
+      val metaClient = createMetaClient(spark, tablePath)
+      val lastClustering = metaClient.getActiveTimeline.getLastClusteringInstant
+      assert(lastClustering.isPresent && lastClustering.get.isCompleted,
+        "A COMPLETED clustering (replacecommit) instant must exist after inline clustering; " +
+          "without a completed rewrite the round-trip below proves nothing")
+
+      checkAnswer(s"select id, cast(v as string), ts from $tableName order by id")(
+        Seq(1, "{\"key\":\"value1\"}", 1000),
+        Seq(2, "{\"key\":\"value2\"}", 1000),
+        Seq(3, "{\"key\":\"value3\"}", 1000),
+        Seq(4, "{\"key\":\"value4\"}", 1000)
+      )
+
+      // VARIANT must still surface as the native type after the clustering rewrite.
+      val variantField = spark.table(tableName).schema.find(_.name == "v").get
+      assertResult("variant")(variantField.dataType.typeName)
+    })
+  }
+
+  test("Test COW clustering preserves unshredded VARIANT values") {
+    // Companion to the shredded clustering test above, with shredding disabled. If this
+    // passes while the shredded one fails, the loss is specific to reading the shredded
+    // layout inside the clustering rewrite, not to variant clustering in general.
+    assume(HoodieSparkUtils.gteqSpark4_1, "Variant clustering read-back requires Spark 4.1 or higher")
+
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  v variant,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  preCombineField = 'ts',
+           |  hoodie.parquet.variant.write.shredding.enabled = 'false',
+           |  hoodie.index.type = 'INMEMORY',
+           |  hoodie.parquet.small.file.limit = '0',
+           |  hoodie.clustering.inline = 'true',
+           |  hoodie.clustering.inline.max.commits = '2'
+           | )
+       """.stripMargin)
+
+      spark.sql(s"insert into $tableName values " +
+        "(1, parse_json('{\"key\":\"value1\"}'), 1000), " +
+        "(2, parse_json('{\"key\":\"value2\"}'), 1000)")
+      spark.sql(s"insert into $tableName values " +
+        "(3, parse_json('{\"key\":\"value3\"}'), 1000), " +
+        "(4, parse_json('{\"key\":\"value4\"}'), 1000)")
+
+      val metaClient = createMetaClient(spark, tablePath)
+      val lastClustering = metaClient.getActiveTimeline.getLastClusteringInstant
+      assert(lastClustering.isPresent && lastClustering.get.isCompleted,
+        "A COMPLETED clustering (replacecommit) instant must exist after inline clustering")
+
+      checkAnswer(s"select id, cast(v as string), ts from $tableName order by id")(
+        Seq(1, "{\"key\":\"value1\"}", 1000),
+        Seq(2, "{\"key\":\"value2\"}", 1000),
+        Seq(3, "{\"key\":\"value3\"}", 1000),
+        Seq(4, "{\"key\":\"value4\"}", 1000)
+      )
+    })
+  }
+
+  test("Test bulk_insert row-writer round-trips VARIANT") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    // bulk_insert takes the row-writer path (HoodieRowParquetWriteSupport), which has its
+    // own variant writers (unshredded and shredded); no end-to-end test covered it for
+    // either layout, only writer-level units (TestHoodieRowParquetWriteSupportVariant).
+
+    // Unshredded bulk_insert: full round trip on any Spark 4.x.
+    withTempDir { tmp =>
+      val df = spark.sql(
+        """
+          |SELECT 1L AS id, parse_json('{"key":"value1"}') AS v, 1000L AS ts
+          |UNION ALL
+          |SELECT 2L AS id, parse_json('{"key":"value2"}') AS v, 1000L AS ts
+          |""".stripMargin)
+      df.write.format("hudi")
+        .option("hoodie.table.name", "variant_bulk_insert_unshredded")
+        .option("hoodie.datasource.write.recordkey.field", "id")
+        .option("hoodie.datasource.write.precombine.field", "ts")
+        .option("hoodie.datasource.write.operation", "bulk_insert")
+        .option("hoodie.datasource.write.row.writer.enable", "true")
+        .option("hoodie.parquet.variant.write.shredding.enabled", "false")
+        .mode(SaveMode.Overwrite)
+        .save(tmp.getCanonicalPath)
+
+      val readDf = spark.read.format("hudi").load(tmp.getCanonicalPath)
+      assert(readDf.schema("v").dataType.typeName == "variant",
+        s"v should round-trip as native VariantType, got ${readDf.schema("v").dataType}")
+      val rows = readDf.selectExpr("id", "cast(v as string) as v").orderBy("id").collect()
+      assert(rows.length == 2)
+      assert(rows(0).getString(1) == "{\"key\":\"value1\"}")
+      assert(rows(1).getString(1) == "{\"key\":\"value2\"}")
+    }
+
+    // Shredded bulk_insert exercises the row-writer shredding path end to end; reading
+    // the shredded file back needs Spark 4.1+ (SPARK-54410).
+    if (HoodieSparkUtils.gteqSpark4_1) {
+      withTempDir { tmp =>
+        val df = spark.sql(
+          """
+            |SELECT 1L AS id, parse_json('{"key":"value1"}') AS v, 1000L AS ts
+            |UNION ALL
+            |SELECT 2L AS id, parse_json('{"key":"value2"}') AS v, 1000L AS ts
+            |""".stripMargin)
+        df.write.format("hudi")
+          .option("hoodie.table.name", "variant_bulk_insert_shredded")
+          .option("hoodie.datasource.write.recordkey.field", "id")
+          .option("hoodie.datasource.write.precombine.field", "ts")
+          .option("hoodie.datasource.write.operation", "bulk_insert")
+          .option("hoodie.datasource.write.row.writer.enable", "true")
+          .option("hoodie.parquet.variant.write.shredding.enabled", "true")
+          .option("hoodie.parquet.variant.force.shredding.schema.for.test", "key string")
+          .mode(SaveMode.Overwrite)
+          .save(tmp.getCanonicalPath)
+
+        // The written parquet must actually carry the shredded layout; otherwise the
+        // read-back below silently validates the unshredded path a second time.
+        val parquetFiles = listDataParquetFiles(tmp.getCanonicalPath)
+        assert(parquetFiles.nonEmpty, "Should have at least one data parquet file")
+        parquetFiles.foreach { filePath =>
+          val schema = readParquetSchema(filePath)
+          val variantGroup = getFieldAsGroup(schema, "v")
+          assert(variantGroup.containsField("typed_value"),
+            s"bulk_insert with shredding forced should write typed_value. Schema:\n$variantGroup")
+        }
+
+        val readDf = spark.read.format("hudi").load(tmp.getCanonicalPath)
+        val rows = readDf.selectExpr("id", "cast(v as string) as v").orderBy("id").collect()
+        assert(rows.length == 2)
+        assert(rows(0).getString(1) == "{\"key\":\"value1\"}")
+        assert(rows(1).getString(1) == "{\"key\":\"value2\"}")
+      }
+    }
+  }
+
   test("Test toHiveCompatibleSchema converts VariantType to physical struct") {
     assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -250,6 +250,37 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
       metaClient.reloadActiveTimeline()
       assert(metaClient.getActiveTimeline.getCleanerTimeline.countInstants() > 0,
         "Expected at least one .clean instant on the timeline after compaction")
+
+      // Round 2: the compaction above compacted a log-only slice, so it never read a
+      // parquet base file. Pin that the compacted base file is shredded, then drive a
+      // second compaction that reads it through the internal reader
+      // (SparkFileFormatInternalRowReaderContext) and must carry rows 3 and 4, which
+      // exist only in that base file, forward (#19556).
+      val compactedFiles = listDataParquetFiles(tablePath)
+      assert(compactedFiles.nonEmpty, "Should have a compacted base parquet file")
+      compactedFiles.foreach { filePath =>
+        val parquetSchema = readParquetSchema(filePath)
+        val variantGroup = getFieldAsGroup(parquetSchema, "v")
+        assert(variantGroup.containsField("typed_value"),
+          s"Compacted base file should carry typed_value. Schema:\n$variantGroup")
+      }
+
+      // The v2-merged deltacommit above was the first after the compaction; four more
+      // reach max.delta.commits = 5 and trip the second compaction inline.
+      spark.sql(s"""update $tableName set v = parse_json('{"key":"v1-r2"}'), ts = 1003 where id = 1""")
+      spark.sql(s"""update $tableName set v = parse_json('{"key":"v2-r2"}'), ts = 1004 where id = 2""")
+      spark.sql(s"""update $tableName set v = parse_json('{"key":"v1-r3"}'), ts = 1005 where id = 1""")
+      spark.sql(s"""update $tableName set v = parse_json('{"key":"v2-r3"}'), ts = 1006 where id = 2""")
+
+      metaClient.reloadActiveTimeline()
+      assertResult(2)(metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants.countInstants)
+
+      checkAnswer(s"select id, cast(v as string), ts from $tableName order by id")(
+        Seq(1, "{\"key\":\"v1-r3\"}", 1005),
+        Seq(2, "{\"key\":\"v2-r3\"}", 1006),
+        Seq(3, "{\"key\":\"value3\"}", 1000),
+        Seq(4, "{\"key\":\"value4\"}", 1000)
+      )
     })
   }
 
@@ -296,6 +327,19 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
       spark.sql(s"insert into $tableName values " +
         "(1, parse_json('{\"key\":\"value1\"}'), 1000), " +
         "(2, parse_json('{\"key\":\"value2\"}'), 1000)")
+
+      // The pre-clustering base file must actually carry the shredded layout; without this
+      // check the test silently degrades into the unshredded twin below if the forced
+      // shredding schema ever stops taking effect.
+      val preClusteringFiles = listDataParquetFiles(tablePath)
+      assert(preClusteringFiles.nonEmpty, "Should have at least one data parquet file before clustering")
+      preClusteringFiles.foreach { filePath =>
+        val parquetSchema = readParquetSchema(filePath)
+        val variantGroup = getFieldAsGroup(parquetSchema, "v")
+        assert(variantGroup.containsField("typed_value"),
+          s"Pre-clustering base file should carry typed_value. Schema:\n$variantGroup")
+      }
+
       // Second commit trips inline clustering (max.commits = 2), which rewrites the rows
       // of the first commit too.
       spark.sql(s"insert into $tableName values " +

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark4Adapter.scala
@@ -48,7 +48,7 @@ import org.apache.spark.sql.execution.datasources.parquet.{HoodieFormatTrait, Pa
 import org.apache.spark.sql.hudi.SparkAdapter
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{BaseRelation, Filter}
-import org.apache.spark.sql.types.{BinaryType, DataType, StructType, VariantType}
+import org.apache.spark.sql.types.{BinaryType, DataType, StructField, StructType, VariantType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.types.variant.Variant
@@ -294,6 +294,29 @@ abstract class BaseSpark4Adapter extends SparkAdapter with Logging {
   override def generateVariantWriteShreddingSchema(dataType: DataType, isTopLevel: Boolean, isObjectField: Boolean): StructType = {
     SparkShreddingUtils.addWriteShreddingMetadata(
       SparkShreddingUtils.variantShreddingSchema(dataType, isTopLevel, isObjectField))
+  }
+
+  /**
+   * Shared implementation behind [[SparkAdapter#buildFullVariantReadSchema]] for the 4.x
+   * adapters whose parquet reader can reconstruct shredded variants (4.1+, SPARK-54410).
+   * Spark 4.0 keeps the default None: the write-side methods above have no version gate, so
+   * it does write shredded files, but its reader cannot rebuild them and the projection
+   * shape would not help.
+   */
+  protected final def rewriteTopLevelVariantsForFullRead(schema: StructType): Option[StructType] = {
+    var rewritten = false
+    val fields = schema.fields.map { f =>
+      if (isVariantType(f.dataType)) {
+        rewritten = true
+        // Mirrors RequestedVariantField.fullVariant in PushVariantIntoScan: whole-variant
+        // access is a single child "0" at path "$" with failOnError and UTC.
+        f.copy(dataType = StructType(Array(StructField("0", VariantType,
+          metadata = VariantMetadata("$", failOnError = true, timeZoneId = "UTC").toMetadata))))
+      } else {
+        f
+      }
+    }
+    if (rewritten) Some(StructType(fields)) else None
   }
 
   override def createShreddedVariantWriter(

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
 import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark4_1ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType, VariantType}
+import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatchRow
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StorageLevel._
@@ -236,21 +236,10 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
     VariantMetadata.isVariantStruct(structType)
   }
 
-  override def buildFullVariantReadSchema(schema: StructType): Option[StructType] = {
-    var rewritten = false
-    val fields = schema.fields.map { f =>
-      if (isVariantType(f.dataType)) {
-        rewritten = true
-        // Mirrors RequestedVariantField.fullVariant in PushVariantIntoScan: whole-variant
-        // access is a single child "0" at path "$" with failOnError and UTC.
-        f.copy(dataType = StructType(Array(StructField("0", VariantType,
-          metadata = VariantMetadata("$", failOnError = true, timeZoneId = "UTC").toMetadata))))
-      } else {
-        f
-      }
-    }
-    if (rewritten) Some(StructType(fields)) else None
-  }
+  // Spark 4.1 reconstructs shredded variants on read (SPARK-54410), so opt in to the
+  // shared rewrite; Spark 4.0 stays on the default None.
+  override def buildFullVariantReadSchema(schema: StructType): Option[StructType] =
+    rewriteTopLevelVariantsForFullRead(schema)
 
   override def buildVariantProjector(sparkDataSchema: StructType,
                                      sparkRequiredSchema: StructType): Option[InternalRow => InternalRow] = {

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
 import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark4_1ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType, VariantType}
 import org.apache.spark.sql.vectorized.ColumnarBatchRow
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StorageLevel._
@@ -234,6 +234,22 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
 
   override def isVariantProjectionStruct(structType: StructType): Boolean = {
     VariantMetadata.isVariantStruct(structType)
+  }
+
+  override def buildFullVariantReadSchema(schema: StructType): Option[StructType] = {
+    var rewritten = false
+    val fields = schema.fields.map { f =>
+      if (isVariantType(f.dataType)) {
+        rewritten = true
+        // Mirrors RequestedVariantField.fullVariant in PushVariantIntoScan: whole-variant
+        // access is a single child "0" at path "$" with failOnError and UTC.
+        f.copy(dataType = StructType(Array(StructField("0", VariantType,
+          metadata = VariantMetadata("$", failOnError = true, timeZoneId = "UTC").toMetadata))))
+      } else {
+        f
+      }
+    }
+    if (rewritten) Some(StructType(fields)) else None
   }
 
   override def buildVariantProjector(sparkDataSchema: StructType,

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_2Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_2Adapter.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
 import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark4_2ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType, VariantType}
 import org.apache.spark.sql.vectorized.ColumnarBatchRow
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StorageLevel._
@@ -234,6 +234,22 @@ class Spark4_2Adapter extends BaseSpark4Adapter {
 
   override def isVariantProjectionStruct(structType: StructType): Boolean = {
     VariantMetadata.isVariantStruct(structType)
+  }
+
+  override def buildFullVariantReadSchema(schema: StructType): Option[StructType] = {
+    var rewritten = false
+    val fields = schema.fields.map { f =>
+      if (isVariantType(f.dataType)) {
+        rewritten = true
+        // Mirrors RequestedVariantField.fullVariant in PushVariantIntoScan: whole-variant
+        // access is a single child "0" at path "$" with failOnError and UTC.
+        f.copy(dataType = StructType(Array(StructField("0", VariantType,
+          metadata = VariantMetadata("$", failOnError = true, timeZoneId = "UTC").toMetadata))))
+      } else {
+        f
+      }
+    }
+    if (rewritten) Some(StructType(fields)) else None
   }
 
   override def buildVariantProjector(sparkDataSchema: StructType,

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_2Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_2Adapter.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
 import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark4_2ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType, VariantType}
+import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatchRow
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StorageLevel._
@@ -236,21 +236,10 @@ class Spark4_2Adapter extends BaseSpark4Adapter {
     VariantMetadata.isVariantStruct(structType)
   }
 
-  override def buildFullVariantReadSchema(schema: StructType): Option[StructType] = {
-    var rewritten = false
-    val fields = schema.fields.map { f =>
-      if (isVariantType(f.dataType)) {
-        rewritten = true
-        // Mirrors RequestedVariantField.fullVariant in PushVariantIntoScan: whole-variant
-        // access is a single child "0" at path "$" with failOnError and UTC.
-        f.copy(dataType = StructType(Array(StructField("0", VariantType,
-          metadata = VariantMetadata("$", failOnError = true, timeZoneId = "UTC").toMetadata))))
-      } else {
-        f
-      }
-    }
-    if (rewritten) Some(StructType(fields)) else None
-  }
+  // Spark 4.2 reconstructs shredded variants on read (SPARK-54410), so opt in to the
+  // shared rewrite; Spark 4.0 stays on the default None.
+  override def buildFullVariantReadSchema(schema: StructType): Option[StructType] =
+    rewriteTopLevelVariantsForFullRead(schema)
 
   override def buildVariantProjector(sparkDataSchema: StructType,
                                      sparkRequiredSchema: StructType): Option[InternalRow => InternalRow] = {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19556. Internal write-side reads (clustering, compaction base file reads, upsert merges with the spark record merger) read shredded variant columns as null and wrote the nulls back out, so every rewritten row lost its variant data with no error. These reads don't go through catalyst, so they never get the PushVariantIntoScan rewrite that makes shredded reads work for normal queries: they ask the parquet reader for a plain VariantType, the reader clips the shredded group down to {metadata, value}, and value is physically null in a shredded file.

The avro reader path has a separate defect with the same symptom, tracked in #19567 and not addressed here.

### Summary and Changelog

Internal parquet base file reads now request variant columns the same way PushVariantIntoScan would, so the reader reconstructs shredded values and rewrites carry them forward.

- New SparkAdapter.buildFullVariantReadSchema rewrites top-level VariantType fields into the full-variant projection struct (one child "0" at path $, same shape as RequestedVariantField.fullVariant). The shared implementation lives in BaseSpark4Adapter; Spark 4.1/4.2 opt in, older versions return None since their readers cannot reconstruct shredded values (SPARK-54410). Spark 4.0 does write shredded files -- its read-side gap is pre-existing and unchanged here. Only top-level variant columns are rewritten; no production write path can shred a nested variant today (that needs the test-only force config until shredding-schema inference lands), so the nested leg is deferred until such files can exist.
- SparkFileFormatInternalRowReaderContext applies the rewrite when there is no catalyst-provided required schema and the file is a parquet base file, then projects child 0 back out so downstream still sees a native variant. No change for Lance/ORC/log files. Query paths that build this context without a catalyst schema (MOR incremental relation, streaming, CDC) read shredded variants as null the same way and are fixed by the same rewrite.
- Tests: shredded COW clustering round trip (the #19556 repro) with a typed_value layout assertion so it cannot silently degrade into the unshredded twin, an unshredded twin with the inverse no-typed_value layout pin, bulk_insert row-writer round trips for both layouts, a second MOR compaction round that reads the shredded base file produced by the first compaction back through the internal reader, and a batch incremental round trip over the shredded table. Streaming and CDC round trips (the no-catalyst-schema query legs) are tracked in #19578. The clustering tests set small.file.limit=0 so the second insert doesn't bin-pack through the small file merge, which is #19567 territory and would muddy the repro.

### Impact

Wrong-results fix with no intended behavior change. The rewrite applies to any read that builds the internal reader context without a catalyst-provided schema: write-side reads (clustering, compaction, upsert merges), CDC queries (the only default-config query path that constructs it this way), and the legacy RDD query paths (streaming source, MergeOnRead relations) when hoodie.file.group.reader.enabled=false. All of these read shredded variants as null before this fix. Batch incremental queries on any table version, and streaming under the default file-group reader, scan through the file format with a catalyst schema instead; the incremental leg is covered by a round trip in TestVariantDataType, and CDC plus fgreader-disabled streaming round trips are tracked in #19578. Only variant columns on spark 4.1+ are affected.

### Risk Level

low. The rewrite only kicks in for reads of parquet base files with top-level variant columns and no catalyst-provided schema, on spark 4.1+. Verified with TestVariantDataType, TestVectorDataSource and the blob service round trip suites on spark4.1, and the same suites on spark3.5 where the new hook is a no-op.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
