### PR TITLE
[HUDI-5621] Decouple Hive from integ-test-bundle [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -139,10 +139,7 @@
                   <include>org.apache.spark:spark-streaming-kafka-0-10_${scala.binary.version}</include>
                   <include>com.101tec:zkclient</include>
 
-                  <include>org.apache.hive:hive-common</include>
-                  <include>org.apache.hive:hive-service</include>
-                  <include>org.apache.hive:hive-jdbc</include>
-                  <include>org.apache.hive:hive-exec</include>
+                  
 
                   <include>com.yammer.metrics:metrics-core</include>
 
@@ -198,46 +195,7 @@
                   <pattern>org.apache.commons.io.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.commons.io.</shadedPattern>
                 </relocation>
-                <relocation>
-                  <pattern>org.apache.hive.jdbc.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hive.jdbc.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.hive.common.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hive.common.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.hadoop.hive.common.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hadoop.hive.common.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.hadoop.hive.shims.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hadoop.hive.shims.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.hadoop.hive.thrift.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hadoop.hive.thrift.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.hadoop.hive.serde2.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hadoop.hive.serde2.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.hadoop.hive.io.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hadoop.hive.io.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.hive.service.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hive.service.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.hadoop.hive.service.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hadoop_hive.service.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.hive.org.apache.thrift.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hive.org.apache.thrift.</shadedPattern>
-                </relocation>
+                
                 <relocation>
                   <pattern>org.apache.thrift.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.thrift.</shadedPattern>
@@ -245,10 +203,6 @@
                 <relocation>
                   <pattern>com.facebook.fb303.</pattern>
                   <shadedPattern>org.apache.hudi.com.facebook.fb303.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.hive.jdbc.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.hive.jdbc.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.codahale.metrics.</pattern>
@@ -464,84 +418,6 @@
     </dependency>
 
     <dependency>
-      <groupId>${hive.groupid}</groupId>
-      <artifactId>hive-exec</artifactId>
-      <version>${hive.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.pentaho</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>${hive.groupid}</groupId>
-      <artifactId>hive-metastore</artifactId>
-      <version>${hive.version}</version>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.hbase</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>${hive.groupid}</groupId>
-      <artifactId>hive-jdbc</artifactId>
-      <version>${hive.version}</version>
-      <classifier>standalone</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.pentaho</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>${hive.groupid}</groupId>
-      <artifactId>hive-jdbc</artifactId>
-      <version>${hive.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>${hive.groupid}</groupId>
-      <artifactId>hive-common</artifactId>
-      <version>${hive.version}</version>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.13</version>
@@ -703,3 +579,4 @@
 
   </dependencies>
 </project>
+


### PR DESCRIPTION
### Change Logs

Remove the direct `org.apache.hive:*` dependencies from the integ-test bundle pom, along with the corresponding shade includes and relocations. The Hive functionality is still available through the separate `hudi-hive-sync-bundle` module, which is the dedicated bundle for Hive sync operations.

### Impact

- The `hudi-integ-test-bundle` no longer bundles Hive artifacts directly
- Hive sync functionality is still available via `hudi-hive-sync-bundle`
- `hudi-hive-sync` (Hudi's own module) is still included in the bundle as before
- Follows the same pattern as HUDI-9020 (Remove HBase dependencies from Hudi)

### Checklist

- [x] Commit message follows the pattern `[HUDI-5621] ...`
- [x] Changes are limited to `packaging/hudi-integ-test-bundle/pom.xml`
- [x] Removed: `org.apache.hive:*` dependencies (hive-exec, hive-metastore, hive-jdbc, hive-common)
- [x] Removed: `org.apache.hive:*` and `org.apache.hadoop.hive:*` shade includes
- [x] Removed: Hive-specific shade relocations (11 relocations)

Fixes #15724