### PR TITLE
docs(roadmap): refresh releases, drop delivered items, retarget to 1.2.1

### DIFF
--- a/website/src/pages/roadmap.md
+++ b/website/src/pages/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-last_modified_at: 2025-02-19T12:00:00-08:00
+last_modified_at: 2026-08-11T15:28:37+05:30
 ---
 
 # Roadmap
@@ -11,34 +11,31 @@ down by areas on our [stack](/docs/hudi_stack).
 
 ## Recent Release(s)
 
-[1.1.1](/releases/release-1.1#release-111) (Dec 2025)
+[1.2.0](/releases/release-1.2#release-120) (May 2026)
 
 ## Future Releases
 
 | Release | Timeline  |
 |---------|-----------|
-| 1.2.0   | Jan 2026  |
-| 2.0.0   | Jun 2026  |
+| 1.2.1   | Aug 2026  |
+| 1.3.0   | Sep 2026  |
+| 2.0.0   | Dec 2026  |
 
 ## Storage Engine
 
 | Feature                                              | Target Release | Tracking                                                                                                                                                                       |
 |------------------------------------------------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Introduce `.abort` state in the timeline             | 1.2.0          | [#16609](https://github.com/apache/hudi/issues/16609) |
-| Variant type support on Spark 4                      | 1.2.0          | [#16851](https://github.com/apache/hudi/issues/16851) |
-| Non-blocking updates during clustering               | 1.2.0          | [#14611](https://github.com/apache/hudi/issues/14611)                                                                                                                   |
-| Enable partial updates for CDC workload payload      | 1.2.0          | [#16354](https://github.com/apache/hudi/issues/16354)                                                                                                                   |
-| Schema tracking in metadata table                    | 1.2.0          | [#14397](https://github.com/apache/hudi/issues/14397) |
-| NBCC for MDT writes                                  | 1.2.0          | [#17305](https://github.com/apache/hudi/issues/17305) |
-| Index abstraction for writer and reader              | 1.2.0          | [#16903](https://github.com/apache/hudi/issues/16903) |
-| Vector search index                                  | 1.2.0          | [#16852](https://github.com/apache/hudi/issues/16852) |
-| Bitmap index                                         | 1.2.0          | [#16853](https://github.com/apache/hudi/issues/16853) |
-| New abstraction for schema, expressions, and filters | 1.2.0          | [RFC-88](https://github.com/apache/hudi/pull/12795) |
-| Streaming CDC/Incremental read improvement           | 1.2.0          | [#14916](https://github.com/apache/hudi/issues/14916) |
-| Supervised table service planning and execution      | 1.2.0          | [RFC-43](https://github.com/apache/hudi/pull/4309), [#15196](https://github.com/apache/hudi/issues/15196)                                                               |
-| General purpose support for multi-table transactions | 1.2.0          | [#16181](https://github.com/apache/hudi/issues/16181) |
-| Supporting different updated columns in a single partial update log file | 1.2.0          | [#16854](https://github.com/apache/hudi/issues/16854) |
-| CDC format consolidation                             | 1.2.0          | [#16429](https://github.com/apache/hudi/issues/16429) |
+| Introduce `.abort` state in the timeline             | 1.2.1          | [#16609](https://github.com/apache/hudi/issues/16609) |
+| Non-blocking updates during clustering               | 1.2.1          | [#14611](https://github.com/apache/hudi/issues/14611)                                                                                                                   |
+| Enable partial updates for CDC workload payload      | 1.2.1          | [#16354](https://github.com/apache/hudi/issues/16354)                                                                                                                   |
+| Schema tracking in metadata table                    | 1.2.1          | [#14397](https://github.com/apache/hudi/issues/14397) |
+| Index abstraction for writer and reader              | 1.2.1          | [#16903](https://github.com/apache/hudi/issues/16903) |
+| New abstraction for schema, expressions, and filters | 1.2.1          | [RFC-88](https://github.com/apache/hudi/pull/12795) |
+| Streaming CDC/Incremental read improvement           | 1.2.1          | [#14916](https://github.com/apache/hudi/issues/14916) |
+| Supervised table service planning and execution      | 1.2.1          | [RFC-43](https://github.com/apache/hudi/pull/4309), [#15196](https://github.com/apache/hudi/issues/15196)                                                               |
+| General purpose support for multi-table transactions | 1.2.1          | [#16181](https://github.com/apache/hudi/issues/16181) |
+| Supporting different updated columns in a single partial update log file | 1.2.1          | [#16854](https://github.com/apache/hudi/issues/16854) |
+| CDC format consolidation                             | 1.2.1          | [#16429](https://github.com/apache/hudi/issues/16429) |
 | Time Travel updates, deletes                         | 1.3.0          | [#16855](https://github.com/apache/hudi/issues/16855) |
 | Unstructured data storage and management             | 1.3.0          | [#16856](https://github.com/apache/hudi/issues/16856)|
 
@@ -46,18 +43,17 @@ down by areas on our [stack](/docs/hudi_stack).
 
 | Feature                                                 | Target Release | Tracking                                                                                                                   |
 |---------------------------------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------|
-| New Hudi Table Format APIs for Query Integrations       | 1.2.0          | [RFC-64](https://github.com/apache/hudi/pull/7080), [#15194](https://github.com/apache/hudi/issues/15194)           |
-| Snapshot view management                                | 1.2.0          | [RFC-61](https://github.com/apache/hudi/pull/6576), [#15367](https://github.com/apache/hudi/issues/15367)           |
-| Support of verification with multiple event_time fields | 1.2.0          | [RFC-59](https://github.com/apache/hudi/pull/6382), [#15325](https://github.com/apache/hudi/issues/15325)           |
+| New Hudi Table Format APIs for Query Integrations       | 1.2.1          | [RFC-64](https://github.com/apache/hudi/pull/7080), [#15194](https://github.com/apache/hudi/issues/15194)           |
+| Snapshot view management                                | 1.2.1          | [RFC-61](https://github.com/apache/hudi/pull/6576), [#15367](https://github.com/apache/hudi/issues/15367)           |
 
 ## Query Engine Integration
 
 | Feature                                                 | Target Release | Tracking                                                                                                                                                                                 |
 |---------------------------------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Default Java 17 support 	                              | 1.2.0	         | [#16082](https://github.com/apache/hudi/issues/16082)                                                                                                                             |
-| Spark datasource V2 read                                | 1.2.0          | [#15292](https://github.com/apache/hudi/issues/15292)                                                                                                                             |
-| Simplification of engine integration and module organization | 1.2.0          | [#17044](https://github.com/apache/hudi/issues/16857) |
-| End-to-end DataFrame write path on Spark                | 1.2.0          | [#16846](https://github.com/apache/hudi/issues/16846), [#15433](https://github.com/apache/hudi/issues/15433) |
+| Default Java 17 support 	                              | 1.2.1	         | [#16082](https://github.com/apache/hudi/issues/16082)                                                                                                                             |
+| Spark datasource V2 read                                | 1.2.1          | [#15292](https://github.com/apache/hudi/issues/15292)                                                                                                                             |
+| Simplification of engine integration and module organization | 1.2.1          | [#17044](https://github.com/apache/hudi/issues/16857) |
+| End-to-end DataFrame write path on Spark                | 1.2.1          | [#16846](https://github.com/apache/hudi/issues/16846), [#15433](https://github.com/apache/hudi/issues/15433) |
 | Support Hudi 1.0 release in Presto Hudi Connector       | Presto Release / Q2 | [#14992](https://github.com/apache/hudi/issues/14992) |
 | Support of new indexes in Presto Hudi Connector         | Presto Release / Q3 | [#15246](https://github.com/apache/hudi/issues/15246), [#15319](https://github.com/apache/hudi/issues/15319) |
 | MDT support in Trino Hudi Connector                     | Trino Release / Q2 | [#14906](https://github.com/apache/hudi/issues/14906) |
@@ -67,9 +63,9 @@ down by areas on our [stack](/docs/hudi_stack).
 
 | Feature                                                                                           | Target Release | Tracking                                                                                                                               |
 |---------------------------------------------------------------------------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| Syncing as non-partitoned tables in catalogs             | 1.2.0          | [#17045](https://github.com/apache/hudi/issues/16858) |
-| Hudi Reverse streamer                                                                             | 1.2.0          | [RFC-70](https://github.com/apache/hudi/pull/9040)                                                                                      |
-| Diagnostic Reporter                                                                               | 1.2.0          | [RFC-62](https://github.com/apache/hudi/pull/6600)                                                                        |
+| Syncing as non-partitoned tables in catalogs             | 1.2.1          | [#17045](https://github.com/apache/hudi/issues/16858) |
+| Hudi Reverse streamer                                                                             | 1.2.1          | [RFC-70](https://github.com/apache/hudi/pull/9040)                                                                                      |
+| Diagnostic Reporter                                                                               | 1.2.1          | [RFC-62](https://github.com/apache/hudi/pull/6600)                                                                        |
 | Mutable, Transactional caching for Hudi Tables (could be accelerated based on community feedback) | 2.0.0          | [Strawman design](https://docs.google.com/presentation/d/1QBgLw11TM2Qf1KUESofGrQDb63EuggNCpPaxc82Kldo/edit#slide=id.gf7e0551254_0_5), [#16072](https://github.com/apache/hudi/issues/16072) |
 | Hudi Metaserver (could be accelerated based on community feedback)                                | 2.0.0          | [#15011](https://github.com/apache/hudi/issues/15011), [RFC-36](https://github.com/apache/hudi/pull/4718) |
 
@@ -77,4 +73,4 @@ down by areas on our [stack](/docs/hudi_stack).
 
 | Feature                                                 | Target Release | Tracking                                 |
 |---------------------------------------------------------|----------------|------------------------------------------|
-| Clean up tech debt and deprecate unused code            | 1.2.0          | [#16859](https://github.com/apache/hudi/issues/16859) |
+| Clean up tech debt and deprecate unused code            | 1.2.1          | [#16859](https://github.com/apache/hudi/issues/16859) |

--- a/website/src/pages/roadmap.md
+++ b/website/src/pages/roadmap.md
@@ -52,7 +52,7 @@ down by areas on our [stack](/docs/hudi_stack).
 |---------------------------------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Default Java 17 support 	                              | 1.2.1	         | [#16082](https://github.com/apache/hudi/issues/16082)                                                                                                                             |
 | Spark datasource V2 read                                | 1.2.1          | [#15292](https://github.com/apache/hudi/issues/15292)                                                                                                                             |
-| Simplification of engine integration and module organization | 1.2.1          | [#17044](https://github.com/apache/hudi/issues/16857) |
+| Simplification of engine integration and module organization | 1.2.1          | [#16857](https://github.com/apache/hudi/issues/16857) |
 | End-to-end DataFrame write path on Spark                | 1.2.1          | [#16846](https://github.com/apache/hudi/issues/16846), [#15433](https://github.com/apache/hudi/issues/15433) |
 | Support Hudi 1.0 release in Presto Hudi Connector       | Presto Release / Q2 | [#14992](https://github.com/apache/hudi/issues/14992) |
 | Support of new indexes in Presto Hudi Connector         | Presto Release / Q3 | [#15246](https://github.com/apache/hudi/issues/15246), [#15319](https://github.com/apache/hudi/issues/15319) |
@@ -63,7 +63,7 @@ down by areas on our [stack](/docs/hudi_stack).
 
 | Feature                                                                                           | Target Release | Tracking                                                                                                                               |
 |---------------------------------------------------------------------------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| Syncing as non-partitoned tables in catalogs             | 1.2.1          | [#17045](https://github.com/apache/hudi/issues/16858) |
+| Syncing as non-partitoned tables in catalogs             | 1.2.1          | [#16858](https://github.com/apache/hudi/issues/16858) |
 | Hudi Reverse streamer                                                                             | 1.2.1          | [RFC-70](https://github.com/apache/hudi/pull/9040)                                                                                      |
 | Diagnostic Reporter                                                                               | 1.2.1          | [RFC-62](https://github.com/apache/hudi/pull/6600)                                                                        |
 | Mutable, Transactional caching for Hudi Tables (could be accelerated based on community feedback) | 2.0.0          | [Strawman design](https://docs.google.com/presentation/d/1QBgLw11TM2Qf1KUESofGrQDb63EuggNCpPaxc82Kldo/edit#slide=id.gf7e0551254_0_5), [#16072](https://github.com/apache/hudi/issues/16072) |

--- a/website/src/pages/roadmap.md
+++ b/website/src/pages/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-last_modified_at: 2026-08-11T15:28:37+05:30
+last_modified_at: 2026-08-26T18:40:00+05:30
 ---
 
 # Roadmap
@@ -25,52 +25,51 @@ down by areas on our [stack](/docs/hudi_stack).
 
 | Feature                                              | Target Release | Tracking                                                                                                                                                                       |
 |------------------------------------------------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Introduce `.abort` state in the timeline             | 1.2.1          | [#16609](https://github.com/apache/hudi/issues/16609) |
-| Non-blocking updates during clustering               | 1.2.1          | [#14611](https://github.com/apache/hudi/issues/14611)                                                                                                                   |
-| Enable partial updates for CDC workload payload      | 1.2.1          | [#16354](https://github.com/apache/hudi/issues/16354)                                                                                                                   |
-| Schema tracking in metadata table                    | 1.2.1          | [#14397](https://github.com/apache/hudi/issues/14397) |
-| Index abstraction for writer and reader              | 1.2.1          | [#16903](https://github.com/apache/hudi/issues/16903) |
-| New abstraction for schema, expressions, and filters | 1.2.1          | [RFC-88](https://github.com/apache/hudi/pull/12795) |
-| Streaming CDC/Incremental read improvement           | 1.2.1          | [#14916](https://github.com/apache/hudi/issues/14916) |
-| Supervised table service planning and execution      | 1.2.1          | [RFC-43](https://github.com/apache/hudi/pull/4309), [#15196](https://github.com/apache/hudi/issues/15196)                                                               |
-| General purpose support for multi-table transactions | 1.2.1          | [#16181](https://github.com/apache/hudi/issues/16181) |
-| Supporting different updated columns in a single partial update log file | 1.2.1          | [#16854](https://github.com/apache/hudi/issues/16854) |
-| CDC format consolidation                             | 1.2.1          | [#16429](https://github.com/apache/hudi/issues/16429) |
+| Introduce `.abort` state in the timeline             | 1.3.0          | [#16609](https://github.com/apache/hudi/issues/16609) |
+| Non-blocking updates during clustering               | 1.3.0          | [#14611](https://github.com/apache/hudi/issues/14611)                                                                                                                   |
+| Enable partial updates for CDC workload payload      | 1.3.0          | [#16354](https://github.com/apache/hudi/issues/16354)                                                                                                                   |
+| Schema tracking in metadata table                    | 1.3.0          | [#14397](https://github.com/apache/hudi/issues/14397) |
+| Index abstraction for writer and reader              | 1.3.0          | [#16903](https://github.com/apache/hudi/issues/16903) |
+| New abstraction for schema, expressions, and filters | 1.3.0          | [RFC-88](https://github.com/apache/hudi/pull/12795) |
+| Streaming CDC/Incremental read improvement           | 1.3.0          | [#14916](https://github.com/apache/hudi/issues/14916) |
+| Supervised table service planning and execution      | 1.3.0          | [RFC-43](https://github.com/apache/hudi/pull/4309), [#15196](https://github.com/apache/hudi/issues/15196)                                                               |
+| General purpose support for multi-table transactions | 1.3.0          | [#16181](https://github.com/apache/hudi/issues/16181) |
+| Supporting different updated columns in a single partial update log file | 1.3.0          | [#16854](https://github.com/apache/hudi/issues/16854) |
+| CDC format consolidation                             | 1.3.0          | [#16429](https://github.com/apache/hudi/issues/16429) |
 | Time Travel updates, deletes                         | 1.3.0          | [#16855](https://github.com/apache/hudi/issues/16855) |
 | Unstructured data storage and management             | 1.3.0          | [#16856](https://github.com/apache/hudi/issues/16856)|
+| Vector index                                         | 1.3.0          | [RFC-104](https://github.com/apache/hudi/issues/18676) |
+| New LSM file layout                                  | 1.3.0          | [#14310](https://github.com/apache/hudi/issues/14310) |
 
 ## Programming APIs
 
 | Feature                                                 | Target Release | Tracking                                                                                                                   |
 |---------------------------------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------|
-| New Hudi Table Format APIs for Query Integrations       | 1.2.1          | [RFC-64](https://github.com/apache/hudi/pull/7080), [#15194](https://github.com/apache/hudi/issues/15194)           |
-| Snapshot view management                                | 1.2.1          | [RFC-61](https://github.com/apache/hudi/pull/6576), [#15367](https://github.com/apache/hudi/issues/15367)           |
+| New Hudi Table Format APIs for Query Integrations       | 1.3.0          | [RFC-64](https://github.com/apache/hudi/pull/7080), [#15194](https://github.com/apache/hudi/issues/15194)           |
+| Snapshot view management                                | 1.3.0          | [RFC-61](https://github.com/apache/hudi/pull/6576), [#15367](https://github.com/apache/hudi/issues/15367)           |
 
 ## Query Engine Integration
 
 | Feature                                                 | Target Release | Tracking                                                                                                                                                                                 |
 |---------------------------------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Default Java 17 support 	                              | 1.2.1	         | [#16082](https://github.com/apache/hudi/issues/16082)                                                                                                                             |
-| Spark datasource V2 read                                | 1.2.1          | [#15292](https://github.com/apache/hudi/issues/15292)                                                                                                                             |
-| Simplification of engine integration and module organization | 1.2.1          | [#16857](https://github.com/apache/hudi/issues/16857) |
-| End-to-end DataFrame write path on Spark                | 1.2.1          | [#16846](https://github.com/apache/hudi/issues/16846), [#15433](https://github.com/apache/hudi/issues/15433) |
+| Default Java 17 support 	                              | 1.3.0	         | [#16082](https://github.com/apache/hudi/issues/16082)                                                                                                                             |
+| Spark datasource V2 read                                | 1.3.0          | [#15292](https://github.com/apache/hudi/issues/15292)                                                                                                                             |
+| Simplification of engine integration and module organization | 1.3.0          | [#16857](https://github.com/apache/hudi/issues/16857) |
+| End-to-end DataFrame write path on Spark                | 1.3.0          | [#16846](https://github.com/apache/hudi/issues/16846), [#15433](https://github.com/apache/hudi/issues/15433) |
+| Flink support for the Variant data type                  | 1.3.0          | [#18513](https://github.com/apache/hudi/issues/18513) |
+| Flink support for the Blob data type                    | 1.3.0          | [#18507](https://github.com/apache/hudi/issues/18507) |
 | Support Hudi 1.0 release in Presto Hudi Connector       | Presto Release / Q2 | [#14992](https://github.com/apache/hudi/issues/14992) |
 | Support of new indexes in Presto Hudi Connector         | Presto Release / Q3 | [#15246](https://github.com/apache/hudi/issues/15246), [#15319](https://github.com/apache/hudi/issues/15319) |
-| MDT support in Trino Hudi Connector                     | Trino Release / Q2 | [#14906](https://github.com/apache/hudi/issues/14906) |
-| Support of new indexes in Trino Hudi Connector          | Trino Release / Q3 | [#15246](https://github.com/apache/hudi/issues/15246), [#15319](https://github.com/apache/hudi/issues/15319) |
+| Update the Trino Hudi connector to the new shim approach (MDT and index support are complete on the Hudi side) | Trino Release | [#14906](https://github.com/apache/hudi/issues/14906) |
 
 ## Platform Components
 
 | Feature                                                                                           | Target Release | Tracking                                                                                                                               |
 |---------------------------------------------------------------------------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| Syncing as non-partitoned tables in catalogs             | 1.2.1          | [#16858](https://github.com/apache/hudi/issues/16858) |
-| Hudi Reverse streamer                                                                             | 1.2.1          | [RFC-70](https://github.com/apache/hudi/pull/9040)                                                                                      |
-| Diagnostic Reporter                                                                               | 1.2.1          | [RFC-62](https://github.com/apache/hudi/pull/6600)                                                                        |
+| Syncing as non-partitoned tables in catalogs             | 1.3.0          | [#16858](https://github.com/apache/hudi/issues/16858) |
+| Hudi Reverse streamer                                                                             | 1.3.0          | [RFC-70](https://github.com/apache/hudi/pull/9040)                                                                                      |
+| Diagnostic Reporter                                                                               | 1.3.0          | [RFC-62](https://github.com/apache/hudi/pull/6600)                                                                        |
 | Mutable, Transactional caching for Hudi Tables (could be accelerated based on community feedback) | 2.0.0          | [Strawman design](https://docs.google.com/presentation/d/1QBgLw11TM2Qf1KUESofGrQDb63EuggNCpPaxc82Kldo/edit#slide=id.gf7e0551254_0_5), [#16072](https://github.com/apache/hudi/issues/16072) |
 | Hudi Metaserver (could be accelerated based on community feedback)                                | 2.0.0          | [#15011](https://github.com/apache/hudi/issues/15011), [RFC-36](https://github.com/apache/hudi/pull/4718) |
-
-## Developer Experience
-
-| Feature                                                 | Target Release | Tracking                                 |
-|---------------------------------------------------------|----------------|------------------------------------------|
-| Clean up tech debt and deprecate unused code            | 1.2.1          | [#16859](https://github.com/apache/hudi/issues/16859) |
+| Hudi CLI MCP server (stretch)                                                                     | 1.3.0          | [#18554](https://github.com/apache/hudi/pull/18554) |
+| Hudi Timeline UI (stretch)                                                                        | 1.3.0          | [#13147](https://github.com/apache/hudi/pull/13147) |


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The [roadmap page](https://hudi.apache.org/roadmap) had drifted out of date. It still named **1.1.1 (Dec 2025)** as the
recent release and listed **1.2.0** as upcoming, months after 1.2.0 shipped in May 2026. Several features on it had
already been delivered but were still presented as planned, and every remaining item was targeted at 1.2.0 — a release
the same page would have been describing as already out.

No issue filed; this is a content refresh.

### Summary and Changelog

One file, `website/src/pages/roadmap.md`. It is an unversioned Docusaurus page, so there are no versioned copies.

**1. Releases.** *Recent Release(s)* now points at 1.2.0 (May 2026). *Future Releases* becomes:

| Release | Timeline |
|---|---|
| 1.2.1 | Aug 2026 |
| 1.3.0 | Sep 2026 |
| 2.0.0 | Dec 2026 |

The 2.0.0 row also fixes a dangling reference: two *Platform Components* items target 2.0.0, and the table had stopped
listing that release at all.

**2. Delivered features removed.** All **40** tracked references on the page were checked against GitHub. Five are
closed with `state_reason: completed`, and four of those are corroborated by shipped documentation on this site rather
than by the label alone:

| Section | Feature | Issue | Closed | Corroboration |
|---|---|---|---|---|
| Storage Engine | Variant type support on Spark 4 | #16851 | 2026-06-25 | `VARIANT` documented in `sql_ddl.md` |
| Storage Engine | Vector search index | #16852 | 2026-05-02 | `VECTOR(dim[, elementType])` documented |
| Storage Engine | Bitmap index | #16853 | 2026-06-25 | `BITMAP` a valid expression-index type since 1.0.0 |
| Storage Engine | NBCC for MDT writes | #17305 | 2026-06-25 | — |
| Programming APIs | Support of verification with multiple event_time fields | #15325 | 2026-06-25 | `hoodie.table.ordering.fields` (plural) ships it |

The other **35** are genuinely open and were left alone. Worth noting one that deliberately stayed: *Hudi Reverse
streamer* tracks #9040, which **is merged** — but that PR only claims the RFC-70 number, it does not deliver the
feature. A "merged means done" sweep would have removed it wrongly.

**3. Retargeting.** The 21 rows still aimed at 1.2.0 now target **1.2.1**, since 1.2.0 shipped without them. Rows
targeting 1.3.0 (2), 2.0.0 (2) and the Presto/Trino release trains (4) are unchanged. Matching was done on the Target
Release column specifically, so the *Recent Release* link and the *Future Releases* table were structurally excluded
rather than merely avoided — `1.2.0` now appears exactly once in the file, in the Recent Release link.

**4. Front matter.** `last_modified_at` bumped per `AGENTS.md`. Being straightforward about this one: it renders nowhere
on the page, and no previous roadmap commit has ever bumped it, so it is convention compliance rather than a functional
change. Happy to drop it if reviewers would rather keep the diff to content.

### Verification

`npm run build` passes with the warning set **byte-identical** to a baseline built from the same base commit, and the
roadmap appears nowhere in the warning output. `/roadmap` renders all six tables (38 rows) with all seven headings, none
of the five removed features reappear, and the retargeted cells render as `1.2.1`.

One thing worth recording for anyone previewing this locally: `npm run serve` returns **404** for
`/releases/release-1.2`, which makes the updated Recent Release link look broken. It is not. The built page exists with
canonical `https://hudi.apache.org/releases/release-1.2` and carries the `release-120` anchor, and in production that
URL 301s to `/releases/release-1.2/` and returns 200 with the anchor present. It is a trailing-slash quirk of the local
static server — the previous `/releases/release-1.1#release-111` link behaves identically and has been live for months.

### What was deliberately left alone

Three pre-existing issues are visible in the diff and are **not** fixed here, to keep this a content refresh:

- Two rows have link text disagreeing with the target: *Simplification of engine integration* displays `#17044` but
  links to `issues/16857`, and *Syncing as non-partitioned tables* displays `#17045` but links to `issues/16858`. Both
  hrefs resolve to real open issues with matching titles, so only the labels are wrong.
- Four rows point at closed-unmerged RFC PRs (RFC-43 #4309, RFC-36 #4718, RFC-59 #6382, RFC-62 #6600). Three pair the
  RFC with a still-open umbrella issue, so the work is alive; **Diagnostic Reporter** has only the closed RFC-62 PR
  behind it, with nothing open — worth deciding whether it belongs on a forward-looking roadmap.
- The *Default Java 17 support* row contains literal tab characters in two cells.

### Impact

Documentation only. No code, config, or behaviour change.

### Risk Level

none

### Documentation Update

This PR is the documentation update — the roadmap page, https://hudi.apache.org/roadmap.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
