### PR TITLE
docs(performance): document Parquet bloom filters and separate them from the bloom index

### DIFF
--- a/website/docs/performance.md
+++ b/website/docs/performance.md
@@ -132,6 +132,56 @@ To enable Data Skipping in your queries make sure to set following properties to
   - `hoodie.metadata.enable` (to enable metadata table use on the read path, enabled by default)
   - `hoodie.metadata.index.column.stats.enable` (to enable column stats index use on the read path)
 
+#### Parquet Bloom Filters
+
+Column stats prune on ranges, so they help least where they are needed most: an equality predicate on a
+high-cardinality column whose min-max range covers almost every file. Parquet's own bloom filters cover that
+case. They are written into the Parquet file itself, and a reader consults them to skip row groups that
+cannot contain the value being searched for.
+
+Hudi passes these through to the Parquet writer, per column, from the **Hadoop** configuration:
+
+| key | meaning |
+| --- | --- |
+| `parquet.bloom.filter.enabled#<column>` | write a bloom filter for `<column>` |
+| `parquet.bloom.filter.expected.ndv#<column>` | expected number of distinct values, which sizes the filter |
+
+`<column>` is any data column you filter on by equality — not the record key, and unrelated to the record-key
+bloom index discussed in the note below. Set the keys on the Hadoop configuration your writer uses; from Spark
+the `spark.hadoop.` prefix forwards them:
+
+```
+--conf spark.hadoop.parquet.bloom.filter.enabled#session_id=true
+--conf spark.hadoop.parquet.bloom.filter.expected.ndv#session_id=100000
+```
+
+Give `expected.ndv` a realistic estimate for the column. Too low and the filter saturates and stops
+eliminating anything; too high and you pay in file size for nothing.
+
+This is a write-time decision: only files written after you set it carry the filters, so an existing table
+picks them up as it is rewritten by ongoing writes, compaction or clustering.
+
+On the read side nothing extra needs configuring for Spark 3.x. Reading the table back through the Hudi
+datasource consults the filters, provided the query carries an equality predicate that can be pushed down to
+the Parquet reader — a query filtering on a value no row group contains skips those row groups entirely.
+Parquet's own read-side switch, `parquet.filter.bloom.enabled`, is left at its default and Hudi never
+overrides it, so there is no reader-side flag to turn on.
+
+:::note
+Do not confuse the keys above with Hudi's own `hoodie.parquet.bloom.filter.enabled`, which is a different
+feature despite the near-identical name. That config controls whether Hudi writes a bloom filter **of record
+keys** into the file footer for use by the [bloom index](indexes.md) during upserts; it defaults to `true`,
+applies only when meta fields are populated, and is implied anyway when `hoodie.index.type` names a `BLOOM`
+index. It has nothing to do with per-column skipping on the read path, and setting it does not enable the
+Parquet column filters described here.
+:::
+
+:::caution
+Hudi applies these settings reflectively, so if the Parquet version on your classpath predates the
+`withBloomFilterEnabled` / `withBloomFilterNDV` builder methods, the keys are **silently ignored** rather
+than rejected. If you see no change in file size or query behaviour, check your Parquet version first.
+:::
+
 ## Related Resources
 
 <h3>Blogs</h3>

--- a/website/versioned_docs/version-1.0.0/performance.md
+++ b/website/versioned_docs/version-1.0.0/performance.md
@@ -131,3 +131,53 @@ To enable Data Skipping in your queries make sure to set following properties to
   - `hoodie.enable.data.skipping` (to control data skipping, enabled by default)
   - `hoodie.metadata.enable` (to enable metadata table use on the read path, enabled by default)
   - `hoodie.metadata.index.column.stats.enable` (to enable column stats index use on the read path)
+
+#### Parquet Bloom Filters
+
+Column stats prune on ranges, so they help least where they are needed most: an equality predicate on a
+high-cardinality column whose min-max range covers almost every file. Parquet's own bloom filters cover that
+case. They are written into the Parquet file itself, and a reader consults them to skip row groups that
+cannot contain the value being searched for.
+
+Hudi passes these through to the Parquet writer, per column, from the **Hadoop** configuration:
+
+| key | meaning |
+| --- | --- |
+| `parquet.bloom.filter.enabled#<column>` | write a bloom filter for `<column>` |
+| `parquet.bloom.filter.expected.ndv#<column>` | expected number of distinct values, which sizes the filter |
+
+`<column>` is any data column you filter on by equality — not the record key, and unrelated to the record-key
+bloom index discussed in the note below. Set the keys on the Hadoop configuration your writer uses; from Spark
+the `spark.hadoop.` prefix forwards them:
+
+```
+--conf spark.hadoop.parquet.bloom.filter.enabled#session_id=true
+--conf spark.hadoop.parquet.bloom.filter.expected.ndv#session_id=100000
+```
+
+Give `expected.ndv` a realistic estimate for the column. Too low and the filter saturates and stops
+eliminating anything; too high and you pay in file size for nothing.
+
+This is a write-time decision: only files written after you set it carry the filters, so an existing table
+picks them up as it is rewritten by ongoing writes, compaction or clustering.
+
+On the read side nothing extra needs configuring for Spark 3.x. Reading the table back through the Hudi
+datasource consults the filters, provided the query carries an equality predicate that can be pushed down to
+the Parquet reader — a query filtering on a value no row group contains skips those row groups entirely.
+Parquet's own read-side switch, `parquet.filter.bloom.enabled`, is left at its default and Hudi never
+overrides it, so there is no reader-side flag to turn on.
+
+:::note
+Do not confuse the keys above with Hudi's own `hoodie.parquet.bloom.filter.enabled`, which is a different
+feature despite the near-identical name. That config controls whether Hudi writes a bloom filter **of record
+keys** into the file footer for use by the [bloom index](indexes.md) during upserts; it defaults to `true`,
+applies only when meta fields are populated, and is implied anyway when `hoodie.index.type` names a `BLOOM`
+index. It has nothing to do with per-column skipping on the read path, and setting it does not enable the
+Parquet column filters described here.
+:::
+
+:::caution
+Hudi applies these settings reflectively, so if the Parquet version on your classpath predates the
+`withBloomFilterEnabled` / `withBloomFilterNDV` builder methods, the keys are **silently ignored** rather
+than rejected. If you see no change in file size or query behaviour, check your Parquet version first.
+:::

--- a/website/versioned_docs/version-1.0.1/performance.md
+++ b/website/versioned_docs/version-1.0.1/performance.md
@@ -132,6 +132,56 @@ To enable Data Skipping in your queries make sure to set following properties to
   - `hoodie.metadata.enable` (to enable metadata table use on the read path, enabled by default)
   - `hoodie.metadata.index.column.stats.enable` (to enable column stats index use on the read path)
 
+#### Parquet Bloom Filters
+
+Column stats prune on ranges, so they help least where they are needed most: an equality predicate on a
+high-cardinality column whose min-max range covers almost every file. Parquet's own bloom filters cover that
+case. They are written into the Parquet file itself, and a reader consults them to skip row groups that
+cannot contain the value being searched for.
+
+Hudi passes these through to the Parquet writer, per column, from the **Hadoop** configuration:
+
+| key | meaning |
+| --- | --- |
+| `parquet.bloom.filter.enabled#<column>` | write a bloom filter for `<column>` |
+| `parquet.bloom.filter.expected.ndv#<column>` | expected number of distinct values, which sizes the filter |
+
+`<column>` is any data column you filter on by equality — not the record key, and unrelated to the record-key
+bloom index discussed in the note below. Set the keys on the Hadoop configuration your writer uses; from Spark
+the `spark.hadoop.` prefix forwards them:
+
+```
+--conf spark.hadoop.parquet.bloom.filter.enabled#session_id=true
+--conf spark.hadoop.parquet.bloom.filter.expected.ndv#session_id=100000
+```
+
+Give `expected.ndv` a realistic estimate for the column. Too low and the filter saturates and stops
+eliminating anything; too high and you pay in file size for nothing.
+
+This is a write-time decision: only files written after you set it carry the filters, so an existing table
+picks them up as it is rewritten by ongoing writes, compaction or clustering.
+
+On the read side nothing extra needs configuring for Spark 3.x. Reading the table back through the Hudi
+datasource consults the filters, provided the query carries an equality predicate that can be pushed down to
+the Parquet reader — a query filtering on a value no row group contains skips those row groups entirely.
+Parquet's own read-side switch, `parquet.filter.bloom.enabled`, is left at its default and Hudi never
+overrides it, so there is no reader-side flag to turn on.
+
+:::note
+Do not confuse the keys above with Hudi's own `hoodie.parquet.bloom.filter.enabled`, which is a different
+feature despite the near-identical name. That config controls whether Hudi writes a bloom filter **of record
+keys** into the file footer for use by the [bloom index](indexes.md) during upserts; it defaults to `true`,
+applies only when meta fields are populated, and is implied anyway when `hoodie.index.type` names a `BLOOM`
+index. It has nothing to do with per-column skipping on the read path, and setting it does not enable the
+Parquet column filters described here.
+:::
+
+:::caution
+Hudi applies these settings reflectively, so if the Parquet version on your classpath predates the
+`withBloomFilterEnabled` / `withBloomFilterNDV` builder methods, the keys are **silently ignored** rather
+than rejected. If you see no change in file size or query behaviour, check your Parquet version first.
+:::
+
 ## Related Resources
 
 <h3>Blogs</h3>

--- a/website/versioned_docs/version-1.0.2/performance.md
+++ b/website/versioned_docs/version-1.0.2/performance.md
@@ -132,6 +132,56 @@ To enable Data Skipping in your queries make sure to set following properties to
   - `hoodie.metadata.enable` (to enable metadata table use on the read path, enabled by default)
   - `hoodie.metadata.index.column.stats.enable` (to enable column stats index use on the read path)
 
+#### Parquet Bloom Filters
+
+Column stats prune on ranges, so they help least where they are needed most: an equality predicate on a
+high-cardinality column whose min-max range covers almost every file. Parquet's own bloom filters cover that
+case. They are written into the Parquet file itself, and a reader consults them to skip row groups that
+cannot contain the value being searched for.
+
+Hudi passes these through to the Parquet writer, per column, from the **Hadoop** configuration:
+
+| key | meaning |
+| --- | --- |
+| `parquet.bloom.filter.enabled#<column>` | write a bloom filter for `<column>` |
+| `parquet.bloom.filter.expected.ndv#<column>` | expected number of distinct values, which sizes the filter |
+
+`<column>` is any data column you filter on by equality — not the record key, and unrelated to the record-key
+bloom index discussed in the note below. Set the keys on the Hadoop configuration your writer uses; from Spark
+the `spark.hadoop.` prefix forwards them:
+
+```
+--conf spark.hadoop.parquet.bloom.filter.enabled#session_id=true
+--conf spark.hadoop.parquet.bloom.filter.expected.ndv#session_id=100000
+```
+
+Give `expected.ndv` a realistic estimate for the column. Too low and the filter saturates and stops
+eliminating anything; too high and you pay in file size for nothing.
+
+This is a write-time decision: only files written after you set it carry the filters, so an existing table
+picks them up as it is rewritten by ongoing writes, compaction or clustering.
+
+On the read side nothing extra needs configuring for Spark 3.x. Reading the table back through the Hudi
+datasource consults the filters, provided the query carries an equality predicate that can be pushed down to
+the Parquet reader — a query filtering on a value no row group contains skips those row groups entirely.
+Parquet's own read-side switch, `parquet.filter.bloom.enabled`, is left at its default and Hudi never
+overrides it, so there is no reader-side flag to turn on.
+
+:::note
+Do not confuse the keys above with Hudi's own `hoodie.parquet.bloom.filter.enabled`, which is a different
+feature despite the near-identical name. That config controls whether Hudi writes a bloom filter **of record
+keys** into the file footer for use by the [bloom index](indexes.md) during upserts; it defaults to `true`,
+applies only when meta fields are populated, and is implied anyway when `hoodie.index.type` names a `BLOOM`
+index. It has nothing to do with per-column skipping on the read path, and setting it does not enable the
+Parquet column filters described here.
+:::
+
+:::caution
+Hudi applies these settings reflectively, so if the Parquet version on your classpath predates the
+`withBloomFilterEnabled` / `withBloomFilterNDV` builder methods, the keys are **silently ignored** rather
+than rejected. If you see no change in file size or query behaviour, check your Parquet version first.
+:::
+
 ## Related Resources
 
 <h3>Blogs</h3>

--- a/website/versioned_docs/version-1.1.1/performance.md
+++ b/website/versioned_docs/version-1.1.1/performance.md
@@ -132,6 +132,56 @@ To enable Data Skipping in your queries make sure to set following properties to
   - `hoodie.metadata.enable` (to enable metadata table use on the read path, enabled by default)
   - `hoodie.metadata.index.column.stats.enable` (to enable column stats index use on the read path)
 
