### PR TITLE
test(io): drive the HFile writer tests through byte arrays instead of a file

### DIFF
--- a/hudi-io/src/test/java/org/apache/hudi/io/hfile/TestHFileWriter.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/hfile/TestHFileWriter.java
@@ -26,7 +26,7 @@ import org.apache.hudi.io.util.IOUtils;
 
 import com.google.protobuf.CodedOutputStream;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.hbase.CellComparatorImpl;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.io.compress.Compression;
@@ -41,12 +41,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -74,6 +71,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class TestHFileWriter {
   private static final Logger LOG = LoggerFactory.getLogger(TestHFileWriter.class);
   private static final HFileContext CONTEXT = HFileContext.builder().build();
+  private static final String[] THREE_KEYS = {"key1", "key2", "key3"};
+  private static final byte[][] THREE_VALUES = {bytes("value1"), bytes("value2"), bytes("value3")};
   // Golden bytes (NONE compression, fixed input) that lock the on-disk encoding of the data block
   // and the root block-index block. Update intentionally ONLY after reviewing HBase-reader
   // compatibility, since any change here is a storage-format change.
@@ -123,23 +122,18 @@ class TestHFileWriter {
     // Block 3: 5   records, whose first key is "key06"
     // Block 4: 1   record,  whose first key is "key11",
     //              whose length is larger than the block size.
-    try (DataOutputStream outputStream = new DataOutputStream(hfileBytes);
-        HFileWriter writer = new HFileWriterImpl(context, outputStream)) {
+    try (HFileWriter writer = new HFileWriterImpl(context, hfileBytes)) {
       // All entries for key00 are stored in the first block.
       for (int i = 0; i < 100; i++) {
-        writer.append("key00", String.format("value%02d", i).getBytes());
+        writer.append("key00", bytes(String.format("value%02d", i)));
       }
       // Otherwise, 5 records in each other blocks.
       for (int i = 1; i < 11; i++) {
-        writer.append(
-            String.format("key%02d", i),
-            String.format("value%02d", i).getBytes());
+        writer.append(String.format("key%02d", i), bytes(String.format("value%02d", i)));
       }
       // Adding a record whose size is larger than block size.
       String longValue = generateRandomStringStream(200);
-      writer.append("key11", longValue.getBytes());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+      writer.append("key11", bytes(longValue));
     }
 
     // Validate.
@@ -179,14 +173,10 @@ class TestHFileWriter {
     // 50 bytes for data part limit.
     HFileContext context = new HFileContext.Builder().blockSize(100).build();
     ByteArrayOutputStream hfileBytes = new ByteArrayOutputStream();
-    try (DataOutputStream outputStream = new DataOutputStream(hfileBytes);
-         HFileWriter writer = new HFileWriterImpl(context, outputStream)) {
+    try (HFileWriter writer = new HFileWriterImpl(context, hfileBytes)) {
       for (int i = 0; i < 50; i++) {
-        writer.append(
-            String.format("key%02d", i), String.format("value%02d", i).getBytes());
+        writer.append(String.format("key%02d", i), bytes(String.format("value%02d", i)));
       }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
 
     // Validate.
@@ -200,10 +190,10 @@ class TestHFileWriter {
       for (int i = 0; i < 50; i++) {
         KeyValue kv = reader.getKeyValue().get();
         assertArrayEquals(
-            String.format("key%02d", i).getBytes(),
-            kv.getKey().getContentInString().getBytes());
+            bytes(String.format("key%02d", i)),
+            bytes(kv.getKey().getContentInString()));
         assertArrayEquals(
-            String.format("value%02d", i).getBytes(),
+            bytes(String.format("value%02d", i)),
             Arrays.copyOfRange(
                 kv.getBytes(),
                 kv.getValueOffset(),
@@ -240,9 +230,7 @@ class TestHFileWriter {
   void writerBlockBytesAreStableFormatLock() throws Exception {
     byte[][] vals = {bytes("v0"), bytes("v1"), bytes("v2")};
     assertSingleBlockBytesMatchGoldenAndHBase(
-        new String[] {"key1", "key2", "key3"},
-        new byte[][] {bytes("value1"), bytes("value2"), bytes("value3")},
-        GOLDEN_DATA_REGION_HEX, GOLDEN_ROOT_INDEX_BLOCK_HEX);
+        THREE_KEYS, THREE_VALUES, GOLDEN_DATA_REGION_HEX, GOLDEN_ROOT_INDEX_BLOCK_HEX);
     assertSingleBlockBytesMatchGoldenAndHBase(
         new String[] {rep('a', 116), rep('b', 8), rep('c', 12)}, vals,
         GOLDEN_VARLEN_DATA_REGION_HEX, GOLDEN_VARLEN_ROOT_INDEX_BLOCK_HEX);
@@ -314,7 +302,7 @@ class TestHFileWriter {
    */
   private static byte[] assertSingleBlockBytesMatchHBase(
       String[] keys, byte[][] values, String dataGolden, String rootGolden) throws Exception {
-    byte[] nativeFile = writeNativeHFile(HFileContext.builder().build(), keys, values, null, null);
+    byte[] nativeFile = writeNativeHFile(CONTEXT, keys, values, null, null);
     String[] nativeBlocks = dataAndRootIndexBlockHex(nativeFile);
     String[] hbaseBlocks = dataAndRootIndexBlockHex(writeHBaseFile(keys, values));
     assertEquals(hbaseBlocks[0], nativeBlocks[0], "native vs HBase data block bytes");
@@ -343,12 +331,14 @@ class TestHFileWriter {
     };
   }
 
-  /** Writes the given records with the HBase HFile writer, matching the native writer's settings. */
+  /**
+   * Writes the given records with the HBase HFile writer, matching the native writer's settings,
+   * returning the complete file as bytes. The HBase writer only needs a position-tracking stream,
+   * so it is driven through an in-memory {@link FSDataOutputStream} rather than a temp file.
+   */
   private static byte[] writeHBaseFile(String[] keys, byte[][] values) throws IOException {
     Configuration conf = new Configuration();
-    FileSystem fs = FileSystem.getLocal(conf);
-    org.apache.hadoop.fs.Path path =
-        new org.apache.hadoop.fs.Path(Files.createTempFile("hbase_fixed_", ".hfile").toString());
+    ByteArrayOutputStream hfileBytes = new ByteArrayOutputStream();
     org.apache.hadoop.hbase.io.hfile.HFileContext context = new HFileContextBuilder()
         .withBlockSize(1024 * 1024)
         .withCompression(Compression.Algorithm.NONE)
@@ -356,15 +346,16 @@ class TestHFileWriter {
         .withCellComparator(CellComparatorImpl.COMPARATOR)
         .withIncludesMvcc(true)
         .build();
-    try (HFile.Writer writer = HFile.getWriterFactory(conf, new CacheConfig(conf))
-        .withPath(fs, path).withFileContext(context).create()) {
+    try (FSDataOutputStream outputStream = new FSDataOutputStream(hfileBytes, null);
+         HFile.Writer writer = HFile.getWriterFactory(conf, new CacheConfig(conf))
+             .withOutputStream(outputStream).withFileContext(context).create()) {
       for (int i = 0; i < keys.length; i++) {
         writer.append(new org.apache.hadoop.hbase.KeyValue(
             keys[i].getBytes(StandardCharsets.UTF_8), new byte[0], new byte[0],
             HConstants.LATEST_TIMESTAMP, values[i]));
       }
     }
-    return Files.readAllBytes(Paths.get(path.toString()));
+    return hfileBytes.toByteArray();
   }
 
   /**
@@ -503,8 +494,7 @@ class TestHFileWriter {
                                          byte[][] values, String metaKey, byte[] metaValue)
       throws IOException {
     ByteArrayOutputStream hfileBytes = new ByteArrayOutputStream();
-    try (DataOutputStream outputStream = new DataOutputStream(hfileBytes);
-         HFileWriter writer = new HFileWriterImpl(context, outputStream)) {
+    try (HFileWriter writer = new HFileWriterImpl(context, hfileBytes)) {
       for (int i = 0; i < keys.length; i++) {
         writer.append(keys[i], values[i]);
       }
@@ -630,12 +620,8 @@ class TestHFileWriter {
   }
 
   /** Writes a three-record HFile with the default context, returning the file bytes. */
-  private static byte[] writeThreeRecordHFile() throws Exception {
-    return writeNativeHFile(
-        CONTEXT,
-        new String[] {"key1", "key2", "key3"},
-        new byte[][] {bytes("value1"), bytes("value2"), bytes("value3")},
-        null, null);
+  private static byte[] writeThreeRecordHFile() throws IOException {
+    return writeNativeHFile(CONTEXT, THREE_KEYS, THREE_VALUES, null, null);
   }
 
   private static void validateHFileSize(byte[] hfile) {

--- a/hudi-io/src/test/java/org/apache/hudi/io/hfile/TestHFileWriter.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/hfile/TestHFileWriter.java
@@ -21,7 +21,6 @@ package org.apache.hudi.io.hfile;
 
 import org.apache.hudi.io.ByteArraySeekableDataInputStream;
 import org.apache.hudi.io.ByteBufferBackedInputStream;
-import org.apache.hudi.io.SeekableDataInputStream;
 import org.apache.hudi.io.hfile.protobuf.generated.HFileProtos;
 import org.apache.hudi.io.util.IOUtils;
 
@@ -36,7 +35,6 @@ import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.WritableUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,12 +44,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -78,7 +73,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestHFileWriter {
   private static final Logger LOG = LoggerFactory.getLogger(TestHFileWriter.class);
-  private static final String TEST_FILE = "test.hfile";
   private static final HFileContext CONTEXT = HFileContext.builder().build();
   // Golden bytes (NONE compression, fixed input) that lock the on-disk encoding of the data block
   // and the root block-index block. Update intentionally ONLY after reviewing HBase-reader
@@ -105,21 +99,16 @@ class TestHFileWriter {
           + "616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161"
           + "616161616161616161616161616161616161616161007fffffffffffffff0400000000";
 
-  @AfterEach
-  public void tearDown() throws IOException {
-    Files.deleteIfExists(Paths.get(TEST_FILE));
-  }
-
   @Test
   void testOverflow() throws Exception {
     // 1. Write data.
-    writeTestFile();
+    byte[] hfile = writeThreeRecordHFile();
     // 2. Validate file size.
-    validateHFileSize();
+    validateHFileSize(hfile);
     // 3. Validate file structure.
-    validateHFileStructure();
+    validateHFileStructure(hfile);
     // 4. Validate consistency with HFileReader.
-    validateConsistencyWithHFileReader();
+    validateConsistencyWithHFileReader(hfile);
     LOG.info("All validations passed!");
   }
 
@@ -127,15 +116,14 @@ class TestHFileWriter {
   void testSameKeyLocation() throws IOException {
     // 165 bytes for data part limit.
     HFileContext context = new HFileContext.Builder().blockSize(165).build();
-    String testFile = TEST_FILE;
+    ByteArrayOutputStream hfileBytes = new ByteArrayOutputStream();
     // CREATE 4 BLOCKs:
     // Block 1: 100 records, whose keys are the same: "key00".
     // Block 2: 5   records, whose first key is "key01"
     // Block 3: 5   records, whose first key is "key06"
     // Block 4: 1   record,  whose first key is "key11",
     //              whose length is larger than the block size.
-    try (DataOutputStream outputStream =
-             new DataOutputStream(Files.newOutputStream(Paths.get(testFile)));
+    try (DataOutputStream outputStream = new DataOutputStream(hfileBytes);
         HFileWriter writer = new HFileWriterImpl(context, outputStream)) {
       // All entries for key00 are stored in the first block.
       for (int i = 0; i < 100; i++) {
@@ -155,11 +143,7 @@ class TestHFileWriter {
     }
 
     // Validate.
-    try (FileChannel channel = FileChannel.open(Paths.get(testFile), StandardOpenOption.READ)) {
-      ByteBuffer buf = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
-      SeekableDataInputStream inputStream =
-          new ByteArraySeekableDataInputStream(new ByteBufferBackedInputStream(buf));
-      HFileReaderImpl reader = new HFileReaderImpl(inputStream, channel.size());
+    try (HFileReaderImpl reader = openReader(hfileBytes.toByteArray())) {
       reader.initializeMetadata();
       // Totally 111 records.
       assertEquals(111, reader.getNumKeyValueEntries());
@@ -194,9 +178,8 @@ class TestHFileWriter {
   void testUniqueKeyLocation() throws IOException {
     // 50 bytes for data part limit.
     HFileContext context = new HFileContext.Builder().blockSize(100).build();
-    String testFile = TEST_FILE;
-    try (DataOutputStream outputStream =
-             new DataOutputStream(Files.newOutputStream(Paths.get(testFile)));
+    ByteArrayOutputStream hfileBytes = new ByteArrayOutputStream();
+    try (DataOutputStream outputStream = new DataOutputStream(hfileBytes);
          HFileWriter writer = new HFileWriterImpl(context, outputStream)) {
       for (int i = 0; i < 50; i++) {
         writer.append(
@@ -207,11 +190,8 @@ class TestHFileWriter {
     }
 
     // Validate.
-    try (FileChannel channel = FileChannel.open(Paths.get(testFile), StandardOpenOption.READ)) {
-      ByteBuffer buf = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
-      SeekableDataInputStream inputStream =
-          new ByteArraySeekableDataInputStream(new ByteBufferBackedInputStream(buf));
-      HFileReaderImpl reader = new HFileReaderImpl(inputStream, channel.size());
+    byte[] hfile = hfileBytes.toByteArray();
+    try (HFileReaderImpl reader = openReader(hfile)) {
       reader.initializeMetadata();
       assertEquals(50, reader.getNumKeyValueEntries());
       HFileTrailer trailer = reader.getTrailer();
@@ -235,12 +215,11 @@ class TestHFileWriter {
       // Each data block's previous-block-offset header (8 bytes at offset 16) must chain back to
       // the prior block, and -1 for the first, so an HBase reader's seekBefore can step back across
       // blocks. The writer once set it to the block's own offset; this guards that regression.
-      byte[] file = Files.readAllBytes(Paths.get(testFile));
       List<IndexEntry> dataIndex = parseIndexBlock(
-          file, (int) trailer.getLoadOnOpenDataOffset(), trailer.getDataIndexCount());
+          hfile, (int) trailer.getLoadOnOpenDataOffset(), trailer.getDataIndexCount());
       assertTrue(dataIndex.size() > 1, "test setup: expected multiple data blocks");
       for (int i = 0; i < dataIndex.size(); i++) {
-        long prevOffset = readLongBE(file, (int) dataIndex.get(i).offset + 16);
+        long prevOffset = readLongBE(hfile, (int) dataIndex.get(i).offset + 16);
         long expected = i == 0 ? -1L : dataIndex.get(i - 1).offset;
         assertEquals(expected, prevOffset, "data block " + i + " previous-block offset");
       }
@@ -316,8 +295,7 @@ class TestHFileWriter {
    */
   private static void assertSingleBlockBytesMatchGoldenAndHBase(
       String[] keys, byte[][] values, String dataGolden, String rootGolden) throws Exception {
-    assertSingleBlockBytesMatchHBase(keys, values, dataGolden, rootGolden);
-    byte[] nativeFile = Files.readAllBytes(Paths.get(TEST_FILE));
+    byte[] nativeFile = assertSingleBlockBytesMatchHBase(keys, values, dataGolden, rootGolden);
     HFileProtos.TrailerProto trailer = validateTrailerSection(nativeFile, keys.length, 0);
     int loadOnOpen = (int) trailer.getLoadOnOpenDataOffset();
     int metaIndexOffset = loadOnOpen + HFILEBLOCK_HEADER_SIZE + readIntBE(nativeFile, loadOnOpen + 8);
@@ -331,11 +309,12 @@ class TestHFileWriter {
    * Asserts the native and HBase writers produce identical single-block data and root index bytes
    * (optionally also matching a pinned golden), and the root-index keyLength is Hadoop VInt. Used
    * without a golden for large keys, where a hardcoded golden of multi-KB key bytes adds no signal.
+   *
+   * @return the native writer's HFile bytes, so callers can assert further on the same file.
    */
-  private static void assertSingleBlockBytesMatchHBase(
+  private static byte[] assertSingleBlockBytesMatchHBase(
       String[] keys, byte[][] values, String dataGolden, String rootGolden) throws Exception {
-    writeNativeFile(TEST_FILE, HFileContext.builder().build(), keys, values, null, null);
-    byte[] nativeFile = Files.readAllBytes(Paths.get(TEST_FILE));
+    byte[] nativeFile = writeNativeHFile(HFileContext.builder().build(), keys, values, null, null);
     String[] nativeBlocks = dataAndRootIndexBlockHex(nativeFile);
     String[] hbaseBlocks = dataAndRootIndexBlockHex(writeHBaseFile(keys, values));
     assertEquals(hbaseBlocks[0], nativeBlocks[0], "native vs HBase data block bytes");
@@ -349,6 +328,7 @@ class TestHFileWriter {
     IndexEntry first =
         parseIndexBlock(nativeFile, indexOf(nativeFile, ROOT_INDEX.getMagic()), 1).get(0);
     assertVarIntIsHadoopNotProtobuf("root index keyLength", first);
+    return nativeFile;
   }
 
   /** Returns {@code [dataRegionHex, rootIndexBlockHex]} for an HFile's raw bytes. */
@@ -405,9 +385,8 @@ class TestHFileWriter {
     String metaKey = makeKey(200, 9999);
     byte[] metaValue = bytes("bloom-filter-payload-bytes");
     // Small block size forces one record per block, so the root index has multiple entries.
-    writeNativeFile(
-        TEST_FILE, new HFileContext.Builder().blockSize(100).build(), keys, values, metaKey, metaValue);
-    byte[] file = Files.readAllBytes(Paths.get(TEST_FILE));
+    byte[] file = writeNativeHFile(
+        new HFileContext.Builder().blockSize(100).build(), keys, values, metaKey, metaValue);
 
     HFileProtos.TrailerProto trailer = validateTrailerSection(file, numRecords, 1);
     int loadOnOpen = (int) trailer.getLoadOnOpenDataOffset();
@@ -415,7 +394,7 @@ class TestHFileWriter {
     int metaIndexOffset = loadOnOpen + HFILEBLOCK_HEADER_SIZE + readIntBE(file, loadOnOpen + 8);
     validateMetaIndexAndBlock(file, metaIndexOffset, metaKey, metaValue);
     validateFileInfoSection(file, metaIndexOffset, (int) trailer.getFileInfoOffset(), keys[numRecords - 1]);
-    assertAllRecordsReadBack(numRecords, keys);
+    assertAllRecordsReadBack(file, numRecords, keys);
   }
 
   /** Validates the trailer magic, protobuf framing, fields, and HFile version; returns the proto. */
@@ -503,11 +482,9 @@ class TestHFileWriter {
   }
 
   /** Reads every record back through the native reader. */
-  private static void assertAllRecordsReadBack(int numRecords, String[] keys) throws IOException {
-    try (FileChannel channel = FileChannel.open(Paths.get(TEST_FILE), StandardOpenOption.READ)) {
-      ByteBuffer buf = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
-      HFileReaderImpl reader = new HFileReaderImpl(
-          new ByteArraySeekableDataInputStream(new ByteBufferBackedInputStream(buf)), channel.size());
+  private static void assertAllRecordsReadBack(byte[] hfile, int numRecords, String[] keys)
+      throws IOException {
+    try (HFileReaderImpl reader = openReader(hfile)) {
       reader.initializeMetadata();
       assertEquals(numRecords, reader.getNumKeyValueEntries());
       reader.seekTo();
@@ -518,12 +495,15 @@ class TestHFileWriter {
     }
   }
 
-  /** Writes the given records (and an optional single meta block) with the native HFile writer. */
-  private static void writeNativeFile(String testFile, HFileContext context, String[] keys,
-                                      byte[][] values, String metaKey, byte[] metaValue)
+  /**
+   * Writes the given records (and an optional single meta block) with the native HFile writer,
+   * returning the complete file as bytes.
+   */
+  private static byte[] writeNativeHFile(HFileContext context, String[] keys,
+                                         byte[][] values, String metaKey, byte[] metaValue)
       throws IOException {
-    try (DataOutputStream outputStream =
-             new DataOutputStream(Files.newOutputStream(Paths.get(testFile)));
+    ByteArrayOutputStream hfileBytes = new ByteArrayOutputStream();
+    try (DataOutputStream outputStream = new DataOutputStream(hfileBytes);
          HFileWriter writer = new HFileWriterImpl(context, outputStream)) {
       for (int i = 0; i < keys.length; i++) {
         writer.append(keys[i], values[i]);
@@ -532,6 +512,13 @@ class TestHFileWriter {
         writer.appendMetaInfo(metaKey, metaValue);
       }
     }
+    return hfileBytes.toByteArray();
+  }
+
+  /** Opens the native reader over an in-memory HFile. */
+  private static HFileReaderImpl openReader(byte[] hfile) {
+    return new HFileReaderImpl(
+        new ByteArraySeekableDataInputStream(new ByteBufferBackedInputStream(hfile)), hfile.length);
   }
 
   /** A parsed block index entry: block offset, on-disk size, raw keyLength vint bytes, and key. */
@@ -642,28 +629,25 @@ class TestHFileWriter {
     return v;
   }
 
-  private static void writeTestFile() throws Exception {
-    try (
-        DataOutputStream outputStream =
-             new DataOutputStream(Files.newOutputStream(Paths.get(TEST_FILE)));
-        HFileWriter writer = new HFileWriterImpl(CONTEXT, outputStream)) {
-      writer.append("key1", "value1".getBytes());
-      writer.append("key2", "value2".getBytes());
-      writer.append("key3", "value3".getBytes());
-    }
+  /** Writes a three-record HFile with the default context, returning the file bytes. */
+  private static byte[] writeThreeRecordHFile() throws Exception {
+    return writeNativeHFile(
+        CONTEXT,
+        new String[] {"key1", "key2", "key3"},
+        new byte[][] {bytes("value1"), bytes("value2"), bytes("value3")},
+        null, null);
   }
 
-  private static void validateHFileSize() throws IOException {
-    Path path = Paths.get(TEST_FILE);
-    long actualSize = Files.size(path);
+  private static void validateHFileSize(byte[] hfile) {
+    long actualSize = hfile.length;
     // Each root block-index entry carries the 10-byte HBase KeyValue suffix (column-family
     // length + timestamp + key type). This file has one index entry, so the size grows by 10.
     long expectedSize = 4547;
     assertEquals(expectedSize, actualSize);
   }
 
-  private static void validateHFileStructure() throws IOException {
-    ByteBuffer fileBuffer = mapFileToBuffer();
+  private static void validateHFileStructure(byte[] hfile) {
+    ByteBuffer fileBuffer = ByteBuffer.wrap(hfile);
 
     // 1. Validate Trailer
     validateTrailer(fileBuffer);
@@ -672,11 +656,8 @@ class TestHFileWriter {
     validateDataBlocks(fileBuffer);
   }
 
-  private static void validateConsistencyWithHFileReader() throws IOException {
-    ByteBuffer content = mapFileToBuffer();
-    try (HFileReader reader = new HFileReaderImpl(
-        new ByteArraySeekableDataInputStream(
-            new ByteBufferBackedInputStream(content)), content.limit())) {
+  private static void validateConsistencyWithHFileReader(byte[] hfile) throws IOException {
+    try (HFileReader reader = openReader(hfile)) {
       reader.initializeMetadata();
       assertEquals(3, reader.getNumKeyValueEntries());
       assertTrue(reader.getMetaInfo(LAST_KEY).isPresent());
@@ -685,12 +666,6 @@ class TestHFileWriter {
       assertEquals(8, reader.getMetaInfo(MAX_MVCC_TS_KEY).get().length);
       assertEquals(1,
           ByteBuffer.wrap(reader.getMetaInfo(KEY_VALUE_VERSION).get()).getInt());
-    }
-  }
-
-  private static ByteBuffer mapFileToBuffer() throws IOException {
-    try (FileChannel channel = FileChannel.open(Paths.get(TEST_FILE), StandardOpenOption.READ)) {
-      return channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17413 (HUDI-9465) — make the HFile writer test operate on a byte-array stream instead of a file.

`TestHFileWriter` wrote every fixture to `test.hfile`, a fixed relative path in the module working directory,
and read it back with `FileChannel.map`. The file was never needed: `HFileWriterImpl` already takes any
`OutputStream`, and `HFileReaderImpl` already reads a `ByteArraySeekableDataInputStream`.

### Summary and Changelog

Test-only; no production code changes.

- Writes go to a `ByteArrayOutputStream`; reads go through a new `openReader(byte[])`, matching the idiom
  already used by `TestHFileMultiBlockScan`, `TestHFileCompatibility` and `TestHFileReadCompatibility`.
- Removes the fixed relative path shared by four test methods, and the `@AfterEach` that existed only to
  delete it.
- Removes a hidden coupling: `assertSingleBlockBytesMatchGoldenAndHBase` re-read the file that
  `assertSingleBlockBytesMatchHBase` had left behind. The latter now returns the bytes.
- Fixes three leaked readers — the old code closed the `FileChannel` but not the `HFileReaderImpl` opened
  inside it. Every reader is now in try-with-resources.
- Renames, since no path is involved any more: `writeNativeFile` → `writeNativeHFile` (returns bytes),
  `writeTestFile` → `writeThreeRecordHFile`; the `validate*` helpers take the bytes instead of reading a file
  behind the caller's back.

The HBase writer fixture keeps its temp file — that writer needs a Hadoop `Path`, and it already uses
`Files.createTempFile` rather than a fixed name.

### Verification

`mvn test checkstyle:check apache-rat:check -pl hudi-io`:

```
Tests run: 125, Failures: 0, Errors: 0, Skipped: 0
You have 0 Checkstyle violations.
Rat check: Unapproved: 0, unknown: 0, generated: 0, approved: 90 licenses.
```

`TestHFileWriter` itself: 6/6. All byte-parity assertions against the HBase writer, the pinned golden hex
blocks and the 4547-byte size check are unchanged and still pass, so the refactor preserves what the test
actually checks.

Grepped for other references to `test.hfile`: none — the constant was local to this class.

### Impact

Test hygiene only. The tests no longer depend on the working directory or on a shared mutable path, and they
close the readers they open.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable — this is a test change; the existing assertions are preserved
- [x] CI passes on my PR
