### PR TITLE
fix(common): scan jar entries in ReflectionUtils#getTopLevelClassesInClasspath

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestReflectionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestReflectionUtils.java
@@ -27,17 +27,34 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathFilter;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.JarURLConnection;
 import java.net.URL;
+import java.net.URLClassLoader;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.ReflectionUtils.getMethod;
+import static org.apache.hudi.common.util.ReflectionUtils.getTopLevelClassesInClasspath;
 import static org.apache.hudi.common.util.ReflectionUtils.isSubClass;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -67,36 +84,229 @@ public class TestReflectionUtils {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"jar:file:/unused.jar!/org/apache/hudi/common/util", "file:/invalid path"})
+  @ValueSource(strings = {"jar:file:/unused.jar!/org/apache/hudi/common/util", "file:/invalid path",
+      "http://example.invalid/org/apache/hudi/common/util"})
   void testGetTopLevelClassesInClasspathSkipsInvalidResources(String invalidResource) {
-    ClassLoader original = Thread.currentThread().getContextClassLoader();
-    ClassLoader loader = new ClassLoader(original) {
+    ClassLoader loader = new ClassLoader(Thread.currentThread().getContextClassLoader()) {
       @Override
       public Enumeration<URL> getResources(String name) throws IOException {
         return Collections.enumeration(Arrays.asList(new URL(invalidResource), TestReflectionUtils.class.getResource("")));
       }
     };
-    try {
-      Thread.currentThread().setContextClassLoader(loader);
-      assertTrue(ReflectionUtils.getTopLevelClassesInClasspath(TestReflectionUtils.class)
-          .anyMatch(TestReflectionUtils.class.getName()::equals));
-    } finally {
-      Thread.currentThread().setContextClassLoader(original);
-    }
+    assertTrue(withContextClassLoader(loader, () ->
+        ReflectionUtils.getTopLevelClassesInClasspath(TestReflectionUtils.class)
+            .anyMatch(TestReflectionUtils.class.getName()::equals)));
   }
 
   @Test
   void testGetTopLevelClassesInClasspathHandlesIOException() {
-    ClassLoader original = Thread.currentThread().getContextClassLoader();
-    ClassLoader loader = new ClassLoader(original) {
+    ClassLoader loader = new ClassLoader(Thread.currentThread().getContextClassLoader()) {
       @Override
       public Enumeration<URL> getResources(String name) throws IOException {
         throw new IOException("Simulated failure enumerating resources");
       }
     };
+    assertFalse(withContextClassLoader(loader, () ->
+        ReflectionUtils.getTopLevelClassesInClasspath(TestReflectionUtils.class).findAny().isPresent()));
+  }
+
+  /**
+   * An exploded directory on the classpath, reached over the "file" protocol. Built explicitly
+   * rather than scanning the test classpath, so the expected set is exact and independent of
+   * whatever else surefire puts on the classpath.
+   */
+  @Test
+  void testGetTopLevelClassesInClasspathFromDirectory(@TempDir Path tempDir) throws Exception {
+    String scanned = ReflectionUtils.class.getPackage().getName();
+    Path root = tempDir.resolve("classes");
+    Path pkgDir = root.resolve(scanned.replace('.', File.separatorChar));
+    Files.createDirectories(pkgDir.resolve("nested"));
+    Files.write(pkgDir.resolve("Alpha.class"), new byte[] {1});
+    Files.write(pkgDir.resolve("Beta.class"), new byte[] {1});
+    Files.write(pkgDir.resolve("nested").resolve("Gamma.class"), new byte[] {1});
+    Files.write(pkgDir.resolve("notaclass.txt"), new byte[] {1});
+
+    List<String> classes = withContextClassLoaderOver(() ->
+        getTopLevelClassesInClasspath(ReflectionUtils.class).collect(Collectors.toList()), root);
+
+    assertEquals(
+        Arrays.asList(scanned + ".Alpha", scanned + ".Beta", scanned + ".nested.Gamma"),
+        classes.stream().sorted().collect(Collectors.toList()),
+        "a directory entry must yield the classes of the package and its subpackages, and nothing else");
+  }
+
+  /**
+   * Classes packaged in a jar are reached over the "jar" protocol, whose URLs are not hierarchical
+   * and so cannot be turned into a {@link File}. Every caller of this method is a bundle
+   * Main class, which is exactly the packaged case.
+   * <p>
+   * The jar is built under the scanned class's own package, and the loader is given no parent, so
+   * the only resource found for that package is the one written here.
+   */
+  @Test
+  void testGetTopLevelClassesInClasspathFromJar(@TempDir Path tempDir) throws Exception {
+    String scanned = ReflectionUtils.class.getPackage().getName();
+    String dir = scanned.replace('.', '/') + "/";
+    Path jar = tempDir.resolve("classes.jar");
+    writeJar(jar,
+        dir,
+        dir + "Alpha.class",
+        dir + "Beta.class",
+        dir + "nested/",
+        dir + "nested/Gamma.class",
+        dir + "notaclass.txt",
+        "org/example/other/Delta.class");
+
+    List<String> classes = withContextClassLoaderOver(() ->
+        getTopLevelClassesInClasspath(ReflectionUtils.class).collect(Collectors.toList()), jar);
+
+    assertEquals(
+        Arrays.asList(scanned + ".Alpha", scanned + ".Beta", scanned + ".nested.Gamma"),
+        classes.stream().sorted().collect(Collectors.toList()),
+        "a jar entry must yield the classes of the package and its subpackages, and nothing else");
+  }
+
+  @Test
+  void testGetTopLevelClassesInClasspathForClassesWithoutAPackage() {
+    // Arrays and primitives have no package, which used to dereference null.
+    assertEquals(0, getTopLevelClassesInClasspath(String[].class).count());
+    assertEquals(0, getTopLevelClassesInClasspath(int.class).count());
+  }
+
+  /**
+   * A jar: URL whose stream handler returns a plain URLConnection rather than a JarURLConnection.
+   * Without the type check the cast throws ClassCastException, which the IOException catch does not
+   * cover, so a single such entry would fail the whole scan.
+   */
+  @Test
+  void testGetTopLevelClassesInClasspathSkipsAJarUrlThatIsNotAJarConnection() throws Exception {
+    URLStreamHandler plainHandler = new URLStreamHandler() {
+      @Override
+      protected URLConnection openConnection(URL url) {
+        return new URLConnection(url) {
+          @Override
+          public void connect() {
+            // Never connected: getTopLevelClassesInClasspath only inspects the connection's type.
+          }
+        };
+      }
+    };
+    URL notAJarConnection =
+        new URL(null, "jar:file:/unused.jar!/org/apache/hudi/common/util", plainHandler);
+    ClassLoader loader = new ClassLoader(Thread.currentThread().getContextClassLoader()) {
+      @Override
+      public Enumeration<URL> getResources(String name) {
+        return Collections.enumeration(Arrays.asList(notAJarConnection, TestReflectionUtils.class.getResource("")));
+      }
+    };
+
+    assertTrue(withContextClassLoader(loader, () ->
+            ReflectionUtils.getTopLevelClassesInClasspath(TestReflectionUtils.class)
+                .anyMatch(TestReflectionUtils.class.getName()::equals)),
+        "an entry whose connection is not a JarURLConnection must be skipped, not fail the scan");
+  }
+
+  /**
+   * The scan must leave a jar it did not open alone. Without setUseCaches(false) it closes the
+   * JVM-wide cached JarFile, and the next read by whoever opened it first fails with
+   * "IllegalStateException: zip file closed".
+   */
+  @Test
+  void testGetTopLevelClassesInClasspathFromJarLeavesASharedJarFileUsable(@TempDir Path tempDir) throws Exception {
+    String scanned = ReflectionUtils.class.getPackage().getName();
+    String dir = scanned.replace('.', '/') + "/";
+    Path jar = tempDir.resolve("shared.jar");
+    writeJar(jar, dir, dir + "Alpha.class");
+
+    // Open it through the shared cache first, the way another reader on the same JVM would.
+    URL entry = new URL("jar:" + jar.toUri().toURL() + "!/" + dir);
+    JarURLConnection shared = (JarURLConnection) entry.openConnection();
+    shared.setUseCaches(true);
+    JarFile sharedJar = shared.getJarFile();
+    try {
+      withContextClassLoaderOver(() -> getTopLevelClassesInClasspath(ReflectionUtils.class).count(), jar);
+      assertDoesNotThrow(() -> sharedJar.getEntry(dir + "Alpha.class"),
+          "the scan must not close a JarFile held open through the JVM-wide cache");
+    } finally {
+      sharedJar.close();
+    }
+  }
+
+  /**
+   * A package path that is a regular file rather than a directory. File#listFiles returns null
+   * there, which used to escape as a NullPointerException.
+   */
+  @Test
+  void testGetTopLevelClassesInClasspathWhenThePackagePathIsAFile(@TempDir Path tempDir) throws Exception {
+    String scanned = ReflectionUtils.class.getPackage().getName();
+    Path root = tempDir.resolve("classes");
+    Path pkgPath = root.resolve(scanned.replace('.', File.separatorChar));
+    Files.createDirectories(pkgPath.getParent());
+    Files.write(pkgPath, new byte[] {1});
+
+    long count = withContextClassLoaderOver(() -> getTopLevelClassesInClasspath(ReflectionUtils.class).count(), root);
+    assertEquals(0, count, "an unreadable package entry must be skipped, not throw");
+  }
+
+  /**
+   * The package resolving to more than one classpath entry, which is the shape surefire produces.
+   * Every entry has to contribute, whichever protocol it uses.
+   */
+  @Test
+  void testGetTopLevelClassesInClasspathUnionsEveryClasspathEntry(@TempDir Path tempDir) throws Exception {
+    String scanned = ReflectionUtils.class.getPackage().getName();
+    String dir = scanned.replace('.', '/') + "/";
+    Path jar = tempDir.resolve("classes.jar");
+    writeJar(jar, dir, dir + "FromJar.class");
+    Path root = tempDir.resolve("classes");
+    Path pkgDir = root.resolve(scanned.replace('.', File.separatorChar));
+    Files.createDirectories(pkgDir);
+    Files.write(pkgDir.resolve("FromDirectory.class"), new byte[] {1});
+
+    List<String> classes = withContextClassLoaderOver(() ->
+        getTopLevelClassesInClasspath(ReflectionUtils.class).collect(Collectors.toList()), jar, root);
+
+    assertEquals(
+        Arrays.asList(scanned + ".FromDirectory", scanned + ".FromJar"),
+        classes.stream().sorted().collect(Collectors.toList()),
+        "a jar entry and a directory entry for the same package must both contribute");
+  }
+
+  /** Writes a jar holding the given entry names; names ending in "/" become directory entries. */
+  private static void writeJar(Path jar, String... entryNames) throws IOException {
+    try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
+      for (String entryName : entryNames) {
+        out.putNextEntry(new JarEntry(entryName));
+        if (!entryName.endsWith("/")) {
+          // Content is irrelevant: the scan reads entry names, never the bytecode.
+          out.write(new byte[] {1, 2, 3});
+        }
+        out.closeEntry();
+      }
+    }
+  }
+
+  /**
+   * Runs the supplier with the thread context class loader reading only from the given classpath
+   * roots, each of which may be a jar or an exploded directory. The loader is given no parent so
+   * the scan sees nothing else.
+   */
+  private static <T> T withContextClassLoaderOver(Supplier<T> supplier, Path... roots) throws IOException {
+    URL[] urls = new URL[roots.length];
+    for (int i = 0; i < roots.length; i++) {
+      urls[i] = roots[i].toUri().toURL();
+    }
+    try (URLClassLoader loader = new URLClassLoader(urls, null)) {
+      return withContextClassLoader(loader, supplier);
+    }
+  }
+
+  /** Runs the supplier with the given thread context class loader, restoring the previous one after. */
+  private static <T> T withContextClassLoader(ClassLoader loader, Supplier<T> supplier) {
+    ClassLoader original = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(loader);
-      assertFalse(ReflectionUtils.getTopLevelClassesInClasspath(TestReflectionUtils.class).findAny().isPresent());
+      return supplier.get();
     } finally {
       Thread.currentThread().setContextClassLoader(original);
     }

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -26,15 +26,19 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.JarURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -44,6 +48,7 @@ import java.util.stream.Stream;
 public class ReflectionUtils {
 
   private static final Map<String, Class<?>> CLAZZ_CACHE = new ConcurrentHashMap<>();
+  private static final String CLASS_FILE_SUFFIX = ".class";
 
   public static Class<?> getClass(String clazzName) {
     return CLAZZ_CACHE.computeIfAbsent(clazzName, c -> {
@@ -130,15 +135,79 @@ public class ReflectionUtils {
    */
   public static Stream<String> getTopLevelClassesInClasspath(Class<?> clazz) {
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-    String packageName = clazz.getPackage().getName();
+    // Arrays and primitives have no package, and Class#getPackage is also null when the class was
+    // loaded by a loader that defines no package for it.
+    Package pkg = clazz.getPackage();
+    if (pkg == null) {
+      return Stream.empty();
+    }
+    String packageName = pkg.getName();
     String path = packageName.replace('.', '/');
     try {
       return Collections.list(classLoader.getResources(path)).stream()
-          .map(ReflectionUtils::toDirectory)
-          .filter(Objects::nonNull)
-          .flatMap(directory -> findClasses(directory, packageName).stream());
+          .flatMap(resource -> classNamesIn(resource, packageName));
     } catch (IOException e) {
       log.error("Unable to fetch Resources in package {}", packageName, e);
+      return Stream.empty();
+    }
+  }
+
+  /**
+   * Class names under a single classpath entry for the package, whether that entry is an exploded
+   * directory or a jar.
+   *
+   * <p>A jar entry cannot go through {@link #toDirectory}: a {@code jar:} URL is non-hierarchical,
+   * so {@code new File(uri)} throws and the entry would be dropped. Every bundle {@code Main} class
+   * runs from inside a shaded jar, so that path has to be read through the jar connection instead.
+   *
+   * @param resource    a classpath entry holding the package
+   * @param packageName the package being scanned
+   * @return class names found under that entry, empty if it cannot be read
+   */
+  private static Stream<String> classNamesIn(URL resource, String packageName) {
+    if ("jar".equals(resource.getProtocol())) {
+      return classNamesInJar(resource, packageName);
+    }
+    File directory = toDirectory(resource);
+    return directory == null ? Stream.empty() : findClasses(directory, packageName).stream();
+  }
+
+  /**
+   * Class names under the package inside a jar, read through the jar connection.
+   *
+   * @param resource    a {@code jar:} classpath entry holding the package
+   * @param packageName the package being scanned
+   * @return class names found in that jar, empty if the jar cannot be read
+   */
+  private static Stream<String> classNamesInJar(URL resource, String packageName) {
+    try {
+      URLConnection connection = resource.openConnection();
+      if (!(connection instanceof JarURLConnection)) {
+        // A jar: URL served by a non-JDK stream handler. Skip it rather than let the cast throw,
+        // since this method exists to stop such an entry from failing the whole scan.
+        log.warn("Skipping classpath entry {}, {} is not a JarURLConnection", resource, connection.getClass());
+        return Stream.empty();
+      }
+      JarURLConnection jarConnection = (JarURLConnection) connection;
+      // Without this the JarFile is cached and shared JVM-wide, and closing it below would leave
+      // any reader that opened the same jar first with "IllegalStateException: zip file closed".
+      jarConnection.setUseCaches(false);
+      // Derived from the package rather than from JarURLConnection#getEntryName. On a multi-release
+      // jar the loader resolves the package to META-INF/versions/N/<pkg>/ on JDK 9-23 but to <pkg>/
+      // on 8 and 24+, so anchoring to the entry name would make the result JDK dependent and would
+      // drop classes that exist only in the base directory.
+      String entryPrefix = packageName.replace('.', '/') + '/';
+      try (JarFile jar = jarConnection.getJarFile()) {
+        // Collected before the jar is closed, since the returned stream outlives this method.
+        return jar.stream()
+            .map(JarEntry::getName)
+            .filter(name -> name.startsWith(entryPrefix) && name.endsWith(CLASS_FILE_SUFFIX))
+            .map(name -> name.substring(0, name.length() - CLASS_FILE_SUFFIX.length()).replace('/', '.'))
+            .collect(Collectors.toList())
+            .stream();
+      }
+    } catch (IOException e) {
+      log.error("Unable to read jar for {}", resource, e);
       return Stream.empty();
     }
   }
@@ -171,11 +240,18 @@ public class ReflectionUtils {
       return classes;
     }
     File[] files = directory.listFiles();
-    for (File file : Objects.requireNonNull(files)) {
+    if (files == null) {
+      // Null for an unreadable directory, or for a package path that is a regular file. Skipping it
+      // keeps one bad classpath entry from failing the whole scan, as the jar branch above does.
+      log.warn("Unable to list {}, skipping it", directory);
+      return classes;
+    }
+    for (File file : files) {
       if (file.isDirectory()) {
         classes.addAll(findClasses(file, packageName + "." + file.getName()));
-      } else if (file.getName().endsWith(".class")) {
-        classes.add(packageName + '.' + file.getName().substring(0, file.getName().length() - 6));
+      } else if (file.getName().endsWith(CLASS_FILE_SUFFIX)) {
+        classes.add(packageName + '.'
+            + file.getName().substring(0, file.getName().length() - CLASS_FILE_SUFFIX.length()));
       }
     }
     return classes;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Follow-up to #19784, which landed the simplification of `ReflectionUtils#getTopLevelClassesInClasspath` but not the JAR-entry scanning. Two problems are still live on master.

**A `jar:` URL is dropped.** It is non-hierarchical, so `new File(uri)` throws and `toDirectory` logs the failure and returns `null`, which the stream then filters out. A caller scanning from inside a shaded jar therefore finds nothing and prints nothing. Before #19784 the same case threw `IllegalArgumentException: URI is not hierarchical`; it is now a silent no-op, which is harder to notice.

**`Class#getPackage` is null for arrays and primitives**, so `ReflectionUtils.java:133` still throws `NullPointerException` for `getTopLevelClassesInClasspath(String[].class)`.

### Summary and Changelog

`getTopLevelClassesInClasspath` now reads jar entries instead of dropping them, and returns an empty stream for a class with no package.

- `classNamesIn` dispatches on protocol. `jar:` goes through `JarURLConnection`; every other protocol keeps the `toDirectory` + `findClasses` path exactly as #19784 merged it.
- Null-package guard for arrays and primitives.
- `setUseCaches(false)` before `getJarFile()`, so the scan does not close a `JarFile` held open through the JVM-wide cache.

Hardening from review, all the same class of problem — one bad classpath entry must not fail the whole scan:

- A `jar:` URL served by a non-JDK stream handler is type-checked and skipped rather than throwing `ClassCastException`.
- The entry prefix stays derived from the package name. Taking it from `JarURLConnection#getEntryName` was tried in review and reverted: on a multi-release jar the loader resolves the package to `META-INF/versions/N/<pkg>/` on JDK 9-23 but to `<pkg>/` on 8 and 24+, so that anchor makes the scan JDK dependent and drops classes present only in the base directory. Measured on JDK 17 with a jar holding `Alpha` and `BaseOnly` in the base and `Alpha` and `VersionedOnly` under `META-INF/versions/9/`: the entry-name anchor yields `[Alpha, VersionedOnly]`, the package-derived one `[Alpha, BaseOnly]`.
- `findClasses` returns empty instead of dereferencing a null from `File#listFiles`, which happens when the package path is a regular file or an unreadable directory.
- `findClasses` shares `CLASS_FILE_SUFFIX` with the jar branch rather than repeating the `".class"` literal and the magic `6`.

### Impact

`getTopLevelClassesInClasspath` returns classes when the package lives in a jar, where it previously returned nothing. No caller signature changes.

Scope note on who benefits: of the 15 built bundles that contain `ReflectionUtils`, only `hudi-cli-bundle` ships `org/slf4j/LoggerFactory.class`. `ReflectionUtils` is annotated `@Slf4j`, so its `<clinit>` needs that class, and in the other bundles a `Main` invoked from the bare jar fails with `NoClassDefFoundError: org/slf4j/LoggerFactory` before reaching this code, with or without this change. This fix is what makes the scan work wherever slf4j is on the classpath — the cli bundle, and any embedding that supplies slf4j itself. An earlier version of this description claimed all bundle `Main` classes start working; that was measured with slf4j already on the classpath and was wrong.

### Risk Level

low

Confined to one method and its two private helpers in `hudi-io`. The directory branch is #19784's code, unchanged.

`TestReflectionUtils` is 13/13 (11 methods, one parameterized over 3 values). `checkstyle:check` and `apache-rat:check` clean on `hudi-io`, `checkstyle:check` clean on `hudi-common`.

Each fix is pinned by a test that fails without it, verified by reverting them one at a time:

| reverted | failure |
| --- | --- |
| null-package guard | `...ForClassesWithoutAPackage` — `NullPointerException: Cannot invoke "java.lang.Package.getName()"` |
| jar dispatch | `...FromJar` — empty result |
| `setUseCaches(false)` | `...LeavesASharedJarFileUsable` — `IllegalStateException: zip file closed` |
| `File#listFiles` null guard | `...WhenThePackagePathIsAFile` — `NullPointerException` |
| `instanceof JarURLConnection` check | `...SkipsAJarUrlThatIsNotAJarConnection` — `ClassCastException` |

The two tests #19784 added still pass. `"jar:file:/unused.jar!/..."` no longer reaches `toDirectory`; it enters `classNamesInJar`, where `getJarFile()` on a missing jar throws `IOException` and returns empty. A third `@ValueSource` entry, `"http://example.invalid/..."`, restores coverage of `toDirectory`'s `IllegalArgumentException` arm, which that parameter used to provide.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