+#### Parquet Bloom Filters
+
+Column stats prune on ranges, so they help least where they are needed most: an equality predicate on a
+high-cardinality column whose min-max range covers almost every file. Parquet's own bloom filters cover that
+case. They are written into the Parquet file itself, and a reader consults them to skip row groups that
+cannot contain the value being searched for.
+
+Hudi passes these through to the Parquet writer, per column, from the **Hadoop** configuration:
+
+| key | meaning |
+| --- | --- |
+| `parquet.bloom.filter.enabled#<column>` | write a bloom filter for `<column>` |
+| `parquet.bloom.filter.expected.ndv#<column>` | expected number of distinct values, which sizes the filter |
+
+`<column>` is any data column you filter on by equality — not the record key, and unrelated to the record-key
+bloom index discussed in the note below. Set the keys on the Hadoop configuration your writer uses; from Spark
+the `spark.hadoop.` prefix forwards them:
+
+```
+--conf spark.hadoop.parquet.bloom.filter.enabled#session_id=true
+--conf spark.hadoop.parquet.bloom.filter.expected.ndv#session_id=100000
+```
+
+Give `expected.ndv` a realistic estimate for the column. Too low and the filter saturates and stops
+eliminating anything; too high and you pay in file size for nothing.
+
+This is a write-time decision: only files written after you set it carry the filters, so an existing table
+picks them up as it is rewritten by ongoing writes, compaction or clustering.
+
+On the read side nothing extra needs configuring for Spark 3.x. Reading the table back through the Hudi
+datasource consults the filters, provided the query carries an equality predicate that can be pushed down to
+the Parquet reader — a query filtering on a value no row group contains skips those row groups entirely.
+Parquet's own read-side switch, `parquet.filter.bloom.enabled`, is left at its default and Hudi never
+overrides it, so there is no reader-side flag to turn on.
+
+:::note
+Do not confuse the keys above with Hudi's own `hoodie.parquet.bloom.filter.enabled`, which is a different
+feature despite the near-identical name. That config controls whether Hudi writes a bloom filter **of record
+keys** into the file footer for use by the [bloom index](indexes.md) during upserts; it defaults to `true`,
+applies only when meta fields are populated, and is implied anyway when `hoodie.index.type` names a `BLOOM`
+index. It has nothing to do with per-column skipping on the read path, and setting it does not enable the
+Parquet column filters described here.
+:::
+
+:::caution
+Hudi applies these settings reflectively, so if the Parquet version on your classpath predates the
+`withBloomFilterEnabled` / `withBloomFilterNDV` builder methods, the keys are **silently ignored** rather
+than rejected. If you see no change in file size or query behaviour, check your Parquet version first.
+:::
+
 ## Related Resources
 
 <h3>Blogs</h3>

--- a/website/versioned_docs/version-1.2.0/performance.md
+++ b/website/versioned_docs/version-1.2.0/performance.md
@@ -132,6 +132,56 @@ To enable Data Skipping in your queries make sure to set following properties to
   - `hoodie.metadata.enable` (to enable metadata table use on the read path, enabled by default)
   - `hoodie.metadata.index.column.stats.enable` (to enable column stats index use on the read path)
 
+#### Parquet Bloom Filters
+
+Column stats prune on ranges, so they help least where they are needed most: an equality predicate on a
+high-cardinality column whose min-max range covers almost every file. Parquet's own bloom filters cover that
+case. They are written into the Parquet file itself, and a reader consults them to skip row groups that
+cannot contain the value being searched for.
+
+Hudi passes these through to the Parquet writer, per column, from the **Hadoop** configuration:
+
+| key | meaning |
+| --- | --- |
+| `parquet.bloom.filter.enabled#<column>` | write a bloom filter for `<column>` |
+| `parquet.bloom.filter.expected.ndv#<column>` | expected number of distinct values, which sizes the filter |
+
+`<column>` is any data column you filter on by equality — not the record key, and unrelated to the record-key
+bloom index discussed in the note below. Set the keys on the Hadoop configuration your writer uses; from Spark
+the `spark.hadoop.` prefix forwards them:
+
+```
+--conf spark.hadoop.parquet.bloom.filter.enabled#session_id=true
+--conf spark.hadoop.parquet.bloom.filter.expected.ndv#session_id=100000
+```
+
+Give `expected.ndv` a realistic estimate for the column. Too low and the filter saturates and stops
+eliminating anything; too high and you pay in file size for nothing.
+
+This is a write-time decision: only files written after you set it carry the filters, so an existing table
+picks them up as it is rewritten by ongoing writes, compaction or clustering.
+
+On the read side nothing extra needs configuring for Spark 3.x. Reading the table back through the Hudi
+datasource consults the filters, provided the query carries an equality predicate that can be pushed down to
+the Parquet reader — a query filtering on a value no row group contains skips those row groups entirely.
+Parquet's own read-side switch, `parquet.filter.bloom.enabled`, is left at its default and Hudi never
+overrides it, so there is no reader-side flag to turn on.
+
+:::note
+Do not confuse the keys above with Hudi's own `hoodie.parquet.bloom.filter.enabled`, which is a different
+feature despite the near-identical name. That config controls whether Hudi writes a bloom filter **of record
+keys** into the file footer for use by the [bloom index](indexes.md) during upserts; it defaults to `true`,
+applies only when meta fields are populated, and is implied anyway when `hoodie.index.type` names a `BLOOM`
+index. It has nothing to do with per-column skipping on the read path, and setting it does not enable the
+Parquet column filters described here.
+:::
+
+:::caution
+Hudi applies these settings reflectively, so if the Parquet version on your classpath predates the
+`withBloomFilterEnabled` / `withBloomFilterNDV` builder methods, the keys are **silently ignored** rather
+than rejected. If you see no change in file size or query behaviour, check your Parquet version first.
+:::
+
 ## Related Resources
 
 <h3>Blogs</h3>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #16063 (HUDI-6456), "Add parquet blooms documentation".

Hudi forwards Parquet's per-column bloom filter settings through to the Parquet writer, but the only trace of
bloom filters in the docs was one auto-generated row in `configurations.md` — and that row is for a **different
feature** with a near-identical name. So nothing told a user that these keys exist, that they are per column,
or that they are read from the Hadoop configuration:

```
parquet.bloom.filter.enabled#<column>
parquet.bloom.filter.expected.ndv#<column>
```

### Summary and Changelog

Adds a **Parquet Bloom Filters** subsection to `performance.md`, under `Read Path` next to `Data Skipping`,
because that is precisely the gap it fills: column stats prune on ranges and so help least for an equality
predicate on a high-cardinality column whose min-max spans nearly every file — which is what a bloom filter
covers.

The section states the two keys, that they are per column, how to set them from Spark (`spark.hadoop.` prefix),
how to size `expected.ndv`, that it is a write-time decision so an existing table only picks them up as it is
rewritten, and — added after review — **what the read side needs**: nothing, on Spark 3.x, beyond an equality
predicate that can be pushed down.

Two caveats are called out, because both are easy to get wrong and neither was written down anywhere:

1. **`hoodie.parquet.bloom.filter.enabled` is not this feature.** It controls whether Hudi writes a bloom
   filter **of record keys** into the footer for the [bloom index](https://hudi.apache.org/docs/indexes) during
   upserts. It defaults to `true`, applies only when meta fields are populated, and is implied anyway when
   `hoodie.index.type` names a `BLOOM` index. Setting it does **not** enable per-column Parquet filters. Given
   the names differ by one prefix, a user reading `configurations.md` could reasonably conclude the opposite.
2. **The settings are applied reflectively and failure is swallowed.** On a Parquet without
   `withBloomFilterEnabled` / `withBloomFilterNDV`, the keys are silently ignored rather than rejected.

### Verification

Docs change, so no test to add — said plainly rather than implied. Every claim was read off master
(`3ba31dd37fff`):

| claim | source |
| --- | --- |
| keys are read from the **Hadoop** config, per column | `HoodieBaseParquetWriter.handleParquetBloomFilters`, `:98-119` — iterates the `Configuration` and splits the column off each key |
| exact key spelling | `HoodieBaseParquetWriter:52-53`, and `TestHoodieParquetBloom.scala:36-37` sets `parquet.bloom.filter.enabled#bloom_col` / `expected.ndv#bloom_col` on `jsc.hadoopConfiguration` |
| forwarded via `withBloomFilterEnabled` / `withBloomFilterNDV` | `:105` and `:114`, invoked by reflection |
| silently ignored on an older Parquet | `:107-109` and `:116-118` — `NoSuchMethodException` is caught and skipped |
| `hoodie.parquet.bloom.filter.enabled` is about record-key blooms for the bloom index | `HoodieStorageConfig:252-258` (default `true`, since 0.15.0) and `HoodieFileWriterFactory.enableBloomFilter:141-146` (`populateMetaFields && (thisConfig ‖ index.type contains BLOOM)`) |
| Flink sets them the same way | `TestHoodieRowDataParquetConfigInjector:100-101` |
| **the read path actually consults them** | `TestHoodieParquetBloomFilter` (hudi-spark): sets the write keys, disables `parquet.filter.columnindex.enabled` and `parquet.filter.stats.enabled` so only a bloom can skip, then asserts **0** row groups scanned for an absent value vs **1** for a present one, reading via `spark.read.format("hudi")`, over BULK_INSERT / INSERT / UPSERT / INSERT_OVERWRITE on COW |
| `parquet.filter.bloom.enabled` left at its default | that same test disables *stats* and *columnindex* but never the bloom switch, and `grep` finds Hudi setting it nowhere |

**Version coverage.** The feature ships in every currently-supported release, so the section is added to the
current docs *and to all five supported versioned copies*:

| tree | why |
| --- | --- |
| `website/docs/` | current / next |
| `versioned_docs/version-1.2.0`, `1.1.1`, `1.0.2`, `1.0.1`, `1.0.0` | all ≥ 0.14.0, so all have the feature |

Checked rather than assumed: `handleParquetBloomFilters` is **absent** at `release-0.13.1` and present from
`release-0.14.0` onward, and the `hoodie.parquet.bloom.filter.enabled` config it is contrasted against reads
`defaultValue(true)` / `sinceVersion("0.15.0")` identically at `release-1.0.0`, `1.0.2`, `1.1.1` and `1.2.0`
— so every claim in the text is accurate for each version it lands in. The five-version fan-out matches how
other cross-version docs fixes have been applied (#19555, #19459). The 0.15.x and 0.14.x copies are left
alone: they have had no, or nearly no, doc commits in the last six months and are effectively frozen.

`version-1.0.0/performance.md` has **no** `## Related Resources` heading — its page ends after Data Skipping —
so there the section is appended at the end of the file rather than before that anchor. Everywhere else it is
inserted before it.

Markdown checked by running `markdownlint` over all six files **before and after** and comparing rule
*classes* rather than counts, since these files already carry findings:

```
before: MD007 MD009 MD012 MD013 MD031 MD033 MD040
after : MD007 MD009 MD012 MD013 MD031 MD033 MD040   ->  no new class of finding
```

Also checked across all six: every `<column>` occurrence sits inside inline code, so nothing new is exposed
to the MDX parser; the `indexes.md` link target exists in **every** one of the five versioned trees so the
relative link resolves in each; and the inserted region is byte-identical in all six files.

Deliberately **not** naming `TestHoodieParquetBloomFilter` in the docs page itself: a user-facing reference to a
test class rots silently on a rename, which is the objection @hudi-agent raised on #19486. The evidence lives
here and in the commit message instead.

**Not done:** the Docusaurus build (`website/node_modules` absent, full install heavy). The section adds a
table, a fenced block and two admonitions, all constructs already used on this page.

### Relationship to #9056

@parisni opened **#9056** ("[HUDI-6456] [DOC] Add parquet blooms documentation") for this same issue in
June 2023, and it is still open. I did not see it when I opened this PR — I checked the issue timeline for
cross-referenced PRs, and because #9056 predates the JIRA-migrated issue it never linked there, even though
hudi-bot had posted a "Linked PR(s)" comment naming it. That was my error and I have said so on both threads.

The two differ in shape: #9056 adds a dedicated `parquet_bloom.md` page (plus a Parquet Config section in
`configurations.md`), where this one adds a section to `performance.md` next to Data Skipping. #9056 also
carries material this PR does not — how dictionary encoding makes blooms redundant below ~40k distinct
values, and NDV rationale — while this PR carries the config name collision, the silent-reflection caveat and
the five-version fan-out that #9056 does not have. I have posted those findings on #9056 as review comments
too, so they are available whichever shape a committer prefers, and I am happy to fold this content into that
PR instead if that is the preference.

### Impact

Documentation only — no code, config, API or format change. Two features whose names differ by one prefix are
now distinguishable, and a write-side knob that previously required reading `HoodieBaseParquetWriter` to
discover is now documented.

### Risk Level

none

### Documentation Update

This is the documentation update. Targets `asf-site`; applied to `docs/` plus the five supported versioned
copies (1.2.0, 1.1.1, 1.0.2, 1.0.1, 1.0.0), as justified in Verification above.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable — n/a for docs; verification table above instead
- [ ] CI passes on my PR — `asf-site` PRs do not run the `master` gates; `markdownlint` parity checked locally
      as described
