### PR TITLE
docs(clustering): document the row writer path and its default

### DIFF
--- a/website/docs/clustering.md
+++ b/website/docs/clustering.md
@@ -202,6 +202,28 @@ The available strategies are as follows:
    consistent bucket index and only applicable to the Spark engine. Set `hoodie.clustering.execution.strategy.class`
    to `org.apache.hudi.client.clustering.run.strategy.SparkConsistentBucketClusteringExecutionStrategy`.
 
+#### Row writer
+
+On Spark, the execution strategies above can rewrite the data either through the row writer, which operates on
+a `Dataset<Row>` and avoids converting records to Avro, or through the older RDD path. Which one runs is decided
+by a single config:
+
+| Config Name | Default | Description |
+|-------------|---------|-------------|
+| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+
+Two things about that default are worth knowing, because they are not the same statement:
+
+* The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
+  from a datasource write takes the row-writer path unless you turn it off.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
+  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
+  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
+  `true`, so a standalone clustering job also uses the row writer by default.
+
+To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
+clustering job reads.
+
 ### Update Strategy
 
 Currently, clustering can only be scheduled for tables/partitions not receiving any concurrent updates. By default,

--- a/website/docs/clustering.md
+++ b/website/docs/clustering.md
@@ -215,7 +215,11 @@ by a single config:
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
-  from a datasource write takes the row-writer path unless you turn it off.
+  from a datasource write takes the row-writer path unless you turn it off. One case turns it off without anyone
+  setting it: the config carries an infer function that resolves to `false` when the operation is `bulk_insert`,
+  meta fields are not populated, and `hoodie.combine.before.insert` is on, so that combine-before-insert is not
+  silently skipped. Clustering inheriting those write properties then takes the RDD path. If clustering did not
+  use the row writer and nothing in your config says so, that combination is the first thing to check.
 * Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
   what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
   config from raw properties. In-process async clustering from a Spark datasource streaming write and
@@ -225,7 +229,14 @@ Two things about that default are worth knowing, because they are not the same s
   by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
-clustering job reads.
+clustering job reads. Note this is not a clustering-only switch: it is the general Spark write config, documented
+as "when set to true, will perform write operations directly using the spark native `Row` representation", and it
+gates the row-writer path for ordinary `bulk_insert` writes too. On an inline or async clustering job attached to
+a datasource write, turning it off therefore also turns the row writer off for that job's ingestion writes. A
+standalone `HoodieClusteringJob` is the case where it affects clustering alone. A Hudi Streamer job's *ingestion*
+writes are unaffected either way, since its row writer is gated by a separate
+`hoodie.streamer.write.row.writer.enable` that defaults to `false`; only its clustering reads the key discussed
+above.
 
 ### Update Strategy
 

--- a/website/docs/clustering.md
+++ b/website/docs/clustering.md
@@ -210,16 +210,19 @@ by a single config:
 
 | Config Name | Default | Description |
 |-------------|---------|-------------|
-| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+| `hoodie.datasource.write.row.writer.enable` | `true` | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. This is the config's own default; the fallback applied when the config is absent differs by release, see below.<br /><br />`Config Param: ENABLE_ROW_WRITER`<br />`Since Version: 0.9.0` |
 
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
   from a datasource write takes the row-writer path unless you turn it off.
-* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
-  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
-  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
-  `true`, so a standalone clustering job also uses the row writer by default.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
+  what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
+  config from raw properties. In-process async clustering from a Spark datasource streaming write and
+  `CALL run_clustering` do not: both go through the datasource write defaults, so they carry the key as `true`.
+  The fallback has not been stable across releases: it was `false` in 0.14.0, 0.14.2, 0.15.0 and 0.15.1, and
+  `true` in 0.14.1 and from 1.0.0 onwards. On this release it is `true`, so those two paths use the row writer
+  by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
 clustering job reads.

--- a/website/versioned_docs/version-1.0.0/clustering.md
+++ b/website/versioned_docs/version-1.0.0/clustering.md
@@ -156,6 +156,34 @@ The available strategies are as follows:
    consistent bucket index and only applicable to the Spark engine. Set `hoodie.clustering.execution.strategy.class`
    to `org.apache.hudi.client.clustering.run.strategy.SparkConsistentBucketClusteringExecutionStrategy`.
 
