### PR TITLE
docs(record-merger): document projection compatibility and mandatory merge fields

### DIFF
--- a/website/docs/record_merger.md
+++ b/website/docs/record_merger.md
@@ -93,12 +93,26 @@ interface HoodieRecordMerger {
     }
 
     <T> BufferedRecord<T> partialMerge(BufferedRecord<T> older, BufferedRecord<T> newer,
-                                       Schema readerSchema, RecordContext<T> recordContext,
+                                       HoodieSchema readerSchema, RecordContext<T> recordContext,
                                        TypedProperties props) throws IOException {
         // Merges records which can contain partial updates.
         // Returns a non-null BufferedRecord with only changed fields included.
         // If the result represents a deletion, set HoodieOperation.DELETE on the returned record.
         // Ordering values must always be set if there are ordering fields for the table.
+        ...
+    }
+
+    boolean isProjectionCompatible() {
+        // Whether this merger can work on a projection of the table schema rather than every column.
+        // Defaults to false, which makes MOR reads fetch all columns. See "Projection compatibility" below.
+        ...
+    }
+
+    String[] getMandatoryFieldsForMerging(HoodieSchema dataSchema, HoodieTableConfig cfg,
+                                          TypedProperties properties) {
+        // The columns merge() and partialMerge() read, beyond those the query itself requests.
+        // Only consulted when isProjectionCompatible() returns true.
+        // Defaults to the record key field plus the ordering fields.
         ...
     }
 
@@ -122,7 +136,54 @@ When implementing the `HoodieRecordMerger` interface, follow these guidelines to
 
 5. **Associative property**: The `merge()` method should be associative: `merge(a, merge(b, c))` should yield the same result as `merge(merge(a, b), c)` for any three versions A, B, C of the same record.
 
+6. **Declare every column your merge logic reads**: if you make the merger projection compatible, `getMandatoryFieldsForMerging()` must list every column `merge()` and `partialMerge()` touch that the query does not already request. See below.
+
 For more details on the implementation, see [RFC 101](https://github.com/apache/hudi/blob/master/rfc/rfc-101/rfc-101.md).
+
+#### Projection compatibility
+
+On a Merge-on-Read table the reader would rather fetch only the columns a query asks for. It cannot do that
+safely for a custom merger, because it has no way to know which columns your merge logic reads. Two methods
+resolve that, and they work as a pair:
+
+* `isProjectionCompatible()` — defaults to **`false`**, which tells the reader to fall back to reading the
+  **full table schema**. Merging is always correct in this mode, but a query selecting two columns still
+  reads every column of every log block, so it is the slower option. `COMMIT_TIME_ORDERING` and
+  `EVENT_TIME_ORDERING` are projection compatible; a `CUSTOM` merger is not until you say so.
+* `getMandatoryFieldsForMerging()` — only consulted once `isProjectionCompatible()` returns `true`. The
+  reader then reads the columns the query requested **plus** the ones this method names. Its default is the
+  record key field and the ordering fields, which is what a merger comparing only an ordering value needs.
+
+The two must agree, and this is where it goes wrong: if you return `true` from
+`isProjectionCompatible()` and your merge logic reads a column that is neither requested by the query nor
+returned by `getMandatoryFieldsForMerging()`, that column is absent from the records your merger receives.
+What happens next is up to your code — reading the missing field typically fails with a
+`NullPointerException`, and a merger that tolerates a null there will instead make its decision on
+incomplete data and return a silently wrong result. Either way it is query-dependent, showing up only for
+queries that do not happen to select the column themselves, which makes it easy to miss in testing.
+
+So if your merger compares, say, a `priority` column to decide a winner, either declare it:
+
+```Java
+@Override
+public boolean isProjectionCompatible() {
+    return true;
+}
+
+@Override
+public String[] getMandatoryFieldsForMerging(HoodieSchema dataSchema, HoodieTableConfig cfg,
+                                             TypedProperties properties) {
+    // Keep the defaults - record key and ordering fields - and add the column merge() reads, so the
+    // reader includes it even when a query does not project it.
+    LinkedHashSet<String> fields = new LinkedHashSet<>(
+            Arrays.asList(HoodieRecordMerger.super.getMandatoryFieldsForMerging(dataSchema, cfg, properties)));
+    fields.add("priority");
+    return fields.toArray(new String[0]);
+}
+```
+
+or leave `isProjectionCompatible()` at its default `false` and accept the full-schema read. Both are correct;
+only the half-way position, projection compatible without declaring the fields, is not.
 
 ### Merge Mode Configs
 

--- a/website/versioned_docs/version-1.1.1/record_merger.md
+++ b/website/versioned_docs/version-1.1.1/record_merger.md
@@ -102,6 +102,20 @@ interface HoodieRecordMerger {
         ...
     }
 
+    boolean isProjectionCompatible() {
+        // Whether this merger can work on a projection of the table schema rather than every column.
+        // Defaults to false, which makes MOR reads fetch all columns. See "Projection compatibility" below.
+        ...
+    }
+
+    String[] getMandatoryFieldsForMerging(Schema dataSchema, HoodieTableConfig cfg,
+                                          TypedProperties properties) {
+        // The columns merge() and partialMerge() read, beyond those the query itself requests.
+        // Only consulted when isProjectionCompatible() returns true.
+        // Defaults to the record key field plus the ordering fields.
+        ...
+    }
+
     HoodieRecordType getRecordType() {...}
 
     String getMergingStrategy() {...}
@@ -122,7 +136,54 @@ When implementing the `HoodieRecordMerger` interface, follow these guidelines to
 
 5. **Associative property**: The `merge()` method should be associative: `merge(a, merge(b, c))` should yield the same result as `merge(merge(a, b), c)` for any three versions A, B, C of the same record.
 
+6. **Declare every column your merge logic reads**: if you make the merger projection compatible, `getMandatoryFieldsForMerging()` must list every column `merge()` and `partialMerge()` touch that the query does not already request. See below.
+
 For more details on the implementation, see [RFC 101](https://github.com/apache/hudi/blob/master/rfc/rfc-101/rfc-101.md).
+
+#### Projection compatibility
+
+On a Merge-on-Read table the reader would rather fetch only the columns a query asks for. It cannot do that
+safely for a custom merger, because it has no way to know which columns your merge logic reads. Two methods
+resolve that, and they work as a pair:
+
+* `isProjectionCompatible()` — defaults to **`false`**, which tells the reader to fall back to reading the
+  **full table schema**. Merging is always correct in this mode, but a query selecting two columns still
+  reads every column of every log block, so it is the slower option. `COMMIT_TIME_ORDERING` and
+  `EVENT_TIME_ORDERING` are projection compatible; a `CUSTOM` merger is not until you say so.
+* `getMandatoryFieldsForMerging()` — only consulted once `isProjectionCompatible()` returns `true`. The
+  reader then reads the columns the query requested **plus** the ones this method names. Its default is the
+  record key field and the ordering fields, which is what a merger comparing only an ordering value needs.
+
+The two must agree, and this is where it goes wrong: if you return `true` from
+`isProjectionCompatible()` and your merge logic reads a column that is neither requested by the query nor
+returned by `getMandatoryFieldsForMerging()`, that column is absent from the records your merger receives.
+What happens next is up to your code — reading the missing field typically fails with a
+`NullPointerException`, and a merger that tolerates a null there will instead make its decision on
+incomplete data and return a silently wrong result. Either way it is query-dependent, showing up only for
+queries that do not happen to select the column themselves, which makes it easy to miss in testing.
+
+So if your merger compares, say, a `priority` column to decide a winner, either declare it:
+
+```Java
+@Override
+public boolean isProjectionCompatible() {
+    return true;
+}
+
+@Override
+public String[] getMandatoryFieldsForMerging(Schema dataSchema, HoodieTableConfig cfg,
+                                             TypedProperties properties) {
+    // Keep the defaults - record key and ordering fields - and add the column merge() reads, so the
+    // reader includes it even when a query does not project it.
+    LinkedHashSet<String> fields = new LinkedHashSet<>(
+            Arrays.asList(HoodieRecordMerger.super.getMandatoryFieldsForMerging(dataSchema, cfg, properties)));
+    fields.add("priority");
+    return fields.toArray(new String[0]);
+}
+```
+
+or leave `isProjectionCompatible()` at its default `false` and accept the full-schema read. Both are correct;
+only the half-way position, projection compatible without declaring the fields, is not.
 
 ### Merge Mode Configs
 

--- a/website/versioned_docs/version-1.2.0/record_merger.md
+++ b/website/versioned_docs/version-1.2.0/record_merger.md
@@ -93,12 +93,26 @@ interface HoodieRecordMerger {
     }
 
     <T> BufferedRecord<T> partialMerge(BufferedRecord<T> older, BufferedRecord<T> newer,
-                                       Schema readerSchema, RecordContext<T> recordContext,
+                                       HoodieSchema readerSchema, RecordContext<T> recordContext,
                                        TypedProperties props) throws IOException {
         // Merges records which can contain partial updates.
         // Returns a non-null BufferedRecord with only changed fields included.
         // If the result represents a deletion, set HoodieOperation.DELETE on the returned record.
         // Ordering values must always be set if there are ordering fields for the table.
+        ...
+    }
+
+    boolean isProjectionCompatible() {
+        // Whether this merger can work on a projection of the table schema rather than every column.
+        // Defaults to false, which makes MOR reads fetch all columns. See "Projection compatibility" below.
+        ...
+    }
+
+    String[] getMandatoryFieldsForMerging(HoodieSchema dataSchema, HoodieTableConfig cfg,
+                                          TypedProperties properties) {
+        // The columns merge() and partialMerge() read, beyond those the query itself requests.
+        // Only consulted when isProjectionCompatible() returns true.
+        // Defaults to the record key field plus the ordering fields.
         ...
     }
 
@@ -122,7 +136,54 @@ When implementing the `HoodieRecordMerger` interface, follow these guidelines to
 
 5. **Associative property**: The `merge()` method should be associative: `merge(a, merge(b, c))` should yield the same result as `merge(merge(a, b), c)` for any three versions A, B, C of the same record.
 
+6. **Declare every column your merge logic reads**: if you make the merger projection compatible, `getMandatoryFieldsForMerging()` must list every column `merge()` and `partialMerge()` touch that the query does not already request. See below.
+
 For more details on the implementation, see [RFC 101](https://github.com/apache/hudi/blob/master/rfc/rfc-101/rfc-101.md).
+
+#### Projection compatibility
+
+On a Merge-on-Read table the reader would rather fetch only the columns a query asks for. It cannot do that
+safely for a custom merger, because it has no way to know which columns your merge logic reads. Two methods
+resolve that, and they work as a pair:
+
+* `isProjectionCompatible()` — defaults to **`false`**, which tells the reader to fall back to reading the
+  **full table schema**. Merging is always correct in this mode, but a query selecting two columns still
+  reads every column of every log block, so it is the slower option. `COMMIT_TIME_ORDERING` and
+  `EVENT_TIME_ORDERING` are projection compatible; a `CUSTOM` merger is not until you say so.
+* `getMandatoryFieldsForMerging()` — only consulted once `isProjectionCompatible()` returns `true`. The
+  reader then reads the columns the query requested **plus** the ones this method names. Its default is the
+  record key field and the ordering fields, which is what a merger comparing only an ordering value needs.
+
+The two must agree, and this is where it goes wrong: if you return `true` from
+`isProjectionCompatible()` and your merge logic reads a column that is neither requested by the query nor
+returned by `getMandatoryFieldsForMerging()`, that column is absent from the records your merger receives.
+What happens next is up to your code — reading the missing field typically fails with a
+`NullPointerException`, and a merger that tolerates a null there will instead make its decision on
+incomplete data and return a silently wrong result. Either way it is query-dependent, showing up only for
+queries that do not happen to select the column themselves, which makes it easy to miss in testing.
+
+So if your merger compares, say, a `priority` column to decide a winner, either declare it:
+
+```Java
+@Override
+public boolean isProjectionCompatible() {
+    return true;
+}
+
+@Override
+public String[] getMandatoryFieldsForMerging(HoodieSchema dataSchema, HoodieTableConfig cfg,
+                                             TypedProperties properties) {
+    // Keep the defaults - record key and ordering fields - and add the column merge() reads, so the
+    // reader includes it even when a query does not project it.
+    LinkedHashSet<String> fields = new LinkedHashSet<>(
+            Arrays.asList(HoodieRecordMerger.super.getMandatoryFieldsForMerging(dataSchema, cfg, properties)));
+    fields.add("priority");
+    return fields.toArray(new String[0]);
+}
+```
+
+or leave `isProjectionCompatible()` at its default `false` and accept the full-schema read. Both are correct;
+only the half-way position, projection compatible without declaring the fields, is not.
 
 ### Merge Mode Configs
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #16697 (HUDI-8421): *"Right now the user must provide `getMandatoryFieldsForMerging` in record merger
implementation to make sure the functionality is correct. We need to inform the developer through our docs."*

`record_merger.md` is where a developer lands to implement a custom merger. It sketches the interface as
`merge`, `partialMerge`, `getRecordType`, `getMergingStrategy`, and follows with five Implementation
Guidelines. Neither the sketch nor the guidelines mentions `isProjectionCompatible()` or
`getMandatoryFieldsForMerging()` — the pair that decides whether a Merge-on-Read read may project columns
and, if it may, which columns the merger still needs. So the two methods that determine whether a custom
merger produces correct results on a projected read were invisible in the one place you would look for them.

What the code does, and what the docs now say:

- `isProjectionCompatible()` defaults to **`false`**, and for a `CUSTOM` merger
  `FileGroupReaderSchemaHandler` then returns `tableSchema` — the full-schema read. Always correct, never
  pruned.
- Once it returns `true`, the reader reads the query's columns **plus** those named by
  `getMandatoryFieldsForMerging()`; for `CUSTOM` mode that method is the only source of the extra columns.
- Its default is the record key field plus the ordering fields, so a merger that reads anything else must
  declare it.

### Summary and Changelog

- Added `isProjectionCompatible()` and `getMandatoryFieldsForMerging()` to the interface sketch, each with a
  comment on its default.
- Added a sixth Implementation Guideline, and a **Projection compatibility** subsection covering the pairing,
  the performance trade-off, and the failure mode.
- The worked example mirrors `MaxRankRecordMerger` in `hudi-trino`'s tests — real compiling code in this repo
  — rather than an invented snippet: it preserves the interface defaults through
  `HoodieRecordMerger.super.getMandatoryFieldsForMerging(...)` and adds its own column.
- Corrected the `partialMerge` signature in the sketch, which still showed Avro `Schema` for the reader
  schema. `release-1.2.md` already lists `partialMerge` among the source-breaking signature changes.

### Verification

This is a docs change, so there is no test to add — stated plainly rather than implied. Every claim was read
off master instead of recalled:

| claim in the docs | verified against |
| --- | --- |
| `isProjectionCompatible()` defaults to `false` | `HoodieRecordMerger.java:139-141` |
| default `false` ⇒ full table schema for `CUSTOM` | `FileGroupReaderSchemaHandler.java:215-218` (returns `this.tableSchema`) |
| mandatory fields only consulted once projection compatible | same early return, plus `:245-247` where `CUSTOM` delegates to the merger |
| reader reads requested **+** mandatory fields | `FileGroupReaderSchemaHandler.java:221-234` |
| default = record key + ordering fields | `HoodieRecordMerger.java:146-161` |
| commit-time and event-time ordering are projection compatible | `HoodieRecordMerger.java:137` |
| the `super`-preserving example compiles | `MaxRankRecordMerger.java:73-83`, the only in-tree caller of that default |

**Three files, and they are deliberately not identical.** The signature differs by release, checked at the
release refs rather than assumed:

- `website/docs/` and `versioned_docs/version-1.2.0/` — `HoodieSchema` (`release-1.2.0` line 146)
- `versioned_docs/version-1.1.1/` — Avro `Schema` (`release-1.1.1` line 147), so `partialMerge` there is
  already correct and is left untouched; only the two new methods are added, with the 1.1 type

`versioned_docs/version-1.0.x` carries the interface sketch but has no Implementation Guidelines section, so
it is out of scope.

Markdown checked by running `markdownlint` over the three files **before and after**, and comparing rule
classes rather than raw counts, since the pristine files already have 237 `MD013` findings:

```
before: MD013/line-length MD033/no-inline-html
after : MD013/line-length MD033/no-inline-html   ->  no new class of finding
```

That comparison caught two things I had introduced and have fixed: `-` bullets where this file uses `*`
(`MD004`), and a double blank line (`MD012`). Code-fence count is even in all three files, and the RFC-101
pointer stays at the end of Implementation Guidelines rather than drifting under the new subsection.

**Not done:** I did not run the Docusaurus build (`website/node_modules` is absent and a full install is
heavy). The change adds only fenced code blocks and prose using constructs already present in the same file,
and introduces no inline HTML, so MDX risk is low — but I would rather say so than imply a build passed.

### Impact

Documentation only. No code, config, API or format change. A developer implementing a custom `HoodieRecordMerger`
can now find out from the docs that projecting reads and declaring merge columns are coupled, instead of from a
wrong query result.

### Risk Level

none

### Documentation Update

This *is* the documentation update. Targets the `asf-site` branch; no release note needed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable — n/a for a docs change; verification table above instead
- [ ] CI passes on my PR — `asf-site` PRs do not run the `master` gates; `markdownlint` parity checked
      locally as described

**Screenshots:**

<img width="779" height="726" alt="Screenshot 2026-08-12 at 11 53 57 AM" src="https://github.com/user-attachments/assets/156cf8c3-5aa8-4101-97be-1193a8bdd60b" />
<img width="809" height="564" alt="Screenshot 2026-08-12 at 11 54 11 AM" src="https://github.com/user-attachments/assets/7a69f44c-0c80-4cc3-aca6-335e2a54b1d0" />
<img width="804" height="832" alt="Screenshot 2026-08-12 at 11 54 29 AM" src="https://github.com/user-attachments/assets/5d918aa3-ef78-4f22-9e24-ba14b76b46c2" />
