### PR TITLE
test(flink): stabilize Sink V2 UID assertion

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/v2/utils/TestPipelinesV2.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/v2/utils/TestPipelinesV2.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
@@ -78,7 +79,8 @@ class TestPipelinesV2 {
 
     assertEquals(4, sink.getTransformation().getParallelism());
     assertEquals("sink_v2", sink.getTransformation().getName());
-    assertEquals("uid_sink_v2_sink_v2_test", sink.getTransformation().getUid());
+    assertTrue(sink.getTransformation().getUid()
+        .matches("uid_sink_v2(?:_\\d+)?_sink_v2_test"));
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`TestPipelinesV2#testSinkUsesModeSpecificParallelismAndStableIdentity` assumes that the first Sink V2 operator created in a shared test JVM has no numeric UID suffix. `Pipelines.opUID` intentionally uses a process-wide counter to disambiguate repeated operator names, so the test can fail when another test creates a Sink V2 operator first.

**Error Log**

```log
[ERROR] org.apache.hudi.sink.v2.utils.TestPipelinesV2.testSinkUsesModeSpecificParallelismAndStableIdentity -- Time elapsed: 0.005 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <uid_sink_v2_sink_v2_test> but was: <uid_sink_v2_5_sink_v2_test>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at org.apache.hudi.sink.v2.utils.TestPipelinesV2.testSinkUsesModeSpecificParallelismAndStableIdentity(TestPipelinesV2.java:81)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
```

File for reference:
[job-logs_fail.txt](https://github.com/user-attachments/files/31063089/job-logs_fail.txt)


### Summary and Changelog

Update the Sink V2 UID assertion to accept the optional numeric disambiguation suffix while continuing to verify the stable operator name and table identity components.

### Impact

Test-only change. There is no public API, runtime behavior, or performance impact.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
