### PR TITLE
fix(utilities): bound the archived timeline load when summarizing a metadata table mismatch

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV2.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV2.java
@@ -50,6 +50,7 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorage
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -128,6 +129,16 @@ public class TestArchivedTimelineV2 extends HoodieCommonTestHarness {
     archivedTimeline.loadCompletedInstantDetailsInMemory(instantTime, instantTime);
 
     assertArrayEquals(commitMetadata, archivedTimeline.getInstantDetails(archivedInstant).get());
+  }
+
+  @Test
+  void testLoadingInstantsInClosedRange() throws Exception {
+    writeArchivedTimeline(10, 10000000);
+    // now we got 50 instants (10000001 to 10000050) spread in 5 parquets.
+    HoodieArchivedTimeline archivedTimeline = metaClient.getArchivedTimeline("10000011", "10000020");
+    assertThat(archivedTimeline.firstInstant().map(HoodieInstant::requestedTime).orElse(""), is("10000011"));
+    assertThat(archivedTimeline.lastInstant().map(HoodieInstant::requestedTime).orElse(""), is("10000020"));
+    assertEquals(10, archivedTimeline.countInstants());
   }
 
   @Test

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -625,6 +625,22 @@ public class HoodieTableMetaClient implements Serializable {
     return instantiateArchivedTimeline(startTs);
   }
 
+  /**
+   * Returns a fresh archived timeline covering [startTs, endTs], both bounds inclusive.
+   * <p>
+   * The range is pushed down into the load, so the cost is proportional to the range rather than
+   * to the whole archive. Unlike the other accessors this one is never cached: {@code archivedTimelineMap}
+   * is keyed by start instant alone, so a range-bounded timeline stored there would be handed out
+   * to callers asking for an open-ended one.
+   *
+   * @param startTs The start instant time (inclusive) of the archived timeline.
+   * @param endTs   The end instant time (inclusive) of the archived timeline.
+   * @return the archived timeline restricted to the given range.
+   */
+  public HoodieArchivedTimeline getArchivedTimeline(String startTs, String endTs) {
+    return tableFormat.getTimelineFactory().createArchivedTimeline(this, startTs, endTs);
+  }
+
   private HoodieArchivedTimeline instantiateArchivedTimeline(String startTs) {
     return StringUtils.isNullOrEmpty(startTs)
         ? tableFormat.getTimelineFactory().createArchivedTimeline(this)

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineFactory.java
@@ -35,6 +35,19 @@ public abstract class TimelineFactory implements Serializable {
 
   public abstract HoodieArchivedTimeline createArchivedTimeline(HoodieTableMetaClient metaClient, boolean shouldLoadInstants);
 
+  /**
+   * Creates an archived timeline holding the completed instants within [startTs, endTs], both bounds
+   * inclusive. The range is pushed down into the load, so instants outside it are never materialized.
+   * <p>
+   * Only completed instants are returned, matching {@link #createArchivedTimeline(HoodieTableMetaClient, String)}.
+   * An instant archived without ever completing is a failed write rather than a committed one, so callers
+   * asking whether an instant was committed must not see it here.
+   *
+   * @param startTs the earliest instant time to load, inclusive.
+   * @param endTs   the latest instant time to load, inclusive.
+   */
+  public abstract HoodieArchivedTimeline createArchivedTimeline(HoodieTableMetaClient metaClient, String startTs, String endTs);
+
   public abstract ArchivedTimelineLoader createArchivedTimelineLoader();
 
   public abstract HoodieActiveTimeline createActiveTimeline(HoodieTableMetaClient metaClient);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/TimelineV1Factory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/TimelineV1Factory.java
@@ -65,6 +65,11 @@ public class TimelineV1Factory extends TimelineFactory {
   }
 
   @Override
+  public HoodieArchivedTimeline createArchivedTimeline(HoodieTableMetaClient metaClient, String startTs, String endTs) {
+    return new ArchivedTimelineV1(metaClient, startTs, endTs);
+  }
+
+  @Override
   public ArchivedTimelineLoader createArchivedTimelineLoader() {
     return new ArchivedTimelineLoaderV1();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineV2.java
@@ -112,6 +112,18 @@ public class ArchivedTimelineV2 extends BaseTimelineV2 implements HoodieArchived
   }
 
   /**
+   * Loads completed instants from startTs(inclusive) to endTs(inclusive).
+   */
+  public ArchivedTimelineV2(HoodieTableMetaClient metaClient, String startTs, String endTs) {
+    this.metaClient = metaClient;
+    setInstants(loadInstants(new HoodieArchivedTimeline.ClosedClosedTimeRangeFilter(startTs, endTs), HoodieArchivedTimeline.LoadMode.METADATA));
+    this.cursorInstant = startTs;
+    // multiple casts will make this lambda serializable -
+    // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
+    this.instantReader = this;
+  }
+
+  /**
    * For serialization and de-serialization only.
    *
    * @deprecated

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/TimelineV2Factory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/TimelineV2Factory.java
@@ -65,6 +65,11 @@ public class TimelineV2Factory extends TimelineFactory {
   }
 
   @Override
+  public HoodieArchivedTimeline createArchivedTimeline(HoodieTableMetaClient metaClient, String startTs, String endTs) {
+    return new ArchivedTimelineV2(metaClient, startTs, endTs);
+  }
+
+  @Override
   public ArchivedTimelineLoader createArchivedTimelineLoader() {
     return new ArchivedTimelineLoaderV2();
   }

--- a/hudi-common/src/test/java/org/apache/hudi/tableformat/TestTimelineFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/tableformat/TestTimelineFactory.java
@@ -70,6 +70,11 @@ public class TestTimelineFactory extends TimelineFactory {
   }
 
   @Override
+  public HoodieArchivedTimeline createArchivedTimeline(HoodieTableMetaClient metaClient, String startTs, String endTs) {
+    return new ArchivedTimelineV2(metaClient, startTs, endTs);
+  }
+
+  @Override
   public ArchivedTimelineLoader createArchivedTimelineLoader() {
     return new ArchivedTimelineLoaderV2();
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV1.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV1.java
@@ -139,6 +139,10 @@ public class TestArchivedTimelineV1 extends HoodieCommonTestHarness {
 
     List<HoodieInstant> completedInstants = getCompletedInstantForTs(instants, Arrays.asList("05", "08", "09"));
     assertEquals(completedInstants, timeline.getInstants());
+
+    HoodieArchivedTimeline factoryTimeline =
+        TimelineLayout.TIMELINE_LAYOUT_V1.getTimelineFactory().createArchivedTimeline(metaClient, "05", "09");
+    assertEquals(completedInstants, factoryTimeline.getInstants());
   }
 
   @Test
@@ -153,6 +157,12 @@ public class TestArchivedTimelineV1 extends HoodieCommonTestHarness {
 
     // All the completed instants should be returned
     assertEquals(instants.stream().filter(HoodieInstant::isCompleted).collect(Collectors.toList()), timeline.getInstants());
+
+    // The range spans instants 01 and 11, which are archived without ever completing; the factory must
+    // not surface them either, otherwise a failed write reads as a committed one.
+    HoodieArchivedTimeline factoryTimeline =
+        TimelineLayout.TIMELINE_LAYOUT_V1.getTimelineFactory().createArchivedTimeline(metaClient, "01", "11");
+    assertEquals(instants.stream().filter(HoodieInstant::isCompleted).collect(Collectors.toList()), factoryTimeline.getInstants());
   }
 
   @Test

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -1517,7 +1517,7 @@ public class HoodieMetadataTableValidator implements Serializable {
               + "metadata table. File system-based listing: %d & MDT-based listing: %d. %s",
           fileSliceListFromFS.size(),
           fileSliceListFromMetadataTable.size(),
-          computeDiffSummary(fileSliceListFromMetadataTable, fileSliceListFromFS, metaClient, cfg.logDetailMaxLength));
+          computeDiffSummarySafely(fileSliceListFromMetadataTable, fileSliceListFromFS, metaClient, cfg.logDetailMaxLength));
       mismatch = true;
     } else if (!fileSliceListFromMetadataTable.equals(fileSliceListFromFS)) {
       // In-memory cache for the set of committed files of commits of interest
@@ -1567,6 +1567,21 @@ public class HoodieMetadataTableValidator implements Serializable {
     }
   }
 
+  /**
+   * Computes the diff summary for a detected mismatch, degrading to a placeholder if the computation
+   * itself fails. The summary is only a diagnostic, so it must never be able to mask the mismatch it
+   * is describing by propagating out of the enclosing validation.
+   */
+  static String computeDiffSummarySafely(List<FileSlice> fileSliceListFromMetadataTable, List<FileSlice> fileSliceListFromFS,
+                                         HoodieTableMetaClient metaClient, int logDetailMaxLength) {
+    try {
+      return computeDiffSummary(fileSliceListFromMetadataTable, fileSliceListFromFS, metaClient, logDetailMaxLength);
+    } catch (Exception e) {
+      log.warn("Failed to compute the file slice diff summary; reporting the mismatch without it", e);
+      return "Diff summary unavailable: " + e;
+    }
+  }
+
   static String computeDiffSummary(List<FileSlice> fileSliceListFromMetadataTable, List<FileSlice> fileSliceListFromFS,
                                     HoodieTableMetaClient metaClient, int logDetailMaxLength) {
     Set<HoodieFileGroupId> fileGroupIdsFromFS = fileSliceListFromFS.stream()
@@ -1587,12 +1602,10 @@ public class HoodieMetadataTableValidator implements Serializable {
       if (!nonActiveInstantTimes.isEmpty()) {
         String maxInstant = nonActiveInstantTimes.stream().max(Comparator.naturalOrder()).orElse(null);
         String minInstant = nonActiveInstantTimes.stream().min(Comparator.naturalOrder()).orElse(null);
-        Set<String> archivedInstants = metaClient.getArchivedTimeline()
-            .findInstantsInRange(minInstant, maxInstant)
+        Set<String> archivedInstants = metaClient.getArchivedTimeline(minInstant, maxInstant)
             .getInstantsAsStream()
             .map(HoodieInstant::requestedTime)
             .collect(Collectors.toSet());
-        // truncate start instant since range is not
         Set<String> missingCommits = nonActiveInstantTimes.stream().filter(instant -> !archivedInstants.contains(instant)).collect(Collectors.toSet());
         if (!missingCommits.isEmpty()) {
           log.warn("File slices in file system belong to missing commits: {}", String.join(",", missingCommits));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -44,6 +44,7 @@ import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieCommandBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.InstantComparison;
@@ -133,7 +134,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -1086,6 +1089,88 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
             listMdt.size(), computeDiffSummary(listMdt, listFs, metaClient, logDetailMaxLength)),
         exception.getMessage());
     verify(spyTimeline, times(2)).readInstantContent(any(), any());
+  }
+
+  @Test
+  void testValidateFileSlicesTreatsArchivedBoundaryInstantAsCommitted() {
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    String partition = "partition10";
+    String label = "metadata item";
+
+    TimeGenerator timeGenerator = TimeGenerators
+        .getTimeGenerator(HoodieTimeGeneratorConfig.defaultConfig(basePath),
+            HadoopFSUtils.getStorageConf(jsc.hadoopConfiguration()));
+    Pair<List<FileSlice>, List<FileSlice>> filelistPair = generateTwoEqualFileSliceList(5, timeGenerator);
+    List<FileSlice> listMdt = filelistPair.getLeft();
+    List<FileSlice> listFs = filelistPair.getRight();
+
+    // A single file slice present only in the file system, so its base instant is both the min and the
+    // max of the range the diff summary looks up. It is archived, hence not a missing commit.
+    FileSlice extraFileSlice = generateRandomFileSlice(
+        TimelineUtils.generateInstantTime(true, timeGenerator),
+        TimelineUtils.generateInstantTime(true, timeGenerator),
+        TimelineUtils.generateInstantTime(true, timeGenerator)).getLeft();
+    listFs.add(extraFileSlice);
+    String archivedInstantTime = extraFileSlice.getBaseInstantTime();
+
+    HoodieTableMetaClient spyMetaClient = spy(metaClient);
+    HoodieActiveTimeline spyTimeline = spy(metaClient.getActiveTimeline());
+    doReturn(spyTimeline).when(spyMetaClient).getActiveTimeline();
+    HoodieTimeline mockRollbackTimeline = mock(HoodieTimeline.class, RETURNS_DEEP_STUBS);
+    doReturn(mockRollbackTimeline).when(spyTimeline).getRollbackTimeline();
+
+    HoodieArchivedTimeline mockArchivedTimeline = mock(HoodieArchivedTimeline.class);
+    when(mockArchivedTimeline.getInstantsAsStream()).thenReturn(Stream.of(
+        new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, archivedInstantTime,
+            InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
+    doReturn(mockArchivedTimeline).when(spyMetaClient).getArchivedTimeline(archivedInstantTime, archivedInstantTime);
+
+    assertThrows(
+        HoodieValidationException.class,
+        () -> validator.validateFileSlices(listMdt, listFs, partition, spyMetaClient, label));
+
+    // The range must be pushed down with both bounds inclusive, so the boundary instant resolves as
+    // archived and the rollback plan scan is never triggered.
+    verify(spyMetaClient).getArchivedTimeline(archivedInstantTime, archivedInstantTime);
+    verify(mockRollbackTimeline, never()).getInstantsAsStream();
+  }
+
+  @Test
+  void testValidateFileSlicesReportsMismatchWhenDiffSummaryFails() {
+    HoodieMetadataTableValidator.Config config = new HoodieMetadataTableValidator.Config();
+    config.basePath = basePath;
+    MockHoodieMetadataTableValidator validator = new MockHoodieMetadataTableValidator(jsc, config);
+    String partition = "partition10";
+    String label = "metadata item";
+
+    TimeGenerator timeGenerator = TimeGenerators
+        .getTimeGenerator(HoodieTimeGeneratorConfig.defaultConfig(basePath),
+            HadoopFSUtils.getStorageConf(jsc.hadoopConfiguration()));
+    Pair<List<FileSlice>, List<FileSlice>> filelistPair = generateTwoEqualFileSliceList(5, timeGenerator);
+    List<FileSlice> listMdt = filelistPair.getLeft();
+    List<FileSlice> listFs = filelistPair.getRight();
+    listFs.add(generateRandomFileSlice(
+        TimelineUtils.generateInstantTime(true, timeGenerator),
+        TimelineUtils.generateInstantTime(true, timeGenerator),
+        TimelineUtils.generateInstantTime(true, timeGenerator)).getLeft());
+
+    HoodieTableMetaClient spyMetaClient = spy(metaClient);
+    HoodieIOException injectedFailure = new HoodieIOException("simulated timeline read failure");
+    doThrow(injectedFailure).when(spyMetaClient).getActiveTimeline();
+
+    Exception exception = assertThrows(
+        HoodieValidationException.class,
+        () -> validator.validateFileSlices(listMdt, listFs, partition, spyMetaClient, label));
+    assertEquals(
+        String.format(
+            "Validation of %s for partition %s failed for table: %s. "
+                + "Number of file slices based on the file system does not match that based on the "
+                + "metadata table. File system-based listing: %d & MDT-based listing: %d. "
+                + "Diff summary unavailable: %s",
+            label, partition, basePath, listFs.size(), listMdt.size(), injectedFailure),
+        exception.getMessage());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19625

### Summary and Changelog

The metadata table validator consulted the archived timeline to classify file slices found only on storage, but loaded the whole archive and then filtered the range in memory. That could OOM an executor while the error message was being built, which discarded the mismatch verdict the validator had already reached, and the half-open `findInstantsInRange` always misclassified an archived instant equal to the range lower bound as a missing commit.

Changes:

- Add `TimelineFactory.createArchivedTimeline(metaClient, startTs, endTs)` and a matching `HoodieTableMetaClient.getArchivedTimeline(startTs, endTs)`, returning the completed instants in the closed range. The V1 factory delegates to the existing `ArchivedTimelineV1(metaClient, startTs, endTs)`; a new `ArchivedTimelineV2` constructor uses `ClosedClosedTimeRangeFilter`, so both layouts agree on boundary semantics. The accessor deliberately bypasses `archivedTimelineMap`, which is keyed by start instant alone and would otherwise hand a range-bounded timeline to a caller asking for an open-ended one.
- Switch `HoodieMetadataTableValidator.computeDiffSummary` to that accessor and drop the in-memory `findInstantsInRange`, which fixes both the unbounded load and the off-by-one.
- Wrap the summary in `computeDiffSummarySafely`, so a failure while computing a diagnostic degrades the message instead of propagating and masking the mismatch it describes.

### Impact

`TimelineFactory` gains an abstract method, so any out-of-tree subclass needs to implement it. Both in-tree implementations and the test format are updated. No storage format or config change.

Validator behavior changes in two user-visible ways: an archived instant equal to the range lower bound is now correctly reported as archived rather than as a missing commit, which also stops a spurious `missingCommits` from triggering a scan that reads every rollback plan from storage; and the archive read for the diagnostic is now proportional to the instant range rather than to the whole archive.

One intentional deviation worth flagging for review: the new accessor returns completed instants only, matching its `createArchivedTimeline(metaClient, startTs)` sibling. The V1 archive also holds requested and inflight entries, and the previous no-arg path surfaced them, so on a table-version-6 table an instant archived without ever completing now classifies as a missing commit rather than as archived. That is the intended reading, since such an instant is a failed write, but it is a behavior change rather than a pure bug fix.

### Risk Level

low

The change is confined to a new API plus one validator call site. Verified with red-then-green: reverting the validator change makes `testValidateFileSlicesReportsMismatchWhenDiffSummaryFails` fail with `expected: <HoodieValidationException> but was: <HoodieIOException>`, reproducing the lost-verdict failure mode, and makes `testValidateFileSlicesTreatsArchivedBoundaryInstantAsCommitted` fail because the range accessor is never reached. Substituting the half-open filter for `ClosedClosedTimeRangeFilter` in the V2 constructor makes the new range test fail on the lower bound, confirming it pins inclusivity rather than passing vacuously. `TestArchivedTimelineV1`, `TestArchivedTimelineV2`, `TestHoodieMetadataTableValidator` and the pluggable-table-format suite that exercises the new abstract method all pass, and checkstyle is clean on the touched modules.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
