### PR TITLE
fix(core): gate the timeline path configs on the table version

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -299,11 +299,13 @@ public class HoodieTableConfig extends HoodieConfig {
   public static final ConfigProperty<String> TIMELINE_HISTORY_PATH = ConfigProperty
       .key("hoodie.timeline.history.path")
       .defaultValue("history")
+      .sinceVersion("1.0.0")
       .withDocumentation("path under the meta folder, to store timeline history at.");
 
   public static final ConfigProperty<String> TIMELINE_PATH = ConfigProperty
       .key("hoodie.timeline.path")
       .defaultValue("timeline")
+      .sinceVersion("1.0.0")
       .withDocumentation("path under the meta folder, to store timeline instants at.");
 
   public static final ConfigProperty<Boolean> BOOTSTRAP_INDEX_ENABLE = ConfigProperty

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -381,6 +382,29 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
     config.setValue(RECORD_MERGE_MODE, COMMIT_TIME_ORDERING.name());
     HoodieTableConfig.dropInvalidConfigs(config);
     assertTrue(config.contains(RECORD_MERGE_MODE));
+  }
+
+  /**
+   * The timeline path configs describe the timeline layout version 2 folders, which a table below
+   * table version 8 does not have: it keeps its timeline in {@code .hoodie} and resolves the archived
+   * timeline through {@link HoodieTableConfig#ARCHIVELOG_FOLDER}. Persisting them onto such a table
+   * records a layout it does not use.
+   */
+  @ParameterizedTest
+  @CsvSource({"SIX,false", "SEVEN,false", "EIGHT,true", "NINE,true"})
+  void testDropInvalidConfigsForTimelineLayoutConfigs(HoodieTableVersion tableVersion, boolean retained) {
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(HoodieTableConfig.VERSION, String.valueOf(tableVersion.versionCode()));
+    config.setValue(HoodieTableConfig.TIMELINE_PATH, "timeline");
+    config.setValue(HoodieTableConfig.TIMELINE_HISTORY_PATH, "history");
+    config.setValue(HoodieTableConfig.ARCHIVELOG_FOLDER, "archived");
+
+    HoodieTableConfig.dropInvalidConfigs(config);
+
+    assertEquals(retained, config.contains(HoodieTableConfig.TIMELINE_PATH));
+    assertEquals(retained, config.contains(HoodieTableConfig.TIMELINE_HISTORY_PATH));
+    // the legacy archive folder carries the archived timeline location at every table version
+    assertTrue(config.contains(HoodieTableConfig.ARCHIVELOG_FOLDER));
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19562

### Summary and Changelog

`hoodie.timeline.path` and `hoodie.timeline.history.path` describe the timeline layout version 2 folders, introduced with table version 8. A table below that version keeps its timeline directly under `.hoodie` and resolves its archived timeline through `hoodie.archivelog.folder`, so neither config has meaning there.

Neither declared a `sinceVersion`, and `HoodieTableConfig.dropInvalidConfigs()` only strips a config that declares one, so both were persisted into the `hoodie.properties` of tables that do not use the layout they describe. `RECORD_MERGE_MODE` declares `.sinceVersion("1.0.0")` and is correctly dropped from a version 6 table, which is the behaviour these two were missing.

Changes:

- Declare `sinceVersion("1.0.0")` on `TIMELINE_PATH` and `TIMELINE_HISTORY_PATH` so the existing gate drops them below table version 8.
- Add `TestHoodieTableConfig` coverage across table versions 6, 7, 8 and 9, with literal per-version expectations, also asserting that `ARCHIVELOG_FOLDER` is retained at every version.

`hoodie.table.format` was considered alongside these and deliberately left alone. Its introducing version is not the version at which it becomes meaningful: the table format SPI is orthogonal to the table version, nothing in the codebase gates a custom format on table version 9, and no upgrade handler restores the config. Gating it on `sinceVersion` would silently and permanently discard a custom format on any table below version 9, so excluding that config needs a different mechanism.

### Impact

Tables created below version 8 no longer carry the two timeline layout version 2 configs in their properties file.

No read path changes. Every consumer resolves these through `getStringOrDefault`, and the only provider that reads them, `TimelinePathProviderV2`, is selected exclusively at layout version 2 where the configs are retained. `TimelinePathProviderV1` reads neither. Resolved timeline and archive paths were verified unchanged at table versions 6, 7, 8 and 9.

Existing tables are not modified; the gate applies when properties are written. Upgrade is unaffected, since `SevenToEightUpgradeHandler` re-adds `TIMELINE_PATH` through `HoodieTableConfig.update()`, which does not run the gate.

One cosmetic inconsistency remains: a table upgraded from 6 or 7 to 8 will not carry `hoodie.timeline.history.path`, because that handler adds `hoodie.timeline.path` but not its sibling. Both resolve to the same default either way.

No public API change.

### Risk Level

low

Confined to which keys are written into `hoodie.properties`. Verified that no consumer reads either config through a null-returning accessor, and that resolved paths are identical before and after across four table versions. Reverting the change fails the added test at versions 6 and 7.

### Documentation Update

none

No config is added or removed and no default value changes; this records the version at which two existing configs were introduced.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
