### PR TITLE
feat(trino): track trinodb/trino master via a pinned SHA

### DIFF
--- a/.github/workflows/hudi_trino_ci.yml
+++ b/.github/workflows/hudi_trino_ci.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'hudi-trino/**'
       - '.github/workflows/hudi_trino_ci.yml'
+      - 'scripts/trino/**'
       # Upstream modules the connector build installs (the -am closure of the JDK 17
       # install step) plus the poms that own trino.version and the dependency pins.
       # Keep in sync with the case patterns in detect-trino-changes below.
@@ -77,6 +78,7 @@ jobs:
             case "$f" in
               hudi-trino/*) TRINO=true ;;
               .github/workflows/hudi_trino_ci.yml) TRINO=true ;;
+              scripts/trino/*) TRINO=true ;;
               # Upstream modules the connector build installs (the -am closure of the JDK 17
               # install step) plus the poms that own trino.version and the dependency pins.
               # Keep in sync with the push paths above.
@@ -105,6 +107,16 @@ jobs:
       - name: Checkout repository
         if: needs.changes.outputs.trino == 'true'
         uses: actions/checkout@v5
+      - name: Read Trino pin
+        id: trino-pin
+        if: needs.changes.outputs.trino == 'true'
+        run: |
+          set -euo pipefail
+          TRINO_SHA=$(sed -n 's|.*<trino.sha>\(.*\)</trino.sha>.*|\1|p' pom.xml)
+          TRINO_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
+          echo "Pinned trinodb/trino $TRINO_VERSION at $TRINO_SHA"
+          echo "trino_sha=$TRINO_SHA" >> "$GITHUB_OUTPUT"
+          echo "trino_version=$TRINO_VERSION" >> "$GITHUB_OUTPUT"
       # Hudi targets Java 11 and uses Lombok 1.18.36, which does not run on JDK 25.
       # Build the upstream modules hudi-trino depends on under JDK 17 first,
       # install them into the local m2, then build the connector itself under JDK 25.
@@ -127,20 +139,32 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
           cache: maven
-      # Trino does not publish trino-spi / trino-filesystem / trino-hive test-jars to
-      # Maven Central. Check out the matching release tag and install just the modules
-      # whose test classifiers we need into the local m2.
-      - name: Checkout trinodb/trino at 481
+      - name: Purge Trino artifacts from the local m2
         if: needs.changes.outputs.trino == 'true'
+        # Artifacts an older pin left behind carry the same SNAPSHOT coordinates as the current ones.
+        run: rm -rf ~/.m2/repository/io/trino
+      # Trino publishes neither SNAPSHOT artifacts nor the trino-spi / trino-filesystem /
+      # trino-hive / trino-main test-jars, so every io.trino dependency is built from the
+      # pinned trinodb/trino commit and cached under that commit.
+      - name: Restore Trino artifacts for the pinned commit
+        id: trino-m2
+        if: needs.changes.outputs.trino == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/io/trino
+          key: trino-m2-v1-${{ steps.trino-pin.outputs.trino_sha }}
+          # No restore-keys on purpose: a partial restore from another pin collides on the
+          # same SNAPSHOT coordinates and poisons the build.
+      - name: Checkout trinodb/trino at the pinned commit
+        if: needs.changes.outputs.trino == 'true' && steps.trino-m2.outputs.cache-hit != 'true'
         uses: actions/checkout@v5
         with:
           repository: trinodb/trino
-          ref: '481'
+          ref: ${{ steps.trino-pin.outputs.trino_sha }}
           path: trino-src
-      - name: Install Trino test-jars (JDK 25)
-        if: needs.changes.outputs.trino == 'true'
-        working-directory: trino-src
-        run: mvn $MVN_ARGS install -pl :trino-spi,:trino-filesystem,:trino-hive,:trino-main -am -DskipTests -Dair.check.skip-all=true
+      - name: Build Trino artifacts from source (JDK 25)
+        if: needs.changes.outputs.trino == 'true' && steps.trino-m2.outputs.cache-hit != 'true'
+        run: scripts/trino/bootstrap_trino.sh trino-src --skip-checkout
       - name: Build connector (JDK 25)
         if: needs.changes.outputs.trino == 'true'
         run: mvn $MVN_ARGS -Phudi-trino -pl hudi-trino install -Dmaven.test.skip=true

--- a/.github/workflows/hudi_trino_ci.yml
+++ b/.github/workflows/hudi_trino_ci.yml
@@ -114,6 +114,11 @@ jobs:
           set -euo pipefail
           TRINO_SHA=$(sed -n 's|.*<trino.sha>\(.*\)</trino.sha>.*|\1|p' pom.xml)
           TRINO_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
+          # sed -n ...p exits 0 on no match; an empty value would checkout/cache garbage.
+          if [ -z "$TRINO_SHA" ] || [ -z "$TRINO_VERSION" ]; then
+            echo "ERROR: could not read trino.sha/trino.version from pom.xml" >&2
+            exit 1
+          fi
           echo "Pinned trinodb/trino $TRINO_VERSION at $TRINO_SHA"
           echo "trino_sha=$TRINO_SHA" >> "$GITHUB_OUTPUT"
           echo "trino_version=$TRINO_VERSION" >> "$GITHUB_OUTPUT"
@@ -152,7 +157,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository/io/trino
-          key: trino-m2-v2-${{ steps.trino-pin.outputs.trino_sha }}
+          key: trino-m2-v2-${{ hashFiles('scripts/trino/bootstrap_trino.sh') }}-${{ steps.trino-pin.outputs.trino_sha }}
           # No restore-keys on purpose: a partial restore from another pin collides on the
           # same SNAPSHOT coordinates and poisons the build.
       - name: Checkout trinodb/trino at the pinned commit

--- a/.github/workflows/hudi_trino_ci.yml
+++ b/.github/workflows/hudi_trino_ci.yml
@@ -152,7 +152,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository/io/trino
-          key: trino-m2-v1-${{ steps.trino-pin.outputs.trino_sha }}
+          key: trino-m2-v2-${{ steps.trino-pin.outputs.trino_sha }}
           # No restore-keys on purpose: a partial restore from another pin collides on the
           # same SNAPSHOT coordinates and poisons the build.
       - name: Checkout trinodb/trino at the pinned commit

--- a/.github/workflows/hudi_trino_compat.yml
+++ b/.github/workflows/hudi_trino_compat.yml
@@ -5,10 +5,12 @@ on:
     - cron: '17 4 * * *'
   workflow_dispatch:
 
-# The failure handler files/updates a drift report issue.
+# The failure handler files/updates a drift report issue; on success the job pushes the
+# pin-advance branch and opens its PR.
 permissions:
-  contents: read
+  contents: write
   issues: write
+  pull-requests: write
 
 env:
   MVN_ARGS: -e -ntp -B -V -Dgpg.skip -Djacoco.skip
@@ -28,6 +30,13 @@ jobs:
           repository: trinodb/trino
           ref: master
           path: trino
+      - name: Read trinodb/trino HEAD
+        id: trino-head
+        run: |
+          set -euo pipefail
+          HEAD_SHA=$(git -C trino rev-parse HEAD)
+          echo "trinodb/trino master is at $HEAD_SHA"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
       # Hudi targets Java 11 and uses Lombok 1.18.36, which does not run on JDK 25.
       # Install the upstream Hudi modules under JDK 17 first, then compile the connector
       # under JDK 25.
@@ -59,11 +68,12 @@ jobs:
           echo "trino_version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Detected Trino version: $VERSION"
       - name: Install Trino modules from master (JDK 25)
-        working-directory: trino
-        # hudi-trino compiles against these plus their transitive modules (spi, cache, metastore,
-        # hive-formats, memory-context). They must come from the master checkout -- resolving from
-        # Maven Central would defeat the point of the drift check.
-        run: mvn $MVN_ARGS install -pl :trino-hive,:trino-filesystem-manager,:trino-parquet,:trino-plugin-toolkit -am -DskipTests -Dair.check.skip-all=true
+        # Same module set the pinned build uses, so a green compile here is a promotable pin. The
+        # script purges ~/.m2/repository/io/trino itself and only warns when master's version has
+        # rolled past the pinned trino.version.
+        env:
+          HEAD_SHA: ${{ steps.trino-head.outputs.head_sha }}
+        run: hudi/scripts/trino/bootstrap_trino.sh trino --skip-checkout --ref "$HEAD_SHA"
       - name: Compile hudi-trino against current Trino SPI (JDK 25)
         id: compile
         working-directory: hudi
@@ -71,6 +81,48 @@ jobs:
           mvn $MVN_ARGS -Phudi-trino \
             -Dtrino.version=${{ steps.trino-version.outputs.trino_version }} \
             -pl hudi-trino compile
+      - name: Save Trino artifacts under the candidate pin
+        # Pre-seeds the gating CI cache, which keys on the sha, so the pin advance below does not
+        # make every PR rebuild Trino from source.
+        if: steps.compile.outcome == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository/io/trino
+          key: trino-m2-v1-${{ steps.trino-head.outputs.head_sha }}
+      - name: Propose pin advance
+        # Pin PRs are human-merged by policy. Org settings may forbid GITHUB_TOKEN from creating
+        # PRs; the branch still lands and the PR is then opened by hand.
+        working-directory: hudi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.trino-head.outputs.head_sha }}
+          TRINO_VERSION: ${{ steps.trino-version.outputs.trino_version }}
+          BASE_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          PINNED_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -B bot/trino-pin
+          sed -i "s|<trino.sha>.*</trino.sha>|<trino.sha>${HEAD_SHA}</trino.sha>|" pom.xml
+          if [ "$TRINO_VERSION" != "$PINNED_VERSION" ]; then
+            # Version rollover: the shim's parent tracks trino.version.
+            sed -i "s|<trino.version>.*</trino.version>|<trino.version>${TRINO_VERSION}</trino.version>|" pom.xml
+            sed -i "/<parent>/,/<\/parent>/ s|<version>.*</version>|<version>${TRINO_VERSION}</version>|" docker/trino/shim/pom.xml
+          fi
+          if git diff --quiet; then
+            echo "Pin is already at ${HEAD_SHA}; nothing to propose."
+            exit 0
+          fi
+          TITLE="build(trino): advance trino master pin to ${HEAD_SHA:0:12}"
+          git commit -am "$TITLE"
+          git push --force origin bot/trino-pin
+          if [ -n "$(gh pr list --head bot/trino-pin --state open --json number --jq '.[].number')" ]; then
+            echo "Open pin PR picked up the force-push."
+            exit 0
+          fi
+          gh pr create --base "$BASE_BRANCH" --head bot/trino-pin --title "$TITLE" \
+            --body "hudi-trino compiles against trinodb/trino ${TRINO_VERSION} at ${HEAD_SHA}."
       - name: Open issue on failure
         # Only a connector compile failure is SPI drift. A bare failure() would also file
         # the issue for a failed checkout or a broken trinodb/trino master build, with an

--- a/.github/workflows/hudi_trino_compat.yml
+++ b/.github/workflows/hudi_trino_compat.yml
@@ -5,12 +5,14 @@ on:
     - cron: '17 4 * * *'
   workflow_dispatch:
 
-# The failure handler files/updates a drift report issue; on success the job pushes the
-# pin-advance branch and opens its PR.
+# Two jobs on purpose: the build job executes mvnw from a fresh trinodb/trino master
+# checkout, so it must never hold a push-capable token; the propose job holds
+# contents: write but runs no third-party code. The failure handler files/updates a
+# drift report issue; on success the propose job pushes the pin-advance branch and a
+# human opens the PR (a GITHUB_TOKEN-created PR would start no workflow runs, so the
+# required checks could never report).
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 env:
   MVN_ARGS: -e -ntp -B -V -Dgpg.skip -Djacoco.skip
@@ -19,6 +21,12 @@ jobs:
   compile-against-trino-master:
     name: Compile hudi-trino against trinodb/trino master
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    outputs:
+      head_sha: ${{ steps.trino-head.outputs.head_sha }}
+      trino_version: ${{ steps.trino-version.outputs.trino_version }}
     steps:
       - name: Checkout Hudi
         uses: actions/checkout@v5
@@ -89,40 +97,6 @@ jobs:
         with:
           path: ~/.m2/repository/io/trino
           key: trino-m2-v2-${{ steps.trino-head.outputs.head_sha }}
-      - name: Propose pin advance
-        # Pin PRs are human-merged by policy. Org settings may forbid GITHUB_TOKEN from creating
-        # PRs; the branch still lands and the PR is then opened by hand.
-        working-directory: hudi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ steps.trino-head.outputs.head_sha }}
-          TRINO_VERSION: ${{ steps.trino-version.outputs.trino_version }}
-          BASE_BRANCH: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          PINNED_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git checkout -B bot/trino-pin
-          sed -i "s|<trino.sha>.*</trino.sha>|<trino.sha>${HEAD_SHA}</trino.sha>|" pom.xml
-          if [ "$TRINO_VERSION" != "$PINNED_VERSION" ]; then
-            # Version rollover: the shim's parent tracks trino.version.
-            sed -i "s|<trino.version>.*</trino.version>|<trino.version>${TRINO_VERSION}</trino.version>|" pom.xml
-            sed -i "/<parent>/,/<\/parent>/ s|<version>.*</version>|<version>${TRINO_VERSION}</version>|" docker/trino/shim/pom.xml
-          fi
-          if git diff --quiet; then
-            echo "Pin is already at ${HEAD_SHA}; nothing to propose."
-            exit 0
-          fi
-          TITLE="build(trino): advance trino master pin to ${HEAD_SHA:0:12}"
-          git commit -am "$TITLE"
-          git push --force origin bot/trino-pin
-          if [ -n "$(gh pr list --head bot/trino-pin --state open --json number --jq '.[].number')" ]; then
-            echo "Open pin PR picked up the force-push."
-            exit 0
-          fi
-          gh pr create --base "$BASE_BRANCH" --head bot/trino-pin --title "$TITLE" \
-            --body "hudi-trino compiles against trinodb/trino ${TRINO_VERSION} at ${HEAD_SHA}."
       - name: Open issue on failure
         # Only a connector compile failure is SPI drift. A bare failure() would also file
         # the issue for a failed checkout or a broken trinodb/trino master build, with an
@@ -155,3 +129,59 @@ jobs:
               title: `hudi-trino SPI drift detected against Trino ${version}`,
               body: `${marker}\nNightly compatibility build failed against Trino ${version}. See ${runUrl}.`,
             });
+
+  propose-pin-advance:
+    name: Push pin-advance branch
+    runs-on: ubuntu-latest
+    needs: compile-against-trino-master
+    # The only job with a push credential; it checks out apache/hudi alone and runs no
+    # Maven or third-party code. Pin PRs are opened and merged by humans.
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Hudi
+        uses: actions/checkout@v5
+      - name: Push pin-advance branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ needs.compile-against-trino-master.outputs.head_sha }}
+          TRINO_VERSION: ${{ needs.compile-against-trino-master.outputs.trino_version }}
+          BASE_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          PINNED_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -B bot/trino-pin
+          sed -i "s|<trino.sha>.*</trino.sha>|<trino.sha>${HEAD_SHA}</trino.sha>|" pom.xml
+          if [ "$TRINO_VERSION" != "$PINNED_VERSION" ]; then
+            # Version rollover: the shim's parent tracks trino.version.
+            sed -i "s|<trino.version>.*</trino.version>|<trino.version>${TRINO_VERSION}</trino.version>|" pom.xml
+            sed -i "/<parent>/,/<\/parent>/ s|<version>.*</version>|<version>${TRINO_VERSION}</version>|" docker/trino/shim/pom.xml
+          fi
+          # Keep trino.e2e.version current too; without this it silently stops being
+          # "the latest released Trino" at the next upstream release. Best-effort: an
+          # API hiccup must not block the pin advance.
+          LATEST_RELEASE=$(gh api repos/trinodb/trino/releases/latest --jq .tag_name || true)
+          if printf '%s' "$LATEST_RELEASE" | grep -qE '^[0-9]+$'; then
+            sed -i "s|<trino.e2e.version>.*</trino.e2e.version>|<trino.e2e.version>${LATEST_RELEASE}</trino.e2e.version>|" pom.xml
+          else
+            echo "Could not determine the latest Trino release ('${LATEST_RELEASE}'); leaving trino.e2e.version unchanged."
+          fi
+          if git diff --quiet; then
+            echo "Pin is already at ${HEAD_SHA}; nothing to propose."
+            exit 0
+          fi
+          TITLE="chore(trino): advance trino master pin to ${HEAD_SHA:0:12}"
+          git commit -am "$TITLE"
+          git push --force origin bot/trino-pin
+          {
+            echo "## Pin advance pushed to bot/trino-pin"
+            echo ""
+            echo "hudi-trino compiles against trinodb/trino ${TRINO_VERSION} at ${HEAD_SHA}."
+            echo "Open the PR (bot-created PRs trigger no workflow runs, so a human does this):"
+            echo ""
+            echo '```'
+            echo "gh pr create --repo ${GITHUB_REPOSITORY} --base ${BASE_BRANCH} --head bot/trino-pin --title \"${TITLE}\" --body \"Nightly-verified pin advance; see the Hudi Trino SPI Compatibility run.\""
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/hudi_trino_compat.yml
+++ b/.github/workflows/hudi_trino_compat.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '17 4 * * *'
   workflow_dispatch:
+    inputs:
+      trino_ref:
+        description: 'trinodb/trino ref to verify and pin (default: master HEAD); the release pin-back dispatches this with the released tag'
+        required: false
+        default: 'master'
 
 # Two jobs on purpose: the build job executes mvnw from a fresh trinodb/trino master
 # checkout, so it must never hold a push-capable token; the propose job holds
@@ -32,11 +37,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: hudi
-      - name: Checkout trinodb/trino master
+      - name: Checkout trinodb/trino
         uses: actions/checkout@v5
         with:
           repository: trinodb/trino
-          ref: master
+          # Scheduled runs track master; a manual dispatch may pin any ref, e.g. a release tag
+          ref: ${{ inputs.trino_ref || 'master' }}
           path: trino
       - name: Read trinodb/trino HEAD
         id: trino-head

--- a/.github/workflows/hudi_trino_compat.yml
+++ b/.github/workflows/hudi_trino_compat.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/.m2/repository/io/trino
-          key: trino-m2-v1-${{ steps.trino-head.outputs.head_sha }}
+          key: trino-m2-v2-${{ steps.trino-head.outputs.head_sha }}
       - name: Propose pin advance
         # Pin PRs are human-merged by policy. Org settings may forbid GITHUB_TOKEN from creating
         # PRs; the branch still lands and the PR is then opened by hand.

--- a/.github/workflows/hudi_trino_compat.yml
+++ b/.github/workflows/hudi_trino_compat.yml
@@ -62,7 +62,9 @@ jobs:
           cache: maven
       - name: Install upstream Hudi modules (JDK 17)
         working-directory: hudi
-        run: mvn $MVN_ARGS install -pl :hudi-common,:hudi-hive-sync,:hudi-io,:hudi-sync-common -am -Dmaven.test.skip=true -Drat.skip -Dcheckstyle.skip
+        # hudi-client-common and hudi-java-client are needed by the test step's
+        # hudi-trino-tests profile, same as in hudi_trino_ci.yml.
+        run: mvn $MVN_ARGS install -pl :hudi-common,:hudi-hive-sync,:hudi-io,:hudi-sync-common,:hudi-client-common,:hudi-java-client -am -Dmaven.test.skip=true -Drat.skip -Dcheckstyle.skip
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
@@ -95,6 +97,15 @@ jobs:
           mvn $MVN_ARGS -Phudi-trino \
             -Dtrino.version=${{ steps.trino-version.outputs.trino_version }} \
             -pl hudi-trino compile
+      - name: Run hudi-trino tests against current Trino SPI (JDK 25)
+        id: test
+        working-directory: hudi
+        # Drift that only breaks test sources or test behavior (deleted test containers,
+        # renamed tracing spans) must block the pin advance too, not just main-source drift.
+        run: |
+          mvn $MVN_ARGS -Phudi-trino,hudi-trino-tests \
+            -Dtrino.version=${{ steps.trino-version.outputs.trino_version }} \
+            -pl hudi-trino test
       - name: Save Trino artifacts under the candidate pin
         # Pre-seeds the gating CI cache, which keys on the sha, so the pin advance below does not
         # make every PR rebuild Trino from source.
@@ -102,12 +113,12 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/.m2/repository/io/trino
-          key: trino-m2-v2-${{ steps.trino-head.outputs.head_sha }}
+          key: trino-m2-v2-${{ hashFiles('hudi/scripts/trino/bootstrap_trino.sh') }}-${{ steps.trino-head.outputs.head_sha }}
       - name: Open issue on failure
-        # Only a connector compile failure is SPI drift. A bare failure() would also file
-        # the issue for a failed checkout or a broken trinodb/trino master build, with an
+        # Only a connector compile or test failure is SPI drift. A bare failure() would also
+        # file the issue for a failed checkout or a broken trinodb/trino master build, with an
         # empty version in the title when the failure is before Read Trino version.
-        if: failure() && steps.compile.outcome == 'failure'
+        if: failure() && (steps.compile.outcome == 'failure' || steps.test.outcome == 'failure')
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/hudi_trino_e2e.yml
+++ b/.github/workflows/hudi_trino_e2e.yml
@@ -77,6 +77,12 @@ jobs:
           TRINO_SHA=$(sed -n 's|.*<trino.sha>\(.*\)</trino.sha>.*|\1|p' pom.xml)
           TRINO_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
           E2E_VERSION=$(sed -n 's|.*<trino.e2e.version>\(.*\)</trino.e2e.version>.*|\1|p' pom.xml)
+          # sed -n ...p exits 0 on no match; an empty sha would make the commits API answer
+          # for the default branch and silently skip the suite, so fail loudly instead.
+          if [ -z "$TRINO_SHA" ] || [ -z "$TRINO_VERSION" ] || [ -z "$E2E_VERSION" ]; then
+            echo "ERROR: could not read trino.sha/trino.version/trino.e2e.version from pom.xml" >&2
+            exit 1
+          fi
           echo "Connector builds at $TRINO_VERSION ($TRINO_SHA); server image is $E2E_VERSION"
           echo "trino_sha=$TRINO_SHA" >> "$GITHUB_OUTPUT"
           echo "trino_version=$TRINO_VERSION" >> "$GITHUB_OUTPUT"
@@ -99,15 +105,17 @@ jobs:
           # any commit reachable from the pin that touched a boundary-crossing path after the
           # released tag's commit date (excluding the tag commit itself) is drift. Existence
           # is enough, so the first page settles it -- truncation cannot yield a false pass.
-          # Only two surfaces cross the plugin/server boundary and are therefore gated:
-          # core/trino-spi (the server provides it to the plugin classloader) and the
-          # reflective HdfsFileSystemLoader contract (bundled trino-filesystem-manager loads
-          # the server image's version-matched hdfs jar set; see docker/trino/Dockerfile).
-          # lib/trino-filesystem ships inside the plugin dir, so it cannot skew the boot.
+          # Gated paths are the surfaces where server-built and pin-built classes meet:
+          # core/trino-spi (the server provides it to the plugin classloader), and the
+          # HdfsFileSystemLoader contract, where bundled trino-filesystem-manager loads the
+          # server image's version-matched hdfs jar set (see docker/trino/Dockerfile) whose
+          # HdfsClassLoader then delegates the exact packages io.trino.filesystem and
+          # io.trino.memory.context back to the plugin's bundled copies -- so those two libs
+          # cross the boundary precisely BECAUSE they are bundled.
           TAG_SHA=$(gh api "repos/trinodb/trino/commits/${E2E_VERSION}" --jq .sha)
           TAG_DATE=$(gh api "repos/trinodb/trino/commits/${E2E_VERSION}" --jq .commit.committer.date)
           DRIFTED=false
-          for p in core/trino-spi lib/trino-filesystem-manager lib/trino-hdfs; do
+          for p in core/trino-spi lib/trino-filesystem lib/trino-filesystem-manager lib/trino-hdfs lib/trino-memory-context; do
             # Assign before iterating: a failing substitution in the for-list would not trip
             # set -e, and gh api prints the error body to stdout, so a transient API error
             # would otherwise iterate over error JSON and silently skip the suite.
@@ -178,7 +186,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository/io/trino
-          key: trino-m2-v2-${{ steps.trino-pin.outputs.trino_sha }}
+          key: trino-m2-v2-${{ hashFiles('scripts/trino/bootstrap_trino.sh') }}-${{ steps.trino-pin.outputs.trino_sha }}
           # No restore-keys on purpose: a partial restore from another pin collides on the
           # same SNAPSHOT coordinates and poisons the build.
       - name: Checkout trinodb/trino at the pinned commit

--- a/.github/workflows/hudi_trino_e2e.yml
+++ b/.github/workflows/hudi_trino_e2e.yml
@@ -96,16 +96,25 @@ jobs:
           # Per-path commit queries, NOT the compare API: compare caps its file list at 300
           # and a single Trino release cycle already exceeds that, so a capped compare would
           # flag every pin more than a release old as drifted. The commits API is uncapped;
-          # any commit reachable from the pin that touched an SPI-relevant path after the
+          # any commit reachable from the pin that touched a boundary-crossing path after the
           # released tag's commit date (excluding the tag commit itself) is drift. Existence
           # is enough, so the first page settles it -- truncation cannot yield a false pass.
+          # Only two surfaces cross the plugin/server boundary and are therefore gated:
+          # core/trino-spi (the server provides it to the plugin classloader) and the
+          # reflective HdfsFileSystemLoader contract (bundled trino-filesystem-manager loads
+          # the server image's version-matched hdfs jar set; see docker/trino/Dockerfile).
+          # lib/trino-filesystem ships inside the plugin dir, so it cannot skew the boot.
           TAG_SHA=$(gh api "repos/trinodb/trino/commits/${E2E_VERSION}" --jq .sha)
           TAG_DATE=$(gh api "repos/trinodb/trino/commits/${E2E_VERSION}" --jq .commit.committer.date)
           DRIFTED=false
-          for p in core/trino-spi lib/trino-filesystem lib/trino-filesystem-manager lib/trino-hdfs; do
-            for c in $(gh api "repos/trinodb/trino/commits?sha=${TRINO_SHA}&path=${p}&since=${TAG_DATE}" --jq '.[].sha'); do
+          for p in core/trino-spi lib/trino-filesystem-manager lib/trino-hdfs; do
+            # Assign before iterating: a failing substitution in the for-list would not trip
+            # set -e, and gh api prints the error body to stdout, so a transient API error
+            # would otherwise iterate over error JSON and silently skip the suite.
+            SHAS=$(gh api "repos/trinodb/trino/commits?sha=${TRINO_SHA}&path=${p}&since=${TAG_DATE}" --jq '.[].sha')
+            for c in $SHAS; do
               if [ "$c" != "$TAG_SHA" ]; then
-                echo "SPI-relevant change under ${p}: ${c}"
+                echo "Boundary-crossing change under ${p}: ${c}"
                 DRIFTED=true
               fi
             done

--- a/.github/workflows/hudi_trino_e2e.yml
+++ b/.github/workflows/hudi_trino_e2e.yml
@@ -27,6 +27,7 @@ on:
       - 'hudi-integ-test/**'
       - 'pom.xml'
       - '.github/workflows/hudi_trino_e2e.yml'
+      - 'scripts/trino/**'
   pull_request:
     branches:
       - master
@@ -41,6 +42,7 @@ on:
       - 'hudi-integ-test/**'
       - 'pom.xml'
       - '.github/workflows/hudi_trino_e2e.yml'
+      - 'scripts/trino/**'
   workflow_dispatch:
 
 concurrency:
@@ -91,24 +93,23 @@ jobs:
           E2E_VERSION: ${{ steps.trino-pin.outputs.e2e_version }}
         run: |
           set -euo pipefail
-          COMPARE="$RUNNER_TEMP/trino-compare.json"
-          gh api "repos/trinodb/trino/compare/${E2E_VERSION}...${TRINO_SHA}" > "$COMPARE"
-          COUNT=$(jq '.files | length' "$COMPARE")
+          # Per-path commit queries, NOT the compare API: compare caps its file list at 300
+          # and a single Trino release cycle already exceeds that, so a capped compare would
+          # flag every pin more than a release old as drifted. The commits API is uncapped;
+          # any commit reachable from the pin that touched an SPI-relevant path after the
+          # released tag's commit date (excluding the tag commit itself) is drift. Existence
+          # is enough, so the first page settles it -- truncation cannot yield a false pass.
+          TAG_SHA=$(gh api "repos/trinodb/trino/commits/${E2E_VERSION}" --jq .sha)
+          TAG_DATE=$(gh api "repos/trinodb/trino/commits/${E2E_VERSION}" --jq .commit.committer.date)
           DRIFTED=false
-          # The compare API caps the file list at 300; treat a capped list as drifted rather
-          # than trusting a truncated sample.
-          if [ "$COUNT" -ge 300 ]; then
-            DRIFTED=true
-          fi
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            case "$f" in
-              core/trino-spi/*|lib/trino-filesystem/*|lib/trino-filesystem-manager/*|lib/trino-hdfs/*)
-                echo "SPI-relevant change: $f"
+          for p in core/trino-spi lib/trino-filesystem lib/trino-filesystem-manager lib/trino-hdfs; do
+            for c in $(gh api "repos/trinodb/trino/commits?sha=${TRINO_SHA}&path=${p}&since=${TAG_DATE}" --jq '.[].sha'); do
+              if [ "$c" != "$TAG_SHA" ]; then
+                echo "SPI-relevant change under ${p}: ${c}"
                 DRIFTED=true
-                ;;
-            esac
-          done <<< "$(jq -r '.files[].filename' "$COMPARE")"
+              fi
+            done
+          done
           echo "drifted=$DRIFTED" >> "$GITHUB_OUTPUT"
           if [ "$DRIFTED" = "true" ]; then
             {

--- a/.github/workflows/hudi_trino_e2e.yml
+++ b/.github/workflows/hudi_trino_e2e.yml
@@ -168,7 +168,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository/io/trino
-          key: trino-m2-v1-${{ steps.trino-pin.outputs.trino_sha }}
+          key: trino-m2-v2-${{ steps.trino-pin.outputs.trino_sha }}
           # No restore-keys on purpose: a partial restore from another pin collides on the
           # same SNAPSHOT coordinates and poisons the build.
       - name: Checkout trinodb/trino at the pinned commit

--- a/.github/workflows/hudi_trino_e2e.yml
+++ b/.github/workflows/hudi_trino_e2e.yml
@@ -16,9 +16,9 @@ on:
       #                         which compiles the whole module, so a break
       #                         anywhere in it fails this pipeline -- not just
       #                         under integ2/.
-      #   pom.xml               owns trino.version, which the shim pom's parent,
-      #                         the Dockerfile TRINO_VERSION arg and the
-      #                         hardcoded 481 paths below all track by hand.
+      #   pom.xml               owns trino.version / trino.sha / trino.e2e.version:
+      #                         the shim pom's parent, the plugin dir path and the
+      #                         server image version below are all derived from them.
       - 'hudi-trino/**'
       - 'docker/trino/**'
       - 'docker/compose/docker-compose_hadoop340_hive2310_spark402*'
@@ -62,12 +62,65 @@ jobs:
     # hudi-trino at HEAD, assembles the plugin dir via the in-repo shim
     # (docker/trino/shim, standing in for the not-yet-released upstream
     # trinodb/trino plugin/trino-hudi shim), bakes it into a local
-    # apachehudi/hudi-trino_481 image, and runs ITTestTrino* against the
-    # spark402 compose stack (the only pair with the trinocoordinator service).
+    # apachehudi/hudi-trino-e2e image on top of the released trino.e2e.version
+    # server, and runs ITTestTrino* against the spark402 compose stack (the only
+    # pair with the trinocoordinator service).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Read Trino pin
+        id: trino-pin
+        run: |
+          set -euo pipefail
+          TRINO_SHA=$(sed -n 's|.*<trino.sha>\(.*\)</trino.sha>.*|\1|p' pom.xml)
+          TRINO_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
+          E2E_VERSION=$(sed -n 's|.*<trino.e2e.version>\(.*\)</trino.e2e.version>.*|\1|p' pom.xml)
+          echo "Connector builds at $TRINO_VERSION ($TRINO_SHA); server image is $E2E_VERSION"
+          echo "trino_sha=$TRINO_SHA" >> "$GITHUB_OUTPUT"
+          echo "trino_version=$TRINO_VERSION" >> "$GITHUB_OUTPUT"
+          echo "e2e_version=$E2E_VERSION" >> "$GITHUB_OUTPUT"
+      - name: SPI drift gate
+        id: spi-drift
+        # The plugin is built at the pin but loaded by the released trino.e2e.version server, so
+        # any SPI / filesystem change between the two can make the image unbootable. Skip the run
+        # instead of reporting a failure that no connector change caused.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRINO_SHA: ${{ steps.trino-pin.outputs.trino_sha }}
+          TRINO_VERSION: ${{ steps.trino-pin.outputs.trino_version }}
+          E2E_VERSION: ${{ steps.trino-pin.outputs.e2e_version }}
+        run: |
+          set -euo pipefail
+          COMPARE="$RUNNER_TEMP/trino-compare.json"
+          gh api "repos/trinodb/trino/compare/${E2E_VERSION}...${TRINO_SHA}" > "$COMPARE"
+          COUNT=$(jq '.files | length' "$COMPARE")
+          DRIFTED=false
+          # The compare API caps the file list at 300; treat a capped list as drifted rather
+          # than trusting a truncated sample.
+          if [ "$COUNT" -ge 300 ]; then
+            DRIFTED=true
+          fi
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              core/trino-spi/*|lib/trino-filesystem/*|lib/trino-filesystem-manager/*|lib/trino-hdfs/*)
+                echo "SPI-relevant change: $f"
+                DRIFTED=true
+                ;;
+            esac
+          done <<< "$(jq -r '.files[].filename' "$COMPARE")"
+          echo "drifted=$DRIFTED" >> "$GITHUB_OUTPUT"
+          if [ "$DRIFTED" = "true" ]; then
+            {
+              echo "## Trino E2E skipped: SPI drift window"
+              echo ""
+              echo "The connector is built against trinodb/trino \`${TRINO_VERSION}\` (\`${TRINO_SHA}\`), while the"
+              echo "e2e server image is released Trino \`${E2E_VERSION}\`. SPI / filesystem paths changed between"
+              echo "the two, so this run is skipped until the pin and the released version re-align."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Free disk space
+        if: steps.spi-drift.outputs.drifted != 'true'
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
@@ -75,12 +128,14 @@ jobs:
           sudo rm -rf /usr/local/share/boost
           docker system prune --all --force --volumes
       - name: Pre-pull compose images (fails fast if not published)
+        if: steps.spi-drift.outputs.drifted != 'true'
         run: |
           # Surface a missing sparkadhoc image before the long Maven install. The
           # remaining stack images are pulled by docker-compose at test time; the
           # trino image is built locally below, never pulled.
           docker pull apachehudi/hudi-hadoop_3.4.0-hive_2.3.10-sparkadhoc_4.0.2:latest
       - name: Set up JDK 17
+        if: steps.spi-drift.outputs.drifted != 'true'
         uses: actions/setup-java@v5
         with:
           java-version: '17'
@@ -88,24 +143,50 @@ jobs:
           architecture: x64
           cache: maven
       - name: Build and install Hudi artifacts (JDK 17)
+        if: steps.spi-drift.outputs.drifted != 'true'
         # Full reactor: the compose containers mount the workspace and the tests
         # use bundles staged by the -Pintegration-tests build (e.g.
         # docker/hoodie/hadoop/hive_base/target/hoodie-spark-bundle.jar).
         run:
           mvn clean install -T 2 $SCALA_PROFILE -Dspark4.0 -Dflink1.20 -Pintegration-tests -DskipTests=true -Ddocker.compose.skip=true $MVN_ARGS
       - name: Set up JDK 25
+        if: steps.spi-drift.outputs.drifted != 'true'
         uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
           cache: maven
+      - name: Purge Trino artifacts from the local m2
+        if: steps.spi-drift.outputs.drifted != 'true'
+        # Artifacts an older pin left behind carry the same SNAPSHOT coordinates as the current ones.
+        run: rm -rf ~/.m2/repository/io/trino
+      # The connector and the shim assembly resolve io.trino from the pinned trinodb/trino
+      # commit: Trino publishes no SNAPSHOT artifacts, so nothing here comes from Central.
+      - name: Restore Trino artifacts for the pinned commit
+        id: trino-m2
+        if: steps.spi-drift.outputs.drifted != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/io/trino
+          key: trino-m2-v1-${{ steps.trino-pin.outputs.trino_sha }}
+          # No restore-keys on purpose: a partial restore from another pin collides on the
+          # same SNAPSHOT coordinates and poisons the build.
+      - name: Checkout trinodb/trino at the pinned commit
+        if: steps.spi-drift.outputs.drifted != 'true' && steps.trino-m2.outputs.cache-hit != 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: trinodb/trino
+          ref: ${{ steps.trino-pin.outputs.trino_sha }}
+          path: trino-src
+      - name: Build Trino artifacts from source (JDK 25)
+        if: steps.spi-drift.outputs.drifted != 'true' && steps.trino-m2.outputs.cache-hit != 'true'
+        run: scripts/trino/bootstrap_trino.sh trino-src --skip-checkout
       - name: Build hudi-trino connector (JDK 25)
-        # No trinodb/trino checkout needed: the unpublished Trino test-jars sit
-        # behind the off-by-default hudi-trino-tests profile and packaging
-        # resolves entirely from Maven Central.
+        if: steps.spi-drift.outputs.drifted != 'true'
         run:
           mvn $MVN_ARGS -Phudi-trino -pl hudi-trino install -Dmaven.test.skip=true
       - name: Assemble trino-hudi plugin dir via in-repo shim (JDK 25)
+        if: steps.spi-drift.outputs.drifted != 'true'
         # package, NOT install: installing would shadow the real
         # io.trino:trino-hudi release coordinates in the local m2 (the shim pom
         # also hard-disables install via maven.install.skip).
@@ -117,20 +198,30 @@ jobs:
           HUDI_VERSION=$(mvn -q -ntp help:evaluate -Dexpression=project.version -DforceStdout)
           echo "Building shim against hudi version: $HUDI_VERSION"
           mvn $MVN_ARGS -f docker/trino/shim/pom.xml clean package -DskipTests -Ddep.hudi.version="$HUDI_VERSION"
-      - name: Build apachehudi/hudi-trino_481 image
+      - name: Build apachehudi/hudi-trino-e2e image
+        if: steps.spi-drift.outputs.drifted != 'true'
+        # The plugin dir is named after the version it was built at; the server underneath is
+        # the released trino.e2e.version.
+        env:
+          TRINO_VERSION: ${{ steps.trino-pin.outputs.trino_version }}
+          E2E_VERSION: ${{ steps.trino-pin.outputs.e2e_version }}
         run: |
-          docker/trino/build_image.sh --plugin-dir docker/trino/shim/target/trino-hudi-481
+          PLUGIN_DIR="docker/trino/shim/target/trino-hudi-${TRINO_VERSION}"
+          # trino-maven-plugin 24 emits only the zip; explode it into the plugin dir layout.
+          unzip -o -q "${PLUGIN_DIR}.zip" -d docker/trino/shim/target
+          docker/trino/build_image.sh --plugin-dir "$PLUGIN_DIR" --trino-version "${E2E_VERSION}"
           # Sanity: the shim must have produced a populated plugin dir with a
           # service descriptor jar, or Trino cannot load the plugin at boot.
-          echo "plugin dir jar count: $(ls docker/trino/shim/target/trino-hudi-481 | wc -l)"
-          ls docker/trino/shim/target/trino-hudi-481/*services*.jar
+          echo "plugin dir jar count: $(ls "$PLUGIN_DIR" | wc -l)"
+          ls "$PLUGIN_DIR"/*services*.jar
       - name: Smoke-boot the Trino image standalone
+        if: steps.spi-drift.outputs.drifted != 'true'
         # Catches image-level boot failures (plugin load errors, bad etc/ config)
         # ~30 min before the IT step would, with the full boot log on screen.
         # --hostname trinocoordinator makes the baked discovery.uri self-resolve.
         run: |
           docker run -d --name trino-smoke --hostname trinocoordinator \
-            apachehudi/hudi-trino_481:latest
+            apachehudi/hudi-trino-e2e:latest
           ok=""
           for i in $(seq 1 18); do
             if [ "$(docker inspect -f '{{.State.Running}}' trino-smoke)" != "true" ]; then
@@ -151,6 +242,7 @@ jobs:
           fi
           docker rm -f trino-smoke
       - name: Set up JDK 17 (restore for the IT run)
+        if: steps.spi-drift.outputs.drifted != 'true'
         # setup-java resets JAVA_HOME on each call; hudi-integ-test needs 17.
         uses: actions/setup-java@v5
         with:
@@ -158,6 +250,7 @@ jobs:
           distribution: 'temurin'
           architecture: x64
       - name: Run Trino E2E ITs (JDK 17)
+        if: steps.spi-drift.outputs.drifted != 'true'
         run: |
           # -DskipITs=false overrides the spark4.0 profile's skipITs=true default
           # (see root pom.xml). -Dcompose.profiles=trino starts the profile-gated

--- a/docker/README.md
+++ b/docker/README.md
@@ -200,9 +200,10 @@ changes are needed for the current amd64 plus arm64 image set in this repository
 ## Trino E2E image - `/trino`
 
 The Trino E2E stack does not use the `hoodie/hadoop` image tree. `docker/trino/` builds
-`apachehudi/hudi-trino_<trino-version>` directly on top of the official `trinodb/trino`
-image, baking in a locally-assembled native `trino-hudi` plugin directory and the E2E
-catalog config (`connector.name=hudi`, metastore at `thrift://hivemetastore:9083`).
+`apachehudi/hudi-trino-e2e` directly on top of the official `trinodb/trino` image at the
+root pom's `trino.e2e.version`, baking in a locally-assembled native `trino-hudi` plugin
+directory and the E2E catalog config (`connector.name=hudi`, metastore at
+`thrift://hivemetastore:9083`).
 
 This image is built locally on demand (also by the `hudi_trino_e2e.yml` CI workflow) and
 is NOT published to Docker Hub. The plugin directory comes from the in-repo shim project
@@ -214,7 +215,9 @@ at `docker/trino/shim/` (see `hudi-trino/README.md` for the full build-and-run f
 # cut_release_branch.sh cannot bump the literal default in its own pom.
 HUDI_VERSION=$(mvn -q -ntp help:evaluate -Dexpression=project.version -DforceStdout)
 mvn -f docker/trino/shim/pom.xml clean package -DskipTests -Ddep.hudi.version="$HUDI_VERSION"
-docker/trino/build_image.sh --plugin-dir docker/trino/shim/target/trino-hudi-481
+TRINO_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
+unzip -o -q "docker/trino/shim/target/trino-hudi-$TRINO_VERSION.zip" -d docker/trino/shim/target  # trino-maven-plugin 24 emits only the zip
+docker/trino/build_image.sh --plugin-dir "docker/trino/shim/target/trino-hudi-$TRINO_VERSION"
 ```
 
 The `trinocoordinator` compose service exists only in the

--- a/docker/compose/docker-compose_hadoop340_hive2310_spark402_amd64.yml
+++ b/docker/compose/docker-compose_hadoop340_hive2310_spark402_amd64.yml
@@ -261,7 +261,7 @@ services:
   # docker/trino/empty-overlay (baked-in plugin used); set TRINO_PLUGIN_DIR to a
   # locally-built trino-hudi plugin dir to override it at container start.
   trinocoordinator:
-    image: apachehudi/hudi-trino_481:latest
+    image: apachehudi/hudi-trino-e2e:latest
     profiles: ["trino"]
     hostname: trinocoordinator
     container_name: trinocoordinator

--- a/docker/compose/docker-compose_hadoop340_hive2310_spark402_arm64.yml
+++ b/docker/compose/docker-compose_hadoop340_hive2310_spark402_arm64.yml
@@ -261,7 +261,7 @@ services:
   # docker/trino/empty-overlay (baked-in plugin used); set TRINO_PLUGIN_DIR to a
   # locally-built trino-hudi plugin dir to override it at container start.
   trinocoordinator:
-    image: apachehudi/hudi-trino_481:latest
+    image: apachehudi/hudi-trino-e2e:latest
     profiles: ["trino"]
     hostname: trinocoordinator
     container_name: trinocoordinator

--- a/docker/trino/Dockerfile
+++ b/docker/trino/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARG TRINO_VERSION=481
+ARG TRINO_VERSION=483
 FROM trinodb/trino:${TRINO_VERSION}
 
 USER root

--- a/docker/trino/build_image.sh
+++ b/docker/trino/build_image.sh
@@ -27,9 +27,13 @@
 
 set -e
 
-# Default values
+# Directory of this script, so the build context and pom lookups are stable regardless of cwd
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd)
+
+# Default values. The server version defaults to the root pom's trino.e2e.version (the
+# nightly pin-advance job keeps that current; a literal default here would rot).
 PLUGIN_DIR=""
-TRINO_VERSION="483"
+TRINO_VERSION=$(sed -n 's|.*<trino.e2e.version>\(.*\)</trino.e2e.version>.*|\1|p' "$SCRIPT_DIR/../../pom.xml")
 IMAGE_TAG="latest"
 
 # Parse command-line arguments
@@ -43,8 +47,10 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-# Directory of this script, so the build context path is stable regardless of cwd
-SCRIPT_DIR=$(cd $(dirname "$0") && pwd)
+if [ -z "$TRINO_VERSION" ]; then
+  echo "Error: could not read trino.e2e.version from the root pom and no --trino-version given." >&2
+  exit 1
+fi
 
 # Validate --plugin-dir: required, must exist and be non-empty
 if [ -z "$PLUGIN_DIR" ]; then

--- a/docker/trino/build_image.sh
+++ b/docker/trino/build_image.sh
@@ -15,21 +15,21 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Builds the apachehudi/hudi-trino_<version> image with a locally-built
-# trino-hudi plugin baked in. The plugin dir (typically the in-repo shim's
+# Builds the apachehudi/hudi-trino-e2e image with a locally-built trino-hudi
+# plugin baked in. The plugin dir (typically the in-repo shim's
 # docker/trino/shim/target/trino-hudi-<v>, see docker/trino/shim/pom.xml) is
 # staged into the build context at docker/trino/plugin/ (gitignored), then
 # baked into the image.
 # Usage: ./build_image.sh --plugin-dir <path> [--trino-version <v>] [--image-tag <t>]
-# Typical: ./build_image.sh --plugin-dir "$(dirname "$0")/shim/target/trino-hudi-481"
-# Note: --trino-version must match the shim pom's parent version and the root
-# pom's trino.version property.
+# Typical: ./build_image.sh --plugin-dir "$(dirname "$0")/shim/target/trino-hudi-<trino.version>"
+# Note: --trino-version is the released Trino server image to build on top of
+# (the root pom's trino.e2e.version), not the version the plugin was built at.
 
 set -e
 
 # Default values
 PLUGIN_DIR=""
-TRINO_VERSION="481"
+TRINO_VERSION="483"
 IMAGE_TAG="latest"
 
 # Parse command-line arguments
@@ -66,7 +66,7 @@ echo "Staging plugin from '$PLUGIN_DIR' into '$STAGE_DIR'"
 rm -rf "$STAGE_DIR"
 cp -r "$PLUGIN_DIR" "$STAGE_DIR"
 
-IMAGE="apachehudi/hudi-trino_${TRINO_VERSION}:${IMAGE_TAG}"
+IMAGE="apachehudi/hudi-trino-e2e:${IMAGE_TAG}"
 echo "Building $IMAGE (TRINO_VERSION=${TRINO_VERSION})"
 docker build --build-arg TRINO_VERSION="${TRINO_VERSION}" -t "$IMAGE" "$SCRIPT_DIR"
 

--- a/docker/trino/etc/jvm.config
+++ b/docker/trino/etc/jvm.config
@@ -34,5 +34,5 @@
 # Allow loading dynamic agents (used by JOL, referenced by Trino's runtime).
 -XX:+EnableDynamicAgentLoading
 # NOTE: do NOT add -XX:GCLockerRetryAllocationCount here (Hudi's JDK 11/17 CI
-# workaround): the GCLocker was removed in modern JDKs and the trinodb/trino:481
+# workaround): the GCLocker was removed in modern JDKs and the trinodb/trino server
 # JVM (JDK 25) refuses to start on the unrecognized option.

--- a/docker/trino/shim/pom.xml
+++ b/docker/trino/shim/pom.xml
@@ -33,8 +33,9 @@
   installing would shadow the real io.trino:trino-hudi release coordinates in
   the local repository.
 
-  The parent version below must stay in sync with trino.version in the root pom,
-  the TRINO_VERSION ARG in docker/trino/Dockerfile, and the compose image tag.
+  The parent version below must stay in sync with trino.version in the root pom. On
+  master that version is a -SNAPSHOT and resolves from the local m2 only, so run
+  scripts/trino/bootstrap_trino.sh first; on release branches it resolves from Central.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -42,8 +43,8 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>481</version>
-        <!-- Resolve the parent from Maven Central, never the file system. -->
+        <version>484-SNAPSHOT</version>
+        <!-- Resolve the parent from the repositories, never the file system. -->
         <relativePath />
     </parent>
 
@@ -153,9 +154,10 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- NOTE: unlike the upstream 482-SNAPSHOT shim, jts-core must NOT be
-             declared provided here: it is not part of the Trino 481 SPI surface
-             and SpiDependencyChecker rejects provided scope for it. It ships
-             inside the plugin dir at its transitive scope instead. -->
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/hudi-trino/README.md
+++ b/hudi-trino/README.md
@@ -19,9 +19,21 @@
 
 Hudi connector for Trino (RFC-105). Published as `org.apache.hudi:hudi-trino` -- a regular non-shaded JAR. The Trino-side `trino-hudi` plugin module depends on this artifact and Trino's URLClassLoader isolates the plugin's transitive deps from the rest of the server, so no shading is required.
 
+## Bootstrap Trino (do this first)
+
+On master no `io.trino` artifact resolves from Maven Central: master tracks `trinodb/trino` master at the commit pinned by `trino.sha` in the root pom, and Trino publishes no SNAPSHOT artifacts. One time per pin advance, clone `trinodb/trino` (or reuse a checkout) and build it under JDK 25:
+
+```
+scripts/trino/bootstrap_trino.sh /path/to/trino
+```
+
+Takes roughly 10-30 minutes and installs everything the connector needs, including the four test-jars and the `trino-root` pom.
+
+On release branches `trino.version` is a released number, so compile deps resolve from Central and bootstrap is only needed for running tests.
+
 ## Build
 
-Excluded from default builds. Activate the `hudi-trino` Maven profile:
+Excluded from default builds. Activate the `hudi-trino` Maven profile (after bootstrap):
 
 ```
 # tests need Trino test-jars not on Maven Central (see Running tests); skip them in the default build
@@ -32,18 +44,15 @@ Requires JDK 25 (enforced via `maven-enforcer-plugin`).
 
 ## Running tests
 
-Tests depend on Trino test-jars (`trino-spi`, `trino-filesystem`, `trino-hive`, `trino-main` at the `tests` classifier). Trino does not publish three of those to Maven Central, so the test deps live behind the `hudi-trino-tests` profile, off by default.
+Tests depend on Trino test-jars (`trino-spi`, `trino-filesystem`, `trino-hive`, `trino-main` at the `tests` classifier). Trino publishes none of those, so the test deps live behind the `hudi-trino-tests` profile, off by default.
 
-To run the tests:
-
-1. Build the matching Trino version locally so its `*-tests.jar` artifacts land in your `~/.m2` (see `trino.version` in the root pom for the version to build).
-2. Activate both profiles:
+After bootstrap, activate both profiles:
 
 ```
 mvn -Phudi-trino,hudi-trino-tests -pl hudi-trino test
 ```
 
-CI follows the same two steps: `.github/workflows/hudi_trino_ci.yml` installs the test-jars from a source checkout of the pinned Trino tag, then runs with both profiles enabled.
+CI follows the same two steps: `.github/workflows/hudi_trino_ci.yml` runs `bootstrap_trino.sh` against the pinned commit (cached per `trino.sha`), then runs with both profiles enabled.
 
 ## End-to-end tests (docker)
 
@@ -55,7 +64,11 @@ project mirroring the upstream `trinodb/trino` `plugin/trino-hudi` shim planned 
 RFC-105 (not yet released upstream). CI runs the same flow via
 `.github/workflows/hudi_trino_e2e.yml`.
 
-Local flow:
+The plugin is built at the pinned `trino.version` while the server image is the released
+`trino.e2e.version`; CI auto-skips the suite during SPI drift windows (SPI or filesystem changes
+between the two).
+
+Local flow (after bootstrap):
 
 ```
 # 1. JDK 17: full reactor incl. the integ-test bundles the containers mount
@@ -72,8 +85,11 @@ mvn -Phudi-trino -pl hudi-trino install -Dmaven.test.skip=true
 HUDI_VERSION=$(mvn -q -ntp help:evaluate -Dexpression=project.version -DforceStdout)
 mvn -f docker/trino/shim/pom.xml clean package -DskipTests -Ddep.hudi.version="$HUDI_VERSION"
 
-# 4. Build the Trino image (locally tagged; never published)
-docker/trino/build_image.sh --plugin-dir docker/trino/shim/target/trino-hudi-481
+# 4. Build the Trino image (locally tagged; never published). The base server defaults to
+#    trino.e2e.version; pass --trino-version to override it.
+TRINO_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
+unzip -o -q "docker/trino/shim/target/trino-hudi-$TRINO_VERSION.zip" -d docker/trino/shim/target  # trino-maven-plugin 24 emits only the zip
+docker/trino/build_image.sh --plugin-dir "docker/trino/shim/target/trino-hudi-$TRINO_VERSION"
 
 # 5. JDK 17: run the suite (only the spark402 compose pair has the trino service)
 mvn verify -pl hudi-integ-test -Dscala-2.13 -Dscala.binary.version=2.13 -Dspark4.0 \
@@ -83,7 +99,7 @@ mvn verify -pl hudi-integ-test -Dscala-2.13 -Dscala.binary.version=2.13 -Dspark4
 ```
 
 Fast iteration loop: after changing connector code, redo steps 2-3, then add
-`-Dtrino.plugin.dir=$PWD/docker/trino/shim/target/trino-hudi-481` to step 5. The
+`-Dtrino.plugin.dir=$PWD/docker/trino/shim/target/trino-hudi-$TRINO_VERSION` to step 5. The
 container's overlay entrypoint swaps the freshly built plugin dir in at start, so the
 image rebuild (step 4) is skipped.
 

--- a/hudi-trino/README.md
+++ b/hudi-trino/README.md
@@ -21,7 +21,7 @@ Hudi connector for Trino (RFC-105). Published as `org.apache.hudi:hudi-trino` --
 
 ## Bootstrap Trino (do this first)
 
-On master no `io.trino` artifact resolves from Maven Central: master tracks `trinodb/trino` master at the commit pinned by `trino.sha` in the root pom, and Trino publishes no SNAPSHOT artifacts. One time per pin advance, clone `trinodb/trino` (or reuse a checkout) and build it under JDK 25:
+On master no `io.trino` artifact resolves from Maven Central: master tracks `trinodb/trino` master at the commit pinned by `trino.sha` in the root pom, and Trino publishes no SNAPSHOT artifacts. Pin ownership: the nightly `Hudi Trino SPI Compatibility` job verifies trino HEAD and pushes a `bot/trino-pin` branch (also refreshing `trino.e2e.version`); a committer opens and merges its PR, so the pin advances roughly nightly-to-weekly. One time per pin advance, clone `trinodb/trino` (or reuse a checkout) and build it under JDK 25:
 
 ```
 scripts/trino/bootstrap_trino.sh /path/to/trino
@@ -82,13 +82,15 @@ mvn -Phudi-trino -pl hudi-trino install -Dmaven.test.skip=true
 #    shadow the real io.trino:trino-hudi release coordinates in the local m2).
 #    dep.hudi.version comes from the reactor pom: the shim sits outside the
 #    reactor, so cut_release_branch.sh cannot bump its literal default.
+#    The unzip lives here, not in step 4: the fast-iteration loop below repeats
+#    steps 2-3 only, and `clean` wipes the previously exploded dir.
 HUDI_VERSION=$(mvn -q -ntp help:evaluate -Dexpression=project.version -DforceStdout)
+TRINO_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
 mvn -f docker/trino/shim/pom.xml clean package -DskipTests -Ddep.hudi.version="$HUDI_VERSION"
+unzip -o -q "docker/trino/shim/target/trino-hudi-$TRINO_VERSION.zip" -d docker/trino/shim/target  # trino-maven-plugin 24 emits only the zip
 
 # 4. Build the Trino image (locally tagged; never published). The base server defaults to
 #    trino.e2e.version; pass --trino-version to override it.
-TRINO_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' pom.xml)
-unzip -o -q "docker/trino/shim/target/trino-hudi-$TRINO_VERSION.zip" -d docker/trino/shim/target  # trino-maven-plugin 24 emits only the zip
 docker/trino/build_image.sh --plugin-dir "docker/trino/shim/target/trino-hudi-$TRINO_VERSION"
 
 # 5. JDK 17: run the suite (only the spark402 compose pair has the trino service)

--- a/hudi-trino/pom.xml
+++ b/hudi-trino/pom.xml
@@ -392,6 +392,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/hudi-trino/pom.xml
+++ b/hudi-trino/pom.xml
@@ -453,6 +453,18 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-blob-cache-alluxio</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-blob-cache-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-client</artifactId>
             <scope>test</scope>
         </dependency>

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
@@ -45,6 +45,7 @@ import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.DynamicFilter;
@@ -142,11 +143,13 @@ public class HudiPageSourceProvider
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public ConnectorPageSource createPageSource(
             ConnectorTransactionHandle transaction,
             ConnectorSession session,
             ConnectorSplit connectorSplit,
             ConnectorTableHandle connectorTable,
+            Optional<ConnectorTableCredentials> tableCredentials,
             List<ColumnHandle> columns,
             DynamicFilter dynamicFilter)
     {

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplit.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplit.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePartitionKey;
 import io.trino.plugin.hudi.file.HudiBaseFile;
@@ -28,7 +27,6 @@ import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -78,15 +76,6 @@ public class HudiSplit
         this.partitionKeys = ImmutableList.copyOf(requireNonNull(partitionKeys, "partitionKeys is null"));
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
         this.cachingHostAddresses = requireNonNull(cachingHostAddresses, "cachingHostAddresses is null");
-    }
-
-    public Map<String, String> getSplitInfo()
-    {
-        return ImmutableMap.<String, String>builder()
-                .put("baseFile", baseFile.toString())
-                .put("logFiles", logFiles.toString())
-                .put("commitTime", commitTime)
-                .buildOrThrow();
     }
 
     @JsonProperty

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
@@ -24,13 +24,13 @@ import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitSource;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.Constraint;
-import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.hudi.common.util.HoodieTimer;
@@ -39,6 +39,7 @@ import org.apache.hudi.common.util.Lazy;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiFunction;
@@ -77,7 +78,7 @@ public class HudiSplitManager
             ConnectorTransactionHandle transaction,
             ConnectorSession session,
             ConnectorTableHandle tableHandle,
-            DynamicFilter dynamicFilter,
+            Set<ColumnHandle> dynamicFilterColumns,
             Constraint constraint)
     {
         HudiTableHandle hudiTableHandle = (HudiTableHandle) tableHandle;
@@ -98,7 +99,6 @@ public class HudiSplitManager
                 getMaxSplitsPerSecond(session),
                 getMaxOutstandingSplits(session),
                 lazyAllPartitions,
-                dynamicFilter,
                 getDynamicFilteringWaitTimeout(session));
         return new ClassLoaderSafeConnectorSplitSource(splitSource, HudiSplitManager.class.getClassLoader());
     }

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.hudi;
 
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import io.airlift.log.Logger;
@@ -34,7 +33,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitSource;
-import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.DynamicFilterSnapshot;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
@@ -56,6 +55,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -66,22 +66,18 @@ import static io.trino.plugin.hudi.HudiSessionProperties.getMinimumAssignedSplit
 import static io.trino.plugin.hudi.HudiSessionProperties.getStandardSplitWeightSize;
 import static io.trino.plugin.hudi.HudiSessionProperties.isHudiMetadataTableEnabled;
 import static io.trino.plugin.hudi.HudiSessionProperties.isSizeBasedSplitWeightsEnabled;
-import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class HudiSplitSource
         implements ConnectorSplitSource
 {
     private static final Logger log = Logger.get(HudiSplitSource.class);
 
-    private static final ConnectorSplitBatch EMPTY_BATCH = new ConnectorSplitBatch(ImmutableList.of(), false);
     private final AsyncQueue<ConnectorSplit> queue;
     private final ScheduledFuture splitLoaderFuture;
     private final AtomicReference<TrinoException> trinoException = new AtomicReference<>();
-    private final DynamicFilter dynamicFilter;
+    private final AtomicBoolean finished = new AtomicBoolean();
     private final long dynamicFilteringWaitTimeoutMillis;
-    private final Stopwatch dynamicFilterWaitStopwatch;
 
     public HudiSplitSource(
             ConnectorSession session,
@@ -91,7 +87,6 @@ public class HudiSplitSource
             int maxSplitsPerSecond,
             int maxOutstandingSplits,
             Lazy<Map<String, Partition>> lazyPartitions,
-            DynamicFilter dynamicFilter,
             Duration dynamicFilteringWaitTimeoutMillis)
     {
         boolean enableMetadataTable = isHudiMetadataTableEnabled(session);
@@ -135,33 +130,22 @@ public class HudiSplitSource
                     queue.finish();
                 });
         this.splitLoaderFuture = splitLoaderExecutorService.schedule(splitLoader, 0, TimeUnit.MILLISECONDS);
-        this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
         this.dynamicFilteringWaitTimeoutMillis = dynamicFilteringWaitTimeoutMillis.toMillis();
-        this.dynamicFilterWaitStopwatch = Stopwatch.createStarted();
     }
 
     @Override
-    public CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize)
+    public CompletableFuture<List<ConnectorSplit>> getNextBatch(int maxSize, DynamicFilterSnapshot dynamicFilterSnapshot)
     {
-        // If dynamic filtering is enabled and we haven't timed out, wait for the build side to provide the dynamic filter.
-        long timeLeft = dynamicFilteringWaitTimeoutMillis - dynamicFilterWaitStopwatch.elapsed(MILLISECONDS);
-        if (dynamicFilter.isAwaitable() && timeLeft > 0) {
-            // If the filter is not ready, return an empty batch. The query engine will call getNextBatch() again.
-            // As long as isFinished() is false, effectively polling until the filter is ready or timeout occurs.
-            return dynamicFilter.isBlocked()
-                    .thenApply(_ -> EMPTY_BATCH)
-                    .completeOnTimeout(EMPTY_BATCH, timeLeft, MILLISECONDS);
-        }
-
         TupleDomain<HiveColumnHandle> dynamicFilterPredicate =
-                dynamicFilter.getCurrentPredicate().transformKeys(HiveColumnHandle.class::cast);
+                dynamicFilterSnapshot.currentPredicate().transformKeys(HiveColumnHandle.class::cast);
 
         if (dynamicFilterPredicate.isNone()) {
             close();
-            return completedFuture(new ConnectorSplitBatch(ImmutableList.of(), true));
+            // The queue may still hold undrained splits, so queue.isFinished() would never turn true here
+            finished.set(true);
+            return completedFuture(ImmutableList.of());
         }
 
-        boolean noMoreSplits = isFinished();
         Throwable throwable = trinoException.get();
         if (throwable != null) {
             return CompletableFuture.failedFuture(throwable);
@@ -169,13 +153,9 @@ public class HudiSplitSource
 
         return toCompletableFuture(Futures.transform(
                 queue.getBatchAsync(maxSize),
-                splits ->
-                {
-                    List<ConnectorSplit> filteredSplits = splits.stream()
-                            .filter(split -> partitionMatchesPredicate((HudiSplit) split, dynamicFilterPredicate))
-                            .collect(toImmutableList());
-                    return new ConnectorSplitBatch(filteredSplits, noMoreSplits);
-                },
+                splits -> splits.stream()
+                        .filter(split -> partitionMatchesPredicate((HudiSplit) split, dynamicFilterPredicate))
+                        .collect(toImmutableList()),
                 directExecutor()));
     }
 
@@ -188,7 +168,13 @@ public class HudiSplitSource
     @Override
     public boolean isFinished()
     {
-        return splitLoaderFuture.isDone() && queue.isFinished();
+        return finished.get() || (splitLoaderFuture.isDone() && queue.isFinished());
+    }
+
+    @Override
+    public long getRequestedDynamicFilterWaitTimeoutMillis()
+    {
+        return dynamicFilteringWaitTimeoutMillis;
     }
 
     public static HudiSplitWeightProvider createSplitWeightProvider(ConnectorSession session)

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
@@ -34,6 +34,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.DynamicFilterSnapshot;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
@@ -57,6 +58,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -89,46 +92,66 @@ public class HudiSplitSource
             Lazy<Map<String, Partition>> lazyPartitions,
             Duration dynamicFilteringWaitTimeoutMillis)
     {
-        boolean enableMetadataTable = isHudiMetadataTableEnabled(session);
-        Lazy<HoodieTableMetadata> lazyTableMetadata = Lazy.lazily(() -> {
-            HoodieTimer timer = HoodieTimer.start();
-            HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
-                    .enable(enableMetadataTable)
-                    .build();
-            HoodieTableMetaClient metaClient = tableHandle.getMetaClient();
-            HoodieEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getStorage().getConf());
+        this(
+                new ThrottledAsyncQueue<>(maxSplitsPerSecond, maxOutstandingSplits, executor),
+                splitLoaderExecutorService,
+                (queue, errorListener) -> {
+                    boolean enableMetadataTable = isHudiMetadataTableEnabled(session);
+                    Lazy<HoodieTableMetadata> lazyTableMetadata = Lazy.lazily(() -> {
+                        HoodieTimer timer = HoodieTimer.start();
+                        HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
+                                .enable(enableMetadataTable)
+                                .build();
+                        HoodieTableMetaClient metaClient = tableHandle.getMetaClient();
+                        HoodieEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getStorage().getConf());
 
-            // Defer to the native factory, which creates a HoodieBackedTableMetadata when the
-            // metadata table is enabled and initialized, and falls back to FileSystemBackedTableMetadata
-            // otherwise.
-            HoodieTableMetadata tableMetadata = NativeTableMetadataFactory.getInstance().create(
-                    engineContext, metaClient.getStorage(), metadataConfig, metaClient.getBasePath().toString(), true);
-            log.info("Loaded table metadata for table: %s in %s ms", tableHandle.getSchemaTableName(), timer.endTimer());
-            return tableMetadata;
+                        // Defer to the native factory, which creates a HoodieBackedTableMetadata when the
+                        // metadata table is enabled and initialized, and falls back to FileSystemBackedTableMetadata
+                        // otherwise.
+                        HoodieTableMetadata tableMetadata = NativeTableMetadataFactory.getInstance().create(
+                                engineContext, metaClient.getStorage(), metadataConfig, metaClient.getBasePath().toString(), true);
+                        log.info("Loaded table metadata for table: %s in %s ms", tableHandle.getSchemaTableName(), timer.endTimer());
+                        return tableMetadata;
+                    });
+
+                    HudiDirectoryLister hudiDirectoryLister = new HudiSnapshotDirectoryLister(
+                            session,
+                            tableHandle,
+                            enableMetadataTable,
+                            lazyTableMetadata);
+
+                    return new HudiBackgroundSplitLoader(
+                            session,
+                            tableHandle,
+                            hudiDirectoryLister,
+                            queue,
+                            executor,
+                            createSplitWeightProvider(session),
+                            lazyPartitions,
+                            enableMetadataTable,
+                            lazyTableMetadata,
+                            errorListener);
+                },
+                tableHandle.getSchemaTableName(),
+                dynamicFilteringWaitTimeoutMillis);
+    }
+
+    // Visible for tests: lets a test drive the split loader directly while keeping the
+    // error-listener wiring (set trinoException, then finish the queue -- isFinished
+    // relies on that order) identical to production.
+    HudiSplitSource(
+            AsyncQueue<ConnectorSplit> queue,
+            ScheduledExecutorService splitLoaderExecutorService,
+            BiFunction<AsyncQueue<ConnectorSplit>, Consumer<Throwable>, Runnable> splitLoaderFactory,
+            SchemaTableName tableName,
+            Duration dynamicFilteringWaitTimeoutMillis)
+    {
+        this.queue = queue;
+        Runnable splitLoader = splitLoaderFactory.apply(queue, throwable -> {
+            trinoException.compareAndSet(null, new TrinoException(HUDI_CANNOT_OPEN_SPLIT,
+                    "Failed to generate splits for " + tableName, throwable));
+            queue.finish();
         });
-
-        HudiDirectoryLister hudiDirectoryLister = new HudiSnapshotDirectoryLister(
-                session,
-                tableHandle,
-                enableMetadataTable,
-                lazyTableMetadata);
-
-        this.queue = new ThrottledAsyncQueue<>(maxSplitsPerSecond, maxOutstandingSplits, executor);
-        HudiBackgroundSplitLoader splitLoader = new HudiBackgroundSplitLoader(
-                session,
-                tableHandle,
-                hudiDirectoryLister,
-                queue,
-                executor,
-                createSplitWeightProvider(session),
-                lazyPartitions,
-                enableMetadataTable,
-                lazyTableMetadata,
-                throwable -> {
-                    trinoException.compareAndSet(null, new TrinoException(HUDI_CANNOT_OPEN_SPLIT,
-                            "Failed to generate splits for " + tableHandle.getSchemaTableName(), throwable));
-                    queue.finish();
-                });
         this.splitLoaderFuture = splitLoaderExecutorService.schedule(splitLoader, 0, TimeUnit.MILLISECONDS);
         this.dynamicFilteringWaitTimeoutMillis = dynamicFilteringWaitTimeoutMillis.toMillis();
     }

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
@@ -168,7 +168,11 @@ public class HudiSplitSource
     @Override
     public boolean isFinished()
     {
-        return finished.get() || (splitLoaderFuture.isDone() && queue.isFinished());
+        // The failure callback sets trinoException before finishing the queue, so once the queue
+        // reports finished the exception (if any) is visible here. Claiming finished while an
+        // exception is pending would let the engine stop polling and end the scan silently;
+        // reporting unfinished instead makes the next getNextBatch surface the failure.
+        return finished.get() || (splitLoaderFuture.isDone() && queue.isFinished() && trinoException.get() == null);
     }
 
     @Override

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/cache/HudiCacheKeyProvider.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/cache/HudiCacheKeyProvider.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hudi.cache;
 
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.cache.CacheKeyProvider;
+import io.trino.spi.cache.CacheKey;
 
 import java.util.Optional;
 
@@ -22,7 +23,7 @@ public class HudiCacheKeyProvider
         implements CacheKeyProvider
 {
     @Override
-    public Optional<String> getCacheKey(TrinoInputFile inputFile)
+    public Optional<CacheKey> getCacheKey(TrinoInputFile inputFile)
     {
         String path = inputFile.location().path();
         if (path.endsWith(".trinoSchema") || path.contains("/.trinoPermissions/")
@@ -32,7 +33,8 @@ public class HudiCacheKeyProvider
             // and Hudi table properties file that can be mutable
             return Optional.empty();
         }
-        // Other Hudi data and metadata files are immutable
-        return Optional.of(path);
+        // Other Hudi data and metadata files are immutable, so the location alone identifies the
+        // contents; keying by its components also lets a directory's entries be invalidated by prefix
+        return Optional.of(CacheKeyProvider.locationKey(inputFile.location()));
     }
 }

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
@@ -166,6 +167,19 @@ public class HudiBackgroundSplitLoader
 
         Futures.whenAllComplete(futures)
                 .run(() -> {
+                    // Guava does not order the per-future exception callbacks against this
+                    // combiner, so a failure in the last future could otherwise finish the
+                    // queue before the error listener records it and HudiSplitSource.isFinished
+                    // would answer true with no pending exception. Surface failures here first;
+                    // the listener is idempotent, so double reporting is harmless.
+                    for (ListenableFuture<Void> future : futures) {
+                        try {
+                            Futures.getDone(future);
+                        }
+                        catch (ExecutionException e) {
+                            errorListener.accept(e.getCause());
+                        }
+                    }
                     asyncQueue.finish();
                     log.info("Partition pruning split generation finished on table %s.%s", tableHandle.getSchemaName(), tableHandle.getTableName());
                 }, directExecutor());

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/util/HudiAvroSerializer.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/util/HudiAvroSerializer.java
@@ -496,7 +496,7 @@ public class HudiAvroSerializer
             type.writeObject(output, trinoNativeDecimalValue);
         }
         else {
-            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Unhandled type for Object: " + type.getTypeSignature());
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Unhandled type for Object: " + type.getTypeDescriptor());
         }
     }
 

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
@@ -21,7 +21,7 @@ import io.trino.filesystem.Location;
 import io.trino.metastore.Database;
 import io.trino.metastore.HiveMetastoreFactory;
 import io.trino.plugin.base.util.Closables;
-import io.trino.plugin.hive.containers.Hive3MinioDataLake;
+import io.trino.plugin.hive.containers.Hive3FlociDataLake;
 import io.trino.plugin.hudi.testing.HudiTablesInitializer;
 import io.trino.plugin.hudi.testing.ResourceHudiTablesInitializer;
 import io.trino.plugin.hudi.testing.TpchHudiTablesInitializer;
@@ -35,9 +35,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
-import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Floci.FLOCI_ACCESS_KEY;
+import static io.trino.testing.containers.Floci.FLOCI_REGION;
+import static io.trino.testing.containers.Floci.FLOCI_SECRET_KEY;
 import static java.util.Objects.requireNonNull;
 
 public final class HudiQueryRunner
@@ -56,14 +56,14 @@ public final class HudiQueryRunner
         return new Builder("local:///");
     }
 
-    public static Builder builder(Hive3MinioDataLake hiveMinioDataLake)
+    public static Builder builder(Hive3FlociDataLake hiveFlociDataLake)
     {
-        return new Builder("s3://" + hiveMinioDataLake.getBucketName() + "/")
-                .addConnectorProperty("fs.native-s3.enabled", "true")
-                .addConnectorProperty("s3.aws-access-key", MINIO_ROOT_USER)
-                .addConnectorProperty("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
-                .addConnectorProperty("s3.region", MINIO_REGION)
-                .addConnectorProperty("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
+        return new Builder("s3://" + hiveFlociDataLake.getBucketName() + "/")
+                .addConnectorProperty("fs.s3.enabled", "true")
+                .addConnectorProperty("s3.aws-access-key", FLOCI_ACCESS_KEY)
+                .addConnectorProperty("s3.aws-secret-key", FLOCI_SECRET_KEY)
+                .addConnectorProperty("s3.region", FLOCI_REGION)
+                .addConnectorProperty("s3.endpoint", hiveFlociDataLake.floci().endpoint().toString())
                 .addConnectorProperty("s3.path-style-access", "true");
     }
 
@@ -153,19 +153,19 @@ public final class HudiQueryRunner
         }
     }
 
-    public static final class HudiMinioQueryRunnerMain
+    public static final class HudiFlociQueryRunnerMain
     {
-        private HudiMinioQueryRunnerMain() {}
+        private HudiFlociQueryRunnerMain() {}
 
         public static void main(String[] args)
                 throws Exception
         {
             Logging.initialize();
-            Logger log = Logger.get(HudiMinioQueryRunnerMain.class);
+            Logger log = Logger.get(HudiFlociQueryRunnerMain.class);
 
-            Hive3MinioDataLake hiveMinioDataLake = new Hive3MinioDataLake("test-bucket");
-            hiveMinioDataLake.start();
-            QueryRunner queryRunner = builder(hiveMinioDataLake)
+            Hive3FlociDataLake hiveFlociDataLake = new Hive3FlociDataLake("test-bucket");
+            hiveFlociDataLake.start();
+            QueryRunner queryRunner = builder(hiveFlociDataLake)
                     .addCoordinatorProperty("http-server.http.port", "8080")
                     .setDataLoader(new TpchHudiTablesInitializer(TpchTable.getTables()))
                     .build();

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Level;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
+import io.trino.blob.cache.memory.MemoryBlobCachePlugin;
 import io.trino.filesystem.Location;
 import io.trino.metastore.Database;
 import io.trino.metastore.HiveMetastoreFactory;
@@ -111,6 +112,8 @@ public final class HudiQueryRunner
             DistributedQueryRunner queryRunner = super.build();
             try {
                 queryRunner.installPlugin(new TestingHudiPlugin(queryRunner.getCoordinator().getBaseDataDir().resolve("hudi_data")));
+                queryRunner.installPlugin(new MemoryBlobCachePlugin());
+                queryRunner.loadBlobCacheManager("memory", Map.of("fs.memory-cache.max-size", "128MB"));
                 queryRunner.createCatalog("hudi", "hudi", connectorProperties);
 
                 // Hudi connector does not support creating schema or any other write operations

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCacheFileOperations.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCacheFileOperations.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
 import io.airlift.units.Duration;
+import io.trino.blob.cache.alluxio.AlluxioBlobCachePlugin;
 import io.trino.plugin.hudi.testing.ResourceHudiTablesInitializer;
 import io.trino.plugin.hudi.util.FileOperationUtils.FileOperation;
 import io.trino.testing.AbstractTestQueryFramework;
@@ -63,8 +64,6 @@ public class TestHudiAlluxioCacheFileOperations
         Map<String, String> hudiProperties = ImmutableMap.<String, String>builder()
                 .put("hudi.metadata-enabled", "true")
                 .put("fs.cache.enabled", "true")
-                .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
-                .put("fs.cache.max-sizes", "100MB")
                 .put("hudi.metadata.cache.enabled", "false")
                 // Disable the async table-statistics refresh: on the first query it reads the index
                 // definitions and table-property files (and the metadata table) on a background
@@ -77,6 +76,11 @@ public class TestHudiAlluxioCacheFileOperations
         return HudiQueryRunner.builder()
                 .addConnectorProperties(hudiProperties)
                 .setDataLoader(new ResourceHudiTablesInitializer())
+                .withPlugin(new AlluxioBlobCachePlugin())
+                .withBlobCache("alluxio", ImmutableMap.<String, String>builder()
+                        .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
+                        .put("fs.cache.max-sizes", "100MB")
+                        .buildOrThrow())
                 .setWorkerCount(0)
                 .build();
     }

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCachingSmokeTest.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCachingSmokeTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -52,8 +54,15 @@ public class TestHudiAlluxioCachingSmokeTest
     {
         return ImmutableMap.<String, String>builder()
                 .put("fs.cache.enabled", "true")
+                .buildOrThrow();
+    }
+
+    @Override
+    protected Optional<Map<String, String>> getBlobCacheProperties()
+    {
+        return Optional.of(ImmutableMap.<String, String>builder()
                 .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
                 .put("fs.cache.max-sizes", "1GB")
-                .buildOrThrow();
+                .buildOrThrow());
     }
 }

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiFlociConnectorSmokeTest.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiFlociConnectorSmokeTest.java
@@ -13,7 +13,7 @@
  */
 package io.trino.plugin.hudi;
 
