### PR TITLE
fix(spark): don't prune files with unknown null-count on IS NULL

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
@@ -161,7 +161,7 @@ object DataSkippingUtils extends Logging {
         })
 
       // Filter "colA <=> null"
-      // Translates to "colA_nullCount = null or colA_nullCount > 0" for index lookup
+      // Translates to "colA_nullCount IS NULL OR colA_nullCount > 0" for index lookup
       // (this is equivalent to "colA is null")
       case EqualNullSafe(attrRef: AttributeReference, Literal(null, _)) =>
         getTargetIndexedColumnName(attrRef, indexedCols)
@@ -251,8 +251,8 @@ object DataSkippingUtils extends Logging {
         })
 
       // Filter "colA is null"
-      // Translates to "colA_nullCount = null or colA_nullCount > 0" for index lookup
-      // "colA_nullCount = null" means we are not certain whether the column holds nulls or not,
+      // Translates to "colA_nullCount IS NULL OR colA_nullCount > 0" for index lookup
+      // "colA_nullCount IS NULL" means we are not certain whether the column holds nulls or not,
       // hence we keep the file to ensure this does not affect the query.
       case IsNull(attribute: AttributeReference) =>
         getTargetIndexedColumnName(attribute, indexedCols)
@@ -262,8 +262,8 @@ object DataSkippingUtils extends Logging {
           })
 
       // Filter "colA is not null"
-      // Translates to "colA_nullCount = null or colA_valueCount = null or colA_nullCount < colA_valueCount" for index lookup
-      // "colA_nullCount = null or colA_valueCount = null" means we are not certain whether the column is null or not,
+      // Translates to "colA_nullCount IS NULL OR colA_valueCount IS NULL OR colA_nullCount < colA_valueCount" for index lookup
+      // "colA_nullCount IS NULL OR colA_valueCount IS NULL" means we are not certain whether the column is null or not,
       // hence we return True to ensure this does not affect the query.
       case IsNotNull(attribute: AttributeReference) =>
         getTargetIndexedColumnName(attribute, indexedCols)
@@ -435,18 +435,18 @@ object DataSkippingUtils extends Logging {
       case expr if !expr.resolved => false
 
       // Filter "colA <=> null"
-      // Translates to "colA_nullCount = null or colA_nullCount > 0" for index lookup
+      // Translates to "colA_nullCount IS NULL OR colA_nullCount > 0" for index lookup
       case EqualNullSafe(attrRef: AttributeReference, litNull@Literal(null, _)) =>
         getTargetIndexedColumnName(attrRef, indexedCols).isDefined
 
       // Filter "colA is null"
-      // Translates to "colA_nullCount = null or colA_nullCount > 0" for index lookup
+      // Translates to "colA_nullCount IS NULL OR colA_nullCount > 0" for index lookup
       case IsNull(attribute: AttributeReference) =>
         getTargetIndexedColumnName(attribute, indexedCols).isDefined
 
       // Filter "colA is not null"
-      // Translates to "colA_nullCount = null or colA_valueCount = null or colA_nullCount < colA_valueCount" for index lookup
-      // "colA_nullCount = null or colA_valueCount = null" means we are not certain whether the column is null or not,
+      // Translates to "colA_nullCount IS NULL OR colA_valueCount IS NULL OR colA_nullCount < colA_valueCount" for index lookup
+      // "colA_nullCount IS NULL OR colA_valueCount IS NULL" means we are not certain whether the column is null or not,
       // hence we return True to ensure this does not affect the query.
       case IsNotNull(attribute: AttributeReference) =>
         getTargetIndexedColumnName(attribute, indexedCols).isDefined

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
@@ -160,11 +160,12 @@ object DataSkippingUtils extends Logging {
           Option.empty
         })
 
-      // Filter "colA = null"
-      // Translates to "colA_nullCount = null" for index lookup
-      case EqualNullSafe(attrRef: AttributeReference, litNull @ Literal(null, _)) =>
+      // Filter "colA <=> null"
+      // Translates to "colA_nullCount = null or colA_nullCount > 0" for index lookup
+      // (this is equivalent to "colA is null")
+      case EqualNullSafe(attrRef: AttributeReference, Literal(null, _)) =>
         getTargetIndexedColumnName(attrRef, indexedCols)
-          .map(colName => EqualTo(genColNumNullsExpr(colName), litNull))
+          .map(colName => genColumnIsNullExpression(colName))
           .orElse({
             Option.empty
           })
@@ -250,10 +251,12 @@ object DataSkippingUtils extends Logging {
         })
 
       // Filter "colA is null"
-      // Translates to "colA_nullCount > 0" for index lookup
+      // Translates to "colA_nullCount = null or colA_nullCount > 0" for index lookup
+      // "colA_nullCount = null" means we are not certain whether the column holds nulls or not,
+      // hence we keep the file to ensure this does not affect the query.
       case IsNull(attribute: AttributeReference) =>
         getTargetIndexedColumnName(attribute, indexedCols)
-          .map(colName => GreaterThan(genColNumNullsExpr(colName), Literal(0)))
+          .map(colName => genColumnIsNullExpression(colName))
           .orElse({
             Option.empty
           })
@@ -431,13 +434,13 @@ object DataSkippingUtils extends Logging {
       // If Expression is not resolved, we can't perform the analysis accurately, bailing
       case expr if !expr.resolved => false
 
-      // Filter "colA = null"
-      // Translates to "colA_nullCount = null" for index lookup
+      // Filter "colA <=> null"
+      // Translates to "colA_nullCount = null or colA_nullCount > 0" for index lookup
       case EqualNullSafe(attrRef: AttributeReference, litNull@Literal(null, _)) =>
         getTargetIndexedColumnName(attrRef, indexedCols).isDefined
 
       // Filter "colA is null"
-      // Translates to "colA_nullCount > 0" for index lookup
+      // Translates to "colA_nullCount = null or colA_nullCount > 0" for index lookup
       case IsNull(attribute: AttributeReference) =>
         getTargetIndexedColumnName(attribute, indexedCols).isDefined
 
@@ -478,6 +481,16 @@ object ColumnStatsExpressionUtils {
   @inline def genColMaxValueExpr(colName: String): Expression = sparkAdapter.getExpressionFromColumn(col(getMaxColumnNameFor(colName)))
   @inline def genColNumNullsExpr(colName: String): Expression = sparkAdapter.getExpressionFromColumn(col(getNullCountColumnNameFor(colName)))
   @inline def genColValueCountExpr: Expression = sparkAdapter.getExpressionFromColumn(col(getValueCountColumnNameFor))
+
+  @inline def genColumnIsNullExpression(colName: String): Expression = {
+    val numNullsExpr = genColNumNullsExpr(colName)
+    // NOTE: Column Stats Index isn't guaranteed to hold stats for every column of every file: for ex,
+    //       a column added by schema evolution is missing from the stats of the files written before it,
+    //       and columns of types not supported by the index hold no stats at all. In that case the
+    //       null-count is null, meaning we can't tell whether the file holds null values, and therefore
+    //       such file could NOT be pruned
+    Or(IsNull(numNullsExpr), GreaterThan(numNullsExpr, Literal(0)))
+  }
 
   @inline def genColumnValuesEqualToExpression(colName: String,
                                                value: Expression,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
@@ -229,6 +229,35 @@ object TestDataSkippingUtils {
           IndexRow("file_3", valueCount = 2, A_minValue = 2, A_maxValue = 3, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null)
         ),
         Seq("file_1", "file_2")
+      ),
+      // NOTE: file_1 holds no stats for B (for ex, B was added by schema evolution after it was written),
+      //       hence it could hold nulls for B and could NOT be pruned
+      arguments(
+        "B is null",
+        Seq(
+          IndexRow("file_1", valueCount = 2, A_minValue = 0, A_maxValue = 1, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null),
+          IndexRow("file_2", valueCount = 2, A_minValue = 1, A_maxValue = 2, A_nullCount = 0, B_minValue = "a", B_maxValue = "b", B_nullCount = 0),
+          IndexRow("file_3", valueCount = 2, A_minValue = 2, A_maxValue = 3, A_nullCount = 0, B_minValue = "a", B_maxValue = "b", B_nullCount = 1)
+        ),
+        Seq("file_1", "file_3")
+      ),
+      arguments(
+        "B <=> null",
+        Seq(
+          IndexRow("file_1", valueCount = 2, A_minValue = 0, A_maxValue = 1, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null),
+          IndexRow("file_2", valueCount = 2, A_minValue = 1, A_maxValue = 2, A_nullCount = 0, B_minValue = "a", B_maxValue = "b", B_nullCount = 0),
+          IndexRow("file_3", valueCount = 2, A_minValue = 2, A_maxValue = 3, A_nullCount = 0, B_minValue = "a", B_maxValue = "b", B_nullCount = 1)
+        ),
+        Seq("file_1", "file_3")
+      ),
+      arguments(
+        "A = 1 and B is null",
+        Seq(
+          IndexRow("file_1", valueCount = 2, A_minValue = 0, A_maxValue = 1, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null),
+          IndexRow("file_2", valueCount = 2, A_minValue = 2, A_maxValue = 3, A_nullCount = 0, B_minValue = null, B_maxValue = null, B_nullCount = null),
+          IndexRow("file_3", valueCount = 2, A_minValue = 1, A_maxValue = 2, A_nullCount = 0, B_minValue = "a", B_maxValue = "b", B_nullCount = 0)
+        ),
+        Seq("file_1")
       )
     )
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Data skipping prunes files it must keep when a query filters on `IS NULL` (or `<=> null`)
and the column-stats index holds no stats for that column in that file. Closes #19645.

`DataSkippingUtils` translated:

* `colA is null` → `colA_nullCount > 0`
* `colA <=> null` → `colA_nullCount = null`

The transposed column-stats index fills `min`/`max`/`nullCount` with `null` when a file has
no stats record for a column — a column added by schema evolution (older files hold no
record for it) or a column whose type the index does not support. For such rows the first
predicate evaluates to `null` and the second is `null` for every row, so
`indexDf.where(indexFilter)` drops them and the corresponding files are pruned. Records in
those files are all null for that column, i.e. exactly the rows the query asks for, so the
query silently returns fewer rows than it should.

The `is not null` translation right below already handles the unknown-stats case
(`colA_nullCount = null or colA_valueCount = null or ...`), and the fill-in code in
`ColumnStatsIndexSupport#transpose` assumes "the filter includes an isNull check" — which
held only for `is not null`.

### Summary and Changelog

* `DataSkippingUtils`: `IsNull` and `EqualNullSafe(col, null)` now translate to
  `colA_nullCount is null OR colA_nullCount > 0`, via a new
  `ColumnStatsExpressionUtils#genColumnIsNullExpression` helper. A file whose null-count is
  unknown is kept instead of being pruned; when the null-count is known the pruning
  decision is unchanged.
* `EqualNullSafe(col, null)` previously produced `colA_nullCount = null`, an always-null
  predicate that prunes every indexed file; it now shares the `IS NULL` translation, which
  is what `<=> null` means. (Spark's `NullPropagation` usually rewrites `col <=> null` into
  `col is null` before the filter reaches `HoodieFileIndex`, so this arm is mostly latent —
  but it is reached by callers that translate un-optimized expressions.)
* Comments on both arms (and the mirrored ones in `containsNullOrValueCountBasedFilters`)
  now describe the actual translation.
* `TestDataSkippingUtils`: three cases added to
  `testSupportedAndUnsupportedDataSkippingColumnsSource` (the suite that covers columns
  without stats) — `B is null`, `B <=> null` and `A = 1 and B is null` over an index where
  one file has no stats for `B`. All three fail on master and pass with this change.

No code was copied.

### Impact

Fixes silently incomplete results for `IS NULL` / `<=> null` queries on Spark when data
skipping is enabled and the queried column has no stats in some files (most commonly after
`ADD COLUMN` schema evolution). Files with unknown null-counts are now scanned, so such
queries read a few more files than before — a correctness-required trade-off; queries on
columns that are fully indexed are unaffected.

No public API, config or storage-format change.

### Risk Level

low

The change only relaxes a pruning predicate (strictly fewer files are pruned), so it cannot
introduce new false pruning. Verified with the new and existing `TestDataSkippingUtils`
cases.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
