### PR TITLE
fix(metadata): fix ArrayIndexOutOfBoundsException when 1.x reader merges old MDT records

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -390,6 +390,12 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     return MetadataPartitionType.get(type).combineMetadataPayloads(previousRecord, this);
   }
 
+  private static boolean isHoodieMetadataRecordSchema(Schema schema) {
+    return schema.getType() == Schema.Type.RECORD
+        && "HoodieMetadataRecord".equals(schema.getName())
+        && "org.apache.hudi.avro.model".equals(schema.getNamespace());
+  }
+
   private static String getBloomFilterRecordKey(String partitionName, String fileName) {
     return new PartitionIndexID(getBloomFilterIndexPartitionIdentifier(partitionName)).asBase64EncodedString()
         .concat(new FileIndexID(fileName).asBase64EncodedString());
@@ -426,8 +432,11 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
 
     // TODO: feature(schema): Swap this over to HOODIE_METADATA_SCHEMA after HoodieRecordPayload implementations are using HoodieSchema
     // Uses cached Avro schema reference for O(1) equality check.
-    if (schema == null || schema == HOODIE_METADATA_AVRO_SCHEMA) {
-      // If the schema is same or none is provided, we can return the record directly
+    if (schema == null || schema == HOODIE_METADATA_AVRO_SCHEMA || isHoodieMetadataRecordSchema(schema)) {
+      // If the schema is same/none, or is an older-version HoodieMetadataRecord schema written by a
+      // previous Hudi release (e.g. missing SecondaryIndexMetadata), return the current-schema record
+      // directly. This handles backward compatibility when a 1.x reader reads MDT data written by an
+      // older Hudi version whose HoodieMetadataRecord schema had fewer fields.
       HoodieMetadataRecord record = new HoodieMetadataRecord(key, type, filesystemMetadata, bloomFilterMetadata,
           columnStatMetadata, recordIndexMetadata, secondaryIndexMetadata);
       return Option.of(record);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataPayload.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataPayload.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.util.Option;
@@ -25,6 +26,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.metadata.stats.ValueMetadata;
 
+import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.CollectionUtils.createImmutableMap;
 import static org.apache.hudi.metadata.HoodieIndexVersion.V1;
@@ -376,5 +379,26 @@ public class TestHoodieMetadataPayload extends HoodieCommonTestHarness {
     // Case with only escape characters but no actual separator
     assertThrows(IllegalStateException.class, () -> SecondaryIndexKeyUtils.getSecondaryKeyFromSecondaryIndexKey("part\\one"));
     assertThrows(IllegalStateException.class, () -> SecondaryIndexKeyUtils.getRecordKeyFromSecondaryIndexKey("part\\one"));
+  }
+
+  @Test
+  public void testGetInsertValueWithOldMetadataSchema() throws IOException {
+    // Regression: when a 1.x reader reads MDT data written by an older Hudi release whose
+    // HoodieMetadataRecord schema had fewer fields (e.g. no SecondaryIndexMetadata), the identity
+    // check `schema == HOODIE_METADATA_AVRO_SCHEMA` fails. The else-branch then calls
+    // record.put(TYPE_FIELD_OFFSET=6, ...) on a schema with only 6 fields -> AIOOBE.
+    Schema currentSchema = HoodieMetadataRecord.getClassSchema();
+    List<Schema.Field> oldFields = currentSchema.getFields().subList(0, currentSchema.getFields().size() - 1)
+        .stream()
+        .map(f -> new Schema.Field(f.name(), f.schema(), f.doc(), f.defaultVal()))
+        .collect(Collectors.toList());
+    Schema oldMetadataSchema = Schema.createRecord(
+        currentSchema.getName(), currentSchema.getDoc(), currentSchema.getNamespace(), false, oldFields);
+
+    HoodieRecord<HoodieMetadataPayload> record = HoodieMetadataPayload.createPartitionFilesRecord(
+        PARTITION_NAME, createImmutableMap(Pair.of("file1.parquet", 1000L)), Collections.emptyList());
+    Option<IndexedRecord> result = record.getData().getInsertValue(oldMetadataSchema);
+    assertTrue(result.isPresent());
+    assertEquals(currentSchema, result.get().getSchema());
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19559

When a Hudi 1.x reader reads a Metadata Table (MDT) that was written by an older Hudi release, merging log-file delta records against base-file records throws an `ArrayIndexOutOfBoundsException`:

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: 6
    at org.apache.avro.generic.GenericData$Record.put(GenericData.java:273)
    at org.apache.hudi.metadata.HoodieMetadataPayload.getInsertValue(HoodieMetadataPayload.java:422)
    at org.apache.hudi.metadata.HoodieMetadataPayload.combineAndGetUpdateValue(HoodieMetadataPayload.java:399)
    at org.apache.hudi.common.model.HoodieAvroRecordMerger.merge(HoodieAvroRecordMerger.java:67)
    at org.apache.hudi.common.table.read.BufferedRecordMergerFactory$CustomPayloadRecordMerger.deltaMergeRecords(BufferedRecordMergerFactory.java:404)
    at org.apache.hudi.common.table.read.BufferedRecordMergerFactory$BaseCustomMerger.deltaMerge(BufferedRecordMergerFactory.java:439)
    at org.apache.hudi.common.table.read.buffer.KeyBasedFileGroupRecordBuffer.processNextDataRecord(...)
```

### Summary and Changelog

**Root cause:** `SecondaryIndexMetadata` was added to `HoodieMetadataRecord` in a later Hudi release, growing the schema from 6 to 7 fields. MDT log blocks written by older releases carry the 6-field writer schema in their block header. When merging, `HoodieAvroRecordMerger` retrieves the writer schema from the buffered record and passes it to `HoodieMetadataPayload.getInsertValue(schema)`.

Inside `getInsertValue`, the fast path uses an object-identity check:

```java
if (schema == null || schema == HOODIE_METADATA_AVRO_SCHEMA) {
    // safe path
} else {
    // assumes HOODIE_META_COLUMNS are prepended; uses TYPE_FIELD_OFFSET=6
    record.put(TYPE_FIELD_OFFSET, type);  // index 6 on a 6-field schema → ArrayIndexOutOfBoundsException
}
```

The old 6-field schema is a different `Schema` object from `HOODIE_METADATA_AVRO_SCHEMA` (7 fields), so it fails the identity check and falls into the `else` branch designed for schemas with `HOODIE_META_COLUMNS` prepended. Writing to index 6 on a 6-field schema throws `ArrayIndexOutOfBoundsException`.

**Fix:** Add `isHoodieMetadataRecordSchema(Schema)` that recognises any version of `HoodieMetadataRecord` by Avro record name and namespace. Route these older-version schemas to the same fast path as the current schema, returning a `HoodieMetadataRecord` with the current schema (`SecondaryIndexMetadata` defaults to `null`).

**Changes:**
- `HoodieMetadataPayload.java`: add `isHoodieMetadataRecordSchema()` helper; extend the fast-path guard in `getInsertValue()`
- `TestHoodieMetadataPayload.java`: add `testGetInsertValueWithOldMetadataSchema` regression test that constructs the old 6-field schema and verifies no exception is thrown

### Impact

No user-facing API or config change. Tables written by older Hudi releases can be read safely by a 1.x reader without requiring a table upgrade.

### Risk Level

Low. The change is confined to `getInsertValue()` in `HoodieMetadataPayload`. The added condition only triggers when the schema is a `HoodieMetadataRecord` schema that is not object-identical to `HOODIE_METADATA_AVRO_SCHEMA` (i.e. an older-version schema read from a log block); all other callers are unaffected.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable