### PR TITLE
fix(spark): read shredded variants through the CDC and legacy streaming paths, and restore partition values there

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -180,14 +180,8 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
       HoodieFileFormat.fromFileExtension(filePath.getFileExtension) == HoodieFileFormat.PARQUET
     val (readStructTypeForScan, variantOrdinals) =
       if (sparkRequiredSchema.isEmpty && isParquetBaseFile) {
-        sparkAdapter.buildFullVariantReadSchema(parquetReadStructType) match {
-          case Some(rewritten) =>
-            val ordinals = rewritten.fields.indices
-              .filter(i => rewritten.fields(i).dataType != parquetReadStructType.fields(i).dataType)
-              .toSet
-            (rewritten, ordinals)
-          case None => (parquetReadStructType, Set.empty[Int])
-        }
+        SparkFileFormatInternalRowReaderContext.fullVariantReadSchemaWithOrdinals(parquetReadStructType)
+          .getOrElse((parquetReadStructType, Set.empty[Int]))
       } else {
         (parquetReadStructType, Set.empty[Int])
       }
@@ -479,15 +473,28 @@ object SparkFileFormatInternalRowReaderContext {
   }
 
   /**
-   * Restores native VariantType columns from the full-variant projection shape requested for
-   * internal reads of parquet base files (see SparkAdapter.buildFullVariantReadSchema): each
-   * rewritten column is a struct with a single child "0" holding the reconstructed variant,
-   * so restoring is a projection of that child.
+   * Rewrites top-level VariantType fields of `structType` into the full-variant projection
+   * shape (see SparkAdapter.buildFullVariantReadSchema) and returns it with the ordinals of
+   * the rewritten fields, or None when nothing rewrites (no variant fields, or no shredded
+   * read support on this Spark version). Shared by this context and direct base-file reads
+   * that bypass it (CDCFileGroupIterator's BASE_FILE_INSERT case).
    */
-  private[hudi] def wrapWithVariantRestore(
-      iterator: ClosableIterator[InternalRow],
-      readSchema: StructType,
-      variantOrdinals: Set[Int]): ClosableIterator[InternalRow] = {
+  private[hudi] def fullVariantReadSchemaWithOrdinals(structType: StructType): Option[(StructType, Set[Int])] = {
+    SparkAdapterSupport.sparkAdapter.buildFullVariantReadSchema(structType).map { rewritten =>
+      val ordinals = rewritten.fields.indices
+        .filter(i => rewritten.fields(i).dataType != structType.fields(i).dataType)
+        .toSet
+      (rewritten, ordinals)
+    }
+  }
+
+  /**
+   * Projection restoring native VariantType columns from the full-variant projection shape:
+   * each rewritten column is a struct with a single child "0" holding the reconstructed
+   * variant, so restoring is a projection of that child. NOTE: UnsafeProjection reuses its
+   * output buffer; callers that buffer rows must copy them.
+   */
+  private[hudi] def variantRestoreProjection(readSchema: StructType, variantOrdinals: Set[Int]): UnsafeProjection = {
     val exprs: Seq[Expression] = readSchema.fields.zipWithIndex.map { case (field, i) =>
       val ref = BoundReference(i, field.dataType, field.nullable)
       if (variantOrdinals.contains(i)) {
@@ -496,7 +503,18 @@ object SparkFileFormatInternalRowReaderContext {
         ref: Expression
       }
     }.toSeq
-    val projection = UnsafeProjection.create(exprs)
+    UnsafeProjection.create(exprs)
+  }
+
+  /**
+   * Restores native VariantType columns from the full-variant projection shape requested for
+   * internal reads of parquet base files (see SparkAdapter.buildFullVariantReadSchema).
+   */
+  private[hudi] def wrapWithVariantRestore(
+      iterator: ClosableIterator[InternalRow],
+      readSchema: StructType,
+      variantOrdinals: Set[Int]): ClosableIterator[InternalRow] = {
+    val projection = variantRestoreProjection(readSchema, variantOrdinals)
     new ClosableIterator[InternalRow] {
       override def hasNext: Boolean = iterator.hasNext
       override def next(): InternalRow = projection(iterator.next())

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -427,11 +427,14 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
    * and pass this reader on parquet file. So that, we can query the partition columns.
    */
 
+  protected def getPartitionColumnsAsInternalRow(filePath: StoragePath): InternalRow =
+    getPartitionColumnsAsInternalRowInternal(filePath, metaClient.getBasePath, shouldExtractPartitionValuesFromPartitionPath)
+
   protected def getPartitionColumnsAsInternalRow(file: StoragePathInfo): InternalRow =
-    getPartitionColumnsAsInternalRowInternal(file, metaClient.getBasePath, shouldExtractPartitionValuesFromPartitionPath)
+    getPartitionColumnsAsInternalRow(file.getPath)
 
   protected def getPartitionColumnValuesAsInternalRow(file: StoragePathInfo): InternalRow =
-    getPartitionColumnsAsInternalRowInternal(file,
+    getPartitionColumnsAsInternalRowInternal(file.getPath,
       metaClient.getBasePath, extractPartitionValuesFromPartitionPath = true)
 
   protected def usePartitionValueExtractorOnRead(optParams: Map[String, String], sparkSession: SparkSession): Boolean = {
@@ -439,11 +442,11 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
       DataSourceReadOptions.USE_PARTITION_VALUE_EXTRACTOR_ON_READ.defaultValue).toBoolean
   }
 
-  protected def getPartitionColumnsAsInternalRowInternal(file: StoragePathInfo, basePath: StoragePath,
+  protected def getPartitionColumnsAsInternalRowInternal(filePath: StoragePath, basePath: StoragePath,
                                                          extractPartitionValuesFromPartitionPath: Boolean): InternalRow = {
     if (extractPartitionValuesFromPartitionPath) {
       val tablePathWithoutScheme = basePath.getPathWithoutSchemeAndAuthority
-      val partitionPathWithoutScheme = file.getPath.getParent.getPathWithoutSchemeAndAuthority
+      val partitionPathWithoutScheme = filePath.getParent.getPathWithoutSchemeAndAuthority
       val relativePath = tablePathWithoutScheme.toUri.relativize(partitionPathWithoutScheme.toUri).toString
       val timeZoneId = conf.get("timeZone", sparkSession.sessionState.conf.sessionLocalTimeZone)
       val rowValues = HoodieSparkUtils.parsePartitionColumnValues(

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDDV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDDV2.scala
@@ -33,6 +33,7 @@ import org.apache.hudi.common.table.log.InstantRange.RangeType
 import org.apache.hudi.common.table.read.{HoodieFileGroupReader, HoodieRecordReader}
 import org.apache.hudi.common.table.read.lsm.{HoodieLsmFileGroupReader, LsmReaderUtils}
 import org.apache.hudi.common.util.{Option => HOption}
+import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.collection.ClosableIterator
 import org.apache.hudi.hadoop.utils.HoodieRealtimeRecordReaderUtils.getMaxCompactionMemoryInBytes
 import org.apache.hudi.metadata.HoodieTableMetadata.getDataTableBasePathFromMetadataTable
@@ -47,7 +48,7 @@ import org.apache.spark.{HoodieSparkInputMetricsUtils, Partition, SerializableWr
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
+import org.apache.spark.sql.catalyst.expressions.{BoundReference, Expression, JoinedRow, UnsafeProjection}
 import org.apache.spark.sql.execution.datasources.{FileFormat, SparkColumnarFileReader}
 import org.apache.spark.sql.hudi.MultipleColumnarFileFormatReader
 import org.apache.spark.sql.internal.SQLConf
@@ -158,19 +159,25 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
   private val shouldRerouteVariantSplit: Boolean =
     sparkAdapter.buildFullVariantReadSchema(requiredSchema.structTypeSchema).isDefined
 
+  // Ordinal each table partition column occupies in the required schema, or -1 when it is not
+  // projected. Indexed by the table-config partition-field order, i.e. the very order in which
+  // HoodieBaseRelation#getPartitionColumnsAsInternalRow emits the values carried by a split.
+  // Resolved on the driver: only this array is shipped to the executors.
+  private val partitionColumnOrdinals: Array[Int] = {
+    val caseSensitive = sqlConf.caseSensitiveAnalysis
+    val requiredFieldNames = requiredSchema.structTypeSchema.fieldNames
+    metaClient.getTableConfig.getPartitionFields.orElse(Array.empty[String]).map { partitionColumn =>
+      requiredFieldNames.indexWhere(fieldName =>
+        if (caseSensitive) fieldName == partitionColumn else fieldName.equalsIgnoreCase(partitionColumn))
+    }
+  }
+
   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
     val partition = split.asInstanceOf[HoodieMergeOnReadPartition]
     val bytesReadCallback = HoodieSparkInputMetricsUtils.getFSBytesReadOnThreadCallback()
 
     val iter: Iterator[InternalRow] = partition.split match {
-      // A split whose partition values were parsed off the partition path keeps the fast path even
-      // when re-routing would apply: only that reader appends them (drop.partition.columns,
-      // extract-from-path, bootstrap fast read), and the file-group reader branch below has no
-      // equivalent, so re-routing would trade null variants for null partition columns. Those
-      // splits stay on the pre-existing behaviour; the same gap on the merged branch is older than
-      // this change and is tracked separately.
-      case dataFileOnlySplit if dataFileOnlySplit.logFiles.isEmpty
-        && (!shouldRerouteVariantSplit || dataFileOnlySplit.dataFile.exists(_.partitionValues.numFields > 0)) =>
+      case dataFileOnlySplit if dataFileOnlySplit.logFiles.isEmpty && !shouldRerouteVariantSplit =>
         val projectedReader = projectReader(fileReaders.requiredSchemaReaderSkipMerging, requiredSchema.structTypeSchema)
         projectedReader(dataFileOnlySplit.dataFile.get)
 
@@ -237,7 +244,7 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
                 .withInternalSchemaOpt(HOption.ofNullable(tableSchema.internalSchema.orNull))
                 .build()
             }
-          convertCloseableIterator(fileGroupReader.getClosableIterator)
+          convertCloseableIterator(fileGroupReader.getClosableIterator, partition.split.partitionValues)
         }
     }
 
@@ -282,13 +289,56 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
     }
   }
 
-  private def convertCloseableIterator(closeableFileGroupRecordIterator: ClosableIterator[InternalRow]): Iterator[InternalRow] = {
+  private def convertCloseableIterator(closeableFileGroupRecordIterator: ClosableIterator[InternalRow],
+                                       partitionValues: InternalRow): Iterator[InternalRow] = {
+    // NOTE: built here, i.e. once per split on the executor -- a projection is not serializable.
+    val mapper: InternalRow => InternalRow = partitionValueMapper(partitionValues).getOrElse(identity)
     new Iterator[InternalRow] with Closeable {
       override def hasNext: Boolean = closeableFileGroupRecordIterator.hasNext
 
-      override def next(): InternalRow = closeableFileGroupRecordIterator.next()
+      override def next(): InternalRow = mapper(closeableFileGroupRecordIterator.next())
 
       override def close(): Unit = closeableFileGroupRecordIterator.close()
+    }
+  }
+
+  /**
+   * Builds the mapper splicing a split's partition values into the rows the file-group reader
+   * produces, or None when there is nothing to splice.
+   *
+   * The file-group reader sources every projected column from the data files, so it hands back
+   * nulls for the partition columns whenever those are not persisted there
+   * ([["hoodie.datasource.write.drop.partition.columns"]], read-side extraction from the partition
+   * path, or a bootstrap data-queries-only read). Only the values parsed off the partition path
+   * carry them, which is what a split holds.
+   *
+   * Binding at existing ordinals is sufficient because the output row shape is already correct:
+   * [[org.apache.hudi.common.table.TableSchemaResolver]] re-appends dropped partition columns to
+   * the table schema, so the required schema keeps them and the reader merely fills them with
+   * nulls. No column is added, moved or dropped here.
+   *
+   * @param partitionValues values parsed off the partition path, in table-config partition-field
+   *                        order (matching [[partitionColumnOrdinals]]), empty when the partition
+   *                        columns are read from the data files as usual
+   */
+  private def partitionValueMapper(partitionValues: InternalRow): Option[InternalRow => InternalRow] = {
+    if (partitionValues.numFields == 0 || partitionColumnOrdinals.forall(_ < 0)) {
+      None
+    } else {
+      checkState(partitionValues.numFields == partitionColumnOrdinals.length,
+        s"Expected ${partitionColumnOrdinals.length} partition values but got ${partitionValues.numFields}")
+      val requiredFields = requiredSchema.structTypeSchema.fields
+      // NOTE: The partition values are bound as references into the right half of a JoinedRow rather
+      //       than substituted as literals: literals are inlined into the generated code, so every
+      //       distinct partition value would miss Spark's codegen cache.
+      val projectedFields: Seq[Expression] = requiredFields.zipWithIndex.map { case (field, ordinal) =>
+        val partitionFieldIdx = partitionColumnOrdinals.indexOf(ordinal)
+        val boundOrdinal = if (partitionFieldIdx >= 0) requiredFields.length + partitionFieldIdx else ordinal
+        BoundReference(boundOrdinal, field.dataType, field.nullable)
+      }.toSeq
+      val projection = UnsafeProjection.create(projectedFields)
+      val joinedRow = new JoinedRow()
+      Some((row: InternalRow) => projection.apply(joinedRow(row, partitionValues)))
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDDV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDDV2.scala
@@ -150,17 +150,27 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
 
   // The plain skip-merging reader cannot read a SHREDDED variant base file: it requests native
   // VariantType, which clips the shredded group to {metadata, value} and reads value=null (the
-  // #19556 defect family). Splits with variant columns take the file-group reader below, whose
-  // reader context requests the full-variant projection shape instead (#19578).
-  private val requiredSchemaHasVariant: Boolean =
-    requiredSchema.structTypeSchema.fields.exists(f => sparkAdapter.isVariantType(f.dataType))
+  // #19556 defect family). Such splits take the file-group reader below, whose reader context
+  // requests the full-variant projection shape instead (#19578). Keyed off the adapter building
+  // that shape rather than the mere presence of a variant column: it is None below Spark 4.1,
+  // where the file-group reader would read the same nulls, so re-routing there would cost the
+  // fast path for nothing.
+  private val shouldRerouteVariantSplit: Boolean =
+    sparkAdapter.buildFullVariantReadSchema(requiredSchema.structTypeSchema).isDefined
 
   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
     val partition = split.asInstanceOf[HoodieMergeOnReadPartition]
     val bytesReadCallback = HoodieSparkInputMetricsUtils.getFSBytesReadOnThreadCallback()
 
     val iter: Iterator[InternalRow] = partition.split match {
-      case dataFileOnlySplit if dataFileOnlySplit.logFiles.isEmpty && !requiredSchemaHasVariant =>
+      // A split whose partition values were parsed off the partition path keeps the fast path even
+      // when re-routing would apply: only that reader appends them (drop.partition.columns,
+      // extract-from-path, bootstrap fast read), and the file-group reader branch below has no
+      // equivalent, so re-routing would trade null variants for null partition columns. Those
+      // splits stay on the pre-existing behaviour; the same gap on the merged branch is older than
+      // this change and is tracked separately.
+      case dataFileOnlySplit if dataFileOnlySplit.logFiles.isEmpty
+        && (!shouldRerouteVariantSplit || dataFileOnlySplit.dataFile.exists(_.partitionValues.numFields > 0)) =>
         val projectedReader = projectReader(fileReaders.requiredSchemaReaderSkipMerging, requiredSchema.structTypeSchema)
         projectedReader(dataFileOnlySplit.dataFile.get)
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDDV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDDV2.scala
@@ -148,12 +148,19 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
     }
   }
 
+  // The plain skip-merging reader cannot read a SHREDDED variant base file: it requests native
+  // VariantType, which clips the shredded group to {metadata, value} and reads value=null (the
+  // #19556 defect family). Splits with variant columns take the file-group reader below, whose
+  // reader context requests the full-variant projection shape instead (#19578).
+  private val requiredSchemaHasVariant: Boolean =
+    requiredSchema.structTypeSchema.fields.exists(f => sparkAdapter.isVariantType(f.dataType))
+
   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
     val partition = split.asInstanceOf[HoodieMergeOnReadPartition]
     val bytesReadCallback = HoodieSparkInputMetricsUtils.getFSBytesReadOnThreadCallback()
 
     val iter: Iterator[InternalRow] = partition.split match {
-      case dataFileOnlySplit if dataFileOnlySplit.logFiles.isEmpty =>
+      case dataFileOnlySplit if dataFileOnlySplit.logFiles.isEmpty && !requiredSchemaHasVariant =>
         val projectedReader = projectReader(fileReaders.requiredSchemaReaderSkipMerging, requiredSchema.structTypeSchema)
         projectedReader(dataFileOnlySplit.dataFile.get)
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
@@ -37,7 +37,8 @@ import org.apache.spark.sql.types.StructType
 import scala.collection.JavaConverters._
 
 case class HoodieMergeOnReadFileSplit(dataFile: Option[PartitionedFile],
-                                      logFiles: List[HoodieLogFile]) extends HoodieFileSplit
+                                      logFiles: List[HoodieLogFile],
+                                      partitionValues: InternalRow = InternalRow.empty) extends HoodieFileSplit
 
 case class MergeOnReadSnapshotRelation(override val sqlContext: SQLContext,
                                        override val optParams: Map[String, String],
@@ -132,7 +133,15 @@ abstract class BaseMergeOnReadSnapshotRelation(sqlContext: SQLContext,
           getPartitionColumnsAsInternalRow(file.getPathInfo), file.getPathInfo.getPath, 0, file.getFileSize)
       }
 
-      HoodieMergeOnReadFileSplit(partitionedBaseFile, logFiles)
+      // These values are empty unless the partition columns are omitted from the data files, which is
+      // exactly when a reader has to splice them back into the rows it produces. A log-only slice still
+      // lives in the partition directory, so a log file's path resolves them just as the base file does.
+      // NOTE: HoodieLogFile#getPathInfo is transient and null for log files built from a path.
+      val partitionValues = partitionedBaseFile.map(_.partitionValues).getOrElse {
+        logFiles.headOption.map(f => getPartitionColumnsAsInternalRow(f.getPath)).getOrElse(InternalRow.empty)
+      }
+
+      HoodieMergeOnReadFileSplit(partitionedBaseFile, logFiles, partitionValues)
     }.toList
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadSnapshotRelation.scala
@@ -133,9 +133,11 @@ abstract class BaseMergeOnReadSnapshotRelation(sqlContext: SQLContext,
           getPartitionColumnsAsInternalRow(file.getPathInfo), file.getPathInfo.getPath, 0, file.getFileSize)
       }
 
-      // These values are empty unless the partition columns are omitted from the data files, which is
-      // exactly when a reader has to splice them back into the rows it produces. A log-only slice still
-      // lives in the partition directory, so a log file's path resolves them just as the base file does.
+      // Non-empty exactly when a reader has to take the partition columns off the path rather than the
+      // data files, i.e. on any of shouldExtractPartitionValuesFromPartitionPath's triggers: dropped
+      // partition columns, the extract-from-path read option (which also covers tables that do persist
+      // them), or a bootstrap data-queries-only read. A log-only slice still lives in the partition
+      // directory, so a log file's path resolves them just as the base file does.
       // NOTE: HoodieLogFile#getPathInfo is transient and null for log files built from a path.
       val partitionValues = partitionedBaseFile.map(_.partitionValues).getOrElse {
         logFiles.headOption.map(f => getPartitionColumnsAsInternalRow(f.getPath)).getOrElse(InternalRow.empty)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
@@ -378,8 +378,24 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
 
           val pf = sparkPartitionedFileUtils.createPartitionedFile(
             InternalRow.empty, absCDCPath, 0, fileStatus.getLength)
-          recordIter = baseFileReader.read(pf, originTableSchema.structTypeSchema, new StructType(),
-            toJavaOption(originTableSchema.internalSchema), Seq.empty, conf, tableSchemaOpt)
+          // This read bypasses SparkFileFormatInternalRowReaderContext, so it needs the same
+          // full-variant treatment that context applies: requesting native VariantType against
+          // a SHREDDED base file clips the shredded group to {metadata, value} and reads
+          // value=null, which would surface as null variants in the insert after-images
+          // (#19556 family, #19578). The restore projection reuses one output buffer, hence
+          // the copy before buffering.
+          val baseRows = SparkFileFormatInternalRowReaderContext
+            .fullVariantReadSchemaWithOrdinals(originTableSchema.structTypeSchema) match {
+            case Some((rewritten, ordinals)) =>
+              val restore = SparkFileFormatInternalRowReaderContext.variantRestoreProjection(rewritten, ordinals)
+              baseFileReader.read(pf, rewritten, new StructType(),
+                toJavaOption(originTableSchema.internalSchema), Seq.empty, conf, tableSchemaOpt)
+                .map(row => restore(row).copy(): InternalRow)
+            case None =>
+              baseFileReader.read(pf, originTableSchema.structTypeSchema, new StructType(),
+                toJavaOption(originTableSchema.internalSchema), Seq.empty, conf, tableSchemaOpt)
+          }
+          recordIter = baseRows
             .map(record => BufferedRecords.fromEngineRecord(record, schema, readerContext.getRecordContext, orderingFieldNames, false))
         case BASE_FILE_DELETE =>
           assert(currentCDCFileSplit.getBeforeFileSlice.isPresent)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
@@ -21,6 +21,7 @@ package org.apache.hudi.cdc
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.databind.util.RawValue
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
@@ -33,6 +34,9 @@ class InternalRowToJsonStringConverter(schema: StructType) {
     val _mapper = new ObjectMapper
     _mapper.setSerializationInclusion(Include.NON_ABSENT)
     _mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    // The variant branch below embeds its input verbatim once readTree accepts it, and readTree on
+    // its own is happy to parse a valid prefix and leave the rest unconsumed.
+    _mapper.configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, true)
     _mapper.registerModule(DefaultScalaModule)
     _mapper
   }
@@ -92,15 +96,25 @@ class InternalRowToJsonStringConverter(schema: StructType) {
             case _ => value // fallback
           }
         case dt if dt.typeName == InternalRowToJsonStringConverter.VARIANT_TYPE_NAME =>
-          // VariantVal.toString renders the variant as JSON; embed it as a real JSON node so
-          // the image carries the variant's structure. Falling through to the default would
-          // serialize the VariantVal bean, i.e. its raw value/metadata bytes as base64.
+          // VariantVal.toString renders the variant as JSON; embed that rendering verbatim so the
+          // image carries the variant's structure. Falling through to the default would serialize
+          // the VariantVal bean, i.e. its raw value/metadata bytes as base64.
           // Matched on the type name rather than SparkAdapter.isVariantType: this guard is
           // evaluated for every non-string/array/map/struct field, and resolving the adapter
           // needs a version module that is not on hudi-spark-common's own test classpath.
           val variantJson = value.toString
           try {
-            mapper.readTree(variantJson)
+            // readTree is a validation gate only, and its result is discarded: embedding the parsed
+            // node instead would re-serialize the tree through the generator, and Jackson's write-side
+            // nesting cap (StreamWriteConstraints, also 1000) is enforced by writeValueAsString in
+            // convert, outside this block. A variant deep enough to clear the read limit but not the
+            // write limit once the image's own object levels are added would fail the query there.
+            // RawValue goes out through JsonGenerator.writeRawValue, which keeps no nesting context.
+            val parsed = mapper.readTree(variantJson)
+            // readTree accepts blank input as a MissingNode instead of throwing, and RawValue would
+            // then emit nothing at all, leaving a malformed image. Trailing-token input is refused by
+            // FAIL_ON_TRAILING_TOKENS above, which readTree does not check on its own.
+            if (parsed == null || parsed.isMissingNode) variantJson else new RawValue(variantJson)
           } catch {
             // A variant can hold a field name, string or nesting depth past Jackson's default
             // StreamReadConstraints (50k chars, 20M chars, 1000 levels) while staying well inside

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.cdc
 
+import org.apache.hudi.SparkAdapterSupport
+
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
@@ -90,6 +92,11 @@ class InternalRowToJsonStringConverter(schema: StructType) {
               structMap.toMap
             case _ => value // fallback
           }
+        case dt if SparkAdapterSupport.sparkAdapter.isVariantType(dt) =>
+          // VariantVal.toString renders the variant as JSON; embed it as a real JSON node so
+          // the image carries the variant's structure. Falling through to the default would
+          // serialize the VariantVal bean, i.e. its raw value/metadata bytes as base64.
+          mapper.readTree(value.toString)
         case _ =>
           // For primitive types and other unsupported types, return as is
           value

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
@@ -102,9 +102,14 @@ class InternalRowToJsonStringConverter(schema: StructType) {
           try {
             mapper.readTree(variantJson)
           } catch {
-            // Variant JSON can carry tokens this mapper rejects (a non-finite double renders as
-            // a bare NaN/Infinity), and a CDC image is not worth failing the query over: keep
-            // the rendering as a plain string instead.
+            // A variant can hold a field name, string or nesting depth past Jackson's default
+            // StreamReadConstraints (50k chars, 20M chars, 1000 levels) while staying well inside
+            // the variant size limit, and all three arrive here as StreamConstraintsException. A
+            // CDC image is diagnostic data rather than the table's data, so keep the rendering as
+            // a plain string instead of failing the query over it.
+            // NOTE: value.toString is deliberately outside this block. It throws MALFORMED_VARIANT
+            // on corrupt bytes, which is a data-integrity problem an operator has to see, not a
+            // rendering quirk to paper over -- and there would be no rendering left to fall back to.
             case _: JsonProcessingException => variantJson
           }
         case _ =>

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/InternalRowToJsonStringConverter.scala
@@ -18,9 +18,8 @@
 
 package org.apache.hudi.cdc
 
-import org.apache.hudi.SparkAdapterSupport
-
 import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.spark.sql.catalyst.InternalRow
@@ -92,15 +91,35 @@ class InternalRowToJsonStringConverter(schema: StructType) {
               structMap.toMap
             case _ => value // fallback
           }
-        case dt if SparkAdapterSupport.sparkAdapter.isVariantType(dt) =>
+        case dt if dt.typeName == InternalRowToJsonStringConverter.VARIANT_TYPE_NAME =>
           // VariantVal.toString renders the variant as JSON; embed it as a real JSON node so
           // the image carries the variant's structure. Falling through to the default would
           // serialize the VariantVal bean, i.e. its raw value/metadata bytes as base64.
-          mapper.readTree(value.toString)
+          // Matched on the type name rather than SparkAdapter.isVariantType: this guard is
+          // evaluated for every non-string/array/map/struct field, and resolving the adapter
+          // needs a version module that is not on hudi-spark-common's own test classpath.
+          val variantJson = value.toString
+          try {
+            mapper.readTree(variantJson)
+          } catch {
+            // Variant JSON can carry tokens this mapper rejects (a non-finite double renders as
+            // a bare NaN/Infinity), and a CDC image is not worth failing the query over: keep
+            // the rendering as a plain string instead.
+            case _: JsonProcessingException => variantJson
+          }
         case _ =>
           // For primitive types and other unsupported types, return as is
           value
       }
     }
   }
+}
+
+object InternalRowToJsonStringConverter {
+
+  /**
+   * Type name of Spark's VariantType. Matched by name so this module, which also compiles
+   * against Spark 3 where the type does not exist, needs neither the symbol nor a SparkAdapter.
+   */
+  private val VARIANT_TYPE_NAME = "variant"
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
@@ -179,12 +179,15 @@ class TestInternalRowToJsonStringConverter {
   }
 
   @Test
-  def variantColumnFallsBackToRawRenderingWhenNotJson(): Unit = {
+  def variantColumnFallsBackToRawRenderingWhenJacksonRejectsIt(): Unit = {
     assumeTrue(HoodieSparkUtils.gteqSpark4_0, "VariantType requires Spark 4.0 or higher")
-    // A non-finite double renders as a bare NaN/Infinity token, which the mapper rejects; the
-    // image keeps the raw rendering instead of failing the whole CDC query.
-    val row = InternalRow.fromSeq(Seq(1, variantRendering("NaN")))
-    assertEquals("""{"id":1,"v":"NaN"}""",
+    // Jackson's default StreamReadConstraints cap nesting at 1000 levels, field names at 50k chars
+    // and strings at 20M; a variant can exceed all three well inside its own size limit, and
+    // VariantVal.toString renders it faithfully. The image keeps that rendering rather than failing
+    // the whole CDC query. Nesting is the cheapest of the three to provoke.
+    val tooDeeplyNested = ("[" * 1001) + "1" + ("]" * 1001)
+    val row = InternalRow.fromSeq(Seq(1, variantRendering(tooDeeplyNested)))
+    assertEquals(s"""{"id":1,"v":"$tooDeeplyNested"}""",
       new InternalRowToJsonStringConverter(variantSchema.structTypeSchema).convert(row).toString)
   }
 
@@ -193,6 +196,10 @@ class TestInternalRowToJsonStringConverter {
    * what renders a real variant as JSON. Constructing a genuine VariantVal here would need
    * Spark-4-only symbols, and this module compiles against Spark 3 as well; the end-to-end
    * behaviour over real variants is covered by the CDC round trip in TestVariantDataType.
+   *
+   * Note this stands in only for renderings a real variant can produce. Spark quotes non-finite
+   * doubles (Variant.toJsonImpl guards them with isFinite and takes the appendQuoted arm), so no
+   * variant renders a bare NaN or Infinity token.
    */
   private def variantRendering(json: String): AnyRef = new AnyRef {
     override def toString: String = json

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
@@ -18,15 +18,16 @@
 
 package org.apache.hudi.cdc
 
-import org.apache.hudi.HoodieTableSchema
+import org.apache.hudi.{HoodieSparkUtils, HoodieTableSchema}
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.schema.internal.InternalSchema
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData}
-import org.apache.spark.sql.types.{ArrayType, DataTypes, MapType, Metadata, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, DataType, DataTypes, MapType, Metadata, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 
 class TestInternalRowToJsonStringConverter {
@@ -165,6 +166,49 @@ class TestInternalRowToJsonStringConverter {
     ))
     val converted = emptyMapConverter.convert(row)
     assertEquals("""{"id":8,"name":"empty_map_test","properties":{}}""", converted.toString)
+  }
+
+  @Test
+  def variantColumnEmbedsItsJson(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark4_0, "VariantType requires Spark 4.0 or higher")
+    // VariantVal.toString renders the variant as JSON, so the image must carry that structure
+    // rather than a bean rendering of the raw value/metadata bytes.
+    val row = InternalRow.fromSeq(Seq(1, variantRendering("""{"key":"value1"}""")))
+    assertEquals("""{"id":1,"v":{"key":"value1"}}""",
+      new InternalRowToJsonStringConverter(variantSchema.structTypeSchema).convert(row).toString)
+  }
+
+  @Test
+  def variantColumnFallsBackToRawRenderingWhenNotJson(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark4_0, "VariantType requires Spark 4.0 or higher")
+    // A non-finite double renders as a bare NaN/Infinity token, which the mapper rejects; the
+    // image keeps the raw rendering instead of failing the whole CDC query.
+    val row = InternalRow.fromSeq(Seq(1, variantRendering("NaN")))
+    assertEquals("""{"id":1,"v":"NaN"}""",
+      new InternalRowToJsonStringConverter(variantSchema.structTypeSchema).convert(row).toString)
+  }
+
+  /**
+   * Stands in for a VariantVal: the converter reaches the value only through toString, which is
+   * what renders a real variant as JSON. Constructing a genuine VariantVal here would need
+   * Spark-4-only symbols, and this module compiles against Spark 3 as well; the end-to-end
+   * behaviour over real variants is covered by the CDC round trip in TestVariantDataType.
+   */
+  private def variantRendering(json: String): AnyRef = new AnyRef {
+    override def toString: String = json
+  }
+
+  private def variantSchema: HoodieTableSchema = {
+    val structTypeSchema = new StructType(Array[StructField](
+      StructField("id", DataTypes.IntegerType, nullable = false, Metadata.empty),
+      StructField("v", DataType.fromDDL("variant"), nullable = true, Metadata.empty)))
+    val avroSchemaStr: String =
+      """{"type": "record", "name": "test", "fields": [
+        |{"name": "id", "type": "int"},
+        |{"name": "v", "type": {"type": "record", "name": "variant", "logicalType": "variant",
+        |  "fields": [{"name": "metadata", "type": "bytes"}, {"name": "value", "type": "bytes"}]}}
+        |]}""".stripMargin
+    HoodieTableSchema(structTypeSchema, HoodieSchema.parse(avroSchemaStr), Option.empty[InternalSchema])
   }
 
   private def hoodieTableSchema: HoodieTableSchema = {

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/cdc/TestInternalRowToJsonStringConverter.scala
@@ -191,6 +191,30 @@ class TestInternalRowToJsonStringConverter {
       new InternalRowToJsonStringConverter(variantSchema.structTypeSchema).convert(row).toString)
   }
 
+  @Test
+  def variantColumnSurvivesJacksonWriteSideNestingCap(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark4_0, "VariantType requires Spark 4.0 or higher")
+    // Jackson caps nesting on the write side too, and the image adds its own object level on top of
+    // the variant, so a depth the read side accepts could still fail in writeValueAsString -- outside
+    // the fallback, taking the whole CDC query with it. The rendering is embedded verbatim rather
+    // than as a parsed node precisely so that write-side accounting never sees it.
+    val atReadLimit = ("[" * 1000) + "1" + ("]" * 1000)
+    val row = InternalRow.fromSeq(Seq(1, variantRendering(atReadLimit)))
+    val image = new InternalRowToJsonStringConverter(variantSchema.structTypeSchema).convert(row).toString
+    // Embedded as a real array, i.e. neither the fallback nor a write-side failure.
+    assertEquals(s"""{"id":1,"v":$atReadLimit}""", image)
+  }
+
+  @Test
+  def variantColumnFallsBackWhenRenderingHasTrailingTokens(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark4_0, "VariantType requires Spark 4.0 or higher")
+    // readTree parses a valid prefix and leaves the rest, so without FAIL_ON_TRAILING_TOKENS a
+    // verbatim embed would splice the trailing text straight into the image and corrupt it.
+    val row = InternalRow.fromSeq(Seq(1, variantRendering("""{"a":1} trailing""")))
+    assertEquals("""{"id":1,"v":"{\"a\":1} trailing"}""",
+      new InternalRowToJsonStringConverter(variantSchema.structTypeSchema).convert(row).toString)
+  }
+
   /**
    * Stands in for a VariantVal: the converter reaches the value only through toString, which is
    * what renders a real variant as JSON. Constructing a genuine VariantVal here would need

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLegacyParquetReadPath.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLegacyParquetReadPath.scala
@@ -17,11 +17,11 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.{BaseFileOnlyRelation, DataSourceReadOptions, DataSourceWriteOptions, IncrementalRelationV1, IncrementalRelationV2, ScalaAssertionSupport}
+import org.apache.hudi.{BaseFileOnlyRelation, DataSourceReadOptions, DataSourceWriteOptions, IncrementalRelationV1, IncrementalRelationV2, MergeOnReadIncrementalRelationV2, MergeOnReadSnapshotRelation, ScalaAssertionSupport}
 import org.apache.hudi.common.config.HoodieReaderConfig
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.log.InstantRange.RangeType
-import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
 
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
@@ -156,6 +156,36 @@ class TestLegacyParquetReadPath extends HoodieSparkClientTestBase with ScalaAsse
     assertEquals(expected, actual)
   }
 
+  // Inline compaction is switched on automatically for batch MOR writes (HoodieSparkSqlWriter), so it
+  // is pinned off here to keep the second deltacommit in a log file rather than a rewritten base file.
+  private val morDropPartitionColumnsOpts = Map(
+    DataSourceWriteOptions.TABLE_TYPE.key -> DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
+    HoodieTableConfig.DROP_PARTITION_COLUMNS.key -> "true",
+    HoodieCompactionConfig.INLINE_COMPACT.key -> "false")
+
+  /**
+   * MOR table whose base files do not carry the partition column, so its values exist only on the
+   * partition path. Deltacommit 1 inserts ids 1..30 across p0/p1/p2; deltacommit 2 upserts a strict
+   * subset of the p0 rows, so the p0 file group gains a log file while p1/p2 stay base-only.
+   *
+   * Both "strict subset" and "single partition" are deliberate: the p1/p2 groups keep the
+   * skip-merging fast path in the same query, and the p0 rows left untouched by deltacommit 2 are
+   * served from the base file, which is where the partition column is missing. Note that
+   * HoodieSparkSqlWriter forces drop.partition.columns off for MOR upserts (HUDI-6926), so the log
+   * records themselves do carry the column -- only the base-file records do not.
+   */
+  private def writeMorDropPartitionColumnsCommits(): Unit = {
+    writeBatch(makeRows(1 to 30, ts = 1L, i => i * 10L),
+      DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL, morDropPartitionColumnsOpts)
+    writeBatch(makeRows((1 to 30).filter(_ % 6 == 0), ts = 2L, i => i * 100L),
+      DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL, morDropPartitionColumnsOpts)
+  }
+
+  /** Distinct `partition` values, rendering a null (the symptom under test) as "null" so that the
+   * assertion reports it rather than failing while sorting. */
+  private def distinctPartitions(df: DataFrame): Seq[String] =
+    df.select("partition").distinct().collect().map(r => String.valueOf(r.get(0))).sorted.toSeq
+
   private def fgReaderDf(extraOpts: Map[String, String] = Map.empty): DataFrame =
     spark.read.format("hudi")
       .option(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key, "true")
@@ -191,6 +221,16 @@ class TestLegacyParquetReadPath extends HoodieSparkClientTestBase with ScalaAsse
     assertTrue(hadoopFsRelation.fileFormat.getClass.getSimpleName.contains("LegacyHoodieParquetFileFormat"),
       s"Expected the legacy parquet file format but got ${hadoopFsRelation.fileFormat.getClass.getName}")
     spark.baseRelationToDataFrame(hadoopFsRelation)
+  }
+
+  /**
+   * Legacy MOR snapshot scan through [[MergeOnReadSnapshotRelation]] and [[org.apache.hudi.HoodieMergeOnReadRDDV2]]:
+   * base-only splits take the skip-merging fast path, splits carrying log files the file-group-reader branch.
+   */
+  private def legacyMorSnapshotDf(extraOpts: Map[String, String] = Map.empty): DataFrame = {
+    val metaClient = createMetaClient(spark, basePath)
+    spark.baseRelationToDataFrame(
+      MergeOnReadSnapshotRelation(sqlContext, legacyReadOpts(extraOpts), metaClient, None))
   }
 
   /**
@@ -270,9 +310,7 @@ class TestLegacyParquetReadPath extends HoodieSparkClientTestBase with ScalaAsse
     assertSameRows(newReaderDf, legacyFileFormatDf(extractOpts))
     assertSameRows(newReaderDf, legacyRelationDf(extractOpts))
 
-    val partitions = legacyFileFormatDf(extractOpts)
-      .select("partition").distinct().collect().map(_.getString(0)).sorted.toSeq
-    assertEquals(Seq("p0", "p1", "p2"), partitions)
+    assertEquals(Seq("p0", "p1", "p2"), distinctPartitions(legacyFileFormatDf(extractOpts)))
   }
 
   @Test
@@ -469,5 +507,63 @@ class TestLegacyParquetReadPath extends HoodieSparkClientTestBase with ScalaAsse
       assertWidenedValues(legacyDf)
       assertSameRows(newReaderDf, legacyDf)
     }
+  }
+
+  @Test
+  def testMorSnapshotReadWithDroppedPartitionColumns(): Unit = {
+    writeMorDropPartitionColumnsCommits()
+
+    // The p0 file group carries a log file, so it is served by the file-group-reader branch of
+    // HoodieMergeOnReadRDDV2, which sources every projected column from the files -- and the p0 base
+    // file, holding the rows deltacommit 2 left alone, does not have the partition column. The p1/p2
+    // groups stay base-only in the very same query, so the skip-merging fast path -- the only one
+    // that ever appended the parsed values -- is pinned unregressed at the same time.
+    val newReaderDf = fgReaderDf()
+    assertEquals(30, newReaderDf.count())
+    // Had the updates landed in a rewritten base file instead of a log, the read-optimized query
+    // would already show them and no split in this table would take the merging branch at all.
+    val readOptimizedDf = fgReaderDf(
+      Map(DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL))
+    assertEquals(0, readOptimizedDf.filter(col("ts") === 2L).count())
+
+    val legacyDf = legacyMorSnapshotDf()
+    assertSameRows(newReaderDf, legacyDf)
+    assertEquals(Seq("p0", "p1", "p2"), distinctPartitions(legacyDf))
+
+    // The p0 rows deltacommit 2 left alone are the ones served straight from the base file, where the
+    // partition column does not exist; they must come back as p0 and not as null.
+    val untouchedP0Ids = (1 to 30).filter(i => i % 3 == 0 && i % 6 != 0).map(_.toString)
+    val baseServedP0Df = legacyDf.filter(col("ts") === 1L && col("id").isin(untouchedP0Ids: _*))
+    assertEquals(untouchedP0Ids.size.toLong, baseServedP0Df.count())
+    assertEquals(Seq("p0"), distinctPartitions(baseServedP0Df))
+  }
+
+  @Test
+  def testMorIncrementalReadWithDroppedPartitionColumnsOnLogOnlySlice(): Unit = {
+    writeMorDropPartitionColumnsCommits()
+
+    val metaClient = createMetaClient(spark, basePath)
+    val firstInstant = metaClient.getCommitsTimeline.filterCompletedInstants.firstInstant.get
+
+    // Start-exclusive span covering only the update deltacommit. Its file-system view is built from
+    // the files that deltacommit touched -- log files alone -- so the slice carries no base file and
+    // the split has to resolve its partition values off a log file's path instead.
+    //
+    // NOTE: this test passes with or without the splicing, so unlike the snapshot test above it is
+    // not a repro of the null-partition bug. The rows here come from log records, and those DO carry
+    // the partition column: HUDI-6926 makes a MOR upsert ignore drop.partition.columns. What it does
+    // pin is the log-only resolution itself -- reading the values off HoodieLogFile#getPath, whose
+    // pathInfo is null for these log files -- and that the result agrees with the file-group-reader
+    // oracle.
+    val incOpts = Map(
+      DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+      DataSourceReadOptions.START_COMMIT.key -> firstInstant.getCompletionTime)
+
+    val newReaderDf = fgReaderDf(incOpts)
+    val legacyDf = spark.baseRelationToDataFrame(
+      MergeOnReadIncrementalRelationV2(sqlContext, legacyReadOpts(incOpts), metaClient, None, RangeType.OPEN_CLOSED))
+
+    assertSameRows(newReaderDf, legacyDf)
+    assertEquals(Seq("p0"), distinctPartitions(legacyDf))
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -17,9 +17,9 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.DataSourceReadOptions
+import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
 import org.apache.hudi.DataSourceReadOptions.{START_OFFSET, STREAMING_READ_TABLE_VERSION}
-import org.apache.hudi.DataSourceWriteOptions.{ORDERING_FIELDS, RECORDKEY_FIELD}
+import org.apache.hudi.DataSourceWriteOptions.{ORDERING_FIELDS, RECORDKEY_FIELD, TABLE_TYPE}
 import org.apache.hudi.common.config.HoodieReaderConfig
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_READ}
@@ -379,6 +379,69 @@ class TestStreamingSource extends StreamTest {
 
   test("test mor stream source with legacy file group reader disabled on table version 8") {
     testLegacyIncrementalStreamSource(MERGE_ON_READ, HoodieTableVersion.EIGHT)
+  }
+
+  test("test mor stream source reads shredded variant with legacy file group reader disabled") {
+    // #19578: with the file group reader disabled, MOR streaming batches materialize through
+    // HoodieMergeOnReadRDDV2, the only user-facing path reading shredded variant base files
+    // without a catalyst schema. Covers both RDD branches: the base-only split (first batch,
+    // right after inline compaction) and the merged split (second batch, after a
+    // post-compaction update lands in a log file).
+    assume(HoodieSparkUtils.gteqSpark4_1, "Shredded variant base-file read requires Spark 4.1 or higher")
+
+    withTempDir { inputDir =>
+      val tablePath = s"${inputDir.getCanonicalPath}/test_mor_variant_legacy_stream"
+      HoodieTableMetaClient.newTableBuilder()
+        .setTableType(MERGE_ON_READ)
+        .setTableName(getTableName(tablePath))
+        .setRecordKeyFields("id")
+        .setOrderingFields("ts")
+        .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+
+      // INMEMORY index routes MOR inserts to log files, so the first base file is the
+      // compaction's SHREDDED one; compact = true trips inline compaction on that write.
+      def addVariantData(valuesSql: String, compact: Boolean): Unit = {
+        spark.sql(valuesSql).write.format("org.apache.hudi")
+          .options(commonOptions)
+          .option(TBL_NAME.key, getTableName(tablePath))
+          .option(TABLE_TYPE.key, MERGE_ON_READ.name)
+          .option("hoodie.index.type", "INMEMORY")
+          .option("hoodie.parquet.variant.write.shredding.enabled", "true")
+          .option("hoodie.parquet.variant.force.shredding.schema.for.test", "key string")
+          .option(HoodieCompactionConfig.INLINE_COMPACT.key, compact.toString)
+          .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key, "2")
+          .mode(SaveMode.Append)
+          .save(tablePath)
+      }
+
+      addVariantData("""select 1 as id, parse_json('{"key":"v1"}') as v, 1000L as ts""", compact = false)
+      addVariantData("""select 2 as id, parse_json('{"key":"v2"}') as v, 1000L as ts""", compact = true)
+
+      val df = spark.readStream
+        .format("org.apache.hudi")
+        // force the legacy (non file-group-reader) incremental relation path
+        .option(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key, "false")
+        .load(tablePath)
+        .selectExpr("id", "cast(v as string) as v", "ts")
+
+      testStream(df)(
+        // Base-only split: the compacted shredded base file must round-trip its variants.
+        AssertOnQuery { q => q.processAllAvailable(); true },
+        CheckAnswerRows(Seq(Row(1, "{\"key\":\"v1\"}", 1000L), Row(2, "{\"key\":\"v2\"}", 1000L)),
+          lastOnly = true, isSorted = false),
+        StopStream,
+
+        // Merged split: the update lands in a log file on the compacted slice, so the next
+        // batch merges the shredded base with the log.
+        AssertOnQuery { _ =>
+          addVariantData("""select 1 as id, parse_json('{"key":"v1-updated"}') as v, 1001L as ts""", compact = false)
+          true
+        },
+        StartStream(),
+        AssertOnQuery { q => q.processAllAvailable(); true },
+        CheckAnswerRows(Seq(Row(1, "{\"key\":\"v1-updated\"}", 1001L)), lastOnly = true, isSorted = false)
+      )
+    }
   }
 
   private def testCheckpointTranslation(tableName: String,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -30,7 +30,7 @@ import org.apache.hudi.config.HoodieWriteConfig.{DELETE_PARALLELISM_VALUE, INSER
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.util.JavaConversions
 
-import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
 import org.apache.spark.sql.streaming.StreamTest
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 
@@ -384,9 +384,9 @@ class TestStreamingSource extends StreamTest {
   test("test mor stream source reads shredded variant with legacy file group reader disabled") {
     // #19578: with the file group reader disabled, MOR streaming batches materialize through
     // HoodieMergeOnReadRDDV2, the only user-facing path reading shredded variant base files
-    // without a catalyst schema. Covers both RDD branches: the base-only split (first batch,
-    // right after inline compaction) and the merged split (second batch, after a
-    // post-compaction update lands in a log file).
+    // without a catalyst schema. The first stream covers the base-only split (first batch, the
+    // branch this fix re-routes) and the log-only split (second batch); the second stream covers
+    // the merged base + log split.
     assume(HoodieSparkUtils.gteqSpark4_1, "Shredded variant base-file read requires Spark 4.1 or higher")
 
     withTempDir { inputDir =>
@@ -401,7 +401,12 @@ class TestStreamingSource extends StreamTest {
       // INMEMORY index routes MOR inserts to log files, so the first base file is the
       // compaction's SHREDDED one; compact = true trips inline compaction on that write.
       def addVariantData(valuesSql: String, compact: Boolean): Unit = {
-        spark.sql(valuesSql).write.format("org.apache.hudi")
+        // The write must use the short name: it resolves to Spark4DefaultSource, the only
+        // provider overriding CreatableRelationProvider.supportsDataType to accept VariantType.
+        // The fully qualified "org.apache.hudi" resolves to DefaultSource (short name "hudi_v1"),
+        // which has no override, so DataSource.planForWriting on Spark 4.x rejects the variant
+        // column with UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE.
+        spark.sql(valuesSql).write.format("hudi")
           .options(commonOptions)
           .option(TBL_NAME.key, getTableName(tablePath))
           .option(TABLE_TYPE.key, MERGE_ON_READ.name)
@@ -414,25 +419,44 @@ class TestStreamingSource extends StreamTest {
           .save(tablePath)
       }
 
-      addVariantData("""select 1 as id, parse_json('{"key":"v1"}') as v, 1000L as ts""", compact = false)
-      addVariantData("""select 2 as id, parse_json('{"key":"v2"}') as v, 1000L as ts""", compact = true)
-
-      val df = spark.readStream
+      // The read keeps the fully qualified name: it goes through StreamSourceProvider, which
+      // never calls supportsDataType.
+      def variantStreamDf(): DataFrame = spark.readStream
         .format("org.apache.hudi")
         // force the legacy (non file-group-reader) incremental relation path
         .option(HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key, "false")
         .load(tablePath)
         .selectExpr("id", "cast(v as string) as v", "ts")
 
-      testStream(df)(
-        // Base-only split: the compacted shredded base file must round-trip its variants.
+      // The legacy branch of getBatch materializes the micro batch from an RDD via
+      // internalCreateDataFrame, so the physical plan is a "Scan ExistingRDD"; this fails if the
+      // legacy branch is dropped and the source silently falls back to the file group reader
+      // path, which scans a HadoopFsRelation ("FileScan" / "Scan parquet") instead.
+      val assertLegacyRddPlan = AssertOnQuery { q =>
+        val plan = q.lastExecution.executedPlan.toString
+        assertTrue(plan.contains("Scan ExistingRDD"),
+          "expected the legacy RDD-backed incremental batch, but got plan: " + plan)
+        assertTrue(!plan.contains("FileScan"),
+          "expected no file-group-reader HadoopFsRelation scan, but got plan: " + plan)
+        true
+      }
+
+      addVariantData("""select 1 as id, parse_json('{"key":"v1"}') as v, 1000L as ts""", compact = false)
+      addVariantData("""select 2 as id, parse_json('{"key":"v2"}') as v, 1000L as ts""", compact = true)
+
+      testStream(variantStreamDf())(
+        // Base-only split: this batch spans both deltacommits and the compaction commit, whose
+        // affected files resolve to the compacted shredded base file with no log on top. This is
+        // the branch the fix re-routes to the file group reader.
         AssertOnQuery { q => q.processAllAvailable(); true },
+        assertLegacyRddPlan,
         CheckAnswerRows(Seq(Row(1, "{\"key\":\"v1\"}", 1000L), Row(2, "{\"key\":\"v2\"}", 1000L)),
           lastOnly = true, isSorted = false),
         StopStream,
 
-        // Merged split: the update lands in a log file on the compacted slice, so the next
-        // batch merges the shredded base with the log.
+        // Log-only split: MergeOnReadIncrementalRelationV2 builds its file system view out of the
+        // span's affected files alone, and this span covers only the update deltacommit, so the
+        // slice is the appended log file with no base file.
         AssertOnQuery { _ =>
           addVariantData("""select 1 as id, parse_json('{"key":"v1-updated"}') as v, 1001L as ts""", compact = false)
           true
@@ -440,6 +464,18 @@ class TestStreamingSource extends StreamTest {
         StartStream(),
         AssertOnQuery { q => q.processAllAvailable(); true },
         CheckAnswerRows(Seq(Row(1, "{\"key\":\"v1-updated\"}", 1001L)), lastOnly = true, isSorted = false)
+      )
+
+      // Merged split: a fresh testStream over a fresh streaming DataFrame gets its own
+      // checkpoint, so it replays from the INIT offset and its first batch spans the compaction
+      // commit and the update deltacommit together. Only such a span puts the shredded base file
+      // and the update log file in one affected-file list, giving the base + log slice that
+      // neither batch above produces.
+      testStream(variantStreamDf())(
+        AssertOnQuery { q => q.processAllAvailable(); true },
+        assertLegacyRddPlan,
+        CheckAnswerRows(Seq(Row(1, "{\"key\":\"v1-updated\"}", 1001L), Row(2, "{\"key\":\"v2\"}", 1000L)),
+          lastOnly = true, isSorted = false)
       )
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -286,8 +286,10 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
       // Incremental round trip over the shredded table: batch incremental reads the
       // shredded base file through the file-group-reader file format with a catalyst
       // schema, a stack nothing else in this suite pins for variant columns. The
-      // no-catalyst-schema legs (CDC, and streaming with
-      // hoodie.file.group.reader.enabled=false) are tracked in #19578.
+      // no-catalyst-schema legs are covered by the CDC round trip below and, for
+      // streaming with hoodie.file.group.reader.enabled=false, by
+      // TestStreamingSource#"test mor stream source reads shredded variant with legacy
+      // file group reader disabled".
       val incRows = spark.read.format("hudi")
         .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
         .option(DataSourceReadOptions.START_COMMIT.key, "000")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -20,6 +20,7 @@
 package org.apache.spark.sql.hudi.dml.schema
 
 import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.schema.internal.HoodieSchemaException
 import org.apache.hudi.common.testutils.HoodieTestUtils
@@ -448,82 +449,101 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
     })
   }
 
-  test("Test CDC captures VARIANT values from shredded base files") {
+  test("Test CDC captures VARIANT values from shredded and unshredded base files") {
     // #19578: CDC is the only default-config query path that builds the internal reader
     // context without a catalyst schema, and its BASE_FILE_INSERT case additionally reads
     // the new base file directly, bypassing the context, so it needs its own full-variant
-    // rewrite. One row only on purpose: a COW update rewrites the base file through the
-    // avro merge path, whose shredded-read fix is #19582 (in flight), and a single row
-    // leaves nothing for that path to carry over.
+    // rewrite. That rewrite is picked from the spark adapter and the requested schema alone,
+    // never from the file, so the unshredded leg runs through it too; both layouts are swept
+    // below so neither side of that branch goes uncovered.
     assume(HoodieSparkUtils.gteqSpark4_1, "Shredded variant base-file read requires Spark 4.1 or higher")
 
-    // OP_KEY_ONLY reconstructs both images by reading the (shredded) file slices;
-    // DATA_BEFORE_AFTER (the default) reads the update images from the cdc log instead.
-    // The insert leg takes BASE_FILE_INSERT in both modes.
-    Seq("OP_KEY_ONLY", "DATA_BEFORE_AFTER").foreach { loggingMode =>
-      withTempDir { tmp =>
-        val tableName = generateTableName
-        val tablePath = tmp.getCanonicalPath
-        spark.sql(
-          s"""
-             |create table $tableName (
-             |  id int,
-             |  v variant,
-             |  ts long
-             |) using hudi
-             | location '$tablePath'
-             | tblproperties (
-             |  primaryKey = 'id',
-             |  type = 'cow',
-             |  preCombineField = 'ts',
-             |  'hoodie.table.cdc.enabled' = 'true',
-             |  'hoodie.table.cdc.supplemental.logging.mode' = '$loggingMode',
-             |  hoodie.parquet.variant.write.shredding.enabled = 'true',
-             |  hoodie.parquet.variant.force.shredding.schema.for.test = 'key string',
-             |  hoodie.index.type = 'INMEMORY'
-             | )
-         """.stripMargin)
+    // OP_KEY_ONLY reconstructs both images by reading the file slices; DATA_BEFORE_AFTER
+    // (the default) reads the update images from the cdc log instead. The insert leg takes
+    // BASE_FILE_INSERT in both modes.
+    Seq(true, false).foreach { shredded =>
+      Seq("OP_KEY_ONLY", "DATA_BEFORE_AFTER").foreach { loggingMode =>
+        // SPARK is pinned instead of sweeping both record types: a cdc-enabled table always
+        // writes through FileGroupReaderBasedMergeHandle, and the merger's record type picks
+        // that handle's reader context. AVRO would route the update's base-file read through
+        // HoodieAvroParquetReader, whose shredded read is the separate defect tracked as
+        // #19567/#19582; SPARK routes it through SparkFileFormatInternalRowReaderContext,
+        // fixed in #19558. The CDC read path under test is independent of that choice.
+        withRecordType(Seq(HoodieRecordType.SPARK))(withTempDir { tmp =>
+          val leg = s"$loggingMode, shredded=$shredded"
+          val tableName = generateTableName
+          val tablePath = tmp.getCanonicalPath
+          // The forced shredding schema belongs to the shredded leg only; the unshredded leg
+          // must reach the writer with shredding off and no forced schema.
+          val forceShreddingProp =
+            if (shredded) "hoodie.parquet.variant.force.shredding.schema.for.test = 'key string'," else ""
+          spark.sql(
+            s"""
+               |create table $tableName (
+               |  id int,
+               |  v variant,
+               |  ts long
+               |) using hudi
+               | location '$tablePath'
+               | tblproperties (
+               |  primaryKey = 'id',
+               |  type = 'cow',
+               |  preCombineField = 'ts',
+               |  'hoodie.table.cdc.enabled' = 'true',
+               |  'hoodie.table.cdc.supplemental.logging.mode' = '$loggingMode',
+               |  hoodie.parquet.variant.write.shredding.enabled = '$shredded',
+               |  $forceShreddingProp
+               |  hoodie.index.type = 'INMEMORY'
+               | )
+           """.stripMargin)
 
-        spark.sql(s"""insert into $tableName values (1, parse_json('{"key":"value1"}'), 1000)""")
+          spark.sql(s"""insert into $tableName values (1, parse_json('{"key":"value1"}'), 1000)""")
 
-        // Pin the trigger: the base file the CDC reads must actually be shredded.
-        val baseFiles = listDataParquetFiles(tablePath)
-        assert(baseFiles.nonEmpty, "Should have a base parquet file after the insert")
-        baseFiles.foreach { filePath =>
-          val parquetSchema = readParquetSchema(filePath)
-          val variantGroup = getFieldAsGroup(parquetSchema, "v")
-          assert(variantGroup.containsField("typed_value"),
-            s"Base file should carry typed_value. Schema:\n$variantGroup")
-        }
+          // Pin the layout the CDC reads: without this, one leg silently degrades into a
+          // second copy of the other and its half of the rewrite branch goes uncovered.
+          val baseFiles = listDataParquetFiles(tablePath)
+          assert(baseFiles.nonEmpty, s"[$leg] should have a base parquet file after the insert")
+          baseFiles.foreach { filePath =>
+            val parquetSchema = readParquetSchema(filePath)
+            val variantGroup = getFieldAsGroup(parquetSchema, "v")
+            if (shredded) {
+              assert(variantGroup.containsField("typed_value"),
+                s"[$leg] base file should carry typed_value. Schema:\n$variantGroup")
+            } else {
+              assert(!variantGroup.containsField("typed_value"),
+                s"[$leg] base file must not carry typed_value. Schema:\n$variantGroup")
+            }
+          }
 
-        spark.sql(s"""update $tableName set v = parse_json('{"key":"value2"}'), ts = 1001 where id = 1""")
+          spark.sql(s"""update $tableName set v = parse_json('{"key":"value2"}'), ts = 1001 where id = 1""")
 
-        val cdc = spark.read.format("hudi")
-          .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
-          .option(DataSourceReadOptions.INCREMENTAL_FORMAT.key, DataSourceReadOptions.INCREMENTAL_FORMAT_CDC_VAL)
-          .option(DataSourceReadOptions.START_COMMIT.key, "000")
-          .load(tablePath)
+          val cdc = spark.read.format("hudi")
+            .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+            .option(DataSourceReadOptions.INCREMENTAL_FORMAT.key, DataSourceReadOptions.INCREMENTAL_FORMAT_CDC_VAL)
+            .option(DataSourceReadOptions.START_COMMIT.key, "000")
+            .load(tablePath)
 
-        // Insert leg: the after-image comes from BASE_FILE_INSERT's direct read of the
-        // shredded base file; a null here means that read clipped typed_value away.
-        val insertRows = cdc.where("op = 'i'")
-          .selectExpr("get_json_object(after, '$.v.key') as after_key").collect()
-        assert(insertRows.length == 1, s"[$loggingMode] expected exactly one insert cdc row")
-        assert(insertRows(0).getString(0) == "value1",
-          s"[$loggingMode] insert after-image lost the variant payload: ${insertRows(0)}")
+          // Insert leg: the after-image comes from BASE_FILE_INSERT's direct read of the
+          // base file; a null here means that read dropped the variant payload.
+          val insertRows = cdc.where("op = 'i'")
+            .selectExpr("get_json_object(after, '$.v.key') as after_key").collect()
+          assert(insertRows.length == 1, s"[$leg] expected exactly one insert cdc row")
+          assert(insertRows(0).getString(0) == "value1",
+            s"[$leg] insert after-image lost the variant payload: ${insertRows(0)}")
 
-        // Update leg: images come from slice reads (OP_KEY_ONLY) or the cdc log
-        // (DATA_BEFORE_AFTER); both must carry the variant payloads.
-        val updateRows = cdc.where("op = 'u'")
-          .selectExpr(
-            "get_json_object(before, '$.v.key') as before_key",
-            "get_json_object(after, '$.v.key') as after_key")
-          .collect()
-        assert(updateRows.length == 1, s"[$loggingMode] expected exactly one update cdc row")
-        assert(updateRows(0).getString(0) == "value1",
-          s"[$loggingMode] update before-image lost the variant payload: ${updateRows(0)}")
-        assert(updateRows(0).getString(1) == "value2",
-          s"[$loggingMode] update after-image lost the variant payload: ${updateRows(0)}")
+          // Update leg: images come from slice reads (OP_KEY_ONLY) or the cdc log
+          // (DATA_BEFORE_AFTER); both must carry the variant payloads.
+          val updateRows = cdc.where("op = 'u'")
+            .selectExpr(
+              "get_json_object(before, '$.v.key') as before_key",
+              "get_json_object(after, '$.v.key') as after_key")
+            .collect()
+          assert(updateRows.length == 1, s"[$leg] expected exactly one update cdc row")
+          assert(updateRows(0).getString(0) == "value1",
+            s"[$leg] update before-image lost the variant payload: ${updateRows(0)}")
+          assert(updateRows(0).getString(1) == "value2",
+            s"[$leg] update after-image lost the variant payload: ${updateRows(0)}")
+        })
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -448,6 +448,86 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
     })
   }
 
+  test("Test CDC captures VARIANT values from shredded base files") {
+    // #19578: CDC is the only default-config query path that builds the internal reader
+    // context without a catalyst schema, and its BASE_FILE_INSERT case additionally reads
+    // the new base file directly, bypassing the context, so it needs its own full-variant
+    // rewrite. One row only on purpose: a COW update rewrites the base file through the
+    // avro merge path, whose shredded-read fix is #19582 (in flight), and a single row
+    // leaves nothing for that path to carry over.
+    assume(HoodieSparkUtils.gteqSpark4_1, "Shredded variant base-file read requires Spark 4.1 or higher")
+
+    // OP_KEY_ONLY reconstructs both images by reading the (shredded) file slices;
+    // DATA_BEFORE_AFTER (the default) reads the update images from the cdc log instead.
+    // The insert leg takes BASE_FILE_INSERT in both modes.
+    Seq("OP_KEY_ONLY", "DATA_BEFORE_AFTER").foreach { loggingMode =>
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        val tablePath = tmp.getCanonicalPath
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  v variant,
+             |  ts long
+             |) using hudi
+             | location '$tablePath'
+             | tblproperties (
+             |  primaryKey = 'id',
+             |  type = 'cow',
+             |  preCombineField = 'ts',
+             |  'hoodie.table.cdc.enabled' = 'true',
+             |  'hoodie.table.cdc.supplemental.logging.mode' = '$loggingMode',
+             |  hoodie.parquet.variant.write.shredding.enabled = 'true',
+             |  hoodie.parquet.variant.force.shredding.schema.for.test = 'key string',
+             |  hoodie.index.type = 'INMEMORY'
+             | )
+         """.stripMargin)
+
+        spark.sql(s"""insert into $tableName values (1, parse_json('{"key":"value1"}'), 1000)""")
+
+        // Pin the trigger: the base file the CDC reads must actually be shredded.
+        val baseFiles = listDataParquetFiles(tablePath)
+        assert(baseFiles.nonEmpty, "Should have a base parquet file after the insert")
+        baseFiles.foreach { filePath =>
+          val parquetSchema = readParquetSchema(filePath)
+          val variantGroup = getFieldAsGroup(parquetSchema, "v")
+          assert(variantGroup.containsField("typed_value"),
+            s"Base file should carry typed_value. Schema:\n$variantGroup")
+        }
+
+        spark.sql(s"""update $tableName set v = parse_json('{"key":"value2"}'), ts = 1001 where id = 1""")
+
+        val cdc = spark.read.format("hudi")
+          .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+          .option(DataSourceReadOptions.INCREMENTAL_FORMAT.key, DataSourceReadOptions.INCREMENTAL_FORMAT_CDC_VAL)
+          .option(DataSourceReadOptions.START_COMMIT.key, "000")
+          .load(tablePath)
+
+        // Insert leg: the after-image comes from BASE_FILE_INSERT's direct read of the
+        // shredded base file; a null here means that read clipped typed_value away.
+        val insertRows = cdc.where("op = 'i'")
+          .selectExpr("get_json_object(after, '$.v.key') as after_key").collect()
+        assert(insertRows.length == 1, s"[$loggingMode] expected exactly one insert cdc row")
+        assert(insertRows(0).getString(0) == "value1",
+          s"[$loggingMode] insert after-image lost the variant payload: ${insertRows(0)}")
+
+        // Update leg: images come from slice reads (OP_KEY_ONLY) or the cdc log
+        // (DATA_BEFORE_AFTER); both must carry the variant payloads.
+        val updateRows = cdc.where("op = 'u'")
+          .selectExpr(
+            "get_json_object(before, '$.v.key') as before_key",
+            "get_json_object(after, '$.v.key') as after_key")
+          .collect()
+        assert(updateRows.length == 1, s"[$loggingMode] expected exactly one update cdc row")
+        assert(updateRows(0).getString(0) == "value1",
+          s"[$loggingMode] update before-image lost the variant payload: ${updateRows(0)}")
+        assert(updateRows(0).getString(1) == "value2",
+          s"[$loggingMode] update after-image lost the variant payload: ${updateRows(0)}")
+      }
+    }
+  }
+
   test("Test bulk_insert row-writer round-trips VARIANT") {
     assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19578, and fixes #19594.

#19578 asked for streaming and CDC round-trip coverage of shredded variant reads; writing the coverage surfaced three real defects on those paths, all of the #19556 null-read family (requesting native VariantType against a shredded parquet base file clips the shredded group to `{metadata, value}` and reads `value=null`). Review of the fix surfaced a fourth, unrelated defect on the same RDD, filed as #19594 and fixed here.

1. `HoodieMergeOnReadRDDV2` base-only splits (`dataFileOnlySplit`) bypass the internal reader context entirely and read through the relation's plain skip-merging base reader, so a shredded base file with no log files read null variants. Hit by the legacy (`hoodie.file.group.reader.enabled=false`) streaming/relation path, e.g. any streaming batch over a freshly compacted slice.
2. `CDCFileGroupIterator`'s BASE_FILE_INSERT case reads the new base file directly with the plain table schema, bypassing the context, so CDC after-images of insert commits read null variants. Hit under every supplemental logging mode.
3. `InternalRowToJsonStringConverter` (CDC before/after images) had no VariantType handling, so a variant column fell through to Jackson bean serialization of the raw `VariantVal` bytes instead of the variant's JSON.
4. #19594: `HoodieMergeOnReadRDDV2`'s file-group-reader branch never appended partition values, so partition columns read back NULL whenever they are not persisted in the data files (`drop.partition.columns`, read-side extraction from the partition path, bootstrap data-queries-only). Pre-existing and independent of variants. It is fixed here rather than deferred because fix 1 re-routes base-only splits onto that same branch and would otherwise have widened the gap; carving it out would mean either shipping that regression or keeping a carve-out no test could reach.

### Summary and Changelog

- `HoodieMergeOnReadRDDV2`: splits whose required schema has variant columns skip the plain fast reader and take the file-group reader branch, whose reader context requests the full-variant projection shape (#19558). Gated on `SparkAdapter.buildFullVariantReadSchema(...).isDefined`, which is `None` below Spark 4.1 where the file-group reader would read the same nulls. Base-only splits without variants are unchanged.
- `HoodieMergeOnReadRDDV2`: the file-group-reader branch now appends partition values. The split carries the values parsed on the driver by the same routine the skip-merging reader relies on (off a log file's path when the slice has no base file), and they are bound in with one per-split `UnsafeProjection` over a `JoinedRow`. The output row shape was already correct -- `TableSchemaResolver` re-appends dropped partition columns, so the reader was merely filling them with nulls -- so this is a value substitution at existing ordinals, with no column added, moved or dropped. Inert unless it applies: no values on the split when the columns live in the data files, an empty ordinal array for a non-partitioned table (including the metadata table, whose Avro leg is untouched), and `-1` for unprojected columns.
- `SparkFileFormatInternalRowReaderContext`: the full-variant rewrite and restore projection are factored into reusable helpers (`fullVariantReadSchemaWithOrdinals`, `variantRestoreProjection`); behavior of the context itself is unchanged.
- `CDCFileGroupIterator`: BASE_FILE_INSERT applies the same rewrite/restore around its direct base-file read (with a defensive copy, since the restore projection reuses its output buffer).
- `InternalRowToJsonStringConverter`: variant columns are embedded into before/after images as real JSON nodes via `VariantVal.toString`, so `get_json_object(after, '$.v.key')` works as expected. The column is matched on `DataType.typeName`, not `SparkAdapter.isVariantType`: the guard runs for every non-string/array/map/struct field, and resolving the adapter needs a version module that is not on hudi-spark-common's own test classpath. `readTree` falls back to the raw rendering on `JsonProcessingException`, which is how a variant exceeding Jackson's default `StreamReadConstraints` (50k field names, 20M strings, 1000 nesting levels -- all reachable inside the variant size limit) arrives; `VariantVal.toString` stays outside that block so `MALFORMED_VARIANT` on corrupt bytes still surfaces.

Tests:

- CDC round trip over a COW table in `TestVariantDataType`, sweeping shredded and unshredded layouts against OP_KEY_ONLY and DATA_BEFORE_AFTER, with the on-disk layout pinned per leg. Pinned to `HoodieRecordType.SPARK`, since a cdc table always writes through `FileGroupReaderBasedMergeHandle` and the merger's record type picks that handle's reader context; the AVRO leg's shredded base-file read is the separate defect tracked as #19567.
- Legacy-path MOR streaming round trip in `TestStreamingSource` over a compacted shredded base file, asserting the executed plan is the RDD-backed `Scan ExistingRDD` so it cannot pass through a silent fallback to the file-group reader. One stream covers the base-only and log-only splits; a second, with its own checkpoint, replays from INIT so its first batch spans the compaction commit and the update together, which is the only way to land a base + log slice on this path.
- MOR reads over a `drop.partition.columns` table in `TestLegacyParquetReadPath`, through the directly-constructed legacy relations. The snapshot case uses a partial upsert so one file group merges base plus log while the others stay base-only, exercising the merging branch and the fast path in one query; verified red before fix 4 and green after. A second case covers a log-only slice.
- `TestInternalRowToJsonStringConverter` covers the JSON embedding and the constraints fallback. Before fix 3's detection change, 13 of its 14 cases errored with `ClassNotFoundException: Spark4_2Adapter`.

### Impact

Wrong-results fixes on non-default or CDC paths, plus one image-format improvement. CDC after-images of insert commits and legacy-path reads of base-only shredded slices returned null variants before this change; legacy-path MOR reads of a table whose partition columns live only in the partition path returned null partition columns. CDC images of variant columns now carry the variant's JSON structure; previously they carried a Jackson bean rendering of the raw bytes, which no reader could reasonably consume, so this is considered a fix rather than a breaking format change.

One deliberate behaviour change to call out: with `hoodie.datasource.read.extract.partition.values.from.path=true` on a table that does persist its partition columns, this branch previously returned the file-persisted value and now returns the partition-path-parsed one. That matches the skip-merging reader, the file-format path and the documented flag semantics, including the `TimestampBasedKeyGenerator` caveat noted on `HoodieBaseRelation.shouldExtractPartitionValuesFromPartitionPath`.

### Risk Level

low-medium. The variant routing change only triggers when the schema has variant columns and the adapter supports the rewrite; the CDC direct-read rewrite only rewrites on Spark 4.1+; the image converter change only affects variant columns. Fix 4 touches a shared read path, but `HoodieMergeOnReadRDDV2` runs only for legacy MOR streaming (`hoodie.file.group.reader.enabled=false`) and directly-constructed relations -- batch MOR always scans through `HoodieFileGroupReaderBasedFileFormat`, which appends partition values itself -- and it is a no-op unless the partition columns are absent from the data files.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