+#### Row writer
+
+On Spark, the execution strategies above can rewrite the data either through the row writer, which operates on
+a `Dataset<Row>` and avoids converting records to Avro, or through the older RDD path. Which one runs is decided
+by a single config:
+
+| Config Name | Default | Description |
+|-------------|---------|-------------|
+| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+
+Two things about that default are worth knowing, because they are not the same statement:
+
+* The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
+  from a datasource write takes the row-writer path unless you turn it off.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
+  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
+  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
+  `true`, so a standalone clustering job also uses the row writer by default.
+
+To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
+clustering job reads.
+
+On 1.0.x there is one further condition: even with the config enabled, Hudi falls back to the RDD path when the
+schema cannot be written through the row writer — specifically when `parquet.avro.write-old-list-structure` is
+`false` **and** the schema contains both a small-precision decimal field and a list or map field. It logs
+`Cannot use row writer due to presence of list or map with a small precision decimal field` when that happens.
+That check was removed in later releases.
+
 ### Update Strategy
 
 Currently, clustering can only be scheduled for tables/partitions not receiving any concurrent updates. By default,

--- a/website/versioned_docs/version-1.0.0/clustering.md
+++ b/website/versioned_docs/version-1.0.0/clustering.md
@@ -164,16 +164,19 @@ by a single config:
 
 | Config Name | Default | Description |
 |-------------|---------|-------------|
-| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+| `hoodie.datasource.write.row.writer.enable` | `true` | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. This is the config's own default; the fallback applied when the config is absent differs by release, see below.<br /><br />`Config Param: ENABLE_ROW_WRITER`<br />`Since Version: 0.9.0` |
 
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
   from a datasource write takes the row-writer path unless you turn it off.
-* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
-  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
-  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
-  `true`, so a standalone clustering job also uses the row writer by default.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
+  what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
+  config from raw properties. In-process async clustering from a Spark datasource streaming write and
+  `CALL run_clustering` do not: both go through the datasource write defaults, so they carry the key as `true`.
+  The fallback has not been stable across releases: it was `false` in 0.14.0, 0.14.2, 0.15.0 and 0.15.1, and
+  `true` in 0.14.1 and from 1.0.0 onwards. On this release it is `true`, so those two paths use the row writer
+  by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
 clustering job reads.

--- a/website/versioned_docs/version-1.0.0/clustering.md
+++ b/website/versioned_docs/version-1.0.0/clustering.md
@@ -169,7 +169,11 @@ by a single config:
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
-  from a datasource write takes the row-writer path unless you turn it off.
+  from a datasource write takes the row-writer path unless you turn it off. One case turns it off without anyone
+  setting it: the config carries an infer function that resolves to `false` when the operation is `bulk_insert`,
+  meta fields are not populated, and `hoodie.combine.before.insert` is on, so that combine-before-insert is not
+  silently skipped. Clustering inheriting those write properties then takes the RDD path. If clustering did not
+  use the row writer and nothing in your config says so, that combination is the first thing to check.
 * Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
   what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
   config from raw properties. In-process async clustering from a Spark datasource streaming write and
@@ -179,13 +183,21 @@ Two things about that default are worth knowing, because they are not the same s
   by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
-clustering job reads.
+clustering job reads. Note this is not a clustering-only switch: it is the general Spark write config, documented
+as "when set to true, will perform write operations directly using the spark native `Row` representation", and it
+gates the row-writer path for ordinary `bulk_insert` writes too. On an inline or async clustering job attached to
+a datasource write, turning it off therefore also turns the row writer off for that job's ingestion writes. A
+standalone `HoodieClusteringJob` is the case where it affects clustering alone. A Hudi Streamer job's *ingestion*
+writes are unaffected either way, since its row writer is gated by a separate
+`hoodie.streamer.write.row.writer.enable` that defaults to `false`; only its clustering reads the key discussed
+above.
 
 On 1.0.x there is one further condition: even with the config enabled, Hudi falls back to the RDD path when the
-schema cannot be written through the row writer — specifically when `parquet.avro.write-old-list-structure` is
-`false` **and** the schema contains both a small-precision decimal field and a list or map field. It logs
-`Cannot use row writer due to presence of list or map with a small precision decimal field` when that happens.
-That check was removed in later releases.
+schema cannot be written through the row writer, specifically when `parquet.avro.write-old-list-structure` is
+`false` **and** the schema contains both a small-precision decimal field and a list or map field. That property
+defaults to `true`, so this only applies if you have explicitly disabled it; it is not something a table hits by
+accident. When it does apply, Hudi logs `Cannot use row writer due to presence of list or map with a small
+precision decimal field`. That check was removed in later releases.
 
 ### Update Strategy
 

--- a/website/versioned_docs/version-1.0.1/clustering.md
+++ b/website/versioned_docs/version-1.0.1/clustering.md
@@ -156,6 +156,34 @@ The available strategies are as follows:
    consistent bucket index and only applicable to the Spark engine. Set `hoodie.clustering.execution.strategy.class`
    to `org.apache.hudi.client.clustering.run.strategy.SparkConsistentBucketClusteringExecutionStrategy`.
 
+#### Row writer
+
+On Spark, the execution strategies above can rewrite the data either through the row writer, which operates on
+a `Dataset<Row>` and avoids converting records to Avro, or through the older RDD path. Which one runs is decided
+by a single config:
+
+| Config Name | Default | Description |
+|-------------|---------|-------------|
+| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+
+Two things about that default are worth knowing, because they are not the same statement:
+
+* The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
+  from a datasource write takes the row-writer path unless you turn it off.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
+  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
+  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
+  `true`, so a standalone clustering job also uses the row writer by default.
+
+To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
+clustering job reads.
+
+On 1.0.x there is one further condition: even with the config enabled, Hudi falls back to the RDD path when the
+schema cannot be written through the row writer — specifically when `parquet.avro.write-old-list-structure` is
+`false` **and** the schema contains both a small-precision decimal field and a list or map field. It logs
+`Cannot use row writer due to presence of list or map with a small precision decimal field` when that happens.
+That check was removed in later releases.
+
 ### Update Strategy
 
 Currently, clustering can only be scheduled for tables/partitions not receiving any concurrent updates. By default,

--- a/website/versioned_docs/version-1.0.1/clustering.md
+++ b/website/versioned_docs/version-1.0.1/clustering.md
@@ -164,16 +164,19 @@ by a single config:
 
 | Config Name | Default | Description |
 |-------------|---------|-------------|
-| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+| `hoodie.datasource.write.row.writer.enable` | `true` | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. This is the config's own default; the fallback applied when the config is absent differs by release, see below.<br /><br />`Config Param: ENABLE_ROW_WRITER`<br />`Since Version: 0.9.0` |
 
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
   from a datasource write takes the row-writer path unless you turn it off.
-* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
-  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
-  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
-  `true`, so a standalone clustering job also uses the row writer by default.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
+  what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
+  config from raw properties. In-process async clustering from a Spark datasource streaming write and
+  `CALL run_clustering` do not: both go through the datasource write defaults, so they carry the key as `true`.
+  The fallback has not been stable across releases: it was `false` in 0.14.0, 0.14.2, 0.15.0 and 0.15.1, and
+  `true` in 0.14.1 and from 1.0.0 onwards. On this release it is `true`, so those two paths use the row writer
+  by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
 clustering job reads.

--- a/website/versioned_docs/version-1.0.1/clustering.md
+++ b/website/versioned_docs/version-1.0.1/clustering.md
@@ -169,7 +169,11 @@ by a single config:
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
-  from a datasource write takes the row-writer path unless you turn it off.
+  from a datasource write takes the row-writer path unless you turn it off. One case turns it off without anyone
+  setting it: the config carries an infer function that resolves to `false` when the operation is `bulk_insert`,
+  meta fields are not populated, and `hoodie.combine.before.insert` is on, so that combine-before-insert is not
+  silently skipped. Clustering inheriting those write properties then takes the RDD path. If clustering did not
+  use the row writer and nothing in your config says so, that combination is the first thing to check.
 * Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
   what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
   config from raw properties. In-process async clustering from a Spark datasource streaming write and
@@ -179,13 +183,21 @@ Two things about that default are worth knowing, because they are not the same s
   by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
-clustering job reads.
+clustering job reads. Note this is not a clustering-only switch: it is the general Spark write config, documented
+as "when set to true, will perform write operations directly using the spark native `Row` representation", and it
+gates the row-writer path for ordinary `bulk_insert` writes too. On an inline or async clustering job attached to
+a datasource write, turning it off therefore also turns the row writer off for that job's ingestion writes. A
+standalone `HoodieClusteringJob` is the case where it affects clustering alone. A Hudi Streamer job's *ingestion*
+writes are unaffected either way, since its row writer is gated by a separate
+`hoodie.streamer.write.row.writer.enable` that defaults to `false`; only its clustering reads the key discussed
+above.
 
 On 1.0.x there is one further condition: even with the config enabled, Hudi falls back to the RDD path when the
-schema cannot be written through the row writer — specifically when `parquet.avro.write-old-list-structure` is
-`false` **and** the schema contains both a small-precision decimal field and a list or map field. It logs
-`Cannot use row writer due to presence of list or map with a small precision decimal field` when that happens.
-That check was removed in later releases.
+schema cannot be written through the row writer, specifically when `parquet.avro.write-old-list-structure` is
+`false` **and** the schema contains both a small-precision decimal field and a list or map field. That property
+defaults to `true`, so this only applies if you have explicitly disabled it; it is not something a table hits by
+accident. When it does apply, Hudi logs `Cannot use row writer due to presence of list or map with a small
+precision decimal field`. That check was removed in later releases.
 
 ### Update Strategy
 

--- a/website/versioned_docs/version-1.0.2/clustering.md
+++ b/website/versioned_docs/version-1.0.2/clustering.md
@@ -156,6 +156,34 @@ The available strategies are as follows:
    consistent bucket index and only applicable to the Spark engine. Set `hoodie.clustering.execution.strategy.class`
    to `org.apache.hudi.client.clustering.run.strategy.SparkConsistentBucketClusteringExecutionStrategy`.
 
+#### Row writer
+
+On Spark, the execution strategies above can rewrite the data either through the row writer, which operates on
+a `Dataset<Row>` and avoids converting records to Avro, or through the older RDD path. Which one runs is decided
+by a single config:
+
+| Config Name | Default | Description |
+|-------------|---------|-------------|
+| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+
+Two things about that default are worth knowing, because they are not the same statement:
+
+* The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
+  from a datasource write takes the row-writer path unless you turn it off.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
+  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
+  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
+  `true`, so a standalone clustering job also uses the row writer by default.
+
+To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
+clustering job reads.
+
+On 1.0.x there is one further condition: even with the config enabled, Hudi falls back to the RDD path when the
+schema cannot be written through the row writer — specifically when `parquet.avro.write-old-list-structure` is
+`false` **and** the schema contains both a small-precision decimal field and a list or map field. It logs
+`Cannot use row writer due to presence of list or map with a small precision decimal field` when that happens.
+That check was removed in later releases.
+
 ### Update Strategy
 
 Currently, clustering can only be scheduled for tables/partitions not receiving any concurrent updates. By default,

--- a/website/versioned_docs/version-1.0.2/clustering.md
+++ b/website/versioned_docs/version-1.0.2/clustering.md
@@ -164,16 +164,19 @@ by a single config:
 
 | Config Name | Default | Description |
 |-------------|---------|-------------|
-| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+| `hoodie.datasource.write.row.writer.enable` | `true` | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. This is the config's own default; the fallback applied when the config is absent differs by release, see below.<br /><br />`Config Param: ENABLE_ROW_WRITER`<br />`Since Version: 0.9.0` |
 
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
   from a datasource write takes the row-writer path unless you turn it off.
-* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
-  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
-  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
-  `true`, so a standalone clustering job also uses the row writer by default.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
+  what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
+  config from raw properties. In-process async clustering from a Spark datasource streaming write and
+  `CALL run_clustering` do not: both go through the datasource write defaults, so they carry the key as `true`.
+  The fallback has not been stable across releases: it was `false` in 0.14.0, 0.14.2, 0.15.0 and 0.15.1, and
+  `true` in 0.14.1 and from 1.0.0 onwards. On this release it is `true`, so those two paths use the row writer
+  by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
 clustering job reads.

