### PR TITLE
fix(core): stop forcing the timeline history folder onto pre-v8 tables

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -349,7 +349,7 @@ public class StreamerUtil {
           .setDatabaseName(conf.get(FlinkOptions.DATABASE_NAME))
           .setRecordKeyFields(conf.getString(FlinkOptions.RECORD_KEY_FIELD.key(), null))
           .setOrderingFields(OptionsResolver.getOrderingFieldsStr(conf))
-          .setArchiveLogFolder(TIMELINE_HISTORY_PATH.defaultValue())
+          .setArchiveLogFolder(conf.getString(TIMELINE_HISTORY_PATH.key(), null))
           .setPartitionFields(conf.getString(FlinkOptions.PARTITION_PATH_FIELD.key(), null))
           .setKeyGeneratorClassProp(
               conf.getOptional(FlinkOptions.KEYGEN_CLASS_NAME).orElse(SimpleAvroKeyGenerator.class.getName()))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -282,7 +282,7 @@ class HoodieSparkSqlWriterInternal {
           .build()
       } else {
         val baseFileFormat = hoodieConfig.getStringOrDefault(HoodieTableConfig.BASE_FILE_FORMAT)
-        val archiveLogFolder = hoodieConfig.getStringOrDefault(HoodieTableConfig.TIMELINE_HISTORY_PATH)
+        val archiveLogFolder = hoodieConfig.getString(HoodieTableConfig.TIMELINE_HISTORY_PATH)
         val populateMetaFields = hoodieConfig.getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS)
         val useBaseFormatMetaFile = hoodieConfig.getBooleanOrDefault(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT);
         val payloadClass = hoodieConfig.getString(DataSourceWriteOptions.PAYLOAD_CLASS_NAME)
@@ -740,7 +740,7 @@ class HoodieSparkSqlWriterInternal {
       handleSaveModes(sparkSession, mode, basePath, tableConfig, tableName, WriteOperationType.BOOTSTRAP, fs)
 
       if (!tableExists) {
-        val archiveLogFolder = hoodieConfig.getStringOrDefault(HoodieTableConfig.TIMELINE_HISTORY_PATH)
+        val archiveLogFolder = hoodieConfig.getString(HoodieTableConfig.TIMELINE_HISTORY_PATH)
         val tableVersion = Integer.valueOf(getStringWithAltKeys(parameters, HoodieWriteConfig.WRITE_TABLE_VERSION))
         val partitionColumnsWithType = SparkKeyGenUtils.getPartitionColumnsForKeyGenerator(toProperties(parameters), HoodieTableVersion.fromVersionCode(tableVersion))
         val recordKeyFields = hoodieConfig.getString(DataSourceWriteOptions.RECORDKEY_FIELD)

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
@@ -238,8 +238,7 @@ public class BootstrapExecutorUtils implements Serializable {
         .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(props))
         .setPopulateMetaFields(props.getBoolean(
             POPULATE_META_FIELDS.key(), POPULATE_META_FIELDS.defaultValue()))
-        .setArchiveLogFolder(props.getString(
-            TIMELINE_HISTORY_PATH.key(), TIMELINE_HISTORY_PATH.defaultValue()))
+        .setArchiveLogFolder(props.getString(TIMELINE_HISTORY_PATH.key(), null))
         .setPayloadClassName(cfg.payloadClass)
         .setBaseFileFormat(cfg.baseFileFormat)
         .setTableFormat(props.getString(HoodieTableConfig.TABLE_FORMAT.key(),

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
@@ -211,8 +211,7 @@ public class BootstrapExecutor implements Serializable {
         .setTableFormat(props.getString(HoodieTableConfig.TABLE_FORMAT.key(), HoodieTableConfig.TABLE_FORMAT.defaultValue()))
         .setPopulateMetaFields(props.getBoolean(
             POPULATE_META_FIELDS.key(), POPULATE_META_FIELDS.defaultValue()))
-        .setArchiveLogFolder(props.getString(
-            TIMELINE_HISTORY_PATH.key(), TIMELINE_HISTORY_PATH.defaultValue()))
+        .setArchiveLogFolder(props.getString(TIMELINE_HISTORY_PATH.key(), null))
         .setPayloadClassName(cfg.payloadClassName)
         .setRecordMergeMode(cfg.recordMergeMode)
         .setRecordMergeStrategyId(cfg.recordMergeStrategyId)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -468,7 +468,7 @@ public class StreamSync implements Serializable, Closeable {
             HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.defaultValue()));
     return tableBuilder.setTableType(cfg.tableType)
         .setTableName(cfg.targetTableName)
-        .setArchiveLogFolder(TIMELINE_HISTORY_PATH.defaultValue())
+        .setArchiveLogFolder(props.getString(TIMELINE_HISTORY_PATH.key(), null))
         .setPayloadClassName(payloadClass)
         .setRecordMergeStrategyId(mergeStrategyId)
         .setRecordMergeMode(mergeMode)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamSync.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamSync.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
@@ -35,6 +36,7 @@ import org.apache.hudi.common.util.collection.Triple;
 import org.apache.hudi.config.HoodieErrorTableConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
@@ -54,6 +56,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
@@ -307,6 +310,54 @@ public class TestStreamSync extends SparkClientFunctionalTestHarness {
 
     // then
     verify(tableBuilder, times(1)).setTableVersion(HoodieTableVersion.SIX);
+  }
+
+  /**
+   * Pins where the archived timeline lands for a table created by the streamer. Table versions below
+   * {@link HoodieTableVersion#EIGHT} resolve the archived timeline through {@code hoodie.archivelog.folder}
+   * (timeline layout version 1), so forcing that config to the layout version 2 default {@code history}
+   * relocated the archived timeline of a table version 6 table away from {@code .hoodie/archived}.
+   */
+  @ParameterizedTest
+  @EnumSource(value = HoodieTableVersion.class, names = {"SIX", "SEVEN", "EIGHT", "NINE"})
+  void testInitializeEmptyTableArchiveFolderMatchesTableVersion(HoodieTableVersion tableVersion) throws IOException {
+    HoodieTableMetaClient metaClient = initializeEmptyTableAtVersion(tableVersion, new TypedProperties());
+
+    // the streamer never forces the layout version 2 folder onto the legacy archive folder config
+    assertEquals("archived", metaClient.getTableConfig().getArchivelogFolder());
+    assertEquals(
+        new StoragePath(metaClient.getBasePath(),
+            tableVersion.lesserThan(HoodieTableVersion.EIGHT) ? ".hoodie/archived" : ".hoodie/timeline/history"),
+        metaClient.getArchivePath());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = HoodieTableVersion.class, names = {"SIX", "NINE"})
+  void testInitializeEmptyTableHonoursConfiguredTimelineHistoryPath(HoodieTableVersion tableVersion) throws IOException {
+    TypedProperties props = new TypedProperties();
+    props.put(HoodieTableConfig.TIMELINE_HISTORY_PATH.key(), "myhistory");
+
+    HoodieTableMetaClient metaClient = initializeEmptyTableAtVersion(tableVersion, props);
+
+    assertEquals("myhistory", metaClient.getTableConfig().getArchivelogFolder());
+  }
+
+  private HoodieTableMetaClient initializeEmptyTableAtVersion(HoodieTableVersion tableVersion, TypedProperties props)
+      throws IOException {
+    String tablePath = basePath() + "/" + tableVersion.name();
+    HoodieStreamer.Config cfg = new HoodieStreamer.Config();
+    cfg.targetTableName = "testTableName";
+    cfg.targetBasePath = tablePath;
+    cfg.tableType = "MERGE_ON_READ";
+    props.put(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), tableVersion.versionCode());
+
+    StreamSync streamSync = new StreamSync(cfg, mock(SparkSession.class), props,
+        mock(HoodieSparkEngineContext.class), new HoodieHadoopStorage(tablePath, storageConf()),
+        mock(Configuration.class), client -> true, getSchemaProvider("InputBatch", false),
+        Option.empty(), mock(SourceFormatAdapter.class), Option.empty(), false);
+
+    // matches the production caller, which passes a bare builder
+    return streamSync.initializeEmptyTable(HoodieTableMetaClient.newTableBuilder(), "", storageConf());
   }
 
   private StreamSync setupStreamSync() {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19561

### Summary and Changelog

Table creation passed `TIMELINE_HISTORY_PATH.defaultValue()` (`history`) into `setArchiveLogFolder(...)` regardless of the table version being created.

A table below version 8 uses timeline layout version 1, and `TimelinePathProviderV1.getTimelineHistoryPath()` resolves the archived timeline through `hoodie.archivelog.folder`. Forcing that config to the layout version 2 value meant such a table archived into `.hoodie/archived`'s sibling `.hoodie/history`, diverging from the conventional location.

Changes:

- Remove the hardcoded value from the table creation paths so `TableBuilder.build()` supplies `ARCHIVELOG_FOLDER.defaultValue()`, and pass through only a value the user configured. Five call sites: `StreamSync`, `BootstrapExecutor`, `BootstrapExecutorUtils`, `HoodieSparkSqlWriter` (both table creation branches), and the Flink `StreamerUtil`.
- `HoodieSparkSqlWriter` switches from `getStringOrDefault` to `getString` so an unset config reaches the builder as null rather than as the layout version 2 default.
- Add `TestStreamSync` coverage across table versions 6, 7, 8 and 9, asserting both the persisted config and the resolved archive path, plus a case pinning that an explicitly configured `hoodie.timeline.history.path` is still honoured.

The metadata table already handled this correctly through `HoodieBackedTableMetadataWriterTableVersionSix`, which returns `ARCHIVELOG_FOLDER.defaultValue()`; it is unchanged.

The active timeline is unaffected: `TimelinePathProviderV1` hardcodes `.hoodie` and never consults `hoodie.timeline.path`.

### Impact

Newly created tables below version 8 archive into `.hoodie/archived`, matching the conventional location and the metadata table.

Tables at version 8 and above now record `hoodie.archivelog.folder=archived` where these paths previously wrote `history`. That config has exactly one reader in the codebase, `TimelinePathProviderV1`, which is unreachable at layout version 2, so it is inert for those tables. It becomes meaningful again after a downgrade to version 7 or below, where the new value is the correct one: `EightToSevenDowngradeHandler` writes the converted archived timeline to a hardcoded `.hoodie/archived`, so a table carrying `history` previously ended up pointing at an empty directory after downgrade.

Existing tables are not modified. Any created below version 8 keep `history` in their properties and continue to resolve consistently, since the persisted value is what is read.

No public API change.

### Risk Level

low

The changed config has a single production reader, selected only for timeline layout version 1, so behaviour at layout version 2 is unchanged in effect. Verified with unit tests across four table versions, and by confirming that reverting the change reproduces the original symptom (`expected: <archived> but was: <history>` at table version 6).

### Documentation Update

none

No config is added and no default value changes; this removes a hardcoded override that bypassed an existing default.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
