### PR TITLE
fix(spark-sql): resolve MERGE INTO partition columns so records are not mis-partitioned

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeIntoPartitionFieldResolution.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeIntoPartitionFieldResolution.scala
@@ -25,24 +25,9 @@ import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 
 /**
- * Regression coverage for MERGE INTO partition-column resolution.
- *
- * For a target table bearing a record key, the incoming batch is written from the source alone
- * and Hudi's index tagging identifies updates, keying off `(recordKey, partitionPath)`. Before the
- * fix, a partition column the source did not carry was never back-filled into the source
- * projection (only record-key and ordering columns were), so the key generator resolved it to the
- * default partition and tagging looked in the wrong place. Every incoming record came back
- * not-matched, which is silently destructive in two different ways depending on the clauses:
- *
- *  - `WHEN MATCHED` only: the record falls through to HoodieRecord.SENTINEL in
- *    `ExpressionPayload#processNotMatchedRecord` and is dropped - the statement reports success and
- *    writes an EMPTY COMMIT, leaving the target untouched.
- *  - `WHEN NOT MATCHED ... INSERT` present: the record is inserted into the default partition
- *    instead, DUPLICATING THE PRIMARY KEY across two partitions while the intended update is lost.
- *
- * The assertions below deliberately check the resulting rows AND their `_hoodie_partition_path`,
- * not merely that the data is unchanged. "Unchanged" is exactly what the dropped-record bug
- * produces, so a test asserting only that passes vacuously in the presence of this defect.
+ * Regression coverage for MERGE INTO partition-column resolution. Assertions check
+ * `_hoodie_partition_path` as well as the row values: unchanged data is what a dropped record
+ * produces, so asserting only that passes whether or not the merge did any work.
  */
 class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
 
@@ -75,7 +60,6 @@ class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
         spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
 
         // `dt` appears in neither the source output, the ON condition, nor the assignments.
-        // Before the fix this reported success and wrote an empty commit.
         checkExceptionContain(
           s"""
              |merge into $tableName as t
@@ -101,9 +85,7 @@ class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
         createPartitionedTable(tableName, tableType, s"${tmp.getCanonicalPath}/$tableName")
         spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
 
-        // The most damaging shape: with a NOT MATCHED clause the mis-partitioned record used to be
-        // INSERTED into the default partition, yielding two rows with id=1 in different partitions
-        // (name/dt null on the new one) while the intended update never landed.
+        // With a NOT MATCHED clause a mis-partitioned record is inserted rather than dropped.
         checkExceptionContain(
           s"""
              |merge into $tableName as t
@@ -176,9 +158,8 @@ class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
        """.stripMargin)(expectedError)
         }
 
-        // Untouched either way. Note the partition-changing shape used to be dropped as SENTINEL -
-        // the same empty commit this class guards against - so accepting it would have silently
-        // reinstated the defect for exactly the statement that looks like it should work.
+        // Accepting these would tag the record in the partition it moves TO, missing the existing
+        // version.
         checkAnswer(s"select id, amount, ts, dt, _hoodie_partition_path from $tableName")(
           Seq(1L, 10.0, 1L, "2026-08-11", "dt=2026-08-11")
         )
@@ -233,9 +214,7 @@ class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
         createPartitionedTable(tableName, tableType, s"${tmp.getCanonicalPath}/$tableName")
         spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
 
-        // DeleteAction carries no assignments, so this reaches the resolution by a path none of the
-        // update/insert cases exercise - and it is the common CDC shape. Previously it wrote an
-        // empty commit and deleted nothing.
+        // DeleteAction carries no assignments, so this reaches the resolution by its own path.
         checkExceptionContain(
           s"""
              |merge into $tableName as t
@@ -253,23 +232,8 @@ class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
     }
   }
 
-  // NOTE: CoW only, deliberately. On MOR the same statement fails inside the writer today, before
-  //       this guard is relevant, with
-  //         HoodieKeyException: recordKey value: "null" for field: "id" cannot be null or empty
-  //       raised from SqlKeyGenerator.getPartitionPath during the delta-commit upsert. That is
-  //       pre-existing: this guard only *skips* for this configuration, so the code path is the
-  //       same as without this change. Asserting the MOR shape here would be pinning a separate,
-  //       unrelated defect - it is reported separately as ENG-47158 instead.
-  // Every global index type must be exempted, not just the one that happened to be tested first.
-  // GLOBAL_RECORD_LEVEL_INDEX is the non-deprecated spelling of RECORD_INDEX on the 1.x line and
-  // SparkHoodieIndexFactory maps both onto SparkMetadataTableGlobalRecordLevelIndex, so a set that
-  // lists one and not the other rejects merges that are correct today. Parameterizing over the
-  // types is what makes that a test failure rather than a customer-visible regression.
-  //
-  // Each entry is (index type, the extra confs that put it in the re-keying configuration). The
-  // record-index spellings default `update.partition.path` to false already but need the index
-  // itself enabled in the metadata table; GLOBAL_BLOOM defaults the flag to true, so it is
-  // disabled explicitly.
+  // CoW only: on MOR the same statement hits a separate pre-existing writer defect first.
+  // Each entry is (index type, the confs that put it in the re-keying configuration).
   private val rekeyingGlobalIndexes: Seq[(String, Map[String, String])] = Seq(
     ("GLOBAL_BLOOM", Map("hoodie.bloom.index.update.partition.path" -> "false")),
     ("GLOBAL_SIMPLE", Map("hoodie.simple.index.update.partition.path" -> "false")),
@@ -340,8 +304,7 @@ class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
                |when not matched then insert (id, amount, ts) values (s.id, s.amount, s.ts)
        """.stripMargin)(expectedError)
 
-          // Without this the not-matched row is written to dt=__HIVE_DEFAULT_PARTITION__ with a
-          // null dt, which is what the exemption used to allow through.
+          // A not-matched row admitted here would be written to dt=__HIVE_DEFAULT_PARTITION__.
           checkAnswer(s"select count(*) from $tableName")(Seq(1L))
           checkAnswer(s"select id, amount, dt, _hoodie_partition_path from $tableName")(
             Seq(1L, 10.0, "2026-08-11", "dt=2026-08-11")
@@ -463,12 +426,8 @@ class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
   }
 
   /**
-   * End-to-end regression guard, asserted against the commit timeline rather than the table rows.
-   *
-   * The original defect produced a commit with 0 files and 0 records while reporting success, so no
-   * row-level assertion can catch it: "the data did not change" is indistinguishable from "the
-   * merge legitimately changed nothing". Checking that a successful merge actually wrote records -
-   * and that a rejected one wrote no commit at all - is what closes that hole.
+   * Asserted against the commit timeline, not the rows: a commit with 0 records is
+   * indistinguishable from a merge that legitimately changed nothing.
    */
   test("Test MergeInto e2e: a successful merge writes records, a rejected merge writes no commit") {
     withTempDir { tmp =>
@@ -479,8 +438,7 @@ class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
 
       val commitsAfterInsert = completedCommitCount(basePath)
 
-      // The shape that used to duplicate the key into the default partition must now be rejected,
-      // and must leave the timeline untouched.
+      // The duplicating shape must be rejected, and must leave the timeline untouched.
       checkExceptionContain(
         s"""
            |merge into $tableName as t
@@ -555,13 +513,8 @@ class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
 
         // A regression guard for the ON-condition path when an assignment names the same column.
         //
-        // NOTE: this does NOT exercise the deduplication in requiredAttributesMap, despite the
-        //       shape looking like it should - it passes unchanged against the pre-fix code. Only
-        //       the ON condition contributes an association for `dt`
-        //       (partitionFieldsAssociatedExpressions returns nothing once the ON-condition path
-        //       has covered the column, and assignments are not a resolution source), so there is
-        //       exactly one entry and nothing to dedupe. The case that does reach the fold is
-        //       below, over a record key that is also an ordering field.
+        // NOTE: this does NOT reach the dedupe - only the ON condition contributes an association
+        //       for `dt`, so there is one entry. The case that does reach it is below.
         spark.sql(
           s"""
              |merge into $tableName as t
@@ -579,20 +532,9 @@ class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
     }
   }
 
-  // The one overlap that actually reaches the deduplication in requiredAttributesMap.
-  //
-  // recordKeyAttributeToConditionExpression enumerates record-key and partition-path fields only,
-  // so an ordering field can collide with it exactly when it IS a record key. Here `id` is both
-  // the primary key and the ordering field: the ON condition contributes (id -> s.sid), and
-  // orderingFieldsAssociatedExpressions contributes (id -> s.sid) again from the UPDATE assignment
-  // (which event-time ordering requires). The source carries `sid`, not `id`, so both land in
-  // missingAttributesMap and each emits its own Alias - projecting `id` twice into the batch handed
-  // to the writer.
-  //
-  // The merge outcome is deliberately not asserted beyond identity: with the ordering field equal
-  // on both sides the winner is a tie, and equal-ordering resolution differs between the 0.x and
-  // 1.x lines, so pinning it here would break the planned 0.x backport. The discriminating
-  // property is that the statement completes at all.
+  // The one overlap that reaches the dedupe: `id` is both the record key and the ordering field, so
+  // the ON condition and the assignment each contribute (id -> s.sid) and each emits its own Alias.
+  // The outcome is not asserted beyond identity - equal-ordering resolution differs across lines.
   Seq("cow", "mor").foreach { tableType =>
     test(s"Test MergeInto projects a record key that is also an ordering field only once ($tableType)") {
       withTempDir { tmp =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeIntoPartitionFieldResolution.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeIntoPartitionFieldResolution.scala
@@ -1,0 +1,680 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.dml.others
+
+import org.apache.hudi.common.table.timeline.TimelineUtils
+import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
+
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+
+/**
+ * Regression coverage for MERGE INTO partition-column resolution.
+ *
+ * For a target table bearing a record key, the incoming batch is written from the source alone
+ * and Hudi's index tagging identifies updates, keying off `(recordKey, partitionPath)`. Before the
+ * fix, a partition column the source did not carry was never back-filled into the source
+ * projection (only record-key and ordering columns were), so the key generator resolved it to the
+ * default partition and tagging looked in the wrong place. Every incoming record came back
+ * not-matched, which is silently destructive in two different ways depending on the clauses:
+ *
+ *  - `WHEN MATCHED` only: the record falls through to HoodieRecord.SENTINEL in
+ *    `ExpressionPayload#processNotMatchedRecord` and is dropped - the statement reports success and
+ *    writes an EMPTY COMMIT, leaving the target untouched.
+ *  - `WHEN NOT MATCHED ... INSERT` present: the record is inserted into the default partition
+ *    instead, DUPLICATING THE PRIMARY KEY across two partitions while the intended update is lost.
+ *
+ * The assertions below deliberately check the resulting rows AND their `_hoodie_partition_path`,
+ * not merely that the data is unchanged. "Unchanged" is exactly what the dropped-record bug
+ * produces, so a test asserting only that passes vacuously in the presence of this defect.
+ */
+class TestMergeIntoPartitionFieldResolution extends HoodieSparkSqlTestBase {
+
+  private val expectedError = "Failed to resolve partition fields"
+
+  private def createPartitionedTable(tableName: String, tableType: String, location: String): Unit =
+    spark.sql(
+      s"""
+         |create table $tableName (
+         |  id bigint,
+         |  name string,
+         |  amount double,
+         |  ts bigint,
+         |  dt string
+         |) using hudi
+         | partitioned by (dt)
+         | tblproperties (
+         |   type = '$tableType',
+         |   primaryKey = 'id',
+         |   preCombineField = 'ts'
+         | )
+         | location '$location'
+       """.stripMargin)
+
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test MergeInto rejects an update whose source omits the partition column ($tableType)") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        createPartitionedTable(tableName, tableType, s"${tmp.getCanonicalPath}/$tableName")
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+        // `dt` appears in neither the source output, the ON condition, nor the assignments.
+        // Before the fix this reported success and wrote an empty commit.
+        checkExceptionContain(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 1L as id, 15.0 as amount, 200L as ts
+             |) as s
+             |on t.id = s.id
+             |when matched then update set t.amount = s.amount, t.ts = s.ts
+       """.stripMargin)(expectedError)
+
+        // Target untouched, and still a single row in its original partition.
+        checkAnswer(s"select id, amount, ts, dt, _hoodie_partition_path from $tableName")(
+          Seq(1L, 10.0, 1L, "2026-08-11", "dt=2026-08-11")
+        )
+      }
+    }
+  }
+
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test MergeInto with an INSERT clause cannot duplicate the key into the default partition ($tableType)") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        createPartitionedTable(tableName, tableType, s"${tmp.getCanonicalPath}/$tableName")
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+        // The most damaging shape: with a NOT MATCHED clause the mis-partitioned record used to be
+        // INSERTED into the default partition, yielding two rows with id=1 in different partitions
+        // (name/dt null on the new one) while the intended update never landed.
+        checkExceptionContain(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 1L as id, 99.0 as amount, 9L as ts
+             |) as s
+             |on t.id = s.id
+             |when matched then update set t.amount = s.amount, t.ts = s.ts
+             |when not matched then insert (id, amount, ts) values (s.id, s.amount, s.ts)
+       """.stripMargin)(expectedError)
+
+        // Exactly one row, in the right partition - no duplicate key, no default-partition row.
+        checkAnswer(s"select count(*) from $tableName")(Seq(1L))
+        checkAnswer(s"select id, amount, dt, _hoodie_partition_path from $tableName")(
+          Seq(1L, 10.0, "2026-08-11", "dt=2026-08-11")
+        )
+      }
+    }
+  }
+
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test MergeInto applies when the source projects the partition column ($tableType)") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        createPartitionedTable(tableName, tableType, s"${tmp.getCanonicalPath}/$tableName")
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+        spark.sql(s"insert into $tableName values (2, 'b', 20.0, 1, '2026-08-11')")
+
+        // The ON clause deliberately still matches on the record key alone - it is the source
+        // projection, not the join condition, that governs partition-path resolution.
+        spark.sql(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 1L as id, 15.0 as amount, 200L as ts, '2026-08-11' as dt
+             |) as s
+             |on t.id = s.id
+             |when matched then update set t.amount = s.amount, t.ts = s.ts
+       """.stripMargin)
+
+        // The update landed on the existing record, in place, with no extra row created.
+        checkAnswer(s"select id, name, amount, ts, dt, _hoodie_partition_path from $tableName order by id")(
+          Seq(1L, "a", 15.0, 200L, "2026-08-11", "dt=2026-08-11"),
+          Seq(2L, "b", 20.0, 1L, "2026-08-11", "dt=2026-08-11")
+        )
+      }
+    }
+  }
+
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test MergeInto rejects a partition value supplied only by a MERGE assignment ($tableType)") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        createPartitionedTable(tableName, tableType, s"${tmp.getCanonicalPath}/$tableName")
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+        // An assignment states the record's NEW partition, not the one its existing version
+        // occupies, and key generation runs over the source row before any assignment is
+        // evaluated - so the assignment cannot supply the partition for tagging. Both shapes are
+        // rejected: the value matching the current partition, and the value changing it.
+        Seq("2026-08-11", "2026-08-12").foreach { assignedDt =>
+          checkExceptionContain(
+            s"""
+               |merge into $tableName as t
+               |using (
+               |  select 1L as id, 15.0 as amount, 200L as ts, '$assignedDt' as src_dt
+               |) as s
+               |on t.id = s.id
+               |when matched then update set t.amount = s.amount, t.ts = s.ts, t.dt = s.src_dt
+       """.stripMargin)(expectedError)
+        }
+
+        // Untouched either way. Note the partition-changing shape used to be dropped as SENTINEL -
+        // the same empty commit this class guards against - so accepting it would have silently
+        // reinstated the defect for exactly the statement that looks like it should work.
+        checkAnswer(s"select id, amount, ts, dt, _hoodie_partition_path from $tableName")(
+          Seq(1L, 10.0, 1L, "2026-08-11", "dt=2026-08-11")
+        )
+      }
+    }
+  }
+
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test MergeInto on a non-partitioned table needs no partition column ($tableType)") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id bigint,
+             |  name string,
+             |  amount double,
+             |  ts bigint
+             |) using hudi
+             | tblproperties (
+             |   type = '$tableType',
+             |   primaryKey = 'id',
+             |   preCombineField = 'ts'
+             | )
+             | location '${tmp.getCanonicalPath}/$tableName'
+       """.stripMargin)
+
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1)")
+
+        // No partition columns exist, so the new resolution must not engage at all.
+        spark.sql(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 1L as id, 15.0 as amount, 200L as ts
+             |) as s
+             |on t.id = s.id
+             |when matched then update set t.amount = s.amount, t.ts = s.ts
+       """.stripMargin)
+
+        checkAnswer(s"select id, name, amount, ts from $tableName")(
+          Seq(1L, "a", 15.0, 200L)
+        )
+      }
+    }
+  }
+
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test MergeInto rejects a delete whose source omits the partition column ($tableType)") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        createPartitionedTable(tableName, tableType, s"${tmp.getCanonicalPath}/$tableName")
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+        // DeleteAction carries no assignments, so this reaches the resolution by a path none of the
+        // update/insert cases exercise - and it is the common CDC shape. Previously it wrote an
+        // empty commit and deleted nothing.
+        checkExceptionContain(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 1L as id, 200L as ts
+             |) as s
+             |on t.id = s.id
+             |when matched then delete
+       """.stripMargin)(expectedError)
+
+        checkAnswer(s"select id, amount, dt, _hoodie_partition_path from $tableName")(
+          Seq(1L, 10.0, "2026-08-11", "dt=2026-08-11")
+        )
+      }
+    }
+  }
+
+  // NOTE: CoW only, deliberately. On MOR the same statement fails inside the writer today, before
+  //       this guard is relevant, with
+  //         HoodieKeyException: recordKey value: "null" for field: "id" cannot be null or empty
+  //       raised from SqlKeyGenerator.getPartitionPath during the delta-commit upsert. That is
+  //       pre-existing: this guard only *skips* for this configuration, so the code path is the
+  //       same as without this change. Asserting the MOR shape here would be pinning a separate,
+  //       unrelated defect - it is reported separately as ENG-47158 instead.
+  // Every global index type must be exempted, not just the one that happened to be tested first.
+  // GLOBAL_RECORD_LEVEL_INDEX is the non-deprecated spelling of RECORD_INDEX on the 1.x line and
+  // SparkHoodieIndexFactory maps both onto SparkMetadataTableGlobalRecordLevelIndex, so a set that
+  // lists one and not the other rejects merges that are correct today. Parameterizing over the
+  // types is what makes that a test failure rather than a customer-visible regression.
+  //
+  // Each entry is (index type, the extra confs that put it in the re-keying configuration). The
+  // record-index spellings default `update.partition.path` to false already but need the index
+  // itself enabled in the metadata table; GLOBAL_BLOOM defaults the flag to true, so it is
+  // disabled explicitly.
+  private val rekeyingGlobalIndexes: Seq[(String, Map[String, String])] = Seq(
+    ("GLOBAL_BLOOM", Map("hoodie.bloom.index.update.partition.path" -> "false")),
+    ("GLOBAL_SIMPLE", Map("hoodie.simple.index.update.partition.path" -> "false")),
+    ("RECORD_INDEX", Map(
+      "hoodie.record.index.update.partition.path" -> "false",
+      "hoodie.metadata.enable" -> "true",
+      "hoodie.metadata.record.index.enable" -> "true")),
+    ("GLOBAL_RECORD_LEVEL_INDEX", Map(
+      "hoodie.record.index.update.partition.path" -> "false",
+      "hoodie.metadata.enable" -> "true",
+      "hoodie.metadata.record.index.enable" -> "true")))
+
+  rekeyingGlobalIndexes.foreach { case (indexType, extraConfs) =>
+    test(s"Test MergeInto allows a source without the partition column on a re-keying global index ($indexType, cow)") {
+      withTempDir { tmp =>
+        // A global index looks the record up by key across partitions, and with
+        // update.partition.path disabled HoodieIndexUtils re-keys the incoming record onto the
+        // partition its existing version occupies - so the partition value the source carries is
+        // irrelevant and the merge is correct today. Rejecting it would be a regression.
+        val confs = (extraConfs + ("hoodie.index.type" -> indexType)).toSeq
+        withSQLConf(confs: _*) {
+          val tableName = generateTableName
+          createPartitionedTable(tableName, "cow", s"${tmp.getCanonicalPath}/$tableName")
+          spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+          spark.sql(
+            s"""
+               |merge into $tableName as t
+               |using (
+               |  select 1L as id, 15.0 as amount, 200L as ts
+               |) as s
+               |on t.id = s.id
+               |when matched then update set t.amount = s.amount, t.ts = s.ts
+       """.stripMargin)
+
+          checkAnswer(s"select id, amount, ts, dt, _hoodie_partition_path from $tableName")(
+            Seq(1L, 15.0, 200L, "2026-08-11", "dt=2026-08-11")
+          )
+        }
+      }
+    }
+  }
+
+  private val rekeyingConfsByType: Map[String, Map[String, String]] = rekeyingGlobalIndexes.toMap
+
+  // The re-keying exemption covers MATCHED records only. HoodieIndexUtils#tagGlobalLocationBackToRecords
+  // re-keys a record onto its existing partition, but a record the global lookup does not find is
+  // returned untouched and keeps the partition it arrived with - so a WHEN NOT MATCHED ... INSERT
+  // row still lands in the default partition, duplicating nothing but mis-placing the new key.
+  // Whether a row matches is data-dependent, so the presence of the insert clause is what decides.
+  Seq("GLOBAL_BLOOM", "GLOBAL_RECORD_LEVEL_INDEX").foreach { indexType =>
+    test(s"Test MergeInto requires the partition column when a global-index merge can insert ($indexType, cow)") {
+      withTempDir { tmp =>
+        val confs = (rekeyingConfsByType(indexType) + ("hoodie.index.type" -> indexType)).toSeq
+        withSQLConf(confs: _*) {
+          val tableName = generateTableName
+          createPartitionedTable(tableName, "cow", s"${tmp.getCanonicalPath}/$tableName")
+          spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+          checkExceptionContain(
+            s"""
+               |merge into $tableName as t
+               |using (
+               |  select 2L as id, 77.0 as amount, 7L as ts
+               |) as s
+               |on t.id = s.id
+               |when matched then update set t.amount = s.amount, t.ts = s.ts
+               |when not matched then insert (id, amount, ts) values (s.id, s.amount, s.ts)
+       """.stripMargin)(expectedError)
+
+          // Without this the not-matched row is written to dt=__HIVE_DEFAULT_PARTITION__ with a
+          // null dt, which is what the exemption used to allow through.
+          checkAnswer(s"select count(*) from $tableName")(Seq(1L))
+          checkAnswer(s"select id, amount, dt, _hoodie_partition_path from $tableName")(
+            Seq(1L, 10.0, "2026-08-11", "dt=2026-08-11")
+          )
+        }
+      }
+    }
+  }
+
+  // ... and the same shape is accepted once the source carries the column, so the narrowing above
+  // rejects only what it must.
+  test("Test MergeInto allows a global-index merge that can insert when the source carries the partition column (GLOBAL_BLOOM, cow)") {
+    withTempDir { tmp =>
+      withSQLConf(
+        "hoodie.index.type" -> "GLOBAL_BLOOM",
+        "hoodie.bloom.index.update.partition.path" -> "false") {
+        val tableName = generateTableName
+        createPartitionedTable(tableName, "cow", s"${tmp.getCanonicalPath}/$tableName")
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+        spark.sql(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 2L as id, 'b' as name, 77.0 as amount, 7L as ts, '2026-08-12' as dt
+             |) as s
+             |on t.id = s.id
+             |when matched then update set t.amount = s.amount, t.ts = s.ts
+             |when not matched then insert (id, name, amount, ts, dt)
+             |  values (s.id, s.name, s.amount, s.ts, s.dt)
+       """.stripMargin)
+
+        checkAnswer(s"select id, name, dt, _hoodie_partition_path from $tableName order by id")(
+          Seq(1L, "a", "2026-08-11", "dt=2026-08-11"),
+          Seq(2L, "b", "2026-08-12", "dt=2026-08-12")
+        )
+      }
+    }
+  }
+
+  // The other edge of the same gate: with update.partition.path ENABLED the incoming partition
+  // value does decide placement, so the guard must still engage rather than exempt the table.
+  Seq("RECORD_INDEX", "GLOBAL_RECORD_LEVEL_INDEX").foreach { indexType =>
+    test(s"Test MergeInto still requires the partition column when the global index updates it ($indexType, cow)") {
+      withTempDir { tmp =>
+        withSQLConf(
+          "hoodie.index.type" -> indexType,
+          "hoodie.record.index.update.partition.path" -> "true",
+          "hoodie.metadata.enable" -> "true",
+          "hoodie.metadata.record.index.enable" -> "true") {
+          val tableName = generateTableName
+          createPartitionedTable(tableName, "cow", s"${tmp.getCanonicalPath}/$tableName")
+          spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+          checkExceptionContain(
+            s"""
+               |merge into $tableName as t
+               |using (
+               |  select 1L as id, 15.0 as amount, 200L as ts
+               |) as s
+               |on t.id = s.id
+               |when matched then update set t.amount = s.amount, t.ts = s.ts
+       """.stripMargin)(expectedError)
+
+          checkAnswer(s"select id, amount, ts, dt, _hoodie_partition_path from $tableName")(
+            Seq(1L, 10.0, 1L, "2026-08-11", "dt=2026-08-11")
+          )
+        }
+      }
+    }
+  }
+
+  // The accepting half of the update.partition.path=true configuration: the source DOES carry the
+  // partition column and names a different value, so the guard resolves it and the global index is
+  // free to move the record. Worth pinning separately - the rejecting test above only shows the
+  // guard engages, not that a partition-changing update still works once past it.
+  test("Test MergeInto moves the record when the source carries a new partition value " +
+    "(RECORD_INDEX, update.partition.path=true, cow)") {
+    withTempDir { tmp =>
+      withSQLConf(
+        "hoodie.index.type" -> "RECORD_INDEX",
+        "hoodie.record.index.update.partition.path" -> "true",
+        "hoodie.metadata.enable" -> "true",
+        "hoodie.metadata.record.index.enable" -> "true") {
+        val tableName = generateTableName
+        createPartitionedTable(tableName, "cow", s"${tmp.getCanonicalPath}/$tableName")
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+        spark.sql(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 1L as id, 'a' as name, 15.0 as amount, 200L as ts, '2026-08-12' as dt
+             |) as s
+             |on t.id = s.id
+             |when matched then update set
+             |  t.name = s.name, t.amount = s.amount, t.ts = s.ts, t.dt = s.dt
+       """.stripMargin)
+
+        // Exactly one row, relocated - not one copy per partition, which is what a failure to
+        // re-key would leave behind.
+        checkAnswer(s"select id, amount, ts, dt, _hoodie_partition_path from $tableName")(
+          Seq(1L, 15.0, 200L, "2026-08-12", "dt=2026-08-12")
+        )
+      }
+    }
+  }
+
+  private def completedCommitCount(basePath: String): Int =
+    createMetaClient(spark, basePath)
+      .getActiveTimeline.getAllCommitsTimeline.filterCompletedInstants().countInstants()
+
+  private def lastCommitRecordsWritten(basePath: String): Long = {
+    val timeline = createMetaClient(spark, basePath)
+      .getActiveTimeline.getAllCommitsTimeline.filterCompletedInstants()
+    val lastInstant = timeline.lastInstant()
+    assert(lastInstant.isPresent, "expected at least one completed commit on the timeline")
+    TimelineUtils.getCommitMetadata(lastInstant.get(), timeline).fetchTotalRecordsWritten()
+  }
+
+  /**
+   * End-to-end regression guard, asserted against the commit timeline rather than the table rows.
+   *
+   * The original defect produced a commit with 0 files and 0 records while reporting success, so no
+   * row-level assertion can catch it: "the data did not change" is indistinguishable from "the
+   * merge legitimately changed nothing". Checking that a successful merge actually wrote records -
+   * and that a rejected one wrote no commit at all - is what closes that hole.
+   */
+  test("Test MergeInto e2e: a successful merge writes records, a rejected merge writes no commit") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+      createPartitionedTable(tableName, "cow", basePath)
+      spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+      val commitsAfterInsert = completedCommitCount(basePath)
+
+      // The shape that used to duplicate the key into the default partition must now be rejected,
+      // and must leave the timeline untouched.
+      checkExceptionContain(
+        s"""
+           |merge into $tableName as t
+           |using (
+           |  select 1L as id, 99.0 as amount, 9L as ts
+           |) as s
+           |on t.id = s.id
+           |when matched then update set t.amount = s.amount, t.ts = s.ts
+           |when not matched then insert (id, amount, ts) values (s.id, s.amount, s.ts)
+       """.stripMargin)(expectedError)
+
+      assert(completedCommitCount(basePath) == commitsAfterInsert,
+        "a rejected MERGE INTO must not leave a commit on the timeline")
+
+      // The equivalent statement with the partition column supplied must write a NON-EMPTY commit.
+      spark.sql(
+        s"""
+           |merge into $tableName as t
+           |using (
+           |  select 1L as id, 99.0 as amount, 9L as ts, '2026-08-11' as dt
+           |) as s
+           |on t.id = s.id
+           |when matched then update set t.amount = s.amount, t.ts = s.ts
+       """.stripMargin)
+
+      assert(completedCommitCount(basePath) == commitsAfterInsert + 1,
+        "a successful MERGE INTO must write exactly one new commit")
+
+      val recordsWritten = lastCommitRecordsWritten(basePath)
+      assert(recordsWritten > 0,
+        s"MERGE INTO reported success but wrote $recordsWritten records - the empty-commit regression")
+
+      checkAnswer(s"select id, amount, ts, dt, _hoodie_partition_path from $tableName")(
+        Seq(1L, 99.0, 9L, "2026-08-11", "dt=2026-08-11")
+      )
+    }
+  }
+
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test MergeInto resolves the partition column from the ON condition ($tableType)") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        createPartitionedTable(tableName, tableType, s"${tmp.getCanonicalPath}/$tableName")
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+        // The partition column is supplied only by the ON condition, under a different source name.
+        // recordKeyAttributeToConditionExpression already back-fills this shape, so the partition
+        // resolution must defer to it rather than rejecting the statement.
+        spark.sql(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 1L as id, 15.0 as amount, 200L as ts, '2026-08-11' as event_dt
+             |) as s
+             |on t.id = s.id and t.dt = s.event_dt
+             |when matched then update set t.amount = s.amount, t.ts = s.ts
+       """.stripMargin)
+
+        checkAnswer(s"select id, amount, ts, dt, _hoodie_partition_path from $tableName")(
+          Seq(1L, 15.0, 200L, "2026-08-11", "dt=2026-08-11")
+        )
+      }
+    }
+  }
+
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test MergeInto resolves the partition column from the ON condition when an assignment also sets it ($tableType)") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        createPartitionedTable(tableName, tableType, s"${tmp.getCanonicalPath}/$tableName")
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+        // A regression guard for the ON-condition path when an assignment names the same column.
+        //
+        // NOTE: this does NOT exercise the deduplication in requiredAttributesMap, despite the
+        //       shape looking like it should - it passes unchanged against the pre-fix code. Only
+        //       the ON condition contributes an association for `dt`
+        //       (partitionFieldsAssociatedExpressions returns nothing once the ON-condition path
+        //       has covered the column, and assignments are not a resolution source), so there is
+        //       exactly one entry and nothing to dedupe. The case that does reach the fold is
+        //       below, over a record key that is also an ordering field.
+        spark.sql(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 1L as id, 15.0 as amount, 200L as ts, '2026-08-11' as event_dt
+             |) as s
+             |on t.id = s.id and t.dt = s.event_dt
+             |when matched then update set t.amount = s.amount, t.ts = s.ts, t.dt = s.event_dt
+       """.stripMargin)
+
+        checkAnswer(s"select id, amount, ts, dt, _hoodie_partition_path from $tableName")(
+          Seq(1L, 15.0, 200L, "2026-08-11", "dt=2026-08-11")
+        )
+      }
+    }
+  }
+
+  // The one overlap that actually reaches the deduplication in requiredAttributesMap.
+  //
+  // recordKeyAttributeToConditionExpression enumerates record-key and partition-path fields only,
+  // so an ordering field can collide with it exactly when it IS a record key. Here `id` is both
+  // the primary key and the ordering field: the ON condition contributes (id -> s.sid), and
+  // orderingFieldsAssociatedExpressions contributes (id -> s.sid) again from the UPDATE assignment
+  // (which event-time ordering requires). The source carries `sid`, not `id`, so both land in
+  // missingAttributesMap and each emits its own Alias - projecting `id` twice into the batch handed
+  // to the writer.
+  //
+  // The merge outcome is deliberately not asserted beyond identity: with the ordering field equal
+  // on both sides the winner is a tie, and equal-ordering resolution differs between the 0.x and
+  // 1.x lines, so pinning it here would break the planned 0.x backport. The discriminating
+  // property is that the statement completes at all.
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test MergeInto projects a record key that is also an ordering field only once ($tableType)") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id bigint,
+             |  name string,
+             |  amount double
+             |) using hudi
+             | tblproperties (
+             |   type = '$tableType',
+             |   primaryKey = 'id',
+             |   preCombineField = 'id'
+             | )
+             | location '${tmp.getCanonicalPath}/$tableName'
+       """.stripMargin)
+
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0)")
+
+        spark.sql(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 1L as sid, 'b' as name, 20.0 as amount
+             |) as s
+             |on t.id = s.sid
+             |when matched then update set t.id = s.sid, t.name = s.name, t.amount = s.amount
+       """.stripMargin)
+
+        checkAnswer(s"select count(*) from $tableName")(Seq(1L))
+        checkAnswer(s"select id from $tableName")(Seq(1L))
+        // Which of the two wins is the tie-break difference described above, but the surviving
+        // value must be one of them; anything else is corruption rather than a resolution choice.
+        val amount = spark.sql(s"select amount from $tableName").collect().head.getDouble(0)
+        assert(amount == 10.0 || amount == 20.0, s"unexpected amount after merge: $amount")
+      }
+    }
+  }
+
+  Seq("cow", "mor").foreach { tableType =>
+    test(s"Test MergeInto on a primary-keyless table needs no partition column in the source ($tableType)") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        // No primaryKey: getProcessedInputDf left-outer-joins the target and projects its meta
+        // columns, and MergeIntoKeyGenerator reads `_hoodie_partition_path` from that meta, so a
+        // matched row is already placed correctly without the source carrying `dt`. The partition
+        // resolution must not engage for this table shape.
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id bigint,
+             |  name string,
+             |  amount double,
+             |  ts bigint,
+             |  dt string
+             |) using hudi
+             | partitioned by (dt)
+             | tblproperties (
+             |   type = '$tableType',
+             |   preCombineField = 'ts'
+             | )
+             | location '${tmp.getCanonicalPath}/$tableName'
+       """.stripMargin)
+
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+        spark.sql(
+          s"""
+             |merge into $tableName as t
+             |using (
+             |  select 1L as id, 15.0 as amount, 200L as ts
+             |) as s
+             |on t.id = s.id
+             |when matched then update set t.amount = s.amount, t.ts = s.ts
+       """.stripMargin)
+
+        checkAnswer(s"select id, amount, ts, dt, _hoodie_partition_path from $tableName")(
+          Seq(1L, 15.0, 200L, "2026-08-11", "dt=2026-08-11")
+        )
+      }
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeIntoTable2.scala
@@ -1235,9 +1235,20 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
                 "MERGE INTO field resolution error: No matching assignment found for target table ordering field `ts`"
               )
             } else {
-              spark.sql(
-                updateStatement)
-              // For COMMIT_TIME_ORDERING, ts should be updated to 1003
+              // The partition column `value` is supplied by neither the source projection, the ON
+              // condition, nor the assignments, so the incoming record's partition path cannot be
+              // determined and the statement is now rejected.
+              //
+              // This previously "passed": the record was resolved to the default partition, index
+              // tagging therefore matched nothing, and with no NOT MATCHED clause the record was
+              // dropped as HoodieRecord.SENTINEL - an empty commit. The assertion below only
+              // checked that the row was unchanged, which is exactly what dropping it produces, so
+              // the case passed vacuously whether or not the merge did any work. (Note the merge
+              // assigns `h0.id = s0.id` only, so a correctly-applied merge would leave an
+              // identical row - the old assertion could not distinguish the two outcomes.)
+              checkExceptionContain(updateStatement)(
+                "Failed to resolve partition fields"
+              )
               checkAnswer(s"select id, name, value, ts from $tableName")(
                 Seq(1, "a1", 10, 1000)
               )

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeIntoTable2.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeIntoTable2.scala
@@ -1235,17 +1235,8 @@ class TestMergeIntoTable2 extends HoodieSparkSqlTestBase {
                 "MERGE INTO field resolution error: No matching assignment found for target table ordering field `ts`"
               )
             } else {
-              // The partition column `value` is supplied by neither the source projection, the ON
-              // condition, nor the assignments, so the incoming record's partition path cannot be
-              // determined and the statement is now rejected.
-              //
-              // This previously "passed": the record was resolved to the default partition, index
-              // tagging therefore matched nothing, and with no NOT MATCHED clause the record was
-              // dropped as HoodieRecord.SENTINEL - an empty commit. The assertion below only
-              // checked that the row was unchanged, which is exactly what dropping it produces, so
-              // the case passed vacuously whether or not the merge did any work. (Note the merge
-              // assigns `h0.id = s0.id` only, so a correctly-applied merge would leave an
-              // identical row - the old assertion could not distinguish the two outcomes.)
+              // `value` is the partition column and is supplied by neither the source, the ON
+              // condition, nor the assignments, so the statement is rejected.
               checkExceptionContain(updateStatement)(
                 "Failed to resolve partition fields"
               )

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -22,7 +22,7 @@ import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieSchemaConversionUtils.{convertHoodieSchemaToStructType, convertStructTypeToHoodieSchema}
 import org.apache.hudi.HoodieSparkSqlWriter.CANONICALIZE_SCHEMA
 import org.apache.hudi.common.avro.HoodieAvroUtils
-import org.apache.hudi.common.config.RecordMergeMode
+import org.apache.hudi.common.config.{ConfigProperty, RecordMergeMode}
 import org.apache.hudi.common.model.{HoodieAvroRecordMerger, HoodieRecordMerger}
 import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaUtils}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableVersion, PartialUpdateMode}
