### PR TITLE
docs(concurrency): document the implicit partition key DynamoDB lock provider

### DIFF
--- a/website/docs/concurrency_control.md
+++ b/website/docs/concurrency_control.md
@@ -188,6 +188,32 @@ com.amazonaws:aws-java-sdk-dynamodb
 com.amazonaws:aws-java-sdk-core
 ```
 
+### DynamoDB-Based Lock Provider with Implicit Partition Key
+
+```properties
+hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedImplicitPartitionKeyLockProvider
+```
+
+This variant behaves like the DynamoDB-based lock provider above, except in how it determines the DynamoDB partition
+key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives the key from the table's base path: the
+64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
+scheme take the same lock.
+
+Prefer it when many tables share one lock table. The standard provider requires
+`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
+tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
+serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
+per-table configuration.
+
+Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
+as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.
+
+:::note
+Because rows are keyed by a hash rather than the table name, entries in the DynamoDB lock table are not recognizable at
+a glance. The provider logs the base path together with its derived key when acquiring a lock, which is how to map one
+to the other.
+:::
+
 ### FileSystem based lock provider
 
 FileSystem based lock provider supports multiple writers across different jobs/applications based on atomic create/delete operations of the underlying filesystem.

--- a/website/docs/concurrency_control.md
+++ b/website/docs/concurrency_control.md
@@ -145,7 +145,7 @@ The Amazon DynamoDB–based lock provider supports multi-writing across clusters
 
 Further configurations: [DynamoDB-Based Locks Configurations](configurations.md#DynamoDB-based-Locks-Configurations)
 
-Table creation: Hudi auto-creates the DynamoDB table specified by `hoodie.write.lock.dynamodb.table`. If using an existing table, ensure a `key` attribute (as partition key) exists. `hoodie.write.lock.dynamodb.partition_key` is the value written for the partition key (default: table name), ensuring multiple writers share the same lock.
+Table creation: Hudi auto-creates the DynamoDB table specified by `hoodie.write.lock.dynamodb.table`. If using an existing table, ensure a `key` attribute (as partition key) exists. `hoodie.write.lock.dynamodb.partition_key` is the value written for the partition key (inferred from the table name when unset), ensuring multiple writers share the same lock.
 
 Credential props (if not using the default provider chain):
 
@@ -199,11 +199,11 @@ key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives 
 64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
 scheme take the same lock.
 
-Prefer it when many tables share one lock table. The standard provider requires
-`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
-tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
-serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
-per-table configuration.
+Prefer it when many tables share one lock table. The standard provider takes its partition key from
+`hoodie.write.lock.dynamodb.partition_key`, which you rarely set: when it is absent, Hudi fills it in from the table
+name. Two tables that happen to share a name, in different databases or under different paths, therefore resolve to the
+same lock and serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per
+table with no per-table configuration.
 
 Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
 as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.

--- a/website/versioned_docs/version-1.0.0/concurrency_control.md
+++ b/website/versioned_docs/version-1.0.0/concurrency_control.md
@@ -128,6 +128,32 @@ com.amazonaws:aws-java-sdk-dynamodb
 com.amazonaws:aws-java-sdk-core
 ```
 
+#### DynamoDB-Based Lock Provider with Implicit Partition Key
+
+```properties
+hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedImplicitPartitionKeyLockProvider
+```
+
+This variant behaves like the DynamoDB-based lock provider above, except in how it determines the DynamoDB partition
+key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives the key from the table's base path: the
+64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
+scheme take the same lock.
+
+Prefer it when many tables share one lock table. The standard provider requires
+`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
+tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
+serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
+per-table configuration.
+
+Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
+as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.
+
+:::note
+Because rows are keyed by a hash rather than the table name, entries in the DynamoDB lock table are not recognizable at
+a glance. The provider logs the base path together with its derived key when acquiring a lock, which is how to map one
+to the other.
+:::
+
 #### FileSystem based (not for production use)
 
 FileSystem based lock provider supports multiple writers cross different jobs/applications based on atomic create/delete operations of the underlying filesystem.

--- a/website/versioned_docs/version-1.0.0/concurrency_control.md
+++ b/website/versioned_docs/version-1.0.0/concurrency_control.md
@@ -139,11 +139,11 @@ key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives 
 64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
 scheme take the same lock.
 
-Prefer it when many tables share one lock table. The standard provider requires
-`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
-tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
-serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
-per-table configuration.
+Prefer it when many tables share one lock table. The standard provider takes its partition key from
+`hoodie.write.lock.dynamodb.partition_key`, which you rarely set: when it is absent, Hudi fills it in from the table
+name. Two tables that happen to share a name, in different databases or under different paths, therefore resolve to the
+same lock and serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per
+table with no per-table configuration.
 
 Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
 as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.

--- a/website/versioned_docs/version-1.0.1/concurrency_control.md
+++ b/website/versioned_docs/version-1.0.1/concurrency_control.md
@@ -143,6 +143,32 @@ com.amazonaws:aws-java-sdk-dynamodb
 com.amazonaws:aws-java-sdk-core
 ```
 
+#### DynamoDB-Based Lock Provider with Implicit Partition Key
+
+```properties
+hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedImplicitPartitionKeyLockProvider
+```
+
+This variant behaves like the DynamoDB-based lock provider above, except in how it determines the DynamoDB partition
+key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives the key from the table's base path: the
+64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
+scheme take the same lock.
+
+Prefer it when many tables share one lock table. The standard provider requires
+`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
+tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
+serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
+per-table configuration.
+
+Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
+as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.
+
+:::note
+Because rows are keyed by a hash rather than the table name, entries in the DynamoDB lock table are not recognizable at
+a glance. The provider logs the base path together with its derived key when acquiring a lock, which is how to map one
+to the other.
+:::
+
 #### FileSystem based (not for production use)
 
 FileSystem based lock provider supports multiple writers cross different jobs/applications based on atomic create/delete operations of the underlying filesystem.

--- a/website/versioned_docs/version-1.0.1/concurrency_control.md
+++ b/website/versioned_docs/version-1.0.1/concurrency_control.md
@@ -154,11 +154,11 @@ key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives 
 64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
 scheme take the same lock.
 
-Prefer it when many tables share one lock table. The standard provider requires
-`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
-tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
-serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
-per-table configuration.
+Prefer it when many tables share one lock table. The standard provider takes its partition key from
+`hoodie.write.lock.dynamodb.partition_key`, which you rarely set: when it is absent, Hudi fills it in from the table
+name. Two tables that happen to share a name, in different databases or under different paths, therefore resolve to the
+same lock and serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per
+table with no per-table configuration.
 
 Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
 as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.

--- a/website/versioned_docs/version-1.0.2/concurrency_control.md
+++ b/website/versioned_docs/version-1.0.2/concurrency_control.md
@@ -150,6 +150,32 @@ com.amazonaws:aws-java-sdk-dynamodb
 com.amazonaws:aws-java-sdk-core
 ```
 
+#### DynamoDB-Based Lock Provider with Implicit Partition Key
+
+```properties
+hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedImplicitPartitionKeyLockProvider
+```
+
+This variant behaves like the DynamoDB-based lock provider above, except in how it determines the DynamoDB partition
+key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives the key from the table's base path: the
+64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
+scheme take the same lock.
+
+Prefer it when many tables share one lock table. The standard provider requires
+`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
+tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
+serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
+per-table configuration.
+
+Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
+as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.
+
+:::note
+Because rows are keyed by a hash rather than the table name, entries in the DynamoDB lock table are not recognizable at
+a glance. The provider logs the base path together with its derived key when acquiring a lock, which is how to map one
+to the other.
+:::
+
 #### FileSystem based (not for production use)
 
 FileSystem based lock provider supports multiple writers cross different jobs/applications based on atomic create/delete operations of the underlying filesystem.

--- a/website/versioned_docs/version-1.0.2/concurrency_control.md
+++ b/website/versioned_docs/version-1.0.2/concurrency_control.md
@@ -161,11 +161,11 @@ key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives 
 64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
 scheme take the same lock.
 
-Prefer it when many tables share one lock table. The standard provider requires
-`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
-tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
-serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
-per-table configuration.
+Prefer it when many tables share one lock table. The standard provider takes its partition key from
+`hoodie.write.lock.dynamodb.partition_key`, which you rarely set: when it is absent, Hudi fills it in from the table
+name. Two tables that happen to share a name, in different databases or under different paths, therefore resolve to the
+same lock and serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per
+table with no per-table configuration.
 
 Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
 as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.

--- a/website/versioned_docs/version-1.1.1/concurrency_control.md
+++ b/website/versioned_docs/version-1.1.1/concurrency_control.md
@@ -123,7 +123,7 @@ The Amazon DynamoDB–based lock provider supports multi-writing across clusters
 
 Further configurations: [DynamoDB-Based Locks Configurations](configurations.md#DynamoDB-based-Locks-Configurations)
 
-Table creation: Hudi auto-creates the DynamoDB table specified by `hoodie.write.lock.dynamodb.table`. If using an existing table, ensure a `key` attribute (as partition key) exists. `hoodie.write.lock.dynamodb.partition_key` is the value written for the partition key (default: table name), ensuring multiple writers share the same lock.
+Table creation: Hudi auto-creates the DynamoDB table specified by `hoodie.write.lock.dynamodb.table`. If using an existing table, ensure a `key` attribute (as partition key) exists. `hoodie.write.lock.dynamodb.partition_key` is the value written for the partition key (inferred from the table name when unset), ensuring multiple writers share the same lock.
 
 Credential props (if not using the default provider chain):
 
@@ -177,11 +177,11 @@ key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives 
 64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
 scheme take the same lock.
 
-Prefer it when many tables share one lock table. The standard provider requires
-`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
-tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
-serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
-per-table configuration.
+Prefer it when many tables share one lock table. The standard provider takes its partition key from
+`hoodie.write.lock.dynamodb.partition_key`, which you rarely set: when it is absent, Hudi fills it in from the table
+name. Two tables that happen to share a name, in different databases or under different paths, therefore resolve to the
+same lock and serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per
+table with no per-table configuration.
 
 Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
 as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.

--- a/website/versioned_docs/version-1.1.1/concurrency_control.md
+++ b/website/versioned_docs/version-1.1.1/concurrency_control.md
@@ -166,6 +166,32 @@ com.amazonaws:aws-java-sdk-dynamodb
 com.amazonaws:aws-java-sdk-core
 ```
 
+### DynamoDB-Based Lock Provider with Implicit Partition Key
+
+```properties
+hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedImplicitPartitionKeyLockProvider
+```
+
+This variant behaves like the DynamoDB-based lock provider above, except in how it determines the DynamoDB partition
+key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives the key from the table's base path: the
+64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
+scheme take the same lock.
+
+Prefer it when many tables share one lock table. The standard provider requires
+`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
+tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
+serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
+per-table configuration.
+
+Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
+as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.
+
+:::note
+Because rows are keyed by a hash rather than the table name, entries in the DynamoDB lock table are not recognizable at
+a glance. The provider logs the base path together with its derived key when acquiring a lock, which is how to map one
+to the other.
+:::
+
 ### FileSystem based lock provider
 
 FileSystem based lock provider supports multiple writers across different jobs/applications based on atomic create/delete operations of the underlying filesystem.

--- a/website/versioned_docs/version-1.2.0/concurrency_control.md
+++ b/website/versioned_docs/version-1.2.0/concurrency_control.md
@@ -188,6 +188,32 @@ com.amazonaws:aws-java-sdk-dynamodb
 com.amazonaws:aws-java-sdk-core
 ```
 
+### DynamoDB-Based Lock Provider with Implicit Partition Key
+
+```properties
+hoodie.write.lock.provider=org.apache.hudi.aws.transaction.lock.DynamoDBBasedImplicitPartitionKeyLockProvider
+```
+
+This variant behaves like the DynamoDB-based lock provider above, except in how it determines the DynamoDB partition
+key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives the key from the table's base path: the
+64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
+scheme take the same lock.
+
+Prefer it when many tables share one lock table. The standard provider requires
+`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
+tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
+serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
+per-table configuration.
+
+Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
+as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.
+
+:::note
+Because rows are keyed by a hash rather than the table name, entries in the DynamoDB lock table are not recognizable at
+a glance. The provider logs the base path together with its derived key when acquiring a lock, which is how to map one
+to the other.
+:::
+
 ### FileSystem based lock provider
 
 FileSystem based lock provider supports multiple writers across different jobs/applications based on atomic create/delete operations of the underlying filesystem.

--- a/website/versioned_docs/version-1.2.0/concurrency_control.md
+++ b/website/versioned_docs/version-1.2.0/concurrency_control.md
@@ -145,7 +145,7 @@ The Amazon DynamoDB–based lock provider supports multi-writing across clusters
 
 Further configurations: [DynamoDB-Based Locks Configurations](configurations.md#DynamoDB-based-Locks-Configurations)
 
-Table creation: Hudi auto-creates the DynamoDB table specified by `hoodie.write.lock.dynamodb.table`. If using an existing table, ensure a `key` attribute (as partition key) exists. `hoodie.write.lock.dynamodb.partition_key` is the value written for the partition key (default: table name), ensuring multiple writers share the same lock.
+Table creation: Hudi auto-creates the DynamoDB table specified by `hoodie.write.lock.dynamodb.table`. If using an existing table, ensure a `key` attribute (as partition key) exists. `hoodie.write.lock.dynamodb.partition_key` is the value written for the partition key (inferred from the table name when unset), ensuring multiple writers share the same lock.
 
 Credential props (if not using the default provider chain):
 
@@ -199,11 +199,11 @@ key. Rather than reading `hoodie.write.lock.dynamodb.partition_key`, it derives 
 64-bit xxHash of that path, with `s3a://` normalized to `s3://` so that writers reaching the same table through either
 scheme take the same lock.
 
-Prefer it when many tables share one lock table. The standard provider requires
-`hoodie.write.lock.dynamodb.partition_key`, and when it is not set explicitly Hudi infers it from the table name, so two
-tables that happen to share a name, in different databases or under different paths, resolve to the same lock and
-serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per table with no
-per-table configuration.
+Prefer it when many tables share one lock table. The standard provider takes its partition key from
+`hoodie.write.lock.dynamodb.partition_key`, which you rarely set: when it is absent, Hudi fills it in from the table
+name. Two tables that happen to share a name, in different databases or under different paths, therefore resolve to the
+same lock and serialize writers that never touch the same data. Deriving the key from the base path keeps it unique per
+table with no per-table configuration.
 
 Everything else is unchanged: lock table, region, billing mode, endpoint URL, credentials and IAM permissions all work
 as described above, and `hoodie.write.lock.dynamodb.partition_key` is not read.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #16814. (JIRA: HUDI-8964.)

The **Distributed Locking** section documents the storage-based, ZooKeeper, HiveMetastore, DynamoDB and FileSystem lock
providers, but never mentions `DynamoDBBasedImplicitPartitionKeyLockProvider`. That is exactly what @yihua asked for on
the issue ("the docs of lock providers need to be updated") and what the later backlog triage pinned down.

Confirmed the gap rather than assuming it: `ImplicitPartitionKey` appears nowhere under `website/docs`,
`website/versioned_docs` or `website/learn`.

### Summary and Changelog

Adds a `DynamoDB-Based Lock Provider with Implicit Partition Key` subsection after the existing DynamoDB one, covering
what the key is derived from, when to prefer it, what carries over from the standard provider, and the one operational
consequence of hashed keys.

**What it does.** The class extends `DynamoDBBasedLockProviderBase` and overrides a single method:

```java
String hudiTableBasePathNormalized = s3aToS3(lockConfiguration.getConfig()
    .getString(HoodieCommonConfig.BASE_PATH.key()));
String partitionKey = HashID.generateXXHashAsString(hudiTableBasePathNormalized, HashID.Size.BITS_64);
```

so the DynamoDB partition key is the 64-bit xxHash of the table base path, with `s3a://` normalized to `s3://` so the
same table addressed either way takes one lock.

**Why it is worth documenting.** `DynamoDBBasedLockProvider` *requires* `hoodie.write.lock.dynamodb.partition_key` —
it throws `"Config key is not found"` when absent — and that config has **no default value**, only an infer function
falling back to `HoodieTableConfig.NAME`. So two tables that happen to share a name, in different databases or under
different paths, resolve to the same lock and serialize writers that never touch the same data. Deriving the key from
the base path removes that with no per-table configuration.

The section says "infers it from the table name" rather than "defaults to the table name", because inference via
`withInferFunction` and a literal default are not the same thing and the distinction shows up when the config is
inspected.

### Version scope — checked per release, not assumed

Applied to `next` and **every** 1.x versioned copy. I treated "applicable" as more than "the class exists", because on
a recent docs PR (#19572) a config that existed at 1.0.0/1.0.1 turned out to throw there:

| Release | Class present | Implementation |
|---|---|---|
| release-1.0.0 | yes | identical, md5 `a89ab18e` |
| release-1.0.1 | yes | identical, md5 `a89ab18e` |
| release-1.0.2 | yes | identical, md5 `d03bf9cb` |
| release-1.1.1 | yes | identical, md5 `d03bf9cb` |
| release-1.2.0 | yes | identical, md5 `d03bf9cb` |

The two variants differ by exactly one line — an import moving from `S3Utils.s3aToS3` to `FSUtils.s3aToS3` — so the
xxHash derivation, the `s3a` normalization and the base-class inheritance are the same in all five. Searching the
tracker for the class name returns only this documentation issue, with nothing reporting it broken on any release.

0.14.x and 0.15.x are excluded.

### Placement

The page is laid out differently across versions, so the section adapts rather than being pasted identically:

- `next`, 1.1.1 and 1.2.0 use `### DynamoDB-Based Lock Provider`, so the new section is an `###`
- 1.0.0, 1.0.1 and 1.0.2 use `#### Amazon DynamoDB based`, so it is a `####`

Each is inserted immediately before that version's FileSystem provider heading. The added text is byte-identical within
each of the two groups, and I verified in the rendered HTML that the new heading sits at the same level as its siblings
on both layouts — `h4` next to `h4` on 1.0.2, `h3` next to `h3` on next.

### Site verification

`npm run build` passes with the warning set **byte-identical** to a freshly built baseline at the same base commit
(`d11a5b0adee4`). The earlier baselines were stale after this branch was rebased onto the new head, so the baseline was
rebuilt rather than reused; the stash/restore round-trip used to produce it was checked byte-identical on the way back.

Rendering confirmed under `npm run serve` on `/docs`, `/docs/next`, `/docs/1.1.1`, `/docs/1.0.2`, `/docs/1.0.1` and
`/docs/1.0.0`: the heading, its anchor, the TOC entry, the `properties` code fence and the note all render on each.
`/docs/0.15.1` correctly shows none of it.

### Impact

Documentation only. No code, config, or behaviour change.

### Risk Level

none

### Documentation Update

This PR is the documentation update — the Concurrency Control page, `/docs/concurrency_control#distributed-locking` and
`/docs/next/concurrency_control#distributed-locking`.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
