### PR TITLE
fix(spark): report read.paths, a missing path and a glob path separately

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -88,7 +88,10 @@ object DataSourceReadOptions {
     .noDefaultValue()
     .markAdvanced()
     .sinceVersion("0.9.0")
-    .withDocumentation("Comma separated list of file paths to read within a Hudi table.")
+    .deprecatedAfter("1.2.0")
+    .withDocumentation("Comma separated list of file paths to read within a Hudi table. This config is deprecated "
+      + "as of 1.2.0 and setting it now fails the read. Load the table base path and filter on the partition "
+      + "columns instead: such predicates are pushed down and prune partitions before files are listed.")
 
   @Deprecated
   val READ_PRE_COMBINE_FIELD = HoodieWriteConfig.PRECOMBINE_FIELD_NAME

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -94,19 +94,32 @@ class DefaultSource extends RelationProvider
     val path = optParams.get("path")
     val readPathsStr = optParams.get(DataSourceReadOptions.READ_PATHS.key)
 
-    if (path.isEmpty && readPathsStr.isEmpty) {
-      throw new HoodieException(s"'path' or '${READ_PATHS.key()}' or both must be specified.")
+    // These are three independent problems and each gets its own message. They used to share one
+    // condition, so a user passing plain partition paths through read.paths was told that their
+    // non-glob paths were unsupported glob paths, which is neither true nor actionable.
+    //
+    // Checked before any storage handle is built, so a doomed call does not open one first.
+    //
+    // read.paths is reported ahead of a glob in 'path' because it is the more fundamental of the
+    // two: the option is gone entirely, and its replacement resolves the glob case as well.
+    if (readPathsStr.isDefined) {
+      // Deliberately fires for an explicitly empty value too: setting the key at all is asking for
+      // an option that no longer exists. 1.2.0 already rejected "" here, since Some("") made the
+      // old readPaths.nonEmpty check true, so this keeps the rejection and only reworks the wording.
+      throw new HoodieException(
+        s"'${READ_PATHS.key()}' is no longer supported as of Hudi 1.2.0. ${DefaultSource.LOAD_BASE_PATH_INSTEAD}")
     }
-
-    val readPaths = readPathsStr.map(p => p.split(",").toSeq).getOrElse(Seq())
-    val allPaths = path.map(p => Seq(p)).getOrElse(Seq()) ++ readPaths
+    if (path.isEmpty) {
+      // Does not offer read.paths as an alternative: setting it throws above.
+      throw new HoodieException(s"'path' must be specified. ${DefaultSource.LOAD_BASE_PATH_INSTEAD}")
+    }
+    if (path.get.contains("*")) {
+      throw new HoodieException(
+        s"Glob paths are not supported as of Hudi 1.2.0. ${DefaultSource.LOAD_BASE_PATH_INSTEAD}")
+    }
 
     val storage = HoodieStorageUtils.getStorage(
-      allPaths.head, HadoopFSUtils.getStorageConf(sqlContext.sparkContext.hadoopConfiguration))
-
-    if (path.exists(_.contains("*")) || readPaths.nonEmpty) {
-      throw new HoodieException("Glob paths are not supported for read paths as of Hudi 1.2.0")
-    }
+      path.get, HadoopFSUtils.getStorageConf(sqlContext.sparkContext.hadoopConfiguration))
 
     // Add default options for unspecified read options keys.
     // Effective precedence (low -> high):
@@ -291,6 +304,17 @@ class DefaultSource extends RelationProvider
 object DefaultSource {
 
   private val log = LoggerFactory.getLogger(classOf[DefaultSource])
+
+  /**
+   * What to do instead, appended to every rejection in the 3-arg createRelation so the user is
+   * never told only what does not work. Predicates on the partition columns are pushed down and
+   * prune partitions before any file is listed, which is what selecting paths by hand was for.
+   * See HoodieFileIndex#prunePartitionsAndGetFileSlices.
+   */
+  private[hudi] val LOAD_BASE_PATH_INSTEAD: String =
+    "Load the table base path and filter on the partition columns instead, for example " +
+      "spark.read.format(\"hudi\").load(basePath).where(\"part = 'a'\"): such predicates are " +
+      "pushed down and prune partitions before files are listed."
 
   def createRelation(sqlContext: SQLContext,
                      metaClient: HoodieTableMetaClient,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -306,9 +306,10 @@ object DefaultSource {
   private val log = LoggerFactory.getLogger(classOf[DefaultSource])
 
   /**
-   * What to do instead, appended to every rejection in the 3-arg createRelation so the user is
-   * never told only what does not work. Predicates on the partition columns are pushed down and
-   * prune partitions before any file is listed, which is what selecting paths by hand was for.
+   * What to do instead, appended to every rejection in
+   * `createRelation(sqlContext, optParams, schema)` so the user is never told only what does not
+   * work. Predicates on the partition columns are pushed down and prune partitions before any file
+   * is listed, which is what selecting paths by hand was for.
    * See HoodieFileIndex#prunePartitionsAndGetFileSlices.
    */
   private[hudi] val LOAD_BASE_PATH_INSTEAD: String =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDefaultSourceReadPaths.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDefaultSourceReadPaths.scala
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
+import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator.recordsToStrings
+import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.testutils.HoodieSparkClientTestBase
+
+import org.apache.hadoop.fs.FileSystem
+import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertTrue}
+
+import scala.collection.JavaConverters._
+
+/**
+ * How the datasource reports paths it will not read.
+ *
+ * Glob paths and [[DataSourceReadOptions.READ_PATHS]] were both rejected in 1.2.0, but by a single
+ * condition throwing a single message, so a user passing plain partition paths through read.paths
+ * was told their non-glob paths were unsupported glob paths. These cover the three rejections
+ * separately, and the reads that must keep working around them.
+ */
+class TestDefaultSourceReadPaths extends HoodieSparkClientTestBase {
+
+  var spark: SparkSession = null
+
+  private val readPathsKey = DataSourceReadOptions.READ_PATHS.key
+
+  @BeforeEach override def setUp(): Unit = {
+    initPath()
+    initSparkContexts()
+    spark = sqlContext.sparkSession
+    initTestDataGenerator()
+    initHoodieStorage()
+  }
+
+  @AfterEach override def tearDown(): Unit = {
+    cleanupSparkContexts()
+    cleanupTestDataGenerator()
+    cleanupFileSystem()
+    FileSystem.closeAll()
+    System.gc()
+  }
+
+  private def writeTable(tableType: HoodieTableType, path: String, numRecords: Int = 20): Unit = {
+    val records = recordsToStrings(dataGen.generateInserts("000", numRecords)).asScala.toList
+    val inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
+    inputDF.write.format("hudi")
+      .options(CommonOptionUtils.commonOpts)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key, tableType.name())
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Overwrite)
+      .save(path)
+  }
+
+  /** Every rejection has to say what to do instead, not just what is refused. */
+  private def assertPointsAtReplacement(message: String): Unit = {
+    assertTrue(message.contains("Load the table base path"),
+      s"the message must point at the supported replacement, got: $message")
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // the reads that must keep working
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  def testLoadBasePathStillWorksForCow(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath)
+    assertEquals(20, spark.read.format("hudi").load(basePath).count())
+  }
+
+  @Test
+  def testLoadBasePathStillWorksForMor(): Unit = {
+    writeTable(HoodieTableType.MERGE_ON_READ, basePath)
+    assertEquals(20, spark.read.format("hudi").load(basePath).count())
+  }
+
+  /**
+   * The replacement the error messages recommend. A predicate on the partition column has to keep
+   * returning only that partition, which is what selecting paths by hand used to be for.
+   */
+  @Test
+  def testPartitionPredicateStillPrunes(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath, numRecords = 60)
+    val df = spark.read.format("hudi").load(basePath)
+    val partitions = df.select("partition").distinct().collect().map(_.getString(0))
+    assertTrue(partitions.length > 1, s"need a multi-partition table, got: ${partitions.mkString(",")}")
+
+    val target = partitions.head
+    val pruned = df.where(s"partition = '$target'")
+    assertTrue(pruned.count() > 0, "the predicate must not filter everything away")
+    assertEquals(Seq(target), pruned.select("partition").distinct().collect().map(_.getString(0)).toSeq)
+    assertEquals(df.where(s"partition = '$target'").count(), pruned.count())
+  }
+
+  /**
+   * Reached through Spark's SchemaRelationProvider path, which bypasses the 2-arg overload and so
+   * bypasses its HoodieSchemaNotFoundException catch. The guards run here too, and a table with a
+   * schema must still read.
+   */
+  @Test
+  def testExplicitSchemaLoadStillWorks(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath)
+    val schema = spark.read.format("hudi").load(basePath).schema
+    assertEquals(20, spark.read.format("hudi").schema(schema).load(basePath).count())
+  }
+
+  /** An empty table has no schema on disk; the explicit-schema path must not blow up on it. */
+  @Test
+  def testExplicitSchemaLoadOnSchemalessTableReturnsEmpty(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath)
+    val schema = spark.read.format("hudi").load(basePath).schema
+
+    val emptyPath = basePath + "_empty"
+    val emptyDF = spark.read.json(spark.sparkContext.emptyRDD[String])
+    emptyDF.write.format("hudi")
+      .options(CommonOptionUtils.commonOpts)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Overwrite)
+      .save(emptyPath)
+
+    assertEquals(0, spark.read.format("hudi").schema(schema).load(emptyPath).count())
+  }
+
+  @Test
+  def testSparkSqlReadIsUnaffected(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath)
+    val tableName = "test_default_source_read_paths"
+    spark.sql(s"create table $tableName using hudi location '$basePath'")
+    try {
+      assertEquals(20, spark.sql(s"select * from $tableName").count())
+    } finally {
+      spark.sql(s"drop table if exists $tableName")
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // the three rejections, each reported on its own terms
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The case from the report: plain partition paths, no wildcard anywhere, previously answered
+   * with a complaint about glob paths.
+   */
+  @Test
+  def testReadPathsWithPathReportsReadPathsNotGlob(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath)
+    val plainPartitionPaths = s"$basePath/2015/03/16,$basePath/2015/03/17"
+
+    val e = assertThrowsHoodie {
+      spark.read.format("hudi").option(readPathsKey, plainPartitionPaths).load(basePath).count()
+    }
+    assertTrue(e.getMessage.contains(readPathsKey), s"must name the option, got: ${e.getMessage}")
+    assertFalse(e.getMessage.toLowerCase.contains("glob"),
+      s"nothing here is a glob, so the message must not mention one, got: ${e.getMessage}")
+    assertPointsAtReplacement(e.getMessage)
+  }
+
+  /**
+   * read.paths with no path at all. This slipped past the old first guard, since that only fired
+   * when both were absent, and died further down instead.
+   */
+  @Test
+  def testReadPathsWithoutPathReportsReadPaths(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath)
+
+    val e = assertThrowsHoodie {
+      spark.read.format("hudi").option(readPathsKey, s"$basePath/2015/03/16").load().count()
+    }
+    assertTrue(e.getMessage.contains(readPathsKey), s"must name the option, got: ${e.getMessage}")
+    assertFalse(e.getMessage.toLowerCase.contains("glob"), s"not a glob, got: ${e.getMessage}")
+    assertPointsAtReplacement(e.getMessage)
+  }
+
+  /** Neither option set. Must not advertise read.paths, since setting it throws as well. */
+  @Test
+  def testNeitherOptionReportsPathOnly(): Unit = {
+    val e = assertThrowsHoodie {
+      spark.read.format("hudi").load().count()
+    }
+    assertTrue(e.getMessage.contains("'path' must be specified"), s"got: ${e.getMessage}")
+    assertFalse(e.getMessage.contains(readPathsKey),
+      s"read.paths also throws, so it must not be offered as the alternative, got: ${e.getMessage}")
+    assertPointsAtReplacement(e.getMessage)
+  }
+
+  @Test
+  def testGlobInPathReportsGlob(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath)
+
+    val e = assertThrowsHoodie {
+      spark.read.format("hudi").load(s"$basePath/2015/03/*").count()
+    }
+    assertTrue(e.getMessage.toLowerCase.contains("glob"), s"got: ${e.getMessage}")
+    assertFalse(e.getMessage.contains(readPathsKey),
+      s"read.paths was not set, so it must not appear, got: ${e.getMessage}")
+    assertPointsAtReplacement(e.getMessage)
+  }
+
+  /**
+   * Both wrong at once. read.paths is reported, because the option is gone outright and its
+   * replacement covers the glob case too.
+   */
+  @Test
+  def testReadPathsWinsOverGlobInPath(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath)
+
+    val e = assertThrowsHoodie {
+      spark.read.format("hudi")
+        .option(readPathsKey, s"$basePath/2015/03/16")
+        .load(s"$basePath/2015/03/*")
+        .count()
+    }
+    assertTrue(e.getMessage.contains(readPathsKey), s"read.paths must win, got: ${e.getMessage}")
+    assertFalse(e.getMessage.toLowerCase.contains("glob"),
+      s"the glob message must not win, got: ${e.getMessage}")
+  }
+
+  /**
+   * An explicitly empty value still counts as setting the option. optParams carries Some(""), and
+   * pre-1.2.0 threw on it too, so this keeps the rejection rather than quietly ignoring the key.
+   */
+  @Test
+  def testEmptyReadPathsIsStillRejected(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath)
+
+    val e = assertThrowsHoodie {
+      spark.read.format("hudi").option(readPathsKey, "").load(basePath).count()
+    }
+    assertTrue(e.getMessage.contains(readPathsKey), s"got: ${e.getMessage}")
+    assertPointsAtReplacement(e.getMessage)
+  }
+
+  /** The message the user actually reads has to differ per cause, not just internally. */
+  @Test
+  def testTheThreeRejectionsDoNotShareAMessage(): Unit = {
+    writeTable(HoodieTableType.COPY_ON_WRITE, basePath)
+
+    val readPathsMsg = assertThrowsHoodie {
+      spark.read.format("hudi").option(readPathsKey, s"$basePath/2015/03/16").load(basePath).count()
+    }.getMessage
+    val noPathMsg = assertThrowsHoodie {
+      spark.read.format("hudi").load().count()
+    }.getMessage
+    val globMsg = assertThrowsHoodie {
+      spark.read.format("hudi").load(s"$basePath/2015/03/*").count()
+    }.getMessage
+
+    assertNotEquals(readPathsMsg, noPathMsg)
+    assertNotEquals(readPathsMsg, globMsg)
+    assertNotEquals(noPathMsg, globMsg)
+  }
+
+  /**
+   * Spark wraps datasource failures, so unwrap to the HoodieException the datasource raised rather
+   * than asserting on whatever Spark happened to wrap it in.
+   */
+  private def assertThrowsHoodie(f: => Unit): HoodieException = {
+    val thrown = try {
+      f
+      null
+    } catch {
+      case t: Throwable => t
+    }
+    assertTrue(thrown != null, "expected the read to fail, but it succeeded")
+
+    var cause: Throwable = thrown
+    while (cause != null && !cause.isInstanceOf[HoodieException]) {
+      cause = cause.getCause
+    }
+    assertTrue(cause != null, s"expected a HoodieException somewhere in the chain, got: $thrown")
+    cause.asInstanceOf[HoodieException]
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15174.

#14060 removed glob path support and deprecated `hoodie.datasource.read.paths` in 1.2.0, replacing
the globbing logic with an unconditional throw. The three rejections in `DefaultSource`'s 3-arg
`createRelation` ended up sharing one condition and one message, so the message rarely describes
what the caller actually did.

**A non-glob value is reported as an unsupported glob.** The guard is:

```scala
if (path.exists(_.contains("*")) || readPaths.nonEmpty) {
  throw new HoodieException("Glob paths are not supported for read paths as of Hudi 1.2.0")
}
```

`readPaths.nonEmpty` has nothing to do with wildcards, so a caller passing plain partition paths:

```scala
spark.read.format("hudi")
  .option("hoodie.datasource.read.paths", "prefix/part1,prefix/part2")
  .load(basePath)
```

is told their non-glob paths are unsupported glob paths. There is no wildcard anywhere in that call
and nothing in the message to act on.

**The missing-path message advertises an option that throws.** The guard above it says:

```
'path' or 'hoodie.datasource.read.paths' or both must be specified.
```

A caller who follows that and sets `hoodie.datasource.read.paths` reaches the throw quoted above.

**The config documentation still describes the option as usable.** `READ_PATHS` carries
`@Deprecated` but no `deprecatedAfter(...)`, and reads "Comma separated list of file paths to read
within a Hudi table", with nothing to say that setting it now fails the read.

### Summary and Changelog

The rejections are unchanged. What changes is that each one now says what happened and what to do
instead.

- Split the conflated guard into three independent checks: `read.paths` is set, no `path` was given,
  `path` contains a glob. Each throws its own message.
- Every message names the supported replacement, so no rejection says only what does not work: load
  the table base path and filter on the partition columns. Those predicates are pushed down and
  prune partitions before any file is listed, via `HoodieFileIndex#prunePartitionsAndGetFileSlices`,
  which is what selecting paths by hand was for.
- The missing-path message no longer offers `read.paths` as the alternative, since setting it throws.
- All three checks run before `HoodieStorageUtils.getStorage(...)`, so a call that cannot succeed no
  longer opens a storage handle first. The now-dead `readPaths` and `allPaths` locals are gone, and
  `allPaths.head` becomes `path.get`, which is safe because `path.isEmpty` is rejected above it.
- `READ_PATHS` gains `deprecatedAfter("1.2.0")`, and its documentation states that the option now
  fails the read and what to use instead.

Two cases that needed a deliberate choice rather than falling out of the code:

**When both `read.paths` is set and `path` contains a glob, `read.paths` is reported.** It is the
more fundamental of the two: the option is gone outright, and the replacement it points at resolves
the glob case as well. Pinned by `testReadPathsWinsOverGlobInPath`.

**An explicitly empty `read.paths=""` is still rejected.** `optParams.get` yields `Some("")`, so the
key counts as set. 1.2.0 already rejected it, since `Some("")` made the old `readPaths.nonEmpty`
check true, and treating it as unset here would turn a throw into a successful read. Pinned by
`testEmptyReadPathsIsStillRejected`.

### Impact

None on behaviour. `read.paths` and glob paths are rejected before this change and after it, an
empty `read.paths` is rejected in both, and every read that worked before still works. Only the
wording of the three exceptions and the `READ_PATHS` documentation change.

Users who hit these errors now get a message that matches their input and names the replacement.

### Risk Level

low

Confined to three error paths in one method plus a config doc string. No change to relation
construction, planning or reads. Covered by a new suite of 13 tests, and reverting the change fails
exactly the 7 of them that assert the messages while the 6 no-regression tests keep passing.

### Documentation Update

The `hoodie.datasource.read.paths` config description is updated in this PR to say the option now
fails the read and to point at loading the base path with partition predicates instead. It also
gains `deprecatedAfter("1.2.0")`, so it is rendered as deprecated since that release. No Hudi website
change is needed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