@@ -114,6 +114,9 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
   with PredicateHelper {
 
   private var sparkSession: SparkSession = _
+
+  /** Resolved write config for this statement; populated at the top of [[run]]. */
+  private var mergeIntoProps: Map[String, String] = Map.empty
 
   /**
    * The target table schema without hoodie meta fields.
@@ -266,11 +269,91 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       "ordering fields",
       updatingActions.flatMap(_.assignments))
 
+  /**
+   * Mapping of the target table's partition columns onto the [[sourceTable]] expression supplying
+   * each one - required, not optional, for a target bearing a record key.
+   *
+   * Such a target is written from the [[sourceTable]] alone (see [[getProcessedInputDf]]) and index
+   * tagging keys off `(recordKey, partitionPath)`, so a partition column reaching the writer unset
+   * resolves to the default partition, tags nothing, and makes every record not-matched: dropped as
+   * [[HoodieRecord.SENTINEL]] under `WHEN MATCHED` alone, or inserted into the default partition -
+   * duplicating the primary key - when a `WHEN NOT MATCHED ... INSERT` clause is present.
+   *
+   * Resolved from the `ON` condition first (via [[recordKeyAttributeToConditionExpression]], which
+   * enumerates partition fields but leaves them optional), then from the source-table output;
+   * otherwise the statement is rejected.
+   *
+   * NOTE: MERGE assignments are deliberately not a source. Key generation runs over the source row
+   *       before the payload evaluates any assignment, so `UPDATE SET t.dt = s.new_dt` names the
+   *       record's *new* partition, not the one its existing version occupies - deriving from it
+   *       would miss that version and reinstate this defect.
+   *
+   * Resolves to nothing for a primary-keyless target ([[MergeIntoKeyGenerator]] reads
+   * `_hoodie_partition_path` off the joined target meta, placing a matched row correctly without
+   * it), and for a statement that cannot insert onto a re-keying global index - see
+   * [[isGlobalIndexRekeyingToExistingPartition]], whose re-keying covers matched records only, so
+   * an INSERT clause still requires the column.
+   */
+  private lazy val partitionFieldsAssociatedExpressions: Seq[(Attribute, Expression)] =
+    if (!hasPrimaryKey()
+      || hoodieCatalogTable.partitionFields.isEmpty
+      || (insertingActions.isEmpty && isGlobalIndexRekeyingToExistingPartition(mergeIntoProps))) {
+      Seq.empty
+    } else {
+      val resolver = sparkSession.sessionState.conf.resolver
+      // Already produced by the ON-condition path; re-adding would alias one column twice.
+      val resolvedFromCondition = recordKeyAttributeToConditionExpression
+      hoodieCatalogTable.partitionFields.toSeq.flatMap { partitionField =>
+        if (resolvedFromCondition.exists { case (attr, _) => resolver(attr.name, partitionField) }) {
+          Seq.empty
+        } else {
+          try {
+            resolveFieldAssociationsBetweenSourceAndTarget(
+              resolver,
+              mergeInto.targetTable,
+              mergeInto.sourceTable,
+              Seq(partitionField),
+              "partition fields",
+              Seq.empty)
+          } catch {
+            case _: MergeIntoFieldResolutionException =>
+              throw new MergeIntoFieldResolutionException(
+                s"Failed to resolve partition fields `$partitionField` within the source-table output. " +
+                  s"Project `$partitionField` in the source query, or match on it in the ON condition.")
+          }
+        }
+      }
+    }
+
+  /**
+   * True when a global index will re-key an incoming record onto the partition its existing version
+   * occupies, making the partition value that record carries irrelevant. With
+   * `update.partition.path` disabled - the default for `RECORD_INDEX` -
+   * `HoodieIndexUtils#tagGlobalLocationBackToRecords` tags the incoming record to "the existing
+   * record's partition regardless of being equal or not", so such a merge is correct today with the
+   * column absent from the source and must not be rejected.
+   *
+   * NOTE: this holds only for records the global lookup FINDS; one with no existing location is
+   *       returned untouched and keeps its incoming partition, so callers must additionally
+   *       establish that the statement cannot insert.
+   *
+   * NOTE: [[isGlobalIndexEnabled]] returns the value of `update.partition.path`, so it is true
+   *       precisely when this re-keying does NOT happen - hence the negation. It returns false for
+   *       a non-global index too, so the index type must be checked separately.
+   */
+  private def isGlobalIndexRekeyingToExistingPartition(props: Map[String, String]): Boolean =
+    props.get(HoodieIndexConfig.INDEX_TYPE.key).exists { indexType =>
+      isGlobalIndexType(indexType) && !isGlobalIndexEnabled(indexType, props)
+    }
+
   override def run(sparkSession: SparkSession): Seq[Row] = {
     this.sparkSession = sparkSession
     // TODO move to analysis phase
     // Create the write parameters
     val props = buildMergeIntoConfig(hoodieCatalogTable)
+    // Captured so the source-projection path can read the index type without threading props
+    // through getProcessedInputDf. Set before validate() so downstream lazy vals see it.
+    this.mergeIntoProps = props
     validate(props)
 
     val processedInputDf: DataFrame = getProcessedInputDf
@@ -361,7 +444,16 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
 
     val inputPlanAttributes = inputPlan.output
 
-    val requiredAttributesMap = recordKeyAttributeToConditionExpression ++ orderingFieldsAssociatedExpressions
+    // NOTE: partition columns are required for the same reason record-key columns are - see
+    //       [[partitionFieldsAssociatedExpressions]]. Deduped by target attribute, since one column
+    //       can be reached by more than one path (e.g. an ordering column also matched on in the ON
+    //       condition) and each surviving entry projects its own Alias below.
+    val requiredAttributesMap =
+      (recordKeyAttributeToConditionExpression ++ orderingFieldsAssociatedExpressions ++ partitionFieldsAssociatedExpressions)
+        .foldLeft(Seq.empty[(Attribute, Expression)]) { (acc, association) =>
+          if (acc.exists { case (seen, _) => resolver(seen.name, association._1.name) }) acc
+          else acc :+ association
+        }
 
     val (existingAttributesMap, missingAttributesMap) = requiredAttributesMap.partition {
       case (keyAttr, _) => inputPlanAttributes.exists(attr => resolver(keyAttr.name, attr.name))
@@ -899,7 +991,16 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     */
   private def checkSchemaMergeIntoCompatibility(assignments: Seq[Assignment], props: Map[String, String]): Unit = {
     if (assignments.nonEmpty) {
-      // Assert data type matching for partition key
+      // Assert data type matching for partition key.
+      //
+      // NOTE: an unresolvable partition column is deliberately not an error *here* - this method
+      //       only type-checks, and it is invoked per action with that action's assignments, so a
+      //       column supplied by the other clause would look unresolvable. Whether the column can
+      //       be resolved at all is enforced separately, and later, by
+      //       [[partitionFieldsAssociatedExpressions]] when the source projection is built - which
+      //       is also why this swallow no longer hides the mis-partitioning bug it once did. For a
+      //       primary-keyless target there is nothing to enforce: the partition path is read from
+      //       the target's `_hoodie_partition_path` meta column by [[MergeIntoKeyGenerator]].
       hoodieCatalogTable.partitionFields.foreach {
         partitionField => {
           try {
@@ -1123,17 +1224,28 @@ object MergeIntoHoodieTableCommand {
     }
   }
 
+  // Index types whose lookup spans partitions (by record key alone), each mapped to the config
+  // deciding whether a matched record keeps its incoming partition or is re-keyed onto the existing
+  // one. Deriving both helpers from a single map keeps the two from diverging: a type listed as
+  // global but missing a config would be exempted from the partition-column requirement even with
+  // `update.partition.path` enabled, where the incoming value does decide placement.
+  //
+  // Must agree with SparkHoodieIndexFactory#isGlobalIndex. Both record-index spellings resolve to
+  // SparkMetadataTableGlobalRecordLevelIndex, which reads the same config for either.
+  private val globalIndexUpdatePartitionPathConfigs: Map[String, ConfigProperty[String]] = Map(
+    HoodieIndex.IndexType.GLOBAL_SIMPLE.name -> HoodieIndexConfig.SIMPLE_INDEX_UPDATE_PARTITION_PATH_ENABLE,
+    HoodieIndex.IndexType.GLOBAL_BLOOM.name -> HoodieIndexConfig.BLOOM_INDEX_UPDATE_PARTITION_PATH_ENABLE,
+    HoodieIndex.IndexType.RECORD_INDEX.name -> HoodieIndexConfig.RECORD_INDEX_UPDATE_PARTITION_PATH_ENABLE,
+    HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX.name -> HoodieIndexConfig.RECORD_INDEX_UPDATE_PARTITION_PATH_ENABLE)
+
+  def isGlobalIndexType(indexType: String): Boolean =
+    globalIndexUpdatePartitionPathConfigs.contains(indexType)
+
   // Check if goal index is enabled for specific indexes.
-  def isGlobalIndexEnabled(indexType: String, parameters: Map[String, String]): Boolean = {
-    Seq(
-      HoodieIndex.IndexType.GLOBAL_SIMPLE -> HoodieIndexConfig.SIMPLE_INDEX_UPDATE_PARTITION_PATH_ENABLE,
-      HoodieIndex.IndexType.GLOBAL_BLOOM -> HoodieIndexConfig.BLOOM_INDEX_UPDATE_PARTITION_PATH_ENABLE,
-      HoodieIndex.IndexType.RECORD_INDEX -> HoodieIndexConfig.RECORD_INDEX_UPDATE_PARTITION_PATH_ENABLE
-    ).collectFirst {
-      case (hoodieIndex, config) if indexType == hoodieIndex.name =>
-        parameters.getOrElse(config.key, config.defaultValue().toString).toBoolean
-    }.getOrElse(false)
-  }
+  def isGlobalIndexEnabled(indexType: String, parameters: Map[String, String]): Boolean =
+    globalIndexUpdatePartitionPathConfigs.get(indexType).exists { config =>
+      parameters.getOrElse(config.key, config.defaultValue()).toBoolean
+    }
 
   def useCustomMergeMode(parameters: Map[String, String]): Boolean = {
     val mergeModeOpt = parameters.get(DataSourceWriteOptions.RECORD_MERGE_MODE.key)

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -115,9 +115,6 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
 
   private var sparkSession: SparkSession = _
 
-  /** Resolved write config for this statement; populated at the top of [[run]]. */
-  private var mergeIntoProps: Map[String, String] = Map.empty
-
   /**
    * The target table schema without hoodie meta fields.
    */
@@ -270,34 +267,15 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       updatingActions.flatMap(_.assignments))
 
   /**
-   * Mapping of the target table's partition columns onto the [[sourceTable]] expression supplying
-   * each one - required, not optional, for a target bearing a record key.
+   * Target partition columns mapped onto the [[sourceTable]] expression supplying each, resolved
+   * from the `ON` condition first and then the source output. A keyed target is written from the
+   * source alone, so a partition column missing from it lands in the default partition.
    *
-   * Such a target is written from the [[sourceTable]] alone (see [[getProcessedInputDf]]) and index
-   * tagging keys off `(recordKey, partitionPath)`, so a partition column reaching the writer unset
-   * resolves to the default partition, tags nothing, and makes every record not-matched: dropped as
-   * [[HoodieRecord.SENTINEL]] under `WHEN MATCHED` alone, or inserted into the default partition -
-   * duplicating the primary key - when a `WHEN NOT MATCHED ... INSERT` clause is present.
-   *
-   * Resolved from the `ON` condition first (via [[recordKeyAttributeToConditionExpression]], which
-   * enumerates partition fields but leaves them optional), then from the source-table output;
-   * otherwise the statement is rejected.
-   *
-   * NOTE: MERGE assignments are deliberately not a source. Key generation runs over the source row
-   *       before the payload evaluates any assignment, so `UPDATE SET t.dt = s.new_dt` names the
-   *       record's *new* partition, not the one its existing version occupies - deriving from it
-   *       would miss that version and reinstate this defect.
-   *
-   * Resolves to nothing for a primary-keyless target ([[MergeIntoKeyGenerator]] reads
-   * `_hoodie_partition_path` off the joined target meta, placing a matched row correctly without
-   * it), and for a statement that cannot insert onto a re-keying global index - see
-   * [[isGlobalIndexRekeyingToExistingPartition]], whose re-keying covers matched records only, so
-   * an INSERT clause still requires the column.
+   * NOTE: assignments are not a source - key generation runs before the payload evaluates them, so
+   *       `UPDATE SET t.dt = s.new_dt` names the record's new partition, not its current one.
    */
   private lazy val partitionFieldsAssociatedExpressions: Seq[(Attribute, Expression)] =
-    if (!hasPrimaryKey()
-      || hoodieCatalogTable.partitionFields.isEmpty
-      || (insertingActions.isEmpty && isGlobalIndexRekeyingToExistingPartition(mergeIntoProps))) {
+    if (!hasPrimaryKey() || hoodieCatalogTable.partitionFields.isEmpty) {
       Seq.empty
     } else {
       val resolver = sparkSession.sessionState.conf.resolver
@@ -326,20 +304,12 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     }
 
   /**
-   * True when a global index will re-key an incoming record onto the partition its existing version
-   * occupies, making the partition value that record carries irrelevant. With
-   * `update.partition.path` disabled - the default for `RECORD_INDEX` -
-   * `HoodieIndexUtils#tagGlobalLocationBackToRecords` tags the incoming record to "the existing
-   * record's partition regardless of being equal or not", so such a merge is correct today with the
-   * column absent from the source and must not be rejected.
-   *
-   * NOTE: this holds only for records the global lookup FINDS; one with no existing location is
-   *       returned untouched and keeps its incoming partition, so callers must additionally
-   *       establish that the statement cannot insert.
+   * True when a global index re-keys a matched record onto the partition its existing version
+   * occupies, making the incoming partition value irrelevant. Found records only, so callers must
+   * also establish the statement cannot insert.
    *
    * NOTE: [[isGlobalIndexEnabled]] returns the value of `update.partition.path`, so it is true
-   *       precisely when this re-keying does NOT happen - hence the negation. It returns false for
-   *       a non-global index too, so the index type must be checked separately.
+   *       precisely when this re-keying does NOT happen - hence the negation.
    */
   private def isGlobalIndexRekeyingToExistingPartition(props: Map[String, String]): Boolean =
     props.get(HoodieIndexConfig.INDEX_TYPE.key).exists { indexType =>
@@ -351,12 +321,9 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     // TODO move to analysis phase
     // Create the write parameters
     val props = buildMergeIntoConfig(hoodieCatalogTable)
-    // Captured so the source-projection path can read the index type without threading props
-    // through getProcessedInputDf. Set before validate() so downstream lazy vals see it.
-    this.mergeIntoProps = props
     validate(props)
 
-    val processedInputDf: DataFrame = getProcessedInputDf
+    val processedInputDf: DataFrame = getProcessedInputDf(props)
     // Do the upsert
     executeUpsert(processedInputDf, props)
     // Refresh the table in the catalog
@@ -423,7 +390,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    * <li>{@code ts = source.sts}</li>
    * </ul>
    */
-  private def getProcessedInputDf: DataFrame = {
+  private def getProcessedInputDf(props: Map[String, String]): DataFrame = {
     val resolver = sparkSession.sessionState.analyzer.resolver
 
     // For pkless table, we need to project the meta columns by joining with the target table;
@@ -444,12 +411,16 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
 
     val inputPlanAttributes = inputPlan.output
 
-    // NOTE: partition columns are required for the same reason record-key columns are - see
-    //       [[partitionFieldsAssociatedExpressions]]. Deduped by target attribute, since one column
-    //       can be reached by more than one path (e.g. an ordering column also matched on in the ON
-    //       condition) and each surviving entry projects its own Alias below.
+    // A re-keying global index places a matched record by its existing partition, so the value the
+    // source carries is irrelevant. That covers found records only, hence the insert-clause check.
+    val partitionAssociations =
+      if (insertingActions.isEmpty && isGlobalIndexRekeyingToExistingPartition(props)) Seq.empty
+      else partitionFieldsAssociatedExpressions
+
+    // Deduped by target attribute: one column can be reached by more than one path (e.g. an
+    // ordering column also matched on in the ON condition) and each entry projects its own Alias.
     val requiredAttributesMap =
-      (recordKeyAttributeToConditionExpression ++ orderingFieldsAssociatedExpressions ++ partitionFieldsAssociatedExpressions)
+      (recordKeyAttributeToConditionExpression ++ orderingFieldsAssociatedExpressions ++ partitionAssociations)
         .foldLeft(Seq.empty[(Attribute, Expression)]) { (acc, association) =>
           if (acc.exists { case (seen, _) => resolver(seen.name, association._1.name) }) acc
           else acc :+ association
@@ -564,11 +535,13 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
         // NOTE: For updating clause we allow partial assignments, where only some of the fields of the target
         //       table's records are updated (w/ the missing ones keeping their existing values)
         serializeConditionalAssignments(updatingActions.map(a => (a.condition, a.assignments)),
+          parameters,
           partialAssignmentMode = Some(PartialAssignmentMode.ORIGINAL_VALUE),
           keepUpdatedFieldsOnly = writePartialUpdates),
       // Append (encoded) inserting actions
       PAYLOAD_INSERT_CONDITION_AND_ASSIGNMENTS ->
         serializeConditionalAssignments(insertingActions.map(a => (a.condition, a.assignments)),
+          parameters,
           partialAssignmentMode = Some(PartialAssignmentMode.NULL_VALUE),
           keepUpdatedFieldsOnly = false,
           validator = validateInsertingAssignmentExpression)
@@ -578,7 +551,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     writeParams ++= deletingActions.headOption.map {
       case DeleteAction(condition) =>
         PAYLOAD_DELETE_CONDITION -> serializeConditionalAssignments(Seq(condition -> Seq.empty),
-          keepUpdatedFieldsOnly = false)
+          parameters, keepUpdatedFieldsOnly = false)
     }.toSeq
 
     // Append
@@ -588,7 +561,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       PAYLOAD_RECORD_AVRO_SCHEMA ->
         HoodieSchemaUtils.removeMetadataFields(
           HoodieSchemaConversionUtils.convertUserStructTypeToHoodieSchema(enrichedSourceDF.schema, "record", "")).toString,
-      PAYLOAD_EXPECTED_COMBINED_SCHEMA -> encodeAsBase64String(toStructType(joinedExpectedOutput))
+      PAYLOAD_EXPECTED_COMBINED_SCHEMA -> encodeAsBase64String(toStructType(joinedExpectedOutput(parameters)))
     )
 
     // Append original payload class
@@ -710,13 +683,14 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    * updated fields, to be written to the log files in a MOR table.
    */
   private def serializeConditionalAssignments(conditionalAssignments: Seq[(Option[Expression], Seq[Assignment])],
+                                              props: Map[String, String],
                                               partialAssignmentMode: Option[PartialAssignmentMode] = None,
                                               keepUpdatedFieldsOnly: Boolean,
                                               validator: Expression => Unit = scalaFunction1Noop): String = {
     val boundConditionalAssignments =
       conditionalAssignments.map {
         case (condition, assignments) =>
-          val boundCondition = condition.map(bindReferences).getOrElse(Literal.create(true, BooleanType))
+          val boundCondition = condition.map(bindReferences(_, props)).getOrElse(Literal.create(true, BooleanType))
           // NOTE: For deleting actions there's no assignments provided and no re-ordering is required.
           //       All other actions are expected to provide assignments correspondent to every field
           //       of the [[targetTable]] being assigned
@@ -730,7 +704,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
           //       of these expressions could be inserted into the target table as is
           val boundAssignmentExprs = reorderedAssignments.map {
             case Assignment(attr: Attribute, value) =>
-              val boundExpr = bindReferences(value)
+              val boundExpr = bindReferences(value, props)
               validator(boundExpr)
               // Alias resulting expression w/ target table's expected column name, as well as
               // do casting if necessary
@@ -819,11 +793,11 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    * Binding is necessary for [[ExpressionPayload]] to use the code-gen to effectively perform
    * handling of the records (combining updated records, as well as producing new records to be inserted)
    */
-  private def bindReferences(expr: Expression): Expression = {
+  private def bindReferences(expr: Expression, props: Map[String, String]): Expression = {
     // NOTE: Since original source dataset could be augmented w/ additional columns (please
     //       check its corresponding java-doc for more details) we have to get up-to-date list
     //       of its output attributes
-    val joinedExpectedOutputAttributes = joinedExpectedOutput
+    val joinedExpectedOutputAttributes = joinedExpectedOutput(props)
 
     bindReference(expr, joinedExpectedOutputAttributes, allowFailures = false)
   }
@@ -832,11 +806,11 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    * Output of the expected (left) join of the a) [[sourceTable]] dataset (potentially amended w/ primary-key,
    * ordering columns) with b) existing [[targetTable]]
    */
-  private def joinedExpectedOutput: Seq[Attribute] = {
+  private def joinedExpectedOutput(props: Map[String, String]): Seq[Attribute] = {
     // NOTE: We're relying on [[sourceDataset]] here instead of [[mergeInto.sourceTable]],
     //       as it could be amended to add missing primary-key and/or ordering columns.
     //       Please check [[sourceDataset]] scala-doc for more details
-    (getProcessedInputDf.queryExecution.analyzed.output ++ mergeInto.targetTable.output).filterNot(a => isMetaField(a.name))
+    (getProcessedInputDf(props).queryExecution.analyzed.output ++ mergeInto.targetTable.output).filterNot(a => isMetaField(a.name))
   }
 
   private def validateInsertingAssignmentExpression(expr: Expression): Unit = {
@@ -991,16 +965,9 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     */
   private def checkSchemaMergeIntoCompatibility(assignments: Seq[Assignment], props: Map[String, String]): Unit = {
     if (assignments.nonEmpty) {
-      // Assert data type matching for partition key.
-      //
-      // NOTE: an unresolvable partition column is deliberately not an error *here* - this method
-      //       only type-checks, and it is invoked per action with that action's assignments, so a
-      //       column supplied by the other clause would look unresolvable. Whether the column can
-      //       be resolved at all is enforced separately, and later, by
-      //       [[partitionFieldsAssociatedExpressions]] when the source projection is built - which
-      //       is also why this swallow no longer hides the mis-partitioning bug it once did. For a
-      //       primary-keyless target there is nothing to enforce: the partition path is read from
-      //       the target's `_hoodie_partition_path` meta column by [[MergeIntoKeyGenerator]].
+      // Assert data type matching for partition key. Unresolvable is not an error here: this only
+      // type-checks, per action, so a column supplied by the other clause looks unresolvable.
+      // Resolvability is enforced by [[partitionFieldsAssociatedExpressions]].
       hoodieCatalogTable.partitionFields.foreach {
         partitionField => {
           try {
@@ -1224,14 +1191,9 @@ object MergeIntoHoodieTableCommand {
     }
   }
 
-  // Index types whose lookup spans partitions (by record key alone), each mapped to the config
-  // deciding whether a matched record keeps its incoming partition or is re-keyed onto the existing
-  // one. Deriving both helpers from a single map keeps the two from diverging: a type listed as
-  // global but missing a config would be exempted from the partition-column requirement even with
-  // `update.partition.path` enabled, where the incoming value does decide placement.
-  //
-  // Must agree with SparkHoodieIndexFactory#isGlobalIndex. Both record-index spellings resolve to
-  // SparkMetadataTableGlobalRecordLevelIndex, which reads the same config for either.
+  // Global index types mapped to the config governing whether a matched record is re-keyed onto its
+  // existing partition. One map, so a type cannot be recorded as global without its config.
+  // INMEMORY is excluded: its lookup is keyed by HoodieKey, so it does not span partitions.
   private val globalIndexUpdatePartitionPathConfigs: Map[String, ConfigProperty[String]] = Map(
     HoodieIndex.IndexType.GLOBAL_SIMPLE.name -> HoodieIndexConfig.SIMPLE_INDEX_UPDATE_PARTITION_PATH_ENABLE,
     HoodieIndex.IndexType.GLOBAL_BLOOM.name -> HoodieIndexConfig.BLOOM_INDEX_UPDATE_PARTITION_PATH_ENABLE,

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -115,9 +115,6 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
 
   private var sparkSession: SparkSession = _
 
-  /** Resolved write config for this statement; populated at the top of [[run]]. */
-  private var mergeIntoProps: Map[String, String] = Map.empty
-
   /**
    * The target table schema without hoodie meta fields.
    */
@@ -270,34 +267,15 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       updatingActions.flatMap(_.assignments))
 
   /**
-   * Mapping of the target table's partition columns onto the [[sourceTable]] expression supplying
-   * each one - required, not optional, for a target bearing a record key.
+   * Target partition columns mapped onto the [[sourceTable]] expression supplying each, resolved
+   * from the `ON` condition first and then the source output. A keyed target is written from the
+   * source alone, so a partition column missing from it lands in the default partition.
    *
-   * Such a target is written from the [[sourceTable]] alone (see [[getProcessedInputDf]]) and index
-   * tagging keys off `(recordKey, partitionPath)`, so a partition column reaching the writer unset
-   * resolves to the default partition, tags nothing, and makes every record not-matched: dropped as
-   * [[HoodieRecord.SENTINEL]] under `WHEN MATCHED` alone, or inserted into the default partition -
-   * duplicating the primary key - when a `WHEN NOT MATCHED ... INSERT` clause is present.
-   *
-   * Resolved from the `ON` condition first (via [[recordKeyAttributeToConditionExpression]], which
-   * enumerates partition fields but leaves them optional), then from the source-table output;
-   * otherwise the statement is rejected.
-   *
-   * NOTE: MERGE assignments are deliberately not a source. Key generation runs over the source row
-   *       before the payload evaluates any assignment, so `UPDATE SET t.dt = s.new_dt` names the
-   *       record's *new* partition, not the one its existing version occupies - deriving from it
-   *       would miss that version and reinstate this defect.
-   *
-   * Resolves to nothing for a primary-keyless target ([[MergeIntoKeyGenerator]] reads
-   * `_hoodie_partition_path` off the joined target meta, placing a matched row correctly without
-   * it), and for a statement that cannot insert onto a re-keying global index - see
-   * [[isGlobalIndexRekeyingToExistingPartition]], whose re-keying covers matched records only, so
-   * an INSERT clause still requires the column.
+   * NOTE: assignments are not a source - key generation runs before the payload evaluates them, so
+   *       `UPDATE SET t.dt = s.new_dt` names the record's new partition, not its current one.
    */
   private lazy val partitionFieldsAssociatedExpressions: Seq[(Attribute, Expression)] =
-    if (!hasPrimaryKey()
-      || hoodieCatalogTable.partitionFields.isEmpty
-      || (insertingActions.isEmpty && isGlobalIndexRekeyingToExistingPartition(mergeIntoProps))) {
+    if (!hasPrimaryKey() || hoodieCatalogTable.partitionFields.isEmpty) {
       Seq.empty
     } else {
       val resolver = sparkSession.sessionState.conf.resolver
@@ -326,20 +304,12 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     }
 
   /**
-   * True when a global index will re-key an incoming record onto the partition its existing version
-   * occupies, making the partition value that record carries irrelevant. With
-   * `update.partition.path` disabled - the default for `RECORD_INDEX` -
-   * `HoodieIndexUtils#tagGlobalLocationBackToRecords` tags the incoming record to "the existing
-   * record's partition regardless of being equal or not", so such a merge is correct today with the
-   * column absent from the source and must not be rejected.
-   *
-   * NOTE: this holds only for records the global lookup FINDS; one with no existing location is
-   *       returned untouched and keeps its incoming partition, so callers must additionally
-   *       establish that the statement cannot insert.
+   * True when a global index re-keys a matched record onto the partition its existing version
+   * occupies, making the incoming partition value irrelevant. Found records only, so callers must
+   * also establish the statement cannot insert.
    *
    * NOTE: [[isGlobalIndexEnabled]] returns the value of `update.partition.path`, so it is true
-   *       precisely when this re-keying does NOT happen - hence the negation. It returns false for
-   *       a non-global index too, so the index type must be checked separately.
+   *       precisely when this re-keying does NOT happen - hence the negation.
    */
   private def isGlobalIndexRekeyingToExistingPartition(props: Map[String, String]): Boolean =
     props.get(HoodieIndexConfig.INDEX_TYPE.key).exists { indexType =>
@@ -351,12 +321,9 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     // TODO move to analysis phase
     // Create the write parameters
     val props = buildMergeIntoConfig(hoodieCatalogTable)
-    // Captured so the source-projection path can read the index type without threading props
-    // through getProcessedInputDf. Set before validate() so downstream lazy vals see it.
-    this.mergeIntoProps = props
     validate(props)
 
-    val processedInputDf: DataFrame = getProcessedInputDf
+    val processedInputDf: DataFrame = getProcessedInputDf(props)
     // Do the upsert
     executeUpsert(processedInputDf, props)
     // Refresh the table in the catalog
@@ -423,7 +390,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    * <li>{@code ts = source.sts}</li>
    * </ul>
    */
-  private def getProcessedInputDf: DataFrame = {
+  private def getProcessedInputDf(props: Map[String, String]): DataFrame = {
     val resolver = sparkSession.sessionState.analyzer.resolver
 
     // For pkless table, we need to project the meta columns by joining with the target table;
@@ -444,12 +411,16 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
 
     val inputPlanAttributes = inputPlan.output
 
-    // NOTE: partition columns are required for the same reason record-key columns are - see
-    //       [[partitionFieldsAssociatedExpressions]]. Deduped by target attribute, since one column
-    //       can be reached by more than one path (e.g. an ordering column also matched on in the ON
-    //       condition) and each surviving entry projects its own Alias below.
+    // A re-keying global index places a matched record by its existing partition, so the value the
+    // source carries is irrelevant. That covers found records only, hence the insert-clause check.
+    val partitionAssociations =
+      if (insertingActions.isEmpty && isGlobalIndexRekeyingToExistingPartition(props)) Seq.empty
+      else partitionFieldsAssociatedExpressions
+
+    // Deduped by target attribute: one column can be reached by more than one path (e.g. an
+    // ordering column also matched on in the ON condition) and each entry projects its own Alias.
     val requiredAttributesMap =
-      (recordKeyAttributeToConditionExpression ++ orderingFieldsAssociatedExpressions ++ partitionFieldsAssociatedExpressions)
+      (recordKeyAttributeToConditionExpression ++ orderingFieldsAssociatedExpressions ++ partitionAssociations)
         .foldLeft(Seq.empty[(Attribute, Expression)]) { (acc, association) =>
           if (acc.exists { case (seen, _) => resolver(seen.name, association._1.name) }) acc
           else acc :+ association
@@ -564,11 +535,13 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
         // NOTE: For updating clause we allow partial assignments, where only some of the fields of the target
         //       table's records are updated (w/ the missing ones keeping their existing values)
         serializeConditionalAssignments(updatingActions.map(a => (a.condition, a.assignments)),
+          parameters,
           partialAssignmentMode = Some(PartialAssignmentMode.ORIGINAL_VALUE),
           keepUpdatedFieldsOnly = writePartialUpdates),
       // Append (encoded) inserting actions
       PAYLOAD_INSERT_CONDITION_AND_ASSIGNMENTS ->
         serializeConditionalAssignments(insertingActions.map(a => (a.condition, a.assignments)),
+          parameters,
           partialAssignmentMode = Some(PartialAssignmentMode.NULL_VALUE),
           keepUpdatedFieldsOnly = false,
           validator = validateInsertingAssignmentExpression)
@@ -578,7 +551,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     writeParams ++= deletingActions.headOption.map {
       case DeleteAction(condition) =>
         PAYLOAD_DELETE_CONDITION -> serializeConditionalAssignments(Seq(condition -> Seq.empty),
-          keepUpdatedFieldsOnly = false)
+          parameters, keepUpdatedFieldsOnly = false)
     }.toSeq
 
     // Append
@@ -588,7 +561,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       PAYLOAD_RECORD_AVRO_SCHEMA ->
         HoodieSchemaUtils.removeMetadataFields(
           HoodieSchemaConversionUtils.convertUserStructTypeToHoodieSchema(enrichedSourceDF.schema, "record", "")).toString,
-      PAYLOAD_EXPECTED_COMBINED_SCHEMA -> encodeAsBase64String(toStructType(joinedExpectedOutput))
+      PAYLOAD_EXPECTED_COMBINED_SCHEMA -> encodeAsBase64String(toStructType(joinedExpectedOutput(parameters)))
     )
 
     // Append original payload class
@@ -709,13 +682,14 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    * updated fields, to be written to the log files in a MOR table.
    */
   private def serializeConditionalAssignments(conditionalAssignments: Seq[(Option[Expression], Seq[Assignment])],
+                                              props: Map[String, String],
                                               partialAssignmentMode: Option[PartialAssignmentMode] = None,
                                               keepUpdatedFieldsOnly: Boolean,
                                               validator: Expression => Unit = scalaFunction1Noop): String = {
     val boundConditionalAssignments =
       conditionalAssignments.map {
         case (condition, assignments) =>
-          val boundCondition = condition.map(bindReferences).getOrElse(Literal.create(true, BooleanType))
+          val boundCondition = condition.map(bindReferences(_, props)).getOrElse(Literal.create(true, BooleanType))
           // NOTE: For deleting actions there's no assignments provided and no re-ordering is required.
           //       All other actions are expected to provide assignments correspondent to every field
           //       of the [[targetTable]] being assigned
@@ -729,7 +703,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
           //       of these expressions could be inserted into the target table as is
           val boundAssignmentExprs = reorderedAssignments.map {
             case Assignment(attr: Attribute, value) =>
-              val boundExpr = bindReferences(value)
+              val boundExpr = bindReferences(value, props)
               validator(boundExpr)
               // Alias resulting expression w/ target table's expected column name, as well as
               // do casting if necessary
@@ -818,11 +792,11 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    * Binding is necessary for [[ExpressionPayload]] to use the code-gen to effectively perform
    * handling of the records (combining updated records, as well as producing new records to be inserted)
    */
-  private def bindReferences(expr: Expression): Expression = {
+  private def bindReferences(expr: Expression, props: Map[String, String]): Expression = {
     // NOTE: Since original source dataset could be augmented w/ additional columns (please
     //       check its corresponding java-doc for more details) we have to get up-to-date list
     //       of its output attributes
-    val joinedExpectedOutputAttributes = joinedExpectedOutput
+    val joinedExpectedOutputAttributes = joinedExpectedOutput(props)
 
     bindReference(expr, joinedExpectedOutputAttributes, allowFailures = false)
   }
@@ -831,11 +805,11 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    * Output of the expected (left) join of the a) [[sourceTable]] dataset (potentially amended w/ primary-key,
    * ordering columns) with b) existing [[targetTable]]
    */
-  private def joinedExpectedOutput: Seq[Attribute] = {
+  private def joinedExpectedOutput(props: Map[String, String]): Seq[Attribute] = {
     // NOTE: We're relying on [[sourceDataset]] here instead of [[mergeInto.sourceTable]],
     //       as it could be amended to add missing primary-key and/or ordering columns.
     //       Please check [[sourceDataset]] scala-doc for more details
-    (getProcessedInputDf.queryExecution.analyzed.output ++ mergeInto.targetTable.output).filterNot(a => isMetaField(a.name))
+    (getProcessedInputDf(props).queryExecution.analyzed.output ++ mergeInto.targetTable.output).filterNot(a => isMetaField(a.name))
   }
 
   private def validateInsertingAssignmentExpression(expr: Expression): Unit = {
@@ -990,16 +964,9 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    */
   private def checkSchemaMergeIntoCompatibility(assignments: Seq[Assignment], props: Map[String, String]): Unit = {
     if (assignments.nonEmpty) {
-      // Assert data type matching for partition key.
-      //
-      // NOTE: an unresolvable partition column is deliberately not an error *here* - this method
-      //       only type-checks, and it is invoked per action with that action's assignments, so a
-      //       column supplied by the other clause would look unresolvable. Whether the column can
-      //       be resolved at all is enforced separately, and later, by
-      //       [[partitionFieldsAssociatedExpressions]] when the source projection is built - which
-      //       is also why this swallow no longer hides the mis-partitioning bug it once did. For a
-      //       primary-keyless target there is nothing to enforce: the partition path is read from
-      //       the target's `_hoodie_partition_path` meta column by [[MergeIntoKeyGenerator]].
+      // Assert data type matching for partition key. Unresolvable is not an error here: this only
+      // type-checks, per action, so a column supplied by the other clause looks unresolvable.
+      // Resolvability is enforced by [[partitionFieldsAssociatedExpressions]].
       hoodieCatalogTable.partitionFields.foreach {
         partitionField => {
           try {
@@ -1223,14 +1190,9 @@ object MergeIntoHoodieTableCommand {
     }
   }
 
-  // Index types whose lookup spans partitions (by record key alone), each mapped to the config
-  // deciding whether a matched record keeps its incoming partition or is re-keyed onto the existing
-  // one. Deriving both helpers from a single map keeps the two from diverging: a type listed as
-  // global but missing a config would be exempted from the partition-column requirement even with
-  // `update.partition.path` enabled, where the incoming value does decide placement.
-  //
-  // Must agree with SparkHoodieIndexFactory#isGlobalIndex. Both record-index spellings resolve to
-  // SparkMetadataTableGlobalRecordLevelIndex, which reads the same config for either.
+  // Global index types mapped to the config governing whether a matched record is re-keyed onto its
+  // existing partition. One map, so a type cannot be recorded as global without its config.
+  // INMEMORY is excluded: its lookup is keyed by HoodieKey, so it does not span partitions.
   private val globalIndexUpdatePartitionPathConfigs: Map[String, ConfigProperty[String]] = Map(
     HoodieIndex.IndexType.GLOBAL_SIMPLE.name -> HoodieIndexConfig.SIMPLE_INDEX_UPDATE_PARTITION_PATH_ENABLE,
     HoodieIndex.IndexType.GLOBAL_BLOOM.name -> HoodieIndexConfig.BLOOM_INDEX_UPDATE_PARTITION_PATH_ENABLE,

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -21,7 +21,7 @@ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieSch
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema
 import org.apache.hudi.HoodieSparkSqlWriter.CANONICALIZE_SCHEMA
-import org.apache.hudi.common.config.RecordMergeMode
+import org.apache.hudi.common.config.{ConfigProperty, RecordMergeMode}
 import org.apache.hudi.common.model.{HoodieAvroRecordMerger, HoodieRecordMerger}
 import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaUtils}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableVersion, PartialUpdateMode}
@@ -114,6 +114,9 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
   with PredicateHelper {
 
   private var sparkSession: SparkSession = _
+
+  /** Resolved write config for this statement; populated at the top of [[run]]. */
+  private var mergeIntoProps: Map[String, String] = Map.empty
 
   /**
    * The target table schema without hoodie meta fields.
@@ -266,11 +269,91 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       "ordering fields",
       updatingActions.flatMap(_.assignments))
 
+  /**
+   * Mapping of the target table's partition columns onto the [[sourceTable]] expression supplying
+   * each one - required, not optional, for a target bearing a record key.
+   *
+   * Such a target is written from the [[sourceTable]] alone (see [[getProcessedInputDf]]) and index
+   * tagging keys off `(recordKey, partitionPath)`, so a partition column reaching the writer unset
+   * resolves to the default partition, tags nothing, and makes every record not-matched: dropped as
+   * [[HoodieRecord.SENTINEL]] under `WHEN MATCHED` alone, or inserted into the default partition -
+   * duplicating the primary key - when a `WHEN NOT MATCHED ... INSERT` clause is present.
+   *
+   * Resolved from the `ON` condition first (via [[recordKeyAttributeToConditionExpression]], which
+   * enumerates partition fields but leaves them optional), then from the source-table output;
+   * otherwise the statement is rejected.
+   *
+   * NOTE: MERGE assignments are deliberately not a source. Key generation runs over the source row
+   *       before the payload evaluates any assignment, so `UPDATE SET t.dt = s.new_dt` names the
+   *       record's *new* partition, not the one its existing version occupies - deriving from it
+   *       would miss that version and reinstate this defect.
+   *
+   * Resolves to nothing for a primary-keyless target ([[MergeIntoKeyGenerator]] reads
+   * `_hoodie_partition_path` off the joined target meta, placing a matched row correctly without
+   * it), and for a statement that cannot insert onto a re-keying global index - see
+   * [[isGlobalIndexRekeyingToExistingPartition]], whose re-keying covers matched records only, so
+   * an INSERT clause still requires the column.
+   */
+  private lazy val partitionFieldsAssociatedExpressions: Seq[(Attribute, Expression)] =
+    if (!hasPrimaryKey()
+      || hoodieCatalogTable.partitionFields.isEmpty
+      || (insertingActions.isEmpty && isGlobalIndexRekeyingToExistingPartition(mergeIntoProps))) {
+      Seq.empty
+    } else {
+      val resolver = sparkSession.sessionState.conf.resolver
+      // Already produced by the ON-condition path; re-adding would alias one column twice.
+      val resolvedFromCondition = recordKeyAttributeToConditionExpression
+      hoodieCatalogTable.partitionFields.toSeq.flatMap { partitionField =>
+        if (resolvedFromCondition.exists { case (attr, _) => resolver(attr.name, partitionField) }) {
+          Seq.empty
+        } else {
+          try {
+            resolveFieldAssociationsBetweenSourceAndTarget(
+              resolver,
+              mergeInto.targetTable,
+              mergeInto.sourceTable,
+              Seq(partitionField),
+              "partition fields",
+              Seq.empty)
+          } catch {
+            case _: MergeIntoFieldResolutionException =>
+              throw new MergeIntoFieldResolutionException(
+                s"Failed to resolve partition fields `$partitionField` within the source-table output. " +
+                  s"Project `$partitionField` in the source query, or match on it in the ON condition.")
+          }
+        }
+      }
+    }
+
+  /**
+   * True when a global index will re-key an incoming record onto the partition its existing version
+   * occupies, making the partition value that record carries irrelevant. With
+   * `update.partition.path` disabled - the default for `RECORD_INDEX` -
+   * `HoodieIndexUtils#tagGlobalLocationBackToRecords` tags the incoming record to "the existing
+   * record's partition regardless of being equal or not", so such a merge is correct today with the
+   * column absent from the source and must not be rejected.
+   *
+   * NOTE: this holds only for records the global lookup FINDS; one with no existing location is
+   *       returned untouched and keeps its incoming partition, so callers must additionally
+   *       establish that the statement cannot insert.
+   *
+   * NOTE: [[isGlobalIndexEnabled]] returns the value of `update.partition.path`, so it is true
+   *       precisely when this re-keying does NOT happen - hence the negation. It returns false for
+   *       a non-global index too, so the index type must be checked separately.
+   */
+  private def isGlobalIndexRekeyingToExistingPartition(props: Map[String, String]): Boolean =
+    props.get(HoodieIndexConfig.INDEX_TYPE.key).exists { indexType =>
+      isGlobalIndexType(indexType) && !isGlobalIndexEnabled(indexType, props)
+    }
+
   override def run(sparkSession: SparkSession): Seq[Row] = {
     this.sparkSession = sparkSession
     // TODO move to analysis phase
     // Create the write parameters
     val props = buildMergeIntoConfig(hoodieCatalogTable)
+    // Captured so the source-projection path can read the index type without threading props
+    // through getProcessedInputDf. Set before validate() so downstream lazy vals see it.
+    this.mergeIntoProps = props
     validate(props)
 
     val processedInputDf: DataFrame = getProcessedInputDf
@@ -361,7 +444,16 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
 
     val inputPlanAttributes = inputPlan.output
 
-    val requiredAttributesMap = recordKeyAttributeToConditionExpression ++ orderingFieldsAssociatedExpressions
+    // NOTE: partition columns are required for the same reason record-key columns are - see
+    //       [[partitionFieldsAssociatedExpressions]]. Deduped by target attribute, since one column
+    //       can be reached by more than one path (e.g. an ordering column also matched on in the ON
+    //       condition) and each surviving entry projects its own Alias below.
+    val requiredAttributesMap =
+      (recordKeyAttributeToConditionExpression ++ orderingFieldsAssociatedExpressions ++ partitionFieldsAssociatedExpressions)
+        .foldLeft(Seq.empty[(Attribute, Expression)]) { (acc, association) =>
+          if (acc.exists { case (seen, _) => resolver(seen.name, association._1.name) }) acc
+          else acc :+ association
+        }
 
     val (existingAttributesMap, missingAttributesMap) = requiredAttributesMap.partition {
       case (keyAttr, _) => inputPlanAttributes.exists(attr => resolver(keyAttr.name, attr.name))
@@ -898,7 +990,16 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    */
   private def checkSchemaMergeIntoCompatibility(assignments: Seq[Assignment], props: Map[String, String]): Unit = {
     if (assignments.nonEmpty) {
-      // Assert data type matching for partition key
+      // Assert data type matching for partition key.
+      //
+      // NOTE: an unresolvable partition column is deliberately not an error *here* - this method
+      //       only type-checks, and it is invoked per action with that action's assignments, so a
+      //       column supplied by the other clause would look unresolvable. Whether the column can
+      //       be resolved at all is enforced separately, and later, by
+      //       [[partitionFieldsAssociatedExpressions]] when the source projection is built - which
+      //       is also why this swallow no longer hides the mis-partitioning bug it once did. For a
+      //       primary-keyless target there is nothing to enforce: the partition path is read from
+      //       the target's `_hoodie_partition_path` meta column by [[MergeIntoKeyGenerator]].
       hoodieCatalogTable.partitionFields.foreach {
         partitionField => {
           try {
@@ -1122,17 +1223,28 @@ object MergeIntoHoodieTableCommand {
     }
   }
 
+  // Index types whose lookup spans partitions (by record key alone), each mapped to the config
+  // deciding whether a matched record keeps its incoming partition or is re-keyed onto the existing
+  // one. Deriving both helpers from a single map keeps the two from diverging: a type listed as
+  // global but missing a config would be exempted from the partition-column requirement even with
+  // `update.partition.path` enabled, where the incoming value does decide placement.
+  //
+  // Must agree with SparkHoodieIndexFactory#isGlobalIndex. Both record-index spellings resolve to
+  // SparkMetadataTableGlobalRecordLevelIndex, which reads the same config for either.
+  private val globalIndexUpdatePartitionPathConfigs: Map[String, ConfigProperty[String]] = Map(
+    HoodieIndex.IndexType.GLOBAL_SIMPLE.name -> HoodieIndexConfig.SIMPLE_INDEX_UPDATE_PARTITION_PATH_ENABLE,
+    HoodieIndex.IndexType.GLOBAL_BLOOM.name -> HoodieIndexConfig.BLOOM_INDEX_UPDATE_PARTITION_PATH_ENABLE,
+    HoodieIndex.IndexType.RECORD_INDEX.name -> HoodieIndexConfig.RECORD_INDEX_UPDATE_PARTITION_PATH_ENABLE,
+    HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX.name -> HoodieIndexConfig.RECORD_INDEX_UPDATE_PARTITION_PATH_ENABLE)
+
+  def isGlobalIndexType(indexType: String): Boolean =
+    globalIndexUpdatePartitionPathConfigs.contains(indexType)
+
   // Check if goal index is enabled for specific indexes.
-  def isGlobalIndexEnabled(indexType: String, parameters: Map[String, String]): Boolean = {
-    Seq(
-      HoodieIndex.IndexType.GLOBAL_SIMPLE -> HoodieIndexConfig.SIMPLE_INDEX_UPDATE_PARTITION_PATH_ENABLE,
-      HoodieIndex.IndexType.GLOBAL_BLOOM -> HoodieIndexConfig.BLOOM_INDEX_UPDATE_PARTITION_PATH_ENABLE,
-      HoodieIndex.IndexType.RECORD_INDEX -> HoodieIndexConfig.RECORD_INDEX_UPDATE_PARTITION_PATH_ENABLE
-    ).collectFirst {
-      case (hoodieIndex, config) if indexType == hoodieIndex.name =>
-        parameters.getOrElse(config.key, config.defaultValue().toString).toBoolean
-    }.getOrElse(false)
-  }
+  def isGlobalIndexEnabled(indexType: String, parameters: Map[String, String]): Boolean =
+    globalIndexUpdatePartitionPathConfigs.get(indexType).exists { config =>
+      parameters.getOrElse(config.key, config.defaultValue()).toBoolean
+    }
 
   def useCustomMergeMode(parameters: Map[String, String]): Boolean = {
     val mergeModeOpt = parameters.get(DataSourceWriteOptions.RECORD_MERGE_MODE.key)


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`MERGE INTO` against a **partitioned** table whose source does not supply the partition column silently corrupts the target. Which corruption you get depends only on the clauses present:

| Merge shape | Outcome before this change |
|---|---|
| `WHEN MATCHED` only | Statement reports success, writes an **empty commit** (0 files / 0 records / 0 errors); target untouched |
| `WHEN MATCHED` + `WHEN NOT MATCHED ... INSERT` | Record **inserted into the default partition** - primary key **duplicated across two partitions**, intended update lost, `name`/`dt` null on the new row |

Reproduced locally against `master`:

```
id  name  amount  ts  dt          _hoodie_partition_path
1   NULL  99.0    9   NULL        dt=__HIVE_DEFAULT_PARTITION__     <-- phantom duplicate
1   a     10.0    1   2026-08-11  dt=2026-08-11                     <-- update never applied
```

For a target table bearing a record key, the incoming batch is written from the **source alone** (`getProcessedInputDf`) and index tagging identifies updates, keying off `(recordKey, partitionPath)`. That method back-fills the source projection with the record-key and ordering columns when the source lacks them, but never with partition columns:

```scala
val requiredAttributesMap = recordKeyAttributeToConditionExpression ++ orderingFieldsAssociatedExpressions
```

So a partition column the source does not carry reaches the writer unset, the key generator resolves it to the default partition, tagging looks in the wrong partition and matches nothing, and every incoming record comes back not-matched. From there, with no `WHEN NOT MATCHED` clause the record falls through to `HoodieRecord.SENTINEL` in `ExpressionPayload#processNotMatchedRecord` and is dropped (empty commit); with one, it is inserted into the default partition (duplicate key).

### Summary and Changelog

Users gain a loud failure instead of silent mis-partitioning: a `MERGE INTO` that cannot determine where its records belong is now rejected with the column named, rather than writing an empty commit or duplicating a primary key across partitions.

- Add `partitionFieldsAssociatedExpressions` and feed it into `requiredAttributesMap`, so a partition column the writer needs is **required** rather than silently defaulted. It resolves from the `ON` condition (reusing the associations `recordKeyAttributeToConditionExpression` already produces, so `ON t.dt = s.event_dt` under a different source name keeps working) or from the source-table output, and otherwise rejects the statement.
- This is a validation guard, not a widening. It makes no previously-failing statement work and adds no column to the projection: an association from the `ON` condition is already contributed by `recordKeyAttributeToConditionExpression`, and one from the source output necessarily matches an attribute already in the source plan, so it lands in `existingAttributesMap` and emits no `Alias`.
- Skip for **primary-keyless** targets. They take the joined branch of `getProcessedInputDf`, where the target's meta columns are projected and `MergeIntoKeyGenerator.getPartitionPath` reads `_hoodie_partition_path` off that meta, so matched rows are already placed correctly.
- Skip for **global indexes that re-key to the existing partition**, but only for statements that cannot insert. With `update.partition.path` disabled, `HoodieIndexUtils#tagGlobalLocationBackToRecords` re-keys a record onto its existing partition - but only one the global lookup **finds**; the no-location branch returns the record untouched, so a `WHEN NOT MATCHED ... INSERT` row keeps the partition it arrived with. Whether a given row matches is data-dependent and unknowable at plan time, so the presence of the insert clause decides.
- The skip covers **every** global index type: `GLOBAL_SIMPLE`, `GLOBAL_BLOOM`, `RECORD_INDEX` and `GLOBAL_RECORD_LEVEL_INDEX`. The last is the non-deprecated spelling of `RECORD_INDEX` and `SparkHoodieIndexFactory` maps both onto `SparkMetadataTableGlobalRecordLevelIndex`, so omitting it would reject merges that are correct today. `isGlobalIndexEnabled` maps it too - a type in `globalIndexTypes` but absent from that mapping falls through to `false` and would exempt the table even with `update.partition.path` enabled, inverting the guard.
- **MERGE assignments are deliberately not a resolution source.** Key generation runs over the source row *before* the payload evaluates any assignment, so an assignment states the record's *new* partition, not the one its existing version occupies. Deriving from `UPDATE SET t.dt = s.new_dt` would tag the record in `new_dt`, miss the existing version, and drop it as `SENTINEL`.
- Dedupe `requiredAttributesMap` by target attribute. Reachable today via a record key that is also an ordering field, matched under a different source name: the `ON` condition and the `UPDATE` assignment each contribute an association, neither is present in the source under the target's name, and each emits its own `Alias`. Without the dedupe that fails in the writer with `Duplicate field id in record` from `convertStructTypeToAvroSchema`, so this fixes an existing defect rather than only tidying a projection.
- Update `TestMergeIntoTable2`'s "Allowed-patterns of assignment clauses" `COMMIT_TIME_ORDERING` case, which depended on the old behaviour. Its merge assigns `h0.id = s0.id` only, so a correctly-applied merge and a dropped record left identical rows - the previous assertion could not distinguish them. A comment records why.

No code was copied from elsewhere. Applied to both the `hudi-spark3-common` and `hudi-spark4-common` copies.

### Impact

- Merges that previously corrupted data now either place records correctly or fail loudly.
- Primary-keyless merges, and matched-only merges on a re-keying global index, are unaffected.
- **Behaviour change:** a merge whose partition column is derivable from neither the `ON` condition nor the source output now raises instead of silently no-op'ing or duplicating the key. Such statements were never doing useful work, but a pipeline that ran them "successfully" will now surface an error, and there is no config to opt out. That is the intended direction; flagging it explicitly for the release note.
- Three shapes worth calling out, all of which were silently mis-partitioning before and are now rejected: a merge whose partition column is supplied only by a `MERGE` assignment; an insert-only merge (`WHEN NOT MATCHED THEN INSERT` with no matched clause); and a merge with an insert clause on a re-keying global index. The last is the one existing pipelines are most likely to hit, since such a merge "works" for as long as every incoming row happens to match.
- Adding `GLOBAL_RECORD_LEVEL_INDEX` to `isGlobalIndexEnabled` also affects its other caller, `useGlobalIndex`, which gates MOR partial updates: such a table with `update.partition.path=true` now correctly takes the "partial update is disabled when global index is used" branch (see the HUDI-9257 note there) instead of silently keeping partial updates on.
- No storage-format, schema or public API change.

### Risk Level: medium

Touches `MergeIntoHoodieTableCommand`'s source-projection path on both Spark copies, and converts a previously-silent outcome into an error.

Verification done to mitigate:

- New `TestMergeIntoPartitionFieldResolution`, 30 cases over CoW and MoR: the rejected shapes (update-only, insert clause, delete-only, assignment-supplied); the accepted shapes (source projects the column, `ON` condition under a different source name, primary-keyless, non-partitioned); the re-keying skip parameterised over all four global index types; both edges of `update.partition.path`; the insert-clause narrowing plus a positive case proving it does not over-reject; the dedupe; and an end-to-end case asserted against the commit timeline, because a commit with 0 records leaves the table looking exactly like a merge that legitimately changed nothing.
- The suite was run against `master` to confirm it discriminates: **15 of the 30 fail** there. Thirteen fail at the "expected an exception" assertion - the statements run silently, which is the defect. The other two fail inside the writer with `HoodieSchemaException: Duplicate field id in record`.
- Each load-bearing line was reverted in turn and the suite re-run, confirming exactly the corresponding case fails and no others.
- Row assertions check `_hoodie_partition_path` as well as column values.

### Documentation Update

A release note for the behaviour change described under Impact: a `MERGE INTO` on a partitioned, keyed table whose source does not supply the partition column is now rejected rather than silently writing an empty commit or duplicating the key. No new configs are added and no config defaults change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