-import io.trino.plugin.hive.containers.Hive3MinioDataLake;
+import io.trino.plugin.hive.containers.Hive3FlociDataLake;
 import io.trino.plugin.hudi.testing.TpchHudiTablesInitializer;
 import io.trino.testing.QueryRunner;
 
@@ -21,7 +21,7 @@ import static io.trino.plugin.hive.containers.HiveHadoop.HIVE3_IMAGE;
 import static io.trino.plugin.hudi.testing.HudiTestUtils.COLUMNS_TO_HIDE;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 
-public class TestHudiMinioConnectorSmokeTest
+public class TestHudiFlociConnectorSmokeTest
         extends BaseHudiConnectorSmokeTest
 {
     @Override
@@ -29,11 +29,10 @@ public class TestHudiMinioConnectorSmokeTest
             throws Exception
     {
         String bucketName = "test-hudi-connector-" + randomNameSuffix();
-        Hive3MinioDataLake hiveMinioDataLake = closeAfterClass(new Hive3MinioDataLake(bucketName, HIVE3_IMAGE));
-        hiveMinioDataLake.start();
-        hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);
+        Hive3FlociDataLake hiveFlociDataLake = closeAfterClass(new Hive3FlociDataLake(bucketName, HIVE3_IMAGE));
+        hiveFlociDataLake.start();
 
-        return HudiQueryRunner.builder(hiveMinioDataLake)
+        return HudiQueryRunner.builder(hiveFlociDataLake)
                 .addConnectorProperty("hudi.columns-to-hide", COLUMNS_TO_HIDE)
                 .setDataLoader(new TpchHudiTablesInitializer(REQUIRED_TPCH_TABLES))
                 .build();

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiMemoryCacheFileOperations.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiMemoryCacheFileOperations.java
@@ -76,7 +76,7 @@ public class TestHudiMemoryCacheFileOperations
         assertFileSystemAccesses(
                 query,
                 ImmutableMultiset.<FileOperation>builder()
-                        .addCopies(new FileOperation("FileSystemCache.cacheInput", DATA), 2)
+                        .addCopies(new FileOperation("BlobCache.get", DATA), 2)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 2)
                         .add(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES))
                         .addCopies(new FileOperation("InputFile.newStream", TABLE_PROPERTIES), 2)
@@ -85,7 +85,7 @@ public class TestHudiMemoryCacheFileOperations
         assertFileSystemAccesses(
                 query,
                 ImmutableMultiset.<FileOperation>builder()
-                        .addCopies(new FileOperation("FileSystemCache.cacheInput", DATA), 2)
+                        .addCopies(new FileOperation("BlobCache.get", DATA), 2)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 2)
                         .add(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES))
                         .addCopies(new FileOperation("InputFile.newStream", TABLE_PROPERTIES), 2)
@@ -102,7 +102,7 @@ public class TestHudiMemoryCacheFileOperations
 
         assertFileSystemAccesses(query,
                 ImmutableMultiset.<FileOperation>builder()
-                        .addCopies(new FileOperation("FileSystemCache.cacheInput", DATA), 6)
+                        .addCopies(new FileOperation("BlobCache.get", DATA), 6)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 4)
                         .addCopies(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES), 2)
                         .addCopies(new FileOperation("InputFile.newStream", TABLE_PROPERTIES), 4)
@@ -110,7 +110,7 @@ public class TestHudiMemoryCacheFileOperations
 
         assertFileSystemAccesses(query,
                 ImmutableMultiset.<FileOperation>builder()
-                        .addCopies(new FileOperation("FileSystemCache.cacheInput", DATA), 6)
+                        .addCopies(new FileOperation("BlobCache.get", DATA), 6)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 4)
                         .addCopies(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES), 2)
                         .addCopies(new FileOperation("InputFile.newStream", TABLE_PROPERTIES), 4)
