### PR TITLE
fix(cdc): cast to GenericRecord in PostgresDebeziumAvroPayload toasted-value checks

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
@@ -23,7 +23,6 @@ import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
@@ -109,7 +108,7 @@ public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
       // NON-NULLABLE STRING, NULLABLE STRING, NON-NULLABLE BYTES, NULLABLE BYTES
       if (((GenericRecord) incomingRecord).get(field.name()) != null
           && (containsStringToastedValues(incomingRecord, field) || containsBytesToastedValues(incomingRecord, field))) {
-        ((GenericRecord) incomingRecord).put(field.name(), ((GenericData.Record) currentRecord).get(field.name()));
+        ((GenericRecord) incomingRecord).put(field.name(), ((GenericRecord) currentRecord).get(field.name()));
       }
     });
   }
@@ -140,8 +139,8 @@ public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
     return ((field.schema().getType() == Schema.Type.BYTES
         || (field.schema().getType() == Schema.Type.UNION && field.schema().getTypes().stream().anyMatch(s -> s.getType() == Schema.Type.BYTES)))
         // Check length first as an optimization
-        && ((ByteBuffer) ((GenericData.Record) incomingRecord).get(field.name())).array().length == DEBEZIUM_TOASTED_VALUE.length()
-        && DEBEZIUM_TOASTED_VALUE.equals(fromUTF8Bytes(((ByteBuffer) ((GenericData.Record) incomingRecord).get(field.name())).array())));
+        && ((ByteBuffer) ((GenericRecord) incomingRecord).get(field.name())).array().length == DEBEZIUM_TOASTED_VALUE.length()
+        && DEBEZIUM_TOASTED_VALUE.equals(fromUTF8Bytes(((ByteBuffer) ((GenericRecord) incomingRecord).get(field.name())).array())));
   }
 }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.SerializableIndexedRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
 
@@ -32,6 +33,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import javax.annotation.Nullable;
 
@@ -159,8 +162,17 @@ public class TestPostgresDebeziumAvroPayload {
         "should have thrown because LSN value of the incoming record is null");
   }
 
-  @Test
-  public void testMergeWithToastedValues() throws IOException {
+  /**
+   * The toasted-value merge must work regardless of the concrete {@link IndexedRecord} implementation backing
+   * either side of the merge. Since lazy Avro deserialization landed, {@code BaseAvroPayload#getRecord} hands
+   * back a {@link SerializableIndexedRecord} whenever the payload record does not already carry the exact
+   * {@link Schema} instance being merged with (the common case in production, and after any Kryo round trip).
+   * That implements {@link GenericRecord} but not {@link GenericData.Record}, so casting to the concrete class
+   * threw {@code ClassCastException} on any non-null BYTES column.
+   */
+  @ParameterizedTest
+  @CsvSource({"false,false", "true,false", "false,true", "true,true"})
+  void testMergeWithToastedValues(boolean lazyIncomingRecord, boolean lazyCurrentRecord) throws IOException {
     Schema avroSchema = SchemaBuilder.builder()
         .record("test_schema")
         .namespace("test_namespace")
@@ -173,6 +185,9 @@ public class TestPostgresDebeziumAvroPayload {
         .name("string_null_col_2").type().nullable().stringType().noDefault()
         .name("byte_null_col_2").type().nullable().bytesType().noDefault()
         .endRecord();
+    // An equal but distinct Schema instance is what forces the payload to re-deserialize into a
+    // SerializableIndexedRecord instead of returning the GenericData.Record it was constructed with.
+    Schema incomingSchema = lazyIncomingRecord ? new Schema.Parser().parse(avroSchema.toString()) : avroSchema;
 
     GenericRecord oldVal = new GenericData.Record(avroSchema);
     oldVal.put(DebeziumConstants.FLATTENED_LSN_COL_NAME, 100L);
@@ -183,7 +198,7 @@ public class TestPostgresDebeziumAvroPayload {
     oldVal.put("string_null_col_2", null);
     oldVal.put("byte_null_col_2", null);
 
-    GenericRecord newVal = new GenericData.Record(avroSchema);
+    GenericRecord newVal = new GenericData.Record(incomingSchema);
     newVal.put(DebeziumConstants.FLATTENED_LSN_COL_NAME, 105L);
     newVal.put("string_col", PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE);
     newVal.put("byte_col", ByteBuffer.wrap(getUTF8Bytes(PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE)));
@@ -193,11 +208,14 @@ public class TestPostgresDebeziumAvroPayload {
     newVal.put("byte_null_col_2", ByteBuffer.wrap(getUTF8Bytes("valid byte value")));
 
     PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(Option.of(newVal));
+    IndexedRecord currentValue = lazyCurrentRecord ? SerializableIndexedRecord.createInstance(oldVal) : oldVal;
 
     GenericRecord outputRecord = (GenericRecord) payload
-        .combineAndGetUpdateValue(oldVal, avroSchema).get();
+        .combineAndGetUpdateValue(currentValue, avroSchema).get();
 
-    assertEquals("valid string value", outputRecord.get("string_col"));
+    // Pin that the parameterization really exercises the lazily deserialized implementation.
+    assertEquals(lazyIncomingRecord, outputRecord instanceof SerializableIndexedRecord);
+    assertEquals("valid string value", outputRecord.get("string_col").toString());
     assertEquals("valid byte value", fromUTF8Bytes(((ByteBuffer) outputRecord.get("byte_col")).array()));
     assertNull(outputRecord.get("string_null_col_1"));
     assertNull(outputRecord.get("byte_null_col_1"));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

closes #19563

`PostgresDebeziumAvroPayload` casts to the concrete class `GenericData.Record` in `mergeToastedValuesIfPresent` and `containsBytesToastedValues`. Since #13987 ("perf: Lazy deserialization of Avro indexed record"), `BaseAvroPayload.getRecord` returns a `SerializableIndexedRecord` whenever the payload's record does not already carry the exact `Schema` instance being merged with, which is the ordinary case in production and after any Kryo round trip. `SerializableIndexedRecord` implements `GenericRecord` but does not extend `GenericData.Record`, so any TOAST check on a non-null `BYTES` column throws `ClassCastException`. The sibling `containsStringToastedValues` was already converted to the interface, which is why only `BYTES` columns are affected.

### Summary and Changelog

Debezium Postgres ingestion of tables with a `BYTES` column no longer fails when the incoming event wins the LSN comparison.

* `PostgresDebeziumAvroPayload`: cast to the `GenericRecord` interface instead of the `GenericData.Record` implementation, in `mergeToastedValuesIfPresent` (the record already in storage) and in both reads inside `containsBytesToastedValues`.
* `TestPostgresDebeziumAvroPayload#testMergeWithToastedValues`: turned into a parameterized test over two independent dimensions, whether the incoming record is lazily deserialized (built on an equal but distinct `Schema` instance, which forces the round trip) and whether the record already in storage is a `SerializableIndexedRecord`. An added assertion pins that the lazy path is actually taken, so the parameterization cannot quietly degrade into four copies of the original case. Reverting the payload change fails 3 of the 4 cases with the reported `ClassCastException`; the pre-existing case is the one that passed before.

### Impact

None beyond fixing the crash. The interface cast accepts everything the implementation cast accepted.

### Risk Level

low

Covered by the parameterized regression test above, verified to fail without the payload change.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