--- a/website/versioned_docs/version-1.0.2/clustering.md
+++ b/website/versioned_docs/version-1.0.2/clustering.md
@@ -169,7 +169,11 @@ by a single config:
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
-  from a datasource write takes the row-writer path unless you turn it off.
+  from a datasource write takes the row-writer path unless you turn it off. One case turns it off without anyone
+  setting it: the config carries an infer function that resolves to `false` when the operation is `bulk_insert`,
+  meta fields are not populated, and `hoodie.combine.before.insert` is on, so that combine-before-insert is not
+  silently skipped. Clustering inheriting those write properties then takes the RDD path. If clustering did not
+  use the row writer and nothing in your config says so, that combination is the first thing to check.
 * Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
   what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
   config from raw properties. In-process async clustering from a Spark datasource streaming write and
@@ -179,13 +183,21 @@ Two things about that default are worth knowing, because they are not the same s
   by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
-clustering job reads.
+clustering job reads. Note this is not a clustering-only switch: it is the general Spark write config, documented
+as "when set to true, will perform write operations directly using the spark native `Row` representation", and it
+gates the row-writer path for ordinary `bulk_insert` writes too. On an inline or async clustering job attached to
+a datasource write, turning it off therefore also turns the row writer off for that job's ingestion writes. A
+standalone `HoodieClusteringJob` is the case where it affects clustering alone. A Hudi Streamer job's *ingestion*
+writes are unaffected either way, since its row writer is gated by a separate
+`hoodie.streamer.write.row.writer.enable` that defaults to `false`; only its clustering reads the key discussed
+above.
 
 On 1.0.x there is one further condition: even with the config enabled, Hudi falls back to the RDD path when the
-schema cannot be written through the row writer — specifically when `parquet.avro.write-old-list-structure` is
-`false` **and** the schema contains both a small-precision decimal field and a list or map field. It logs
-`Cannot use row writer due to presence of list or map with a small precision decimal field` when that happens.
-That check was removed in later releases.
+schema cannot be written through the row writer, specifically when `parquet.avro.write-old-list-structure` is
+`false` **and** the schema contains both a small-precision decimal field and a list or map field. That property
+defaults to `true`, so this only applies if you have explicitly disabled it; it is not something a table hits by
+accident. When it does apply, Hudi logs `Cannot use row writer due to presence of list or map with a small
+precision decimal field`. That check was removed in later releases.
 
 ### Update Strategy
 

--- a/website/versioned_docs/version-1.1.1/clustering.md
+++ b/website/versioned_docs/version-1.1.1/clustering.md
@@ -161,6 +161,28 @@ The available strategies are as follows:
    consistent bucket index and only applicable to the Spark engine. Set `hoodie.clustering.execution.strategy.class`
    to `org.apache.hudi.client.clustering.run.strategy.SparkConsistentBucketClusteringExecutionStrategy`.
 
+#### Row writer
+
+On Spark, the execution strategies above can rewrite the data either through the row writer, which operates on
+a `Dataset<Row>` and avoids converting records to Avro, or through the older RDD path. Which one runs is decided
+by a single config:
+
+| Config Name | Default | Description |
+|-------------|---------|-------------|
+| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+
+Two things about that default are worth knowing, because they are not the same statement:
+
+* The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
+  from a datasource write takes the row-writer path unless you turn it off.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
+  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
+  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
+  `true`, so a standalone clustering job also uses the row writer by default.
+
+To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
+clustering job reads.
+
 ### Update Strategy
 
 Currently, clustering can only be scheduled for tables/partitions not receiving any concurrent updates. By default,

--- a/website/versioned_docs/version-1.1.1/clustering.md
+++ b/website/versioned_docs/version-1.1.1/clustering.md
@@ -174,7 +174,11 @@ by a single config:
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
-  from a datasource write takes the row-writer path unless you turn it off.
+  from a datasource write takes the row-writer path unless you turn it off. One case turns it off without anyone
+  setting it: the config carries an infer function that resolves to `false` when the operation is `bulk_insert`,
+  meta fields are not populated, and `hoodie.combine.before.insert` is on, so that combine-before-insert is not
+  silently skipped. Clustering inheriting those write properties then takes the RDD path. If clustering did not
+  use the row writer and nothing in your config says so, that combination is the first thing to check.
 * Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
   what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
   config from raw properties. In-process async clustering from a Spark datasource streaming write and
@@ -184,7 +188,14 @@ Two things about that default are worth knowing, because they are not the same s
   by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
-clustering job reads.
+clustering job reads. Note this is not a clustering-only switch: it is the general Spark write config, documented
+as "when set to true, will perform write operations directly using the spark native `Row` representation", and it
+gates the row-writer path for ordinary `bulk_insert` writes too. On an inline or async clustering job attached to
+a datasource write, turning it off therefore also turns the row writer off for that job's ingestion writes. A
+standalone `HoodieClusteringJob` is the case where it affects clustering alone. A Hudi Streamer job's *ingestion*
+writes are unaffected either way, since its row writer is gated by a separate
+`hoodie.streamer.write.row.writer.enable` that defaults to `false`; only its clustering reads the key discussed
+above.
 
 ### Update Strategy
 

--- a/website/versioned_docs/version-1.1.1/clustering.md
+++ b/website/versioned_docs/version-1.1.1/clustering.md
@@ -169,16 +169,19 @@ by a single config:
 
 | Config Name | Default | Description |
 |-------------|---------|-------------|
-| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+| `hoodie.datasource.write.row.writer.enable` | `true` | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. This is the config's own default; the fallback applied when the config is absent differs by release, see below.<br /><br />`Config Param: ENABLE_ROW_WRITER`<br />`Since Version: 0.9.0` |
 
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
   from a datasource write takes the row-writer path unless you turn it off.
-* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
-  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
-  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
-  `true`, so a standalone clustering job also uses the row writer by default.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
+  what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
+  config from raw properties. In-process async clustering from a Spark datasource streaming write and
+  `CALL run_clustering` do not: both go through the datasource write defaults, so they carry the key as `true`.
+  The fallback has not been stable across releases: it was `false` in 0.14.0, 0.14.2, 0.15.0 and 0.15.1, and
+  `true` in 0.14.1 and from 1.0.0 onwards. On this release it is `true`, so those two paths use the row writer
+  by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
 clustering job reads.

--- a/website/versioned_docs/version-1.2.0/clustering.md
+++ b/website/versioned_docs/version-1.2.0/clustering.md
@@ -202,6 +202,28 @@ The available strategies are as follows:
    consistent bucket index and only applicable to the Spark engine. Set `hoodie.clustering.execution.strategy.class`
    to `org.apache.hudi.client.clustering.run.strategy.SparkConsistentBucketClusteringExecutionStrategy`.
 
+#### Row writer
+
+On Spark, the execution strategies above can rewrite the data either through the row writer, which operates on
+a `Dataset<Row>` and avoids converting records to Avro, or through the older RDD path. Which one runs is decided
+by a single config:
+
+| Config Name | Default | Description |
+|-------------|---------|-------------|
+| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+
+Two things about that default are worth knowing, because they are not the same statement:
+
+* The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
+  from a datasource write takes the row-writer path unless you turn it off.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
+  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
+  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
+  `true`, so a standalone clustering job also uses the row writer by default.
+
+To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
+clustering job reads.
+
 ### Update Strategy
 
 Currently, clustering can only be scheduled for tables/partitions not receiving any concurrent updates. By default,

--- a/website/versioned_docs/version-1.2.0/clustering.md
+++ b/website/versioned_docs/version-1.2.0/clustering.md
@@ -215,7 +215,11 @@ by a single config:
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
-  from a datasource write takes the row-writer path unless you turn it off.
+  from a datasource write takes the row-writer path unless you turn it off. One case turns it off without anyone
+  setting it: the config carries an infer function that resolves to `false` when the operation is `bulk_insert`,
+  meta fields are not populated, and `hoodie.combine.before.insert` is on, so that combine-before-insert is not
+  silently skipped. Clustering inheriting those write properties then takes the RDD path. If clustering did not
+  use the row writer and nothing in your config says so, that combination is the first thing to check.
 * Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
   what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
   config from raw properties. In-process async clustering from a Spark datasource streaming write and
@@ -225,7 +229,14 @@ Two things about that default are worth knowing, because they are not the same s
   by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
-clustering job reads.
+clustering job reads. Note this is not a clustering-only switch: it is the general Spark write config, documented
+as "when set to true, will perform write operations directly using the spark native `Row` representation", and it
+gates the row-writer path for ordinary `bulk_insert` writes too. On an inline or async clustering job attached to
+a datasource write, turning it off therefore also turns the row writer off for that job's ingestion writes. A
+standalone `HoodieClusteringJob` is the case where it affects clustering alone. A Hudi Streamer job's *ingestion*
+writes are unaffected either way, since its row writer is gated by a separate
+`hoodie.streamer.write.row.writer.enable` that defaults to `false`; only its clustering reads the key discussed
+above.
 
 ### Update Strategy
 

--- a/website/versioned_docs/version-1.2.0/clustering.md
+++ b/website/versioned_docs/version-1.2.0/clustering.md
@@ -210,16 +210,19 @@ by a single config:
 
 | Config Name | Default | Description |
 |-------------|---------|-------------|
-| hoodie.datasource.write.row.writer.enable | true | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. |
+| `hoodie.datasource.write.row.writer.enable` | `true` | When enabled, clustering rewrites file groups through the Spark row writer instead of the RDD path. This is the config's own default; the fallback applied when the config is absent differs by release, see below.<br /><br />`Config Param: ENABLE_ROW_WRITER`<br />`Since Version: 0.9.0` |
 
 Two things about that default are worth knowing, because they are not the same statement:
 
 * The config itself defaults to `true`, and Spark datasource writes set it explicitly, so clustering triggered
   from a datasource write takes the row-writer path unless you turn it off.
-* Clustering also applies its own fallback when the config is **absent** from the write config entirely — which
-  is what a standalone or async clustering job sees. That fallback has not been stable across releases: it was
-  `false` in 0.14.0, 0.15.0 and 0.15.1, and `true` in 0.14.1 and from 1.0.0 onwards. On this release it is
-  `true`, so a standalone clustering job also uses the row writer by default.
+* Clustering also applies its own fallback when the config is **absent** from the write config entirely. That is
+  what `HoodieClusteringJob` (spark-submit or hudi-cli) and Hudi Streamer see, since both build their write
+  config from raw properties. In-process async clustering from a Spark datasource streaming write and
+  `CALL run_clustering` do not: both go through the datasource write defaults, so they carry the key as `true`.
+  The fallback has not been stable across releases: it was `false` in 0.14.0, 0.14.2, 0.15.0 and 0.15.1, and
+  `true` in 0.14.1 and from 1.0.0 onwards. On this release it is `true`, so those two paths use the row writer
+  by default as well.
 
 To force the RDD path, set `hoodie.datasource.write.row.writer.enable=false` in the same properties the
 clustering job reads.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Addresses #16461 (HUDI-7659), which asked to *"update 0.14.0 release docs to call out that row writer w/
clustering is enabled by default"*.

**The premise does not hold for 0.14.0, so this PR documents the behaviour where it is actually true instead
of writing a false statement into a release-note page.** Details in Verification below; the short version is
that the clustering fallback for that config read `false` at `release-0.14.0`.

The real gap the ticket points at is genuine and unaddressed: `clustering.md` never mentioned that on Spark
the execution strategies can rewrite file groups either through the **row writer** or through the older RDD
path, which one runs by default, or the config that switches between them. `MultipleSparkJobExecutionStrategy`
picks the path from `hoodie.datasource.write.row.writer.enable`; the docs were silent.

### Summary and Changelog

Adds a **Row writer** subsection under `### Execution Strategy` in `clustering.md`, covering the config, its
default, and how to force the RDD path.

The default is deliberately given two bullets rather than one sentence, because "enabled by default" is two
distinct claims that merely agree on current releases:

* the config itself defaults to `true`, and `HoodieWriterUtils` calls `setDefaultValue(ENABLE_ROW_WRITER)` on
  every Spark datasource write — so clustering driven from a datasource write takes the row path unless turned
  off;
* clustering separately applies its **own fallback** when the key is absent from the write config, which is
  what a standalone or async clustering job sees.

### Verification

Docs change, so no test to add. Every statement was read off the tags rather than recalled.

**The switch itself** — `MultipleSparkJobExecutionStrategy` chooses the path, and the fallback has moved
around across releases:

| ref | `getBooleanOrDefault("hoodie.datasource.write.row.writer.enable", …)` |
| --- | --- |
| `release-0.13.0`, `release-0.13.1` | `false` |
| **`release-0.14.0`** | **`false`** ← the release the ticket names |
| `release-0.14.1` | `true` |
| `release-0.15.0`, `release-0.15.1` | `false` (flipped back) |
| `release-1.0.0` … `release-1.2.0`, master | `true` |

That is why the 0.14.0 release notes are left untouched: for that release the requested sentence would be
incorrect, and 0.15.0 reverted it again. Writing it there would mislead anyone reading the 0.14.0 notes.

**The datasource half:** `HoodieWriterUtils.setDefaultValue(ENABLE_ROW_WRITER)` is present at
`release-1.0.0`, `1.0.1`, `1.0.2`, `1.1.1` and `1.2.0` (and at `0.14.0`), and `ENABLE_ROW_WRITER` itself
carries `defaultValue("true")` — so the two halves of the claim are independently confirmed.

**Version coverage, and why the text is not identical across copies.** Applied to the current docs plus the
five supported versioned copies. `1.0.0`, `1.0.1` and `1.0.2` gate the row path on a second condition —
`HoodieDataTypeUtils.canUseRowWriter(schema, conf)`, which returns `false` when
`parquet.avro.write-old-list-structure` is `false` **and** the schema carries both a small-precision decimal
and a list or map field, logging `Cannot use row writer due to presence of list or map with a small precision
decimal field`. That condition is **absent from 1.1.1 onwards**, so only the three 1.0.x copies describe it:

```
website/docs/clustering.md                          +22   (config only)
website/versioned_docs/version-1.2.0/clustering.md  +22   (config only)
website/versioned_docs/version-1.1.1/clustering.md  +22   (config only)
website/versioned_docs/version-1.0.2/clustering.md  +28   (config + schema gate)
website/versioned_docs/version-1.0.1/clustering.md  +28   (config + schema gate)
website/versioned_docs/version-1.0.0/clustering.md  +28   (config + schema gate)
```

0.15.x and 0.14.x are left alone: their fallback was `false`, so this text would not be true there.

`markdownlint` run over all six files before and after, compared by rule *class* (these pages already carry
ten classes, so raw counts are meaningless): **no new class of finding**. The added region is byte-identical
within each of the two variant groups, contains no `<` or `{` outside inline code, and `#### Row writer` nests
correctly under `### Execution Strategy` and before `### Update Strategy` in every copy.

**Not done:** the Docusaurus build (`website/node_modules` absent, full install heavy). The section adds one
table and prose, both constructs already on this page.

### Impact

Documentation only — no code, config or format change. A behaviour that previously required reading
`MultipleSparkJobExecutionStrategy` to discover is now stated, including the part that trips people up: the
answer differs between a datasource write and a standalone clustering job.

Worth flagging for reviewers: **#17341 (HUDI-8749) "Deprecate clustering with row writer" is open**, asking
whether this path is still needed given the file-group reader flow. If that lands, this section becomes the
natural place to add the deprecation note — documenting it now does not obstruct that, and arguably helps,
since users currently have no way to know which path they are on.

### Risk Level

none

### Documentation Update

This is the documentation update. Targets `asf-site`; applied to `docs/` plus versioned copies 1.2.0, 1.1.1,
1.0.2, 1.0.1 and 1.0.0.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable — n/a for docs; verification tables above instead
- [ ] CI passes on my PR — `asf-site` PRs do not run the `master` gates; `markdownlint` parity checked locally
      as described