@@ -127,7 +127,7 @@ public class TestHudiMemoryCacheFileOperations
     private static Multiset<FileOperation> getFileOperations(QueryRunner queryRunner)
     {
         return queryRunner.getSpans().stream()
-                .filter(span -> span.getName().startsWith("Input.") || span.getName().startsWith("InputFile.") || span.getName().startsWith("FileSystemCache."))
+                .filter(span -> span.getName().startsWith("Input.") || span.getName().startsWith("InputFile.") || span.getName().startsWith("FileSystemCache.") || span.getName().startsWith("BlobCache."))
                 .filter(span -> !span.getName().startsWith("InputFile.newInput"))
                 .filter(span -> !span.getName().startsWith("InputFile.exists"))
                 .filter(span -> !isTrinoSchemaOrPermissions(getFileLocation(span)))

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import io.trino.Session;
+import io.trino.blob.cache.alluxio.AlluxioBlobCachePlugin;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.TrinoInputFile;
@@ -100,15 +101,23 @@ public class TestHudiSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return HudiQueryRunner.builder()
+        HudiQueryRunner.Builder builder = HudiQueryRunner.builder()
                 .setDataLoader(new ResourceHudiTablesInitializer())
-                .addConnectorProperties(getAdditionalHudiProperties())
-                .build();
+                .addConnectorProperties(getAdditionalHudiProperties());
+        getBlobCacheProperties().ifPresent(cacheProperties -> builder
+                .withPlugin(new AlluxioBlobCachePlugin())
+                .withBlobCache("alluxio", cacheProperties));
+        return builder.build();
     }
 
     protected ImmutableMap<String, String> getAdditionalHudiProperties()
     {
         return ImmutableMap.of();
+    }
+
+    protected Optional<Map<String, String>> getBlobCacheProperties()
+    {
+        return Optional.empty();
     }
 
     @Test

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
@@ -947,6 +947,7 @@ public class TestHudiSmokeTest
                 .from(getSession())
                 .withDynamicFilterTimeout("10s")
                 .build();
+        final String tableIdentifier = "hudi:tests." + table.getRoTableName();
 
         // The build side matches no rows, so the completed dynamic filter is NONE and the
         // probe-side split source must report itself finished instead of draining the queue
@@ -954,6 +955,21 @@ public class TestHudiSmokeTest
                 table + " t1 " +
                 "INNER JOIN " + table + " t2 ON t1.id = t2.id " +
                 "WHERE t2.price < 0";
+        MaterializedResult explainRes = getQueryRunner().execute(session, "EXPLAIN ANALYZE " + query);
+        Pattern scanFilterInputRowsPattern = getScanFilterInputRowsPattern(tableIdentifier);
+        Matcher matcher = scanFilterInputRowsPattern.matcher(explainRes.toString());
+        assertThat(matcher.find())
+                .withFailMessage("Could not find 'ScanFilter' for table '%s' with 'dynamicFilters' and 'Input: X rows' stats in EXPLAIN output.\nOutput was:\n%s",
+                        tableIdentifier, explainRes.toString())
+                .isTrue();
+
+        // Zero probe-side input rows pins split elimination at the source: without the NONE
+        // short-circuit the probe would scan all rows and the join would discard them, which
+        // returns the same empty result but reads Input: 4 rows here
+        assertThat(Long.parseLong(matcher.group(1)))
+                .describedAs("Probe side (%s) should read no rows when the dynamic filter is NONE", tableIdentifier)
+                .isEqualTo(0);
+
         assertThat(getQueryRunner().execute(session, query).getRowCount()).isEqualTo(0);
     }
 

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
@@ -941,6 +941,26 @@ public class TestHudiSmokeTest
     @EnumSource(
             value = ResourceHudiTablesInitializer.TestingTable.class,
             names = {"HUDI_MULTI_FG_PT_V6_MOR", "HUDI_MULTI_FG_PT_V8_MOR"})
+    public void testDynamicFilterEliminatesAllSplits(ResourceHudiTablesInitializer.TestingTable table)
+    {
+        Session session = SessionBuilder
+                .from(getSession())
+                .withDynamicFilterTimeout("10s")
+                .build();
+
+        // The build side matches no rows, so the completed dynamic filter is NONE and the
+        // probe-side split source must report itself finished instead of draining the queue
+        @Language("SQL") String query = "SELECT t1.id FROM " +
+                table + " t1 " +
+                "INNER JOIN " + table + " t2 ON t1.id = t2.id " +
+                "WHERE t2.price < 0";
+        assertThat(getQueryRunner().execute(session, query).getRowCount()).isEqualTo(0);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ResourceHudiTablesInitializer.TestingTable.class,
+            names = {"HUDI_MULTI_FG_PT_V6_MOR", "HUDI_MULTI_FG_PT_V8_MOR"})
     public void testDynamicFilterDisabledPredicatePushdown(ResourceHudiTablesInitializer.TestingTable table)
     {
         Session session = SessionBuilder.from(getSession())

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSplitSource.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSplitSource.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi;
+
+import io.airlift.units.Duration;
+import io.trino.plugin.hive.util.AsyncQueue;
+import io.trino.plugin.hive.util.ThrottledAsyncQueue;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.DynamicFilterSnapshot;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestHudiSplitSource
+{
+    private static final SchemaTableName TABLE = new SchemaTableName("tests", "split_source_test");
+    private static final Duration TIMEOUT = new Duration(10, SECONDS);
+    private static final ConnectorSplit DUMMY_SPLIT = new ConnectorSplit() {};
+
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+    @AfterAll
+    public void tearDown()
+    {
+        executor.shutdownNow();
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    public void testNoneDynamicFilterTerminatesSource()
+            throws Exception
+    {
+        AsyncQueue<ConnectorSplit> queue = new ThrottledAsyncQueue<>(100, 100, executor);
+        // Loader that stays "in flight": splits are queued but the queue is never finished,
+        // so only the early-termination path can make the source report finished
+        HudiSplitSource splitSource = new HudiSplitSource(queue, scheduler, (q, errorListener) -> () -> q.offer(DUMMY_SPLIT), TABLE, TIMEOUT);
+
+        CompletableFuture<List<ConnectorSplit>> batch =
+                splitSource.getNextBatch(10, new DynamicFilterSnapshot(TupleDomain.none(), true));
+
+        assertThat(batch).isCompletedWithValueMatching(List::isEmpty);
+        assertThat(splitSource.isFinished()).isTrue();
+    }
+
+    @Test
+    public void testLoaderFailureBlocksFinishedAndSurfaces()
+            throws Exception
+    {
+        AsyncQueue<ConnectorSplit> queue = new ThrottledAsyncQueue<>(100, 100, executor);
+        HudiSplitSource splitSource = new HudiSplitSource(
+                queue,
+                scheduler,
+                (q, errorListener) -> () -> errorListener.accept(new RuntimeException("boom")),
+                TABLE,
+                TIMEOUT);
+        awaitQueueFinished(queue);
+
+        // The failed load finished the queue, but the source must not claim finished while the
+        // failure is undelivered; the next batch is what surfaces it
+        assertThat(splitSource.isFinished()).isFalse();
+        CompletableFuture<List<ConnectorSplit>> batch =
+                splitSource.getNextBatch(10, new DynamicFilterSnapshot(TupleDomain.all(), false));
+        assertThatThrownBy(batch::join)
+                .hasCauseInstanceOf(TrinoException.class)
+                .hasMessageContaining("Failed to generate splits");
+    }
+
+    @Test
+    public void testCompletedLoaderFinishesNormally()
+            throws Exception
+    {
+        AsyncQueue<ConnectorSplit> queue = new ThrottledAsyncQueue<>(100, 100, executor);
+        HudiSplitSource splitSource = new HudiSplitSource(
+                queue,
+                scheduler,
+                (q, errorListener) -> (Runnable) q::finish,
+                TABLE,
+                TIMEOUT);
+        awaitQueueFinished(queue);
+
+        CompletableFuture<List<ConnectorSplit>> batch =
+                splitSource.getNextBatch(10, new DynamicFilterSnapshot(TupleDomain.all(), false));
+        assertThat(batch.join()).isEmpty();
+        assertThat(splitSource.isFinished()).isTrue();
+    }
+
+    private static void awaitQueueFinished(AsyncQueue<ConnectorSplit> queue)
+            throws InterruptedException
+    {
+        for (int i = 0; i < 500 && !queue.isFinished(); i++) {
+            Thread.sleep(10);
+        }
+        assertThat(queue.isFinished()).isTrue();
+    }
+}

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/util/TestTupleDomainUtilsTest.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/util/TestTupleDomainUtilsTest.java
@@ -176,7 +176,7 @@ class TestTupleDomainUtilsTest
         // "other_col" is an irrelevant column
         TupleDomain<String> tupleDomain = TupleDomain.withColumnDomains(Map.of(
                 "key1", Domain.singleValue(BIGINT, 1L), // EQUALS
-                "key2", Domain.multipleValues(VARCHAR, List.of("a", "b")), // IN
+                "key2", Domain.multipleValues(VARCHAR, List.of(Slices.utf8Slice("a"), Slices.utf8Slice("b"))), // IN
                 "other_col", Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 10L)), false)));
         List<String> sourceFields = List.of("key1", "key2");
         assertThat(TupleDomainUtils.areDomainsInOrEqualOnly(tupleDomain, sourceFields)).isTrue();

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,8 @@
     <presto.version>0.273</presto.version>
     <!-- trino.sha is the exact trinodb/trino commit hudi-trino builds against; its project
          version must equal trino.version and the two advance only together. trino.e2e.version is
-         the latest released Trino (e2e server image, trino-jdbc for the integ tests). Keep each
+         the latest released Trino (e2e server image, trino-jdbc for the integ tests); the nightly
+         pin-advance job refreshes all three, humans merge its bot/trino-pin branch. Keep each
          property on one line: the workflows and scripts/trino/bootstrap_trino.sh read them with sed. -->
     <trino.version>484-SNAPSHOT</trino.version>
     <trino.sha>5b82ec9e7116ec1ed3a83f4cc2f8cf9aaa87b12f</trino.sha>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,13 @@
     <hive.parquet.version>1.10.1</hive.parquet.version>
     <hive.avro.version>1.11.4</hive.avro.version>
     <presto.version>0.273</presto.version>
-    <trino.version>481</trino.version>
+    <!-- trino.sha is the exact trinodb/trino commit hudi-trino builds against; its project
+         version must equal trino.version and the two advance only together. trino.e2e.version is
+         the latest released Trino (e2e server image, trino-jdbc for the integ tests). Keep each
+         property on one line: the workflows and scripts/trino/bootstrap_trino.sh read them with sed. -->
+    <trino.version>484-SNAPSHOT</trino.version>
+    <trino.sha>5b82ec9e7116ec1ed3a83f4cc2f8cf9aaa87b12f</trino.sha>
+    <trino.e2e.version>483</trino.e2e.version>
     <hive.exec.classifier>core</hive.exec.classifier>
     <metrics.version>4.1.1</metrics.version>
     <orc.spark.version>1.6.0</orc.spark.version>
@@ -1758,7 +1764,7 @@
       <dependency>
         <groupId>io.trino</groupId>
         <artifactId>trino-jdbc</artifactId>
-        <version>${trino.version}</version>
+        <version>${trino.e2e.version}</version>
       </dependency>
 
       <!-- Zookeeper -->

--- a/release/release_guide.md
+++ b/release/release_guide.md
@@ -290,6 +290,31 @@ Here is how to go about a bug fix release.
 - Go to apache/hudi repo locally and pull this branch. Here after you can work on this branch and push to origin when need be.
 - Do not forget to set the env variables from above section.
 
+## hudi-trino Trino pin-back
+
+On master hudi-trino tracks `trinodb/trino` master at the commit in `trino.sha`, whose `trino.version` is a
+`-SNAPSHOT` that resolves from nowhere but a local build. A release must depend on a released Trino, and the pin-back
+must land on the release branch before the source release is generated (see "Build a release candidate", the Generate
+Source Release step) -- otherwise the voted tarball ships a `-SNAPSHOT` Trino pin that cannot be built from Central.
+
+1. Wait for the latest released Trino `NNN` to be available on Maven Central.
+2. In a `trinodb/trino` checkout, find the tagged commit: `TAG_SHA=$(git rev-list -n1 NNN)`.
+3. If the pin is behind the tag, advance master's pin to `TAG_SHA` first by running the
+   `Hudi Trino SPI Compatibility` workflow via `workflow_dispatch` and merging the pin PR a committer opens from the
+   pushed `bot/trino-pin` branch. If the pin is ahead of the tag, enumerate the adaptations that would be lost with
+   `git log NNN..<pin> -- core/trino-spi lib/trino-filesystem lib/trino-filesystem-manager lib/trino-hdfs`
+   and revert them forward on the release branch only, never on master.
+4. On the release branch set `trino.version=NNN`, `trino.sha=TAG_SHA` and `trino.e2e.version=NNN` in the root
+   pom, the `<parent>` version in `docker/trino/shim/pom.xml`, and the `docker/trino` defaults
+   (`TRINO_VERSION` in `build_image.sh`, `ARG TRINO_VERSION` in `Dockerfile`). Re-check SPI-surface-coupled
+   dependency scopes against `NNN` (e.g. `jts-core` is `provided` because it joined the Trino SPI surface in 482;
+   the shim's SpiDependencyChecker fails the build loudly if a scope no longer matches the target release).
+5. Verify the released Trino resolves from Central against an empty local repository
+   (scope the check to io.trino: the module's hudi siblings are not on Central until this release completes):
+   `mvn dependency:get -Dartifact=io.trino:trino-hive:NNN -Dmaven.repo.local=$(mktemp -d)`
+6. CI and the E2E workflow then run with zero SPI drift; the staging deploy flow in "Build a release candidate"
+   is unchanged.
+
 ## Verify that a Release Build Works
 
 Run "mvn -Prelease clean install" to ensure that the build processes are in good shape. // You need to execute this command once you have the release branch in apache/hudi
@@ -429,23 +454,8 @@ Set up a few environment variables to simplify Maven commands that follow. This 
           and `./scripts/release/deploy_staging_jars_java25.sh 2>&1 | tee -a "/tmp/${RELEASE_VERSION}-${RC_NUM}.deploy3.log"`.
           This step must run after the Java 11 step in 9.4.1, which installs the upstream Hudi modules that hudi-trino
           resolves from the local m2 (the script does not pass `-am` because Lombok cannot run on JDK 25).
-       4. hudi-trino Trino pin-back, to be done on the release branch before 9.4.3. On master hudi-trino tracks
-          `trinodb/trino` master at the commit in `trino.sha`, whose `trino.version` is a `-SNAPSHOT` that resolves from
-          nowhere but a local build; a release must depend on a released Trino instead.
-           1. Wait for the latest released Trino `NNN` to be available on Maven Central.
-           2. In a `trinodb/trino` checkout, find the tagged commit: `TAG_SHA=$(git rev-list -n1 NNN)`.
-           3. If the pin is behind the tag, advance master's pin to `TAG_SHA` first by running the
-              `Hudi Trino SPI Compatibility` workflow via `workflow_dispatch` and merging the pin PR it opens. If the pin
-              is ahead of the tag, enumerate the adaptations that would be lost with
-              `git log NNN..<pin> -- core/trino-spi lib/trino-filesystem lib/trino-filesystem-manager lib/trino-hdfs`
-              and revert them forward on the release branch only, never on master.
-           4. On the release branch set `trino.version=NNN`, `trino.sha=TAG_SHA` and `trino.e2e.version=NNN` in the root
-              pom, the `<parent>` version in `docker/trino/shim/pom.xml`, and the `docker/trino` defaults
-              (`TRINO_VERSION` in `build_image.sh`, `ARG TRINO_VERSION` in `Dockerfile`).
-           5. Verify the released Trino resolves from Central against an empty local repository
-              (scope the check to io.trino: the module's hudi siblings are not on Central until this release completes):
-              `mvn dependency:get -Dartifact=io.trino:trino-hive:NNN -Dmaven.repo.local=$(mktemp -d)`
-           6. CI and the E2E workflow then run with zero SPI drift; the staging deploy flow above is unchanged.
+       4. The hudi-trino Trino pin-back already happened when the release branch was cut (see the
+          "hudi-trino Trino pin-back" section under "Cut a release branch"); the Java 25 deploy needs no extra steps.
    5. Note that each of the Java 17 and Java 25 builds uploads its artifacts to its own separate staging repo. Use the
       `copy_staging_repo.sh` script once per extra staging repo to copy all artifacts into the Java 11 staging repo
       so that all artifacts stay in the same repo.

--- a/release/release_guide.md
+++ b/release/release_guide.md
@@ -429,6 +429,23 @@ Set up a few environment variables to simplify Maven commands that follow. This 
           and `./scripts/release/deploy_staging_jars_java25.sh 2>&1 | tee -a "/tmp/${RELEASE_VERSION}-${RC_NUM}.deploy3.log"`.
           This step must run after the Java 11 step in 9.4.1, which installs the upstream Hudi modules that hudi-trino
           resolves from the local m2 (the script does not pass `-am` because Lombok cannot run on JDK 25).
+       4. hudi-trino Trino pin-back, to be done on the release branch before 9.4.3. On master hudi-trino tracks
+          `trinodb/trino` master at the commit in `trino.sha`, whose `trino.version` is a `-SNAPSHOT` that resolves from
+          nowhere but a local build; a release must depend on a released Trino instead.
+           1. Wait for the latest released Trino `NNN` to be available on Maven Central.
+           2. In a `trinodb/trino` checkout, find the tagged commit: `TAG_SHA=$(git rev-list -n1 NNN)`.
+           3. If the pin is behind the tag, advance master's pin to `TAG_SHA` first by running the
+              `Hudi Trino SPI Compatibility` workflow via `workflow_dispatch` and merging the pin PR it opens. If the pin
+              is ahead of the tag, enumerate the adaptations that would be lost with
+              `git log NNN..<pin> -- core/trino-spi lib/trino-filesystem lib/trino-filesystem-manager lib/trino-hdfs`
+              and revert them forward on the release branch only, never on master.
+           4. On the release branch set `trino.version=NNN`, `trino.sha=TAG_SHA` and `trino.e2e.version=NNN` in the root
+              pom, the `<parent>` version in `docker/trino/shim/pom.xml`, and the `docker/trino` defaults
+              (`TRINO_VERSION` in `build_image.sh`, `ARG TRINO_VERSION` in `Dockerfile`).
+           5. Verify the released Trino resolves from Central against an empty local repository
+              (scope the check to io.trino: the module's hudi siblings are not on Central until this release completes):
+              `mvn dependency:get -Dartifact=io.trino:trino-hive:NNN -Dmaven.repo.local=$(mktemp -d)`
+           6. CI and the E2E workflow then run with zero SPI drift; the staging deploy flow above is unchanged.
    5. Note that each of the Java 17 and Java 25 builds uploads its artifacts to its own separate staging repo. Use the
       `copy_staging_repo.sh` script once per extra staging repo to copy all artifacts into the Java 11 staging repo
       so that all artifacts stay in the same repo.

--- a/release/release_guide.md
+++ b/release/release_guide.md
@@ -299,9 +299,9 @@ Source Release step) -- otherwise the voted tarball ships a `-SNAPSHOT` Trino pi
 
 1. Wait for the latest released Trino `NNN` to be available on Maven Central.
 2. In a `trinodb/trino` checkout, find the tagged commit: `TAG_SHA=$(git rev-list -n1 NNN)`.
-3. If the pin is behind the tag, advance master's pin to `TAG_SHA` first by running the
-   `Hudi Trino SPI Compatibility` workflow via `workflow_dispatch` and merging the pin PR a committer opens from the
-   pushed `bot/trino-pin` branch. If the pin is ahead of the tag, enumerate the adaptations that would be lost with
+3. If the pin is behind the tag, advance master's pin to `TAG_SHA` first by dispatching the
+   `Hudi Trino SPI Compatibility` workflow with `trino_ref=NNN` (it then verifies and pins exactly that tag rather
+   than master HEAD) and merging the pin PR a committer opens from the pushed `bot/trino-pin` branch. If the pin is ahead of the tag, enumerate the adaptations that would be lost with
    `git log NNN..<pin> -- core/trino-spi lib/trino-filesystem lib/trino-filesystem-manager lib/trino-hdfs`
    and revert them forward on the release branch only, never on master.
 4. On the release branch set `trino.version=NNN`, `trino.sha=TAG_SHA` and `trino.e2e.version=NNN` in the root

--- a/release/release_guide.md
+++ b/release/release_guide.md
@@ -302,7 +302,7 @@ Source Release step) -- otherwise the voted tarball ships a `-SNAPSHOT` Trino pi
 3. If the pin is behind the tag, advance master's pin to `TAG_SHA` first by dispatching the
    `Hudi Trino SPI Compatibility` workflow with `trino_ref=NNN` (it then verifies and pins exactly that tag rather
    than master HEAD) and merging the pin PR a committer opens from the pushed `bot/trino-pin` branch. If the pin is ahead of the tag, enumerate the adaptations that would be lost with
-   `git log NNN..<pin> -- core/trino-spi lib/trino-filesystem lib/trino-filesystem-manager lib/trino-hdfs`
+   `git log NNN..<pin> -- core/trino-spi lib/trino-filesystem lib/trino-filesystem-manager lib/trino-hdfs lib/trino-memory-context`
    and revert them forward on the release branch only, never on master.
 4. On the release branch set `trino.version=NNN`, `trino.sha=TAG_SHA` and `trino.e2e.version=NNN` in the root
    pom, the `<parent>` version in `docker/trino/shim/pom.xml`, and the `ARG TRINO_VERSION` default in

--- a/release/release_guide.md
+++ b/release/release_guide.md
@@ -305,8 +305,8 @@ Source Release step) -- otherwise the voted tarball ships a `-SNAPSHOT` Trino pi
    `git log NNN..<pin> -- core/trino-spi lib/trino-filesystem lib/trino-filesystem-manager lib/trino-hdfs`
    and revert them forward on the release branch only, never on master.
 4. On the release branch set `trino.version=NNN`, `trino.sha=TAG_SHA` and `trino.e2e.version=NNN` in the root
-   pom, the `<parent>` version in `docker/trino/shim/pom.xml`, and the `docker/trino` defaults
-   (`TRINO_VERSION` in `build_image.sh`, `ARG TRINO_VERSION` in `Dockerfile`). Re-check SPI-surface-coupled
+   pom, the `<parent>` version in `docker/trino/shim/pom.xml`, and the `ARG TRINO_VERSION` default in
+   `docker/trino/Dockerfile` (`build_image.sh` reads `trino.e2e.version` from the root pom). Re-check SPI-surface-coupled
    dependency scopes against `NNN` (e.g. `jts-core` is `provided` because it joined the Trino SPI surface in 482;
    the shim's SpiDependencyChecker fails the build loudly if a scope no longer matches the target release).
 5. Verify the released Trino resolves from Central against an empty local repository

--- a/rfc/rfc-105/rfc-105.md
+++ b/rfc/rfc-105/rfc-105.md
@@ -125,7 +125,7 @@ apache/hudi : hudi-trino-plugin/    (Maven profile -Phudi-trino,
 | `src/main/java/io/trino/plugin/hudi/HudiPlugin.java` | Implements `io.trino.spi.Plugin`. Single method returning `new HudiConnectorFactory()` (from the `hudi-trino` artifact). ~10 lines. |
 | `src/main/resources/META-INF/services/io.trino.spi.Plugin` | Service-loader pointer to `io.trino.plugin.hudi.HudiPlugin`. |
 | `pom.xml` | `<packaging>trino-plugin</packaging>`; pins `org.apache.hudi:hudi-trino:<version>`; SPI deps as `provided`. |
-| `src/test/java/...` | All current Trino-side tests stay: `HudiQueryRunner`, `TestHudiSmokeTest`, `TestHudiMinioConnectorSmokeTest`, `TestHudiConnectorTest`, `TestHudiSharedMetastore`, `TestHudiSystemTables`, `TestHudiPlugin`, `TestHudiConfig`, plus data initializers. Required by the Trino-side test-coverage commitment. |
+| `src/test/java/...` | All current Trino-side tests stay: `HudiQueryRunner`, `TestHudiSmokeTest`, `TestHudiFlociConnectorSmokeTest`, `TestHudiConnectorTest`, `TestHudiSharedMetastore`, `TestHudiSystemTables`, `TestHudiPlugin`, `TestHudiConfig`, plus data initializers. Required by the Trino-side test-coverage commitment. |
 
 #### Hudi-side `hudi-trino-plugin/` (the engine)
 
@@ -187,7 +187,7 @@ On the Trino side, existing CI continues to build and test `plugin/trino-hudi`, 
 
 ### Test strategy
 
-**Full test duplication.** The Trino-side smoke tests (`TestHudiSmokeTest`, `TestHudiMinioConnectorSmokeTest`, `TestHudiConnectorTest`, etc.) are mirrored on the Hudi side and additionally extended.
+**Full test duplication.** The Trino-side smoke tests (`TestHudiSmokeTest`, `TestHudiFlociConnectorSmokeTest`, `TestHudiConnectorTest`, etc.) are mirrored on the Hudi side and additionally extended.
 
 - **Trino side runs them** on every Trino PR — fulfilling the Trino-side test-coverage commitment.
 - **Hudi side runs them** on every Hudi PR touching `hudi-trino-plugin` — so Hudi contributors catch regressions before they ship in a Hudi release. The Hudi-side suite is also **expanded** with more granular unit tests covering split generation edge cases, all eight index-support strategies, the MOR record-merging path, lazy-commit-time snapshot isolation, and the cache-key provider.

--- a/scripts/trino/bootstrap_trino.sh
+++ b/scripts/trino/bootstrap_trino.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Builds the trinodb/trino modules that hudi-trino compiles and tests against
+## and installs them into the local Maven repository.
+##
+## On master, hudi-trino tracks trinodb/trino master at the commit pinned by the
+## <trino.sha> property in the root pom (whose project version is <trino.version>,
+## e.g. 484-SNAPSHOT). Trino publishes no SNAPSHOT artifacts, so every io.trino
+## dependency must be installed from source by this script before hudi-trino can
+## build. On release branches <trino.version> is a released number and only the
+## test-jars (never published by Trino) need this script.
+##
+## Usage: bootstrap_trino.sh <path-to-trino-checkout> [--ref <sha>] [--skip-checkout] [--keep-m2]
+##
+##   <path-to-trino-checkout>  a trinodb/trino git checkout (clean worktree)
+##   --ref <sha>               build at this commit instead of the pinned <trino.sha>
+##                             (used by the nightly pin-advance workflow at trino HEAD;
+##                             relaxes the version cross-check to a warning)
+##   --skip-checkout           assume the worktree is already at the right commit
+##                             (CI checks out the SHA itself via actions/checkout)
+##   --keep-m2                 do not purge ~/.m2/repository/io/trino first
+##                             (the purge guards against stale artifacts under the
+##                             same SNAPSHOT coordinates from an older pin)
+##
+
+set -euo pipefail
+
+HUDI_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+TRINO_REPO=""
+REF=""
+SKIP_CHECKOUT="false"
+KEEP_M2="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ref)
+      REF="$2"
+      shift 2
+      ;;
+    --skip-checkout)
+      SKIP_CHECKOUT="true"
+      shift
+      ;;
+    --keep-m2)
+      KEEP_M2="true"
+      shift
+      ;;
+    -h|--help)
+      grep '^##' "$0" | sed 's/^## \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      if [[ -z "$TRINO_REPO" ]]; then
+        TRINO_REPO="$1"
+        shift
+      else
+        echo "ERROR: unexpected argument: $1" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$TRINO_REPO" || ! -d "$TRINO_REPO/.git" && ! -f "$TRINO_REPO/.git" ]]; then
+  echo "ERROR: first argument must be a trinodb/trino git checkout" >&2
+  echo "Usage: $0 <path-to-trino-checkout> [--ref <sha>] [--skip-checkout] [--keep-m2]" >&2
+  exit 1
+fi
+
+# The pin lives in the root pom; keep each property on one line (this sed and the
+# CI workflows depend on it).
+PINNED_SHA=$(sed -n 's|.*<trino.sha>\(.*\)</trino.sha>.*|\1|p' "$HUDI_ROOT/pom.xml")
+PINNED_VERSION=$(sed -n 's|.*<trino.version>\(.*\)</trino.version>.*|\1|p' "$HUDI_ROOT/pom.xml")
+
+if [[ -z "$PINNED_VERSION" ]]; then
+  echo "ERROR: could not read <trino.version> from $HUDI_ROOT/pom.xml" >&2
+  exit 1
+fi
+
+RELAXED_VERSION_CHECK="false"
+if [[ -n "$REF" ]]; then
+  RELAXED_VERSION_CHECK="true"
+else
+  REF="$PINNED_SHA"
+  if [[ -z "$REF" ]]; then
+    echo "ERROR: could not read <trino.sha> from $HUDI_ROOT/pom.xml and no --ref given" >&2
+    exit 1
+  fi
+fi
+
+# JDK gate: trino at head enforces JDK 25.
+JAVA_MAJOR=$(java -version 2>&1 | awk -F[\".] '/version/ {print $2}')
+if [[ "$JAVA_MAJOR" != "25" ]]; then
+  echo "ERROR: JDK 25 required to build trino (found major version: ${JAVA_MAJOR:-unknown})." >&2
+  echo "Hint: export JAVA_HOME=\$(/usr/libexec/java_home -v 25)" >&2
+  exit 1
+fi
+
+if ! git -C "$TRINO_REPO" rev-parse --verify --quiet "${REF}^{commit}" > /dev/null; then
+  echo "ERROR: commit $REF not present in $TRINO_REPO" >&2
+  echo "Hint: git -C $TRINO_REPO fetch https://github.com/trinodb/trino.git master --tags" >&2
+  exit 1
+fi
+
+if [[ "$SKIP_CHECKOUT" == "false" ]]; then
+  # Refuse tracked modifications; untracked files are harmless for a checkout.
+  if [[ -n "$(git -C "$TRINO_REPO" status --porcelain -uno)" ]]; then
+    echo "ERROR: $TRINO_REPO has uncommitted tracked changes; commit or stash them first" >&2
+    exit 1
+  fi
+  git -C "$TRINO_REPO" -c advice.detachedHead=false checkout --detach "$REF"
+fi
+
+ACTUAL_VERSION=$("$TRINO_REPO/mvnw" -q -N -f "$TRINO_REPO/pom.xml" help:evaluate -Dexpression=project.version -DforceStdout)
+if [[ "$ACTUAL_VERSION" != "$PINNED_VERSION" ]]; then
+  if [[ "$RELAXED_VERSION_CHECK" == "true" ]]; then
+    echo "WARNING: trino at $REF has version $ACTUAL_VERSION but the pom pins <trino.version>$PINNED_VERSION</trino.version> (version rollover?)"
+  else
+    echo "ERROR: trino at pinned sha $REF has version $ACTUAL_VERSION, but the root pom says <trino.version>$PINNED_VERSION</trino.version>." >&2
+    echo "The pin properties must advance together; fix the pom or your checkout." >&2
+    exit 1
+  fi
+fi
+
+if [[ "$KEEP_M2" == "false" ]]; then
+  # SNAPSHOT coordinates do not change when the pin does, so artifacts from an
+  # older pin are indistinguishable from current ones. Purge to be safe.
+  echo "Purging ~/.m2/repository/io/trino (use --keep-m2 to skip)"
+  rm -rf "$HOME/.m2/repository/io/trino"
+fi
+
+export MAVEN_OPTS="${MAVEN_OPTS:--Xmx4g}"
+
+# Module list rationale:
+# - trino-hive, trino-filesystem-manager, trino-parquet, trino-plugin-toolkit and
+#   their -am closure cover every compile-scope io.trino dependency of hudi-trino
+#   (trino-spi, trino-cache, trino-filesystem, trino-hive-formats,
+#   trino-memory-context, trino-metastore come in transitively).
+# - The remaining modules are hudi-trino's test-scope dependencies.
+# - trino-spi, trino-filesystem, trino-hive, trino-main are the four test-jar
+#   producers needed by the hudi-trino-tests profile; -DskipTests (NOT
+#   -Dmaven.test.skip) is load-bearing: test-jars need compiled test classes.
+# - The -am closure also installs the trino-root pom, which the hudi-trino BOM
+#   import and the docker/trino/shim parent resolve.
+echo "Building trino modules at $REF (version $ACTUAL_VERSION); this takes roughly 10-30 minutes"
+(cd "$TRINO_REPO" && ./mvnw install -am -DskipTests -Dair.check.skip-all=true -T1C \
+  -pl :trino-hive,:trino-filesystem-manager,:trino-parquet,:trino-plugin-toolkit,:trino-main,:trino-testing,:trino-testing-containers,:trino-testing-services,:trino-client,:trino-parser,:trino-hdfs,:trino-tpch,:trino-spi,:trino-filesystem)
+
+echo "Done. io.trino artifacts for $ACTUAL_VERSION are installed in ~/.m2."

--- a/scripts/trino/bootstrap_trino.sh
+++ b/scripts/trino/bootstrap_trino.sh
@@ -161,8 +161,10 @@ export MAVEN_OPTS="${MAVEN_OPTS:--Xmx4g}"
 #   -Dmaven.test.skip) is load-bearing: test-jars need compiled test classes.
 # - The -am closure also installs the trino-root pom, which the hudi-trino BOM
 #   import and the docker/trino/shim parent resolve.
+# - The blob-cache plugins back the cache managers the hudi-trino tests load
+#   (memory unconditionally via HudiQueryRunner, alluxio in the caching tests).
 echo "Building trino modules at $REF (version $ACTUAL_VERSION); this takes roughly 10-30 minutes"
 (cd "$TRINO_REPO" && ./mvnw install -am -DskipTests -Dair.check.skip-all=true -T1C \
-  -pl :trino-hive,:trino-filesystem-manager,:trino-parquet,:trino-plugin-toolkit,:trino-main,:trino-testing,:trino-testing-containers,:trino-testing-services,:trino-client,:trino-parser,:trino-hdfs,:trino-tpch,:trino-spi,:trino-filesystem)
+  -pl :trino-hive,:trino-filesystem-manager,:trino-parquet,:trino-plugin-toolkit,:trino-main,:trino-testing,:trino-testing-containers,:trino-testing-services,:trino-client,:trino-parser,:trino-hdfs,:trino-tpch,:trino-spi,:trino-filesystem,:trino-blob-cache-memory,:trino-blob-cache-alluxio)
 
 echo "Done. io.trino artifacts for $ACTUAL_VERSION are installed in ~/.m2."


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19640. `hudi-trino` pins Trino 481 while Trino is at 483, and the nightly SPI drift job is red against trino master (#19379). Pin-to-pin upgrades arrive as multi-release big-bang migrations.

### Summary and Changelog

Master now tracks trinodb/trino master at a pinned commit (new `trino.sha` + `trino.version=484-SNAPSHOT` in the root pom), built from source since Trino publishes no SNAPSHOT artifacts. Releases still pin a released Trino; the release guide gains the pin-back steps.

- New `scripts/trino/bootstrap_trino.sh` installs the needed `io.trino` modules (incl. the unpublished test-jars) into the local m2; contributors and CI run the same script.
- CI caches the built artifacts per `trino.sha`; the nightly compat job pre-seeds the cache and opens a human-merged `bot/trino-pin` PR when trino HEAD compiles, still filing the drift issue when it does not.
- E2E keeps the released server image (new `trino.e2e.version`, also feeds `trino-jdbc`) and auto-skips with a notice when the pin has SPI drift against it.
- SPI fixups 481 -> pin: split-source rewrite (`DynamicFilterSnapshot`, `ConnectorSplitBatch` removed), `createPageSource` gains the credentials arg, `TypeSignature` -> `TypeDescriptor`, `CacheKeyProvider` returns `CacheKey`, `jts-core` now `provided` (SPI surface), Minio -> Floci test containers.

### Impact

No public API or storage-format change. On master, `io.trino` no longer resolves from Maven Central: run the bootstrap script once per pin advance (see the module README). E2E coverage pauses during drift windows.

### Risk Level

Medium: the split-source rewrite changes completion semantics. Mitigated by mirroring upstream's migrated connector; compile, test-compile, javadoc and the docker shim build are all green locally against the pin, and this PR's CI exercises the new workflows.

### Documentation Update

`hudi-trino/README.md` (bootstrap-first build), `docker/README.md`, `release/release_guide.md` (pin-back subsection). No config or website changes.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
