### PR TITLE
fix(spark): incremental query returns no rows when projection excludes _hoodie_commit_time

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -57,7 +57,7 @@ import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapCol
 import org.apache.spark.sql.hudi.MultipleColumnarFileFormatReader
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnarBatchUtils}
 import org.apache.spark.util.SerializableConfiguration
 
@@ -516,19 +516,73 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     iter.map(mapper.apply(_))
   }
 
+  /**
+   * Columns referenced by `filters` that are present in the table but missing from `schema`.
+   *
+   * A pushed-down filter is evaluated by the Parquet reader against the schema it was asked to
+   * read. If the filter references a column that schema does not contain, the predicate cannot be
+   * satisfied and every row is dropped -- silently, with no error. That is reachable whenever a
+   * caller supplies required filters independently of the projection: an incremental query always
+   * filters on _hoodie_commit_time, but a `count()` projects no columns at all and a
+   * `select(subset)` projects only what the user asked for.
+   *
+   * Candidates come from the full table schema rather than the requested one: on the failing path
+   * the requested schema is itself empty, so it cannot supply the column the filter needs.
+   * Partition columns are excluded by the caller, which appends them separately.
+   */
+  private def filterColumnsMissingFrom(target: StructType,
+                                       candidates: StructType,
+                                       partitionSchema: StructType,
+                                       filters: Seq[Filter]): Seq[StructField] = {
+    if (filters.isEmpty) {
+      Seq.empty
+    } else {
+      val present = target.fieldNames.toSet
+      // Partition columns are appended by the caller from the partition values, not read from the
+      // file. Adding one here would duplicate the field and shift every ordinal after it.
+      val partitionFields = partitionSchema.fieldNames.toSet
+      val available = candidates.fields.map(f => f.name -> f).toMap
+      filters.flatMap(_.references).distinct
+        .filterNot(present.contains)
+        .filterNot(partitionFields.contains)
+        .flatMap(available.get)
+    }
+  }
+
   // executor
   private def readBaseFile(file: PartitionedFile, parquetFileReader: SparkColumnarFileReader, requestedSchema: StructType,
-                           remainingPartitionSchema: StructType, fixedPartitionIndexes: Set[Int], requiredSchema: StructType,
+                           remainingPartitionSchema: StructType, fixedPartitionIndexes: Set[Int], requiredSchemaIn: StructType,
                            partitionSchema: StructType, outputSchema: StructType, filters: Seq[Filter],
                            storageConf: StorageConfiguration[Configuration]): Iterator[InternalRow] = {
+    // Read any column a pushed filter references but the projection omits, then project it back out
+    // below. Without this the reader evaluates the predicate against a schema lacking the column and
+    // returns nothing -- the failure mode described on filterColumnsMissingFrom.
+    //
+    // A strict no-op for every non-incremental read: snapshot, CDC and bootstrap relations all
+    // supply `Seq.empty` for required filters, so there is nothing to reference and nothing to add.
+    val filterOnlyFields =
+      filterColumnsMissingFrom(requiredSchemaIn, tableSchema.structTypeSchema, partitionSchema, filters)
+    val requiredSchema =
+      if (filterOnlyFields.isEmpty) requiredSchemaIn
+      else StructType(requiredSchemaIn.fields ++ filterOnlyFields)
+
     // Detect vector columns and create modified schemas with BinaryType.
     // Each schema is detected independently because ordinals are relative to the schema being
     // modified — outputSchema and requestedSchema may have vector columns at different positions
     // than requiredSchema (e.g. when partition columns are interleaved).
+    // The other two branches read through the output / requested schemas rather than the required
+    // one, so the filter-only columns have to be appended there too or those paths keep hitting the
+    // same missing-column predicate. Appended at the end in the same order, so the trailing
+    // projection back to the caller's schema is a plain prefix drop in every branch.
+    val outputSchemaForRead =
+      if (filterOnlyFields.isEmpty) outputSchema else StructType(outputSchema.fields ++ filterOnlyFields)
+    val requestedSchemaForRead =
+      if (filterOnlyFields.isEmpty) requestedSchema else StructType(requestedSchema.fields ++ filterOnlyFields)
+
     val (modifiedRequiredSchema, vectorCols) = withVectorRewrite(requiredSchema)
     val hasVectors = vectorCols.nonEmpty
-    val (modifiedOutputSchema, outputVectorCols) = if (hasVectors) withVectorRewrite(outputSchema) else (outputSchema, Map.empty[Int, HoodieSchema.Vector])
-    val (modifiedRequestedSchema, _) = if (hasVectors) withVectorRewrite(requestedSchema) else (requestedSchema, Map.empty[Int, HoodieSchema.Vector])
+    val (modifiedOutputSchema, outputVectorCols) = if (hasVectors) withVectorRewrite(outputSchemaForRead) else (outputSchemaForRead, Map.empty[Int, HoodieSchema.Vector])
+    val (modifiedRequestedSchema, _) = if (hasVectors) withVectorRewrite(requestedSchemaForRead) else (requestedSchemaForRead, Map.empty[Int, HoodieSchema.Vector])
 
     val rawIter = if (remainingPartitionSchema.fields.length == partitionSchema.fields.length) {
       //none of partition fields are read from the file, so the reader will do the appending for us
@@ -551,16 +605,29 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       projectIter(iter, StructType(modifiedRequestedSchema.fields ++ remainingPartitionSchema.fields), modifiedOutputSchema)
     }
 
+    // Schema the reader actually produced, filter-only columns included.
+    val producedSchema = if (remainingPartitionSchema.fields.length == partitionSchema.fields.length) {
+      StructType(modifiedRequiredSchema.fields ++ partitionSchema.fields)
+    } else {
+      modifiedOutputSchema
+    }
+
+    // Drop the filter-only columns before handing rows back: they were read so the predicate could
+    // be evaluated, not because the caller asked for them, and the caller's schema must be exact.
+    // Skipped entirely when nothing was added, so every non-incremental read is untouched.
+    val (projectedIter, projectedSchema) =
+      if (filterOnlyFields.isEmpty) {
+        (rawIter, producedSchema)
+      } else {
+        val target = if (hasVectors) withVectorRewrite(outputSchema)._1 else outputSchema
+        (projectIter(rawIter, producedSchema, target), target)
+      }
+
     if (hasVectors) {
       // The raw iterator has BinaryType for vector columns; convert back to ArrayType
-      val readSchema = if (remainingPartitionSchema.fields.length == partitionSchema.fields.length) {
-        StructType(modifiedRequiredSchema.fields ++ partitionSchema.fields)
-      } else {
-        modifiedOutputSchema
-      }
-      wrapWithVectorConversion(rawIter, readSchema, outputSchema, outputVectorCols)
+      wrapWithVectorConversion(projectedIter, projectedSchema, outputSchema, outputVectorCols)
     } else {
-      rawIter
+      projectedIter
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestIncrementalQueryProjection.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestIncrementalQueryProjection.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.functional;
+
+import org.apache.hudi.DataSourceReadOptions;
+import org.apache.hudi.DataSourceWriteOptions;
+import org.apache.hudi.SparkAdapterSupport$;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * An incremental query filters on {@code _hoodie_commit_time}, and that filter is pushed into the
+ * file reader. The reader evaluates a pushed predicate against the schema it was asked to read, so
+ * if the query's projection does not include the filtered column the predicate cannot be satisfied
+ * and every row is dropped -- silently, with no error.
+ *
+ * <p>That made {@code count()} and any projected read return zero rows on a CoW incremental query
+ * while {@code collect()} returned the right ones: {@code collect()} happens to project every
+ * column, including the filtered one, so it worked only incidentally.
+ *
+ * <p>Each case here asserts the same query returns the same rows regardless of what it projects.
+ */
+public class TestIncrementalQueryProjection extends SparkClientFunctionalTestHarness {
+
+  private static StructType schema() {
+    return DataTypes.createStructType(new StructField[] {
+        DataTypes.createStructField("record_key", DataTypes.StringType, true),
+        DataTypes.createStructField("partition_path", DataTypes.StringType, true),
+        DataTypes.createStructField("payload", DataTypes.StringType, true)
+    }).asNullable();
+  }
+
+  private Map<String, String> writeOptions() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "record_key");
+    opts.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+    opts.put(DataSourceWriteOptions.ORDERING_FIELDS().key(), "payload");
+    opts.put(HoodieTableConfig.NAME.key(), "test_incr_projection");
+    opts.put(DataSourceWriteOptions.TABLE_TYPE().key(), "COPY_ON_WRITE");
+    opts.put(HoodieMetadataConfig.ENABLE.key(), "false");
+    opts.put(DataSourceWriteOptions.OPERATION().key(),
+        DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+    return opts;
+  }
+
+  private void write(List<Row> rows, SaveMode mode) {
+    spark().createDataset(rows,
+            SparkAdapterSupport$.MODULE$.sparkAdapter().getCatalystExpressionUtils().getEncoder(schema()))
+        .write().format("hudi").options(writeOptions()).mode(mode).save(basePath());
+  }
+
+  /** Writes two commits and returns their instant times, oldest first. */
+  private List<String> writeTwoCommits() {
+    write(Arrays.asList(
+        RowFactory.create("k1", "p1", "v1"),
+        RowFactory.create("k2", "p1", "v2")), SaveMode.Overwrite);
+    write(Arrays.asList(
+        RowFactory.create("k3", "p1", "v3"),
+        RowFactory.create("k4", "p1", "v4")), SaveMode.Append);
+
+    HoodieTableMetaClient metaClient =
+        HoodieTableMetaClient.builder().setBasePath(basePath()).setConf(storageConf()).build();
+    List<String> instants = new ArrayList<>();
+    metaClient.getActiveTimeline().filterCompletedInstants().getInstants()
+        .forEach(i -> instants.add(i.requestedTime()));
+    Collections.sort(instants);
+    return instants;
+  }
+
+  private Dataset<Row> incrementalFrom(String startCommit) {
+    return spark().read().format("hudi")
+        .option(DataSourceReadOptions.QUERY_TYPE().key(),
+            DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL())
+        .option(DataSourceReadOptions.START_COMMIT().key(), startCommit)
+        .load(basePath());
+  }
+
+  @Test
+  public void incrementalCountMatchesCollect() {
+    List<String> instants = writeTwoCommits();
+    Dataset<Row> incremental = incrementalFrom(instants.get(1));
+
+    // count() projects no columns at all, which is what made it return 0.
+    assertEquals(2, incremental.collectAsList().size(), "collect must return the second commit's rows");
+    assertEquals(2, incremental.count(), "count must agree with collect");
+  }
+
+  @Test
+  public void incrementalProjectedReadMatchesCollect() {
+    List<String> instants = writeTwoCommits();
+    Dataset<Row> incremental = incrementalFrom(instants.get(1));
+
+    // Projecting a subset that excludes _hoodie_commit_time is the general form of the bug;
+    // count() is just its most visible instance.
+    assertEquals(2, incremental.select("record_key").collectAsList().size(),
+        "a projected read must return the same rows as an unprojected one");
+    assertEquals(2, incremental.select("record_key").count());
+    assertEquals(2, incremental.select("record_key", "payload").collectAsList().size());
+  }
+
+  @Test
+  public void incrementalProjectedReadReturnsTheRightRows() {
+    List<String> instants = writeTwoCommits();
+
+    List<String> keys = new ArrayList<>();
+    incrementalFrom(instants.get(1)).select("record_key").collectAsList()
+        .forEach(r -> keys.add(r.getString(0)));
+    Collections.sort(keys);
+
+    // Not just the right count -- the right rows. A filter that silently matched everything would
+    // pass a count-only assertion.
+    assertEquals(Arrays.asList("k3", "k4"), keys);
+  }
+
+  @Test
+  public void snapshotCountIsUnaffected() {
+    writeTwoCommits();
+
+    // A snapshot read supplies no required filters, so the filter-column augmentation must be a
+    // strict no-op here -- otherwise every count() in Hudi would start reading an extra column.
+    Dataset<Row> snapshot = spark().read().format("hudi").load(basePath());
+    assertEquals(4, snapshot.count());
+    assertEquals(4, snapshot.collectAsList().size());
+    assertEquals(4, snapshot.select("record_key").count());
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

**A CoW incremental query returns zero rows whenever its projection excludes `_hoodie_commit_time`.** `count()` is the most visible instance, and it fails silently — a wrong answer that reads as "no new data" rather than an error.

Reproduced on unmodified `master` (`65cf7e8ede7d`), table version 10, on a plain CoW table with no special configuration:

```
collect()               -> 2 rows   (correct)
count()                 -> 0 rows   (WRONG)
select("k").collect()   -> 0 rows   (WRONG)
select("k").count()     -> 0 rows   (WRONG)

snapshot count()        -> 4 rows   (correct — snapshot reads are unaffected)
```

Not specific to a table version, a table type beyond CoW, or any meta-fields configuration.

### Root cause

An incremental query filters on `_hoodie_commit_time` — `IsNotNull` plus an `In` over the instants in range — and those filters are pushed into the file reader as `requiredFilters`. The reader evaluates a pushed predicate against **the schema it was asked to read**, which contains only the columns the query projects.

When the projection omits `_hoodie_commit_time`, the predicate cannot be satisfied and every row is dropped.

`collect()` works only *incidentally*: it happens to project every column, including the filtered one. It is not a working case so much as a case that has not failed yet. `count()` projects nothing at all, and `select(subset)` projects only what the user asked for — both hit it.

Verified by instrumenting `readBaseFile` rather than by inspection. The filters are identical in all three cases; only the schema differs:

| Query | schema passed to the reader | filters | rows |
|---|---|---|---|
| `collect()` | all 7 columns, incl. `_hoodie_commit_time` | `IsNotNull(_hoodie_commit_time)`, `In(...)` | 2 ✅ |
| `count()` | `[]` | *identical* | 0 ❌ |
| `select("k")` | `[k]` | *identical* | 0 ❌ |

Worth noting what is **not** the bug, since both look suspicious and both are correct:

- `isCount` excludes incremental deliberately (`HoodieFileGroupReaderBasedFileFormat:254`). You cannot answer an incremental `count()` from row counts, because only some rows fall in the commit range.
- The fallthrough to the plain Parquet reader for column-less CoW reads is intentional — see HUDI-8079 (`31eea3b9a851`), which only restructured an inner `if` into the guard.

Both mechanisms are right in isolation. The defect is the seam between them: **a required filter references a column, and nothing guarantees that column is in the schema handed to the reader.**

### Summary and Changelog

`readBaseFile` now reads any column a required filter references but the projection omits, then projects it back out before returning so the caller's schema stays exact.

Two details worth review:

- **Partition columns are excluded.** The caller appends those from partition values rather than reading them from the file, so adding one here would duplicate the field and shift every ordinal after it. Not reachable by the repro above — it needs a filter over a partition column — but wrong regardless.
- **Candidate columns come from the full table schema**, not the requested schema. On the failing path the requested schema is itself empty, so it cannot supply the column the filter needs. (My first attempt sourced them from the requested schema; it compiled, read correctly, and did nothing.)

### Impact

**Behavior**: incremental queries that previously returned zero rows now return the correct rows. No other query shape changes.

**Strict no-op for every non-incremental read.** Snapshot, CDC and bootstrap relations all supply `Seq.empty` for required filters, so there is nothing to reference and nothing to add. No extra column is read on the ordinary `count()` path — which matters, since that is the most common query in Hudi.

**Performance**: on an incremental read whose projection omits the filtered column, one extra column is read and then projected away. That is the minimum needed to evaluate the predicate correctly.

**API / storage**: unchanged.

### Risk Level

medium

The change is small and its no-op property is structural rather than incidental. Raised above "low" only because `readBaseFile` is on the shared read path for every Spark query — snapshot, incremental, CDC, bootstrap and MoR all route through it — so the blast radius of a mistake here is wide even though this change is narrow.

### Tests

`TestIncrementalQueryProjection`, four cases:

1. `count()` agrees with `collect()`
2. projected reads agree with unprojected ones
3. a projected read returns the **right rows**, not merely the right number — a filter that silently matched everything would pass a count-only assertion
4. snapshot reads are unaffected, guarding the no-op property

**Verified not vacuous:** with the fix reverted, exactly the three incremental cases fail and the snapshot guard still passes. That check mattered here — the first version of this fix compiled cleanly and did nothing, and a test run only against the fixed build would have looked identical.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
