### PR TITLE
fix(spark): make binary clustering/bulk-insert sort keys Comparable

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieUTF8StringFactory.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieUTF8StringFactory.scala
@@ -21,18 +21,33 @@ import org.apache.hudi.HoodieUTF8String
 
 import org.apache.spark.unsafe.types.UTF8String
 
+import java.nio.ByteBuffer
+
 trait HoodieUTF8StringFactory extends Serializable {
 
   def wrapUTF8String(utf8String: UTF8String): HoodieUTF8String
 
-  private def wrapUTF8StringIfNecessary(obj: AnyRef): AnyRef = {
+  /**
+   * Wrap a sort-column value that is not directly [[Comparable]] on the Spark record path so that
+   * it can be used as a clustering/bulk-insert sort key (see [[org.apache.hudi.common.util.SortUtils]]
+   * -> [[org.apache.hudi.common.util.collection.FlatLists.ofComparableArray]], which casts every
+   * element to Comparable). Two engine types reach here as non-Comparable Java values:
+   *  - Spark strings arrive as [[UTF8String]] (whose natural ordering differs from the Avro path),
+   *    wrapped into a version-specific [[HoodieUTF8String]].
+   *  - Spark binary columns arrive as a raw byte[] (NOT Comparable), which threw
+   *    `ClassCastException: [B cannot be cast to java.lang.Comparable`. The Avro path yields a
+   *    java.nio.ByteBuffer for the same column, so wrapping byte[] with ByteBuffer.wrap keeps the
+   *    exact same (byte-lexicographic) ordering while being Comparable and shuffle-serializable.
+   */
+  private def wrapComparableIfNecessary(obj: AnyRef): AnyRef = {
     obj match {
       case string: UTF8String => wrapUTF8String(string)
+      case bytes: Array[Byte] => ByteBuffer.wrap(bytes)
       case _ => obj
     }
   }
 
   def wrapArrayOfObjects(objects: Array[AnyRef]): Array[AnyRef] = {
-    objects.map(obj => wrapUTF8StringIfNecessary(obj))
+    objects.map(obj => wrapComparableIfNecessary(obj))
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.SerializationUtils;
 import org.apache.hudi.common.util.collection.FlatLists;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -43,6 +44,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -268,6 +270,37 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
 
   private static FlatLists.ComparableList sortKeyOf(byte[] value) {
     return FlatLists.ofComparableArray(UTF8STRING_FACTORY.wrapArrayOfObjects(new Object[] {value}));
+  }
+
+  /**
+   * The wrapped binary sort key must also survive the {@code sortBy} shuffle, not merely be
+   * {@link Comparable} in-JVM. The shuffle key ({@link FlatLists.ComparableList}) is Kryo-serializable
+   * and Hudi always runs the write path with Kryo ({@code HoodieSparkSqlWriter} rejects any other
+   * {@code spark.serializer}), so this round-trips the key through Hudi's Kryo ({@link SerializationUtils})
+   * and asserts the element stays a {@link ByteBuffer} with its ordering intact. Without the
+   * {@code ByteBuffer.wrap} the key holds a raw byte[]: the deserialized element is not a ByteBuffer
+   * (and comparison throws the same ClassCastException the shuffle would), so this test fails.
+   */
+  @Test
+  public void testBinarySortKeySurvivesKryoRoundTrip() throws IOException {
+    FlatLists.ComparableList lo = kryoRoundTrip(sortKeyOf(new byte[] {0x01, 0x02}));
+    FlatLists.ComparableList hi = kryoRoundTrip(sortKeyOf(new byte[] {0x01, 0x03}));
+    FlatLists.ComparableList neg = kryoRoundTrip(sortKeyOf(new byte[] {(byte) 0x80}));
+    FlatLists.ComparableList pos = kryoRoundTrip(sortKeyOf(new byte[] {0x7F}));
+    // Element type must survive Kryo serde — a raw byte[] (no fix) fails this assertion.
+    assertTrue(lo.get(0) instanceof ByteBuffer,
+        "binary sort key element must remain a ByteBuffer after the Kryo round-trip");
+    // Ordering identity and relative order must survive the round-trip (position/limit preserved).
+    assertEquals(0, lo.compareTo(kryoRoundTrip(sortKeyOf(new byte[] {0x01, 0x02}))),
+        "equal keys must stay equal after the Kryo round-trip");
+    assertTrue(lo.compareTo(hi) < 0, "relative ordering must survive the Kryo round-trip");
+    assertTrue(neg.compareTo(pos) < 0,
+        "signed byte ordering (0x80 < 0x7F) must survive the Kryo round-trip");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static FlatLists.ComparableList kryoRoundTrip(FlatLists.ComparableList key) throws IOException {
+    return (FlatLists.ComparableList) SerializationUtils.deserialize(SerializationUtils.serialize(key));
   }
 
   private Comparator<HoodieRecord<? extends HoodieRecordPayload>> getCustomColumnComparator(HoodieSchema schema, boolean prependPartitionPath, String[] sortColumns) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
@@ -54,6 +54,7 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase implements Serializable {
   private static final Comparator<HoodieRecord<? extends HoodieRecordPayload>> KEY_COMPARATOR =
@@ -239,6 +240,34 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
         records1, true, true, true, generateExpectedPartitionNumRecords(records1), Option.of(columnComparator), true);
     testBulkInsertInternalPartitioner(new RDDCustomColumnsSortPartitioner(config),
         records2, true, true, true, generateExpectedPartitionNumRecords(records2), Option.of(columnComparator), true);
+  }
+
+  /**
+   * On the Spark clustering / bulk-insert record path a binary sort column arrives as a
+   * raw byte[], which is not {@link Comparable}. {@code FlatLists.ofComparableArray} casts every
+   * element to Comparable, so this threw "ClassCastException: [B cannot be cast to
+   * java.lang.Comparable" and wedged every clustering attempt. {@code wrapArrayOfObjects} must wrap
+   * byte[] into a Comparable that preserves the Avro path's byte-lexicographic (ByteBuffer) ordering:
+   * signed bytes, shorter-prefix-first.
+   */
+  @Test
+  public void testSortColumnsWithBinaryValueAreComparable() {
+    // Before the fix each sortKeyOf(...) threw ClassCastException: [B cannot be cast to java.lang.Comparable.
+    assertTrue(sortKeyOf(new byte[] {0x01, 0x02}).compareTo(sortKeyOf(new byte[] {0x01, 0x03})) < 0,
+        "byte[] sort key must order like the Avro ByteBuffer path");
+    assertTrue(sortKeyOf(new byte[] {0x01, 0x03}).compareTo(sortKeyOf(new byte[] {0x01, 0x02})) > 0);
+    assertEquals(0, sortKeyOf(new byte[] {0x01, 0x02}).compareTo(sortKeyOf(new byte[] {0x01, 0x02})));
+    // ByteBuffer.compareTo is signed, so 0x80 (-128) sorts before 0x7F (127); lock in the sign.
+    assertTrue(sortKeyOf(new byte[] {(byte) 0x80}).compareTo(sortKeyOf(new byte[] {0x7F})) < 0,
+        "0x80 must sort before 0x7F under the Avro path's signed byte ordering");
+    // A shorter value that is a prefix of a longer one sorts first.
+    assertTrue(sortKeyOf(new byte[] {0x01, 0x02}).compareTo(sortKeyOf(new byte[] {0x01, 0x02, 0x00})) < 0);
+    // Empty binary sorts first.
+    assertTrue(sortKeyOf(new byte[] {}).compareTo(sortKeyOf(new byte[] {0x00})) < 0);
+  }
+
+  private static FlatLists.ComparableList sortKeyOf(byte[] value) {
+    return FlatLists.ofComparableArray(UTF8STRING_FACTORY.wrapArrayOfObjects(new Object[] {value}));
   }
 
   private Comparator<HoodieRecord<? extends HoodieRecordPayload>> getCustomColumnComparator(HoodieSchema schema, boolean prependPartitionPath, String[] sortColumns) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19621

### Summary and Changelog

Clustering and bulk-insert sort keys flow through `SortUtils.getComparableSortColumns` -> `FlatLists.ofComparableArray`, which casts every sort value to `Comparable`. On the Spark record path a BINARY sort column arrives as a raw `byte[]` (not `Comparable`), so `ofComparableArray` threw `ClassCastException: [B cannot be cast to java.lang.Comparable`, failing every clustering / bulk-insert on that column. The Avro path was unaffected because `HoodieAvroUtils.getNestedFieldVal` returns a `java.nio.ByteBuffer` for the same column.

This wraps `byte[]` into `ByteBuffer.wrap(...)` inside the shared `HoodieUTF8StringFactory.wrapArrayOfObjects` hook used by both `RDDCustomColumnsSortPartitioner` and `RDDBucketIndexPartitioner`. `ByteBuffer` is `Comparable`, and it survives the `sortBy` shuffle because the sort key `FlatLists.ComparableList` is `KryoSerializable` and Hudi always runs the write path with Kryo (`HoodieSparkSqlWriter` rejects any other `spark.serializer`) -- so the wrapped `byte[]` rides Kryo exactly as the Avro binary path already does. (`ByteBuffer` is not `java.io.Serializable`, and neither is the key; the shuffle uses Kryo, not Java serialization.) It preserves the exact byte-lexicographic ordering the Avro path already produced, so the change is behavior-preserving and needs no change to `FlatLists`. Adds two tests to `TestBulkInsertInternalPartitioner`: `testSortColumnsWithBinaryValueAreComparable` reproduces the CCE without the fix and asserts the ordering with it, and `testBinarySortKeySurvivesKryoRoundTrip` round-trips the wrapped key through Kryo (via `SerializationUtils`) and asserts the element stays a `ByteBuffer` with its ordering preserved (verified to fail without the fix with the same `ClassCastException`).

### Impact

Clustering and `bulk_insert` can sort by BINARY columns on the Spark record path. No behavior change for existing (string / primitive) sort columns.

### Risk Level

low

Behavior-preserving: the byte-lexicographic ordering is identical to the pre-existing Avro path, and it is covered by a new unit test that fails without the change. The wrapped `ByteBuffer` sort key is shuffled by the sort partitioner exactly as the Avro binary path already shuffles it (the same `ByteBuffer` in the same `FlatLists.ComparableList`), so there is no new serialization behavior (the key rides Kryo, same as the Avro path).

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable

