### PR TITLE
docs(spark): document reading Hudi tables on the Databricks runtime

### DIFF
--- a/website/docs/azure_hoodie.md
+++ b/website/docs/azure_hoodie.md
@@ -25,6 +25,10 @@ There are two storage systems support Hudi .
 This combination works out of the box. No extra config needed.
 
 #### Databricks Spark2.4 on Azure Data Lake Storage Gen 2
+> This recipe targets Databricks on Spark 2.4 and ADLS Gen 2 specifically. For reading Hudi tables on a
+> current Databricks Runtime, see
+> [Reading Hudi tables on the Databricks runtime](/docs/quick-start-guide#reading-hudi-tables-on-the-databricks-runtime).
+
 - Import Hudi jar to databricks workspace
 
 - Mount the file system to dbutils.

--- a/website/docs/azure_hoodie.md
+++ b/website/docs/azure_hoodie.md
@@ -27,7 +27,7 @@ This combination works out of the box. No extra config needed.
 #### Databricks Spark2.4 on Azure Data Lake Storage Gen 2
 > This recipe targets Databricks on Spark 2.4 and ADLS Gen 2 specifically. For reading Hudi tables on a
 > current Databricks Runtime, see
-> [Reading Hudi tables on the Databricks runtime](/docs/quick-start-guide#reading-hudi-tables-on-the-databricks-runtime).
+> [Reading Hudi tables on the Databricks runtime](quick-start-guide.md#reading-hudi-tables-on-the-databricks-runtime).
 
 - Import Hudi jar to databricks workspace
 

--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -28,6 +28,61 @@ Hudi works with Spark 3.3 and above versions. You can follow instructions [here]
 The *default build* Spark version indicates how we build `hudi-spark3-bundle`.
 :::
 
+### Reading Hudi tables on the Databricks runtime
+
+The matrix above is for Apache Spark. The Databricks Runtime (DBR) ships a modified Spark, and a couple of the
+internals Hudi's Spark datasource builds on differ there. Hudi detects those differences at runtime and adapts,
+so there is no Databricks-specific Hudi config to set.
+
+#### Cluster setup
+
+1. **Install the Hudi bundle as a cluster library.** In the cluster's **Libraries** tab, add
+   `org.apache.hudi:hudi-spark<spark.version>-bundle_<scala.version>:<hudi.version>` as Maven coordinates, or
+   upload the jar directly. Pick the bundle that matches the Spark version your DBR release ships — see the
+   support matrix above.
+2. **Set Hudi's Spark configs** in the cluster's **Spark config** box. These are the same four values the
+   quick start passes with `--conf`, in the `key value` form the Databricks UI expects:
+
+   ```
+   spark.serializer org.apache.spark.serializer.KryoSerializer
+   spark.sql.catalog.spark_catalog org.apache.spark.sql.hudi.catalog.HoodieCatalog
+   spark.sql.extensions org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+   spark.kryo.registrator org.apache.spark.HoodieSparkKryoRegistrar
+   ```
+
+3. Read as usual — no extra option is required:
+
+   ```python
+   spark.read.format("hudi").load(basePath)
+   ```
+
+#### What Hudi adapts, and in which release
+
+* **`FileStatusCache`** — DBR changed this API. `SparkHoodieTableFileIndex` checks reflectively for the
+  `putLeafFiles(Path, FileStatus[])` signature before using it and falls back when it is absent, rather than
+  failing with `NoSuchMethodError`. This guard lives in the shared Spark module and has been present since
+  0.15.x, so it applies on the 1.0.x and 1.1.x lines as well.
+* **`PartitionDirectory`** — DBR's Spark 3.4 runtime backports `FileStatusWithMetadata` from Spark 3.5, so
+  `PartitionDirectory` takes a `Seq[FileStatusWithMetadata]` rather than a `Seq[FileStatus]`. That type wraps
+  `FileStatus` by composition instead of extending it, so the elements cannot be cast; Hudi constructs the
+  wrapper reflectively. This adaptation lives in the Spark 3.4 module and **ships in 1.2.0**, so a DBR release
+  built on Spark 3.4 needs Hudi 1.2.0 or later.
+
+:::caution
+Community guides for older Hudi releases tell you to set `hoodie.file.index.enable=false` when reading on
+Databricks. That was the workaround before the adaptations above existed: it falls back from `HoodieFileIndex`
+to `HoodieROTablePathFilter`, which sidesteps the incompatible Spark internals but disables the file index for
+**every** table in the session, losing the listing optimisation it exists for. The config is also deprecated
+(since 0.11.0). On 1.2.0 and later you should not need it; if a read still fails, it remains a fallback, and
+please report the failure.
+:::
+
+:::note
+Individual DBR versions are not part of Hudi's CI matrix, so the above documents the compatibility Hudi
+implements rather than a certified DBR version list. If you hit a read failure on a DBR release, please open an
+issue with the DBR version and the stack trace.
+:::
+
 ### Spark Shell/SQL
 
 <Tabs

--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -28,61 +28,6 @@ Hudi works with Spark 3.3 and above versions. You can follow instructions [here]
 The *default build* Spark version indicates how we build `hudi-spark3-bundle`.
 :::
 
-### Reading Hudi tables on the Databricks runtime
-
-The matrix above is for Apache Spark. The Databricks Runtime (DBR) ships a modified Spark, and a couple of the
-internals Hudi's Spark datasource builds on differ there. Hudi detects those differences at runtime and adapts,
-so there is no Databricks-specific Hudi config to set.
-
-#### Cluster setup
-
-1. **Install the Hudi bundle as a cluster library.** In the cluster's **Libraries** tab, add
-   `org.apache.hudi:hudi-spark<spark.version>-bundle_<scala.version>:<hudi.version>` as Maven coordinates, or
-   upload the jar directly. Pick the bundle that matches the Spark version your DBR release ships — see the
-   support matrix above.
-2. **Set Hudi's Spark configs** in the cluster's **Spark config** box. These are the same four values the
-   quick start passes with `--conf`, in the `key value` form the Databricks UI expects:
-
-   ```
-   spark.serializer org.apache.spark.serializer.KryoSerializer
-   spark.sql.catalog.spark_catalog org.apache.spark.sql.hudi.catalog.HoodieCatalog
-   spark.sql.extensions org.apache.spark.sql.hudi.HoodieSparkSessionExtension
-   spark.kryo.registrator org.apache.spark.HoodieSparkKryoRegistrar
-   ```
-
-3. Read as usual — no extra option is required:
-
-   ```python
-   spark.read.format("hudi").load(basePath)
-   ```
-
-#### What Hudi adapts, and in which release
-
-* **`FileStatusCache`** — DBR changed this API. `SparkHoodieTableFileIndex` checks reflectively for the
-  `putLeafFiles(Path, FileStatus[])` signature before using it and falls back when it is absent, rather than
-  failing with `NoSuchMethodError`. This guard lives in the shared Spark module and has been present since
-  0.15.x, so it applies on the 1.0.x and 1.1.x lines as well.
-* **`PartitionDirectory`** — DBR's Spark 3.4 runtime backports `FileStatusWithMetadata` from Spark 3.5, so
-  `PartitionDirectory` takes a `Seq[FileStatusWithMetadata]` rather than a `Seq[FileStatus]`. That type wraps
-  `FileStatus` by composition instead of extending it, so the elements cannot be cast; Hudi constructs the
-  wrapper reflectively. This adaptation lives in the Spark 3.4 module and **ships in 1.2.0**, so a DBR release
-  built on Spark 3.4 needs Hudi 1.2.0 or later.
-
-:::caution
-Community guides for older Hudi releases tell you to set `hoodie.file.index.enable=false` when reading on
-Databricks. That was the workaround before the adaptations above existed: it falls back from `HoodieFileIndex`
-to `HoodieROTablePathFilter`, which sidesteps the incompatible Spark internals but disables the file index for
-**every** table in the session, losing the listing optimisation it exists for. The config is also deprecated
-(since 0.11.0). On 1.2.0 and later you should not need it; if a read still fails, it remains a fallback, and
-please report the failure.
-:::
-
-:::note
-Individual DBR versions are not part of Hudi's CI matrix, so the above documents the compatibility Hudi
-implements rather than a certified DBR version list. If you hit a read failure on a DBR release, please open an
-issue with the DBR version and the stack trace.
-:::
-
 ### Spark Shell/SQL
 
 <Tabs
@@ -212,6 +157,104 @@ basePath = "file:///tmp/trips_table"
 </TabItem>
 </Tabs
 >
+
+### Reading Hudi tables on the Databricks runtime
+
+The Spark support matrix at the top of this page is for Apache Spark. The Databricks Runtime (DBR) ships a
+modified Spark, and several of the internals Hudi's Spark datasource builds on differ there. Hudi detects those
+differences at runtime and adapts, so there is no Databricks-specific Hudi config to set.
+
+#### Cluster setup
+
+1. **Install the Hudi bundle as a cluster library.** In the cluster's **Libraries** tab, add
+   `org.apache.hudi:hudi-spark<spark.version>-bundle_<scala.version>:<hudi.version>` as Maven coordinates, or
+   upload the jar directly. Pick the bundle that matches the Spark version your DBR release ships (see the
+   support matrix at the top of this page).
+2. **Set Hudi's Spark configs** in the cluster's **Spark config** box, in the `key value` form the Databricks
+   UI expects. Which of them you need depends on what you are doing.
+
+   A DataFrame read needs none of them. Set these two only if you want Kryo serialization, which is a
+   performance choice rather than a correctness one:
+
+   ```
+   spark.serializer org.apache.spark.serializer.KryoSerializer
+   spark.kryo.registrator org.apache.spark.HoodieSparkKryoRegistrar
+   ```
+
+   Set these two only if you want Hudi's Spark SQL support, such as `CREATE TABLE ... USING hudi`, `MERGE INTO`
+   or the `call` procedures:
+
+   ```
+   spark.sql.catalog.spark_catalog org.apache.spark.sql.hudi.catalog.HoodieCatalog
+   spark.sql.extensions org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+   ```
+
+   :::caution
+   `spark.sql.catalog.spark_catalog` replaces the session catalog. On a Unity Catalog enabled cluster, which is
+   the default on current DBR releases, `spark_catalog` is reserved and overriding it can break UC access or stop
+   the session from starting. If you only need to read a Hudi table, leave both SQL configs unset. If a
+   registrator error such as `HoodieSparkKryoRegistrar not found` appears when the bundle is installed as a
+   cluster library, see [#12985](https://github.com/apache/hudi/issues/12985); dropping the two Kryo lines is a
+   workaround, since a read does not need them.
+   :::
+
+3. Read as usual:
+
+   ```python
+   spark.read.format("hudi").load(basePath)
+   ```
+
+#### What Hudi adapts, and in which release
+
+Hudi carries four adaptations for DBR's modified Spark. Which ones matter depends on the Spark version your DBR
+release ships.
+
+| Adaptation | Symptom without it | DBR Spark | Confirmed present in |
+| --- | --- | --- | --- |
+| `FileStatusCache` | `NoSuchMethodError` on `putLeafFiles(Path, FileStatus[])` | all | 0.15.1, and 1.0.2 or later. Absent in 0.15.0, 1.0.0 and 1.0.1 |
+| `PartitionDirectory` / `FileStatusWithMetadata` | elements cannot be cast to `FileStatus` | 3.4 | 0.15.1 and 1.2.0. Absent in 1.0.2 and 1.1.1 |
+| `FileStatusWithMetadata#toFileStatus`, `PartitionedFile.locations` (`Seq` vs `Array`) | read failure on DBR 14.x-16.x; MOR incremental full scan ([#18002](https://github.com/apache/hudi/issues/18002)) | 3.5 and 4.0 | see [#18003](https://github.com/apache/hudi/pull/18003) |
+| `InterpretedPredicate` two-argument constructor | partition-predicate pruning fails ([#14058](https://github.com/apache/hudi/issues/14058)) | 3.4 and later | see [#14059](https://github.com/apache/hudi/pull/14059) |
+
+`SparkHoodieTableFileIndex` checks reflectively for the `putLeafFiles(Path, FileStatus[])` signature before using
+it. When it is absent it falls back to a no-op cache and logs a WARN, so on DBR file listings are not cached
+across queries; that costs listing time on repeated reads but does not fail them. This guard lives in the shared
+`hudi-spark-common` module, so it applies to every Spark version.
+
+The `PartitionDirectory` adaptation is needed because DBR's Spark 3.4 runtime backports `FileStatusWithMetadata`
+from Spark 3.5, so `PartitionDirectory` takes a `Seq[FileStatusWithMetadata]` rather than a `Seq[FileStatus]`.
+That type wraps `FileStatus` by composition instead of extending it, so the elements cannot be cast; Hudi
+constructs the wrapper reflectively through `DatabricksRuntimeHelper`. The helper itself lives in
+`hudi-spark-common`; only its call site is in the Spark 3.4 module.
+
+:::caution
+Community guides for older Hudi releases tell you to set `hoodie.file.index.enable=false` when reading on
+Databricks. That was the workaround before the adaptations above existed: it fell back from `HoodieFileIndex` to
+`HoodieROTablePathFilter`, sidestepping the incompatible Spark internals at the cost of the listing optimisation
+the file index exists for.
+
+Do not reach for it on 1.2.0. The flag is a no-op there: the default read path no longer consults it, and the
+only remaining consumer is reached when reading `.hoodie/metadata` itself. Setting it will not rescue a failing
+read, it will only look as though it might have. The config has also been deprecated since 0.11.0. If a read
+fails on a current release, please report it rather than working around it.
+:::
+
+:::caution
+Reading a table whose metadata table is enabled can fail on DBR against S3 with `InconsistentReadException` or
+`RemoteFileChangedException` ([#16951](https://github.com/apache/hudi/issues/16951), HUDI-9305, open). The
+metadata table is on by default on the write side, so an ordinary table can hit this even on 1.2.0. The current
+workaround is to turn it off for the read:
+
+```python
+spark.read.format("hudi").option("hoodie.metadata.enable", "false").load(basePath)
+```
+:::
+
+:::note
+Individual DBR versions are not part of Hudi's CI matrix, so the above documents the compatibility Hudi
+implements rather than a certified DBR version list. If you hit a read failure on a DBR release, please open an
+issue with the DBR version and the stack trace.
+:::
 
 ## Create Table
 

--- a/website/src/pages/ecosystem.md
+++ b/website/src/pages/ecosystem.md
@@ -31,7 +31,7 @@ In such cases, you can leverage another tool like Apache Spark or Apache Flink t
 | Google DataProc   | [Read + Write](https://cloud.google.com/blog/products/data-analytics/getting-started-with-new-table-formats-on-dataproc) |             |
 | Azure Synapse     | [Read + Write](https://www.onehouse.ai/blog/apache-hudi-on-microsoft-azure)                                              |             |
 | Azure HDInsight   | [Read + Write](https://www.onehouse.ai/blog/apache-hudi-on-microsoft-azure)                                              |             |
-| Databricks        | [Read + Write](https://hudi.apache.org/docs/azure_hoodie/)                                                               |             |
+| Databricks        | [Read](https://hudi.apache.org/docs/quick-start-guide#reading-hudi-tables-on-the-databricks-runtime)                                                               |             |
 | Snowflake         |                                                                                                                          |             |
 | Vertica           | [Read](https://www.vertica.com/kb/Apache_Hudi_TE/Content/Partner/Apache_Hudi_TE.htm)                                     |             |
 | Apache Doris      | [Read](https://doris.apache.org/docs/ecosystem/external-table/hudi-external-table/)                                      |             |

--- a/website/versioned_docs/version-1.2.0/quick-start-guide.md
+++ b/website/versioned_docs/version-1.2.0/quick-start-guide.md
@@ -28,6 +28,61 @@ Hudi works with Spark 3.3 and above versions. You can follow instructions [here]
 The *default build* Spark version indicates how we build `hudi-spark3-bundle`.
 :::
 
+### Reading Hudi tables on the Databricks runtime
+
+The matrix above is for Apache Spark. The Databricks Runtime (DBR) ships a modified Spark, and a couple of the
+internals Hudi's Spark datasource builds on differ there. Hudi detects those differences at runtime and adapts,
+so there is no Databricks-specific Hudi config to set.
+
+#### Cluster setup
+
+1. **Install the Hudi bundle as a cluster library.** In the cluster's **Libraries** tab, add
+   `org.apache.hudi:hudi-spark<spark.version>-bundle_<scala.version>:<hudi.version>` as Maven coordinates, or
+   upload the jar directly. Pick the bundle that matches the Spark version your DBR release ships — see the
+   support matrix above.
+2. **Set Hudi's Spark configs** in the cluster's **Spark config** box. These are the same four values the
+   quick start passes with `--conf`, in the `key value` form the Databricks UI expects:
+
+   ```
+   spark.serializer org.apache.spark.serializer.KryoSerializer
+   spark.sql.catalog.spark_catalog org.apache.spark.sql.hudi.catalog.HoodieCatalog
+   spark.sql.extensions org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+   spark.kryo.registrator org.apache.spark.HoodieSparkKryoRegistrar
+   ```
+
+3. Read as usual — no extra option is required:
+
+   ```python
+   spark.read.format("hudi").load(basePath)
+   ```
+
+#### What Hudi adapts, and in which release
+
+* **`FileStatusCache`** — DBR changed this API. `SparkHoodieTableFileIndex` checks reflectively for the
+  `putLeafFiles(Path, FileStatus[])` signature before using it and falls back when it is absent, rather than
+  failing with `NoSuchMethodError`. This guard lives in the shared Spark module and has been present since
+  0.15.x, so it applies on the 1.0.x and 1.1.x lines as well.
+* **`PartitionDirectory`** — DBR's Spark 3.4 runtime backports `FileStatusWithMetadata` from Spark 3.5, so
+  `PartitionDirectory` takes a `Seq[FileStatusWithMetadata]` rather than a `Seq[FileStatus]`. That type wraps
+  `FileStatus` by composition instead of extending it, so the elements cannot be cast; Hudi constructs the
+  wrapper reflectively. This adaptation lives in the Spark 3.4 module and **ships in 1.2.0**, so a DBR release
+  built on Spark 3.4 needs Hudi 1.2.0 or later.
+
+:::caution
+Community guides for older Hudi releases tell you to set `hoodie.file.index.enable=false` when reading on
+Databricks. That was the workaround before the adaptations above existed: it falls back from `HoodieFileIndex`
+to `HoodieROTablePathFilter`, which sidesteps the incompatible Spark internals but disables the file index for
+**every** table in the session, losing the listing optimisation it exists for. The config is also deprecated
+(since 0.11.0). On 1.2.0 and later you should not need it; if a read still fails, it remains a fallback, and
+please report the failure.
+:::
+
+:::note
+Individual DBR versions are not part of Hudi's CI matrix, so the above documents the compatibility Hudi
+implements rather than a certified DBR version list. If you hit a read failure on a DBR release, please open an
+issue with the DBR version and the stack trace.
+:::
+
 ### Spark Shell/SQL
 
 <Tabs

--- a/website/versioned_docs/version-1.2.0/quick-start-guide.md
+++ b/website/versioned_docs/version-1.2.0/quick-start-guide.md
@@ -30,27 +30,45 @@ The *default build* Spark version indicates how we build `hudi-spark3-bundle`.
 
 ### Reading Hudi tables on the Databricks runtime
 
-The matrix above is for Apache Spark. The Databricks Runtime (DBR) ships a modified Spark, and a couple of the
-internals Hudi's Spark datasource builds on differ there. Hudi detects those differences at runtime and adapts,
-so there is no Databricks-specific Hudi config to set.
+The Spark support matrix at the top of this page is for Apache Spark. The Databricks Runtime (DBR) ships a
+modified Spark, and several of the internals Hudi's Spark datasource builds on differ there. Hudi detects those
+differences at runtime and adapts, so there is no Databricks-specific Hudi config to set.
 
 #### Cluster setup
 
 1. **Install the Hudi bundle as a cluster library.** In the cluster's **Libraries** tab, add
    `org.apache.hudi:hudi-spark<spark.version>-bundle_<scala.version>:<hudi.version>` as Maven coordinates, or
-   upload the jar directly. Pick the bundle that matches the Spark version your DBR release ships — see the
-   support matrix above.
-2. **Set Hudi's Spark configs** in the cluster's **Spark config** box. These are the same four values the
-   quick start passes with `--conf`, in the `key value` form the Databricks UI expects:
+   upload the jar directly. Pick the bundle that matches the Spark version your DBR release ships (see the
+   support matrix at the top of this page).
+2. **Set Hudi's Spark configs** in the cluster's **Spark config** box, in the `key value` form the Databricks
+   UI expects. Which of them you need depends on what you are doing.
+
+   A DataFrame read needs none of them. Set these two only if you want Kryo serialization, which is a
+   performance choice rather than a correctness one:
 
    ```
    spark.serializer org.apache.spark.serializer.KryoSerializer
-   spark.sql.catalog.spark_catalog org.apache.spark.sql.hudi.catalog.HoodieCatalog
-   spark.sql.extensions org.apache.spark.sql.hudi.HoodieSparkSessionExtension
    spark.kryo.registrator org.apache.spark.HoodieSparkKryoRegistrar
    ```
 
-3. Read as usual — no extra option is required:
+   Set these two only if you want Hudi's Spark SQL support, such as `CREATE TABLE ... USING hudi`, `MERGE INTO`
+   or the `call` procedures:
+
+   ```
+   spark.sql.catalog.spark_catalog org.apache.spark.sql.hudi.catalog.HoodieCatalog
+   spark.sql.extensions org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+   ```
+
+   :::caution
+   `spark.sql.catalog.spark_catalog` replaces the session catalog. On a Unity Catalog enabled cluster, which is
+   the default on current DBR releases, `spark_catalog` is reserved and overriding it can break UC access or stop
+   the session from starting. If you only need to read a Hudi table, leave both SQL configs unset. If a
+   registrator error such as `HoodieSparkKryoRegistrar not found` appears when the bundle is installed as a
+   cluster library, see [#12985](https://github.com/apache/hudi/issues/12985); dropping the two Kryo lines is a
+   workaround, since a read does not need them.
+   :::
+
+3. Read as usual:
 
    ```python
    spark.read.format("hudi").load(basePath)
@@ -58,23 +76,48 @@ so there is no Databricks-specific Hudi config to set.
 
 #### What Hudi adapts, and in which release
 
-* **`FileStatusCache`** — DBR changed this API. `SparkHoodieTableFileIndex` checks reflectively for the
-  `putLeafFiles(Path, FileStatus[])` signature before using it and falls back when it is absent, rather than
-  failing with `NoSuchMethodError`. This guard lives in the shared Spark module and has been present since
-  0.15.x, so it applies on the 1.0.x and 1.1.x lines as well.
-* **`PartitionDirectory`** — DBR's Spark 3.4 runtime backports `FileStatusWithMetadata` from Spark 3.5, so
-  `PartitionDirectory` takes a `Seq[FileStatusWithMetadata]` rather than a `Seq[FileStatus]`. That type wraps
-  `FileStatus` by composition instead of extending it, so the elements cannot be cast; Hudi constructs the
-  wrapper reflectively. This adaptation lives in the Spark 3.4 module and **ships in 1.2.0**, so a DBR release
-  built on Spark 3.4 needs Hudi 1.2.0 or later.
+Hudi carries four adaptations for DBR's modified Spark. Which ones matter depends on the Spark version your DBR
+release ships.
+
+| Adaptation | Symptom without it | DBR Spark | Confirmed present in |
+| --- | --- | --- | --- |
+| `FileStatusCache` | `NoSuchMethodError` on `putLeafFiles(Path, FileStatus[])` | all | 0.15.1, and 1.0.2 or later. Absent in 0.15.0, 1.0.0 and 1.0.1 |
+| `PartitionDirectory` / `FileStatusWithMetadata` | elements cannot be cast to `FileStatus` | 3.4 | 0.15.1 and 1.2.0. Absent in 1.0.2 and 1.1.1 |
+| `FileStatusWithMetadata#toFileStatus`, `PartitionedFile.locations` (`Seq` vs `Array`) | read failure on DBR 14.x-16.x; MOR incremental full scan ([#18002](https://github.com/apache/hudi/issues/18002)) | 3.5 and 4.0 | see [#18003](https://github.com/apache/hudi/pull/18003) |
+| `InterpretedPredicate` two-argument constructor | partition-predicate pruning fails ([#14058](https://github.com/apache/hudi/issues/14058)) | 3.4 and later | see [#14059](https://github.com/apache/hudi/pull/14059) |
+
+`SparkHoodieTableFileIndex` checks reflectively for the `putLeafFiles(Path, FileStatus[])` signature before using
+it. When it is absent it falls back to a no-op cache and logs a WARN, so on DBR file listings are not cached
+across queries; that costs listing time on repeated reads but does not fail them. This guard lives in the shared
+`hudi-spark-common` module, so it applies to every Spark version.
+
+The `PartitionDirectory` adaptation is needed because DBR's Spark 3.4 runtime backports `FileStatusWithMetadata`
+from Spark 3.5, so `PartitionDirectory` takes a `Seq[FileStatusWithMetadata]` rather than a `Seq[FileStatus]`.
+That type wraps `FileStatus` by composition instead of extending it, so the elements cannot be cast; Hudi
+constructs the wrapper reflectively through `DatabricksRuntimeHelper`. The helper itself lives in
+`hudi-spark-common`; only its call site is in the Spark 3.4 module.
 
 :::caution
 Community guides for older Hudi releases tell you to set `hoodie.file.index.enable=false` when reading on
-Databricks. That was the workaround before the adaptations above existed: it falls back from `HoodieFileIndex`
-to `HoodieROTablePathFilter`, which sidesteps the incompatible Spark internals but disables the file index for
-**every** table in the session, losing the listing optimisation it exists for. The config is also deprecated
-(since 0.11.0). On 1.2.0 and later you should not need it; if a read still fails, it remains a fallback, and
-please report the failure.
+Databricks. That was the workaround before the adaptations above existed: it fell back from `HoodieFileIndex` to
+`HoodieROTablePathFilter`, sidestepping the incompatible Spark internals at the cost of the listing optimisation
+the file index exists for.
+
+Do not reach for it on 1.2.0. The flag is a no-op there: the default read path no longer consults it, and the
+only remaining consumer is reached when reading `.hoodie/metadata` itself. Setting it will not rescue a failing
+read, it will only look as though it might have. The config has also been deprecated since 0.11.0. If a read
+fails on a current release, please report it rather than working around it.
+:::
+
+:::caution
+Reading a table whose metadata table is enabled can fail on DBR against S3 with `InconsistentReadException` or
+`RemoteFileChangedException` ([#16951](https://github.com/apache/hudi/issues/16951), HUDI-9305, open). The
+metadata table is on by default on the write side, so an ordinary table can hit this even on 1.2.0. The current
+workaround is to turn it off for the read:
+
+```python
+spark.read.format("hudi").option("hoodie.metadata.enable", "false").load(basePath)
+```
 :::
 
 :::note


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15666 (HUDI-5498) — document how to read Hudi tables on the Databricks Spark runtime.

The Spark Support Matrix covers Apache Spark only. Databricks Runtime (DBR) ships a modified Spark, and nothing
in the docs said what happens there. Support itself already landed (#13129, #18256, #18291/#18292,
#18003/#18258, #14059/#18257); only the documentation was missing.

### Summary and Changelog

Adds a **Reading Hudi tables on the Databricks runtime** subsection to `quick-start-guide.md`, after the support
matrix:

- **Cluster setup** — install the `hudi-spark<spark>-bundle_<scala>` jar as a cluster library, and set Hudi's
  four Spark configs in the cluster's *Spark config* box, in the `key value` form that UI takes. Reading then
  needs no extra option.
- **What Hudi adapts** — `FileStatusCache` (DBR changed the API; guarded reflectively to avoid
  `NoSuchMethodError`, in the shared module since 0.15.x) and `PartitionDirectory` (DBR's Spark 3.4 backports
  `FileStatusWithMetadata`, which wraps `FileStatus` rather than extending it, so Hudi constructs it
  reflectively — Spark 3.4 module, ships in 1.2.0).
- A caution on `hoodie.file.index.enable`, which older community guides call mandatory on Databricks: it was the
  workaround before those adaptations, it disables the file index session-wide, and it is deprecated since
  0.11.0. Should not be needed on 1.2.0+; still a fallback if a read fails.

### Verification

Docs only, no test. Claims read off master:

| claim | source |
| --- | --- |
| `FileStatusCache` guarded reflectively | `SparkHoodieTableFileIndex.scala:674-690` |
| `PartitionDirectory` / `FileStatusWithMetadata` handling | `DatabricksRuntimeHelper.scala`, called from `HoodieSpark34PartitionedFileUtils.scala:53` |
| the four cluster configs | identical to `quick-start-guide.md:57-60`; classes exist at `HoodieSparkSessionExtension.scala:29`, `HoodieCatalog.scala:58`, `HoodieSparkKryoRegistrar.scala:53` |
| `hoodie.file.index.enable` deprecated | `DataSourceOptions.scala:97-103`, `deprecatedAfter("0.11.0")` |
| version split | `DatabricksRuntimeHelper` present at `release-1.2.0`, absent at `1.1.1`/`1.0.2`; the `FileStatusCache` guard present from `release-0.15.1` |

Applied to `docs/` + `versioned_docs/version-1.2.0/` only — the 1.1.1 copy would claim compatibility that
release lacks. `markdownlint` shows no new rule class; region identical across both files.

No DBR release is named and no external guide is linked: neither could be verified from this repo, and DBR
versions are not in Hudi's CI matrix. The section says it documents the compatibility Hudi implements, not a
certified version list, and asks for an issue with the DBR version and stack trace on failure.

Not done: the Docusaurus build (`node_modules` absent).

### Impact

Documentation only. Databricks users get a definitive answer — reads work, nothing Hudi-specific to configure,
1.2.0+ for a DBR built on Spark 3.4 — and are steered off a deprecated config that disables the file index
across their session.

### Risk Level

none

### Documentation Update

This is the documentation update, against `asf-site`.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable — n/a for docs
- [ ] CI passes on my PR — `asf-site` PRs do not run the `master` gates; `markdownlint` checked locally
