### PR TITLE
fix(flink): support native log max file size config

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieParquetConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
@@ -108,8 +109,7 @@ public class HoodieRowDataFileWriterFactory extends HoodieFileWriterFactory {
         hoodieConfig.getStringOrDefault(HoodieStorageConfig.HOODIE_PARQUET_FLINK_ROW_DATA_WRITE_SUPPORT_CLASS),
         new Class<?>[] {Configuration.class, HoodieSchema.class, BloomFilter.class},
         conf, schema, filter);
-
-    return new HoodieRowDataParquetWriter(storagePath, getParquetConfig(hoodieConfig, writeSupport),
+    return new HoodieRowDataParquetWriter(storagePath, getParquetConfig(hoodieConfig, writeSupport, storagePath),
         instantTime, taskContextSupplier, populateMetaFields, withOperation);
   }
 
@@ -141,12 +141,31 @@ public class HoodieRowDataFileWriterFactory extends HoodieFileWriterFactory {
 
   private static HoodieParquetConfig<HoodieRowDataParquetWriteSupport> getParquetConfig(
       HoodieConfig config, HoodieRowDataParquetWriteSupport writeSupport) {
+    return getParquetConfig(config, writeSupport,
+        config.getLongOrDefault(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE));
+  }
+
+  private static HoodieParquetConfig<HoodieRowDataParquetWriteSupport> getParquetConfig(
+      HoodieConfig config, HoodieRowDataParquetWriteSupport writeSupport, StoragePath storagePath) {
+    // Native logs handled by this factory are write-once Parquet files whose rollover is decided by
+    // the Parquet writer's canWrite(), not by LOGFILE_MAX_SIZE used for Hudi log containers. Preserve
+    // the Parquet target as the fallback unless a dedicated native-log target is explicitly configured.
+    boolean useNativeLogMaxFileSize = FSUtils.isNativeLogFile(storagePath.getName())
+        && config.contains(HoodieStorageConfig.NATIVE_LOG_MAX_FILE_SIZE);
+    long maxFileSize = useNativeLogMaxFileSize
+        ? config.getLong(HoodieStorageConfig.NATIVE_LOG_MAX_FILE_SIZE)
+        : config.getLongOrDefault(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE);
+    return getParquetConfig(config, writeSupport, maxFileSize);
+  }
+
+  private static HoodieParquetConfig<HoodieRowDataParquetWriteSupport> getParquetConfig(
+      HoodieConfig config, HoodieRowDataParquetWriteSupport writeSupport, long maxFileSize) {
     return new HoodieParquetConfig<>(
         writeSupport,
         getCompressionCodecName(config.getStringOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_NAME)),
         config.getIntOrDefault(HoodieStorageConfig.PARQUET_BLOCK_SIZE),
         config.getIntOrDefault(HoodieStorageConfig.PARQUET_PAGE_SIZE),
-        config.getLongOrDefault(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE),
+        maxFileSize,
         new HadoopStorageConfiguration(writeSupport.getHadoopConf()),
         config.getDoubleOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_RATIO_FRACTION),
         config.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED));

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowDataParquetConfigInjector.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowDataParquetConfigInjector.java
@@ -19,8 +19,11 @@
 package org.apache.hudi.io.storage.row;
 
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieParquetConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.engine.LocalTaskContextSupplier;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
@@ -56,16 +59,21 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedConstruction;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.FLINK;
+import static org.apache.hudi.common.model.LogExtensions.DATA_LOG_EXTENSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockConstruction;
 
 /**
  * Tests for {@link HoodieParquetConfigInjector} functionality in {@link HoodieRowDataFileWriterFactory}.
@@ -229,6 +237,42 @@ public class TestHoodieRowDataParquetConfigInjector extends HoodieFlinkClientTes
 
     // Verify the parquet file was created
     assertTrue(storage.exists(parquetPath));
+  }
+
+  @Test
+  public void testNativeLogMaxFileSize() throws Exception {
+    final String instantTime = "105";
+    HoodieStorage storage = HoodieTestUtils.getStorage(tmpDir.toString());
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE, "120");
+    config.setValue(HoodieStorageConfig.LOGFILE_MAX_SIZE, "1024");
+
+    HoodieSchema schema = HoodieSchemaConverter.convertToSchema(getTestRowType());
+    StoragePath baseFilePath = new StoragePath(basePath + "/partition/path/base.parquet");
+    StoragePath nativeLogPath = new StoragePath(basePath + "/partition/path/"
+        + FSUtils.makeNativeLogFileName("file-1", "0-0-0", instantTime, 1,
+        DATA_LOG_EXTENSION, HoodieFileFormat.PARQUET));
+    HoodieRowDataFileWriterFactory factory = new HoodieRowDataFileWriterFactory(storage);
+    List<HoodieParquetConfig<?>> writerConfigs = new ArrayList<>();
+
+    try (MockedConstruction<HoodieRowDataParquetWriter> ignored = mockConstruction(
+        HoodieRowDataParquetWriter.class,
+        (writer, context) -> writerConfigs.add((HoodieParquetConfig<?>) context.arguments().get(1)))) {
+      // LOGFILE_MAX_SIZE does not apply to native Parquet logs, so they retain the Parquet target.
+      factory.newParquetFileWriter(
+          instantTime, nativeLogPath, config, schema, new LocalTaskContextSupplier());
+
+      // The dedicated override changes native-log sizing without affecting base Parquet files.
+      config.setValue(HoodieStorageConfig.NATIVE_LOG_MAX_FILE_SIZE, "256");
+      factory.newParquetFileWriter(
+          instantTime, baseFilePath, config, schema, new LocalTaskContextSupplier());
+      factory.newParquetFileWriter(
+          instantTime, nativeLogPath, config, schema, new LocalTaskContextSupplier());
+
+      assertEquals(120L, writerConfigs.get(0).getMaxFileSize());
+      assertEquals(120L, writerConfigs.get(1).getMaxFileSize());
+      assertEquals(256L, writerConfigs.get(2).getMaxFileSize());
+    }
   }
 
   @Test

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -42,6 +42,14 @@ public class HoodieStorageConfig extends HoodieConfig {
       .withDocumentation("Target size in bytes for parquet files produced by Hudi write phases. "
           + "For DFS, this needs to be aligned with the underlying filesystem block size for optimal performance.");
 
+  public static final ConfigProperty<String> NATIVE_LOG_MAX_FILE_SIZE = ConfigProperty
+      .key("hoodie.native.log.max.file.size")
+      // Keep this unset so the runtime fallback honors the max file size of the corresponding file format.
+      .noDefaultValue()
+      .markAdvanced()
+      .withDocumentation("Target size in bytes for native log files. When not set, the max file size configured "
+          + "for the corresponding file format is used, for example hoodie.parquet.max.file.size for Parquet.");
+
   public static final ConfigProperty<String> PARQUET_BLOCK_SIZE = ConfigProperty
       .key("hoodie.parquet.block.size")
       .defaultValue(String.valueOf(120 * 1024 * 1024))
@@ -556,6 +564,11 @@ public class HoodieStorageConfig extends HoodieConfig {
 
     public Builder parquetMaxFileSize(long maxFileSize) {
       storageConfig.setValue(PARQUET_MAX_FILE_SIZE, String.valueOf(maxFileSize));
+      return this;
+    }
+
+    public Builder nativeLogMaxFileSize(long maxFileSize) {
+      storageConfig.setValue(NATIVE_LOG_MAX_FILE_SIZE, String.valueOf(maxFileSize));
       return this;
     }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19629.

Flink native Parquet log writers currently use `hoodie.parquet.max.file.size` as their rollover threshold, so native log files cannot be sized independently from base Parquet files.

### Summary and Changelog

- Add the common `hoodie.native.log.max.file.size` configuration in bytes.
- Use it for Flink native Parquet log rollover when explicitly configured.
- Fall back to `hoodie.parquet.max.file.size` when it is not configured, preserving the current default behavior.
- Keep base Parquet files independent from the native log setting.
- Add focused coverage for the fallback, explicit override, and base-file behavior.

### Impact

This is backward compatible by default. Users can opt in to a different native log rollover threshold without changing the target size of base Parquet files or reusing the inline log-file size setting.

### Risk Level

Low. The new configuration is opt-in, and the existing Parquet target remains the fallback.

### Documentation Update

The new common configuration is documented in `HoodieStorageConfig`.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

Validation: `mvn -pl hudi-client/hudi-flink-client -am -Dtest=TestHoodieRowDataParquetConfigInjector#testNativeLogMaxFileSize -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -DskipSparkTests -DskipScalaTests test` (1 test, 0 failures, 0 errors).
