### PR TITLE
fix(spark): make slash-separated date partitioning work on the row writer path

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -307,38 +307,56 @@ public class KeyGenUtils {
    * Turns a {@code yyyy-MM-dd} formatted date value into the {@code yyyy/MM/dd} directory structure
    * requested by {@code hoodie.datasource.write.slash.separated.date.partitioning}.
    *
-   * <p>A value whose dashes would produce a leading, trailing or doubled {@code "/"} is returned
-   * as-is, because the resulting path does not survive the round trip back from storage:
+   * <p>A value whose dash-delimited tokens would produce a path-breaking segment -- an empty
+   * token, {@code "."} or {@code ".."} -- is returned as-is, because the resulting path does not
+   * survive the round trip back from storage:
    *
    * <ul>
-   *   <li>leading -- {@code "-5"} becomes {@code "/5"}, and an absolute relative-partition-path is
-   *   resolved inconsistently: {@code FSUtils#constructAbsolutePath(String, String)} chops the
-   *   leading {@code "/"} while the {@link org.apache.hudi.storage.StoragePath} overload used by
+   *   <li>empty token, leading -- {@code "-5"} becomes {@code "/5"}, and an absolute
+   *   relative-partition-path is resolved inconsistently:
+   *   {@code FSUtils#constructAbsolutePath(String, String)} chops the leading {@code "/"} while the
+   *   {@link org.apache.hudi.storage.StoragePath} overload used by
    *   {@code AbstractTableFileSystemView} lets it URI-resolve away the table base path (the writer
    *   lands in {@code "<base>/5"} but the file-system view in {@code "/5"}, and {@code "-"}
    *   resolves to the base path itself)</li>
-   *   <li>trailing -- {@code "5-"} becomes {@code "5/"}, which {@code StoragePath} normalizes back
-   *   to {@code "5"}, so the writer records a partition string that no longer names its directory
-   *   </li>
-   *   <li>doubled -- {@code "a--b"} becomes {@code "a//b"}, which {@code URI.normalize()} collapses
-   *   to {@code "a/b"}, with the same divergence</li>
+   *   <li>empty token, trailing or interior -- {@code "5-"} becomes {@code "5/"}, which
+   *   {@code StoragePath} normalizes back to {@code "5"}, and {@code "a--b"} becomes
+   *   {@code "a//b"}, which {@code URI.normalize()} collapses to {@code "a/b"} -- either way the
+   *   writer records a partition string that no longer names its directory, so
+   *   {@code FSUtils#getFileName} slices the file name at the wrong offset and the metadata-table
+   *   FILES partition ends up with a truncated entry</li>
+   *   <li>dot segment -- {@code "2026-.-05"} becomes {@code "2026/./05"}, which URI-normalizes to
+   *   {@code "2026/05"}, and {@code "..-a"} becomes {@code "../a"}, which resolves OUTSIDE the
+   *   table base path entirely ({@code PartitionPathEncodeUtils#escapePathName} leaves dots and
+   *   dashes alone, so url-encoding does not neutralize this)</li>
    * </ul>
    *
-   * <p>In the latter two cases the recorded partition string is longer than the directory it
-   * resolves to, so {@code FSUtils#getFileName} slices the file name at the wrong offset and the
-   * metadata-table FILES partition ends up with a truncated entry. None of these values is a date
-   * to begin with, so nothing is lost by not slashing them.
+   * <p>None of these values is a date to begin with, so nothing is lost by not slashing them.
    */
   private static String slashSeparateDateValue(String partitionPath) {
     return hasPathBreakingDash(partitionPath) ? partitionPath : partitionPath.replace('-', '/');
   }
 
   /**
-   * Whether substituting the dashes in {@code partitionPath} would yield a leading, trailing or
-   * doubled path separator. See {@link #slashSeparateDateValue} for why each case is excluded.
+   * Whether substituting the dashes in {@code partitionPath} would yield a path-breaking segment:
+   * any dash-delimited token that is empty (a leading, trailing or doubled dash), {@code "."} or
+   * {@code ".."}. See {@link #slashSeparateDateValue} for why each case is excluded.
    */
   public static boolean hasPathBreakingDash(String partitionPath) {
-    return partitionPath.startsWith("-") || partitionPath.endsWith("-") || partitionPath.contains("--");
+    int tokenStart = 0;
+    int length = partitionPath.length();
+    for (int i = 0; i <= length; i++) {
+      if (i == length || partitionPath.charAt(i) == '-') {
+        int tokenLength = i - tokenStart;
+        if (tokenLength == 0
+            || (tokenLength == 1 && partitionPath.charAt(tokenStart) == '.')
+            || (tokenLength == 2 && partitionPath.charAt(tokenStart) == '.' && partitionPath.charAt(tokenStart + 1) == '.')) {
+          return true;
+        }
+        tokenStart = i + 1;
+      }
+    }
+    return false;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -254,12 +254,14 @@ public class KeyGenUtils {
         if (encodePartitionPath) {
           fieldVal = PartitionPathEncodeUtils.escapePathName(fieldVal);
         }
-        if (hiveStylePartitioning) {
-          fieldVal = partitionPathField + "=" + fieldVal;
-        }
-        // NOTE: See [[slashSeparateDateValue]] on why a leading dash suppresses the substitution
+        // NOTE: See [[slashSeparateDateValue]] on which dashes suppress the substitution. It runs
+        //       before the hive-style prefix so that the guard inspects the bare value, matching
+        //       [[PartitionPathFormatterBase#combine]] -- on "dt=-5" no guard could ever fire
         if (partitionPathFields.size() == 1 && slashSeparatedDatePartitioning) {
           fieldVal = slashSeparateDateValue(fieldVal);
+        }
+        if (hiveStylePartitioning) {
+          fieldVal = partitionPathField + "=" + fieldVal;
         }
         partitionPath.append(fieldVal);
       }
@@ -289,12 +291,14 @@ public class KeyGenUtils {
     if (encodePartitionPath) {
       partitionPath = PartitionPathEncodeUtils.escapePathName(partitionPath);
     }
-    if (hiveStylePartitioning) {
-      partitionPath = partitionPathField + "=" + partitionPath;
-    }
-    // NOTE: See [[slashSeparateDateValue]] on why a leading dash suppresses the substitution
+    // NOTE: See [[slashSeparateDateValue]] on which dashes suppress the substitution. It runs
+    //       before the hive-style prefix so that the guard inspects the bare value, matching
+    //       [[PartitionPathFormatterBase#combine]] -- on "dt=-5" no guard could ever fire
     if (slashSeparatedDatePartitioning) {
       partitionPath = slashSeparateDateValue(partitionPath);
+    }
+    if (hiveStylePartitioning) {
+      partitionPath = partitionPathField + "=" + partitionPath;
     }
     return partitionPath;
   }
@@ -303,17 +307,38 @@ public class KeyGenUtils {
    * Turns a {@code yyyy-MM-dd} formatted date value into the {@code yyyy/MM/dd} directory structure
    * requested by {@code hoodie.datasource.write.slash.separated.date.partitioning}.
    *
-   * <p>A value with a leading dash is returned as-is: substituting would make the partition path
-   * start with {@code "/"}, and an absolute relative-partition-path is resolved inconsistently --
-   * {@link org.apache.hudi.common.fs.FSUtils#constructAbsolutePath(String, String)} chops the
-   * leading {@code "/"} while the {@link org.apache.hudi.storage.StoragePath} overload used by
-   * {@code AbstractTableFileSystemView} lets it URI-resolve away the table base path (a value of
-   * {@code "-5"} lands the writer in {@code "<base>/5"} but the file-system view in {@code "/5"},
-   * and {@code "-"} resolves to the base path itself). Such a value is not a date to begin with,
-   * so nothing is lost by not slashing it.
+   * <p>A value whose dashes would produce a leading, trailing or doubled {@code "/"} is returned
+   * as-is, because the resulting path does not survive the round trip back from storage:
+   *
+   * <ul>
+   *   <li>leading -- {@code "-5"} becomes {@code "/5"}, and an absolute relative-partition-path is
+   *   resolved inconsistently: {@code FSUtils#constructAbsolutePath(String, String)} chops the
+   *   leading {@code "/"} while the {@link org.apache.hudi.storage.StoragePath} overload used by
+   *   {@code AbstractTableFileSystemView} lets it URI-resolve away the table base path (the writer
+   *   lands in {@code "<base>/5"} but the file-system view in {@code "/5"}, and {@code "-"}
+   *   resolves to the base path itself)</li>
+   *   <li>trailing -- {@code "5-"} becomes {@code "5/"}, which {@code StoragePath} normalizes back
+   *   to {@code "5"}, so the writer records a partition string that no longer names its directory
+   *   </li>
+   *   <li>doubled -- {@code "a--b"} becomes {@code "a//b"}, which {@code URI.normalize()} collapses
+   *   to {@code "a/b"}, with the same divergence</li>
+   * </ul>
+   *
+   * <p>In the latter two cases the recorded partition string is longer than the directory it
+   * resolves to, so {@code FSUtils#getFileName} slices the file name at the wrong offset and the
+   * metadata-table FILES partition ends up with a truncated entry. None of these values is a date
+   * to begin with, so nothing is lost by not slashing them.
    */
   private static String slashSeparateDateValue(String partitionPath) {
-    return partitionPath.startsWith("-") ? partitionPath : partitionPath.replace('-', '/');
+    return hasPathBreakingDash(partitionPath) ? partitionPath : partitionPath.replace('-', '/');
+  }
+
+  /**
+   * Whether substituting the dashes in {@code partitionPath} would yield a leading, trailing or
+   * doubled path separator. See {@link #slashSeparateDateValue} for why each case is excluded.
+   */
+  public static boolean hasPathBreakingDash(String partitionPath) {
+    return partitionPath.startsWith("-") || partitionPath.endsWith("-") || partitionPath.contains("--");
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -257,8 +257,9 @@ public class KeyGenUtils {
         if (hiveStylePartitioning) {
           fieldVal = partitionPathField + "=" + fieldVal;
         }
+        // NOTE: See [[slashSeparateDateValue]] on why a leading dash suppresses the substitution
         if (partitionPathFields.size() == 1 && slashSeparatedDatePartitioning) {
-          fieldVal = fieldVal.replace('-', '/');
+          fieldVal = slashSeparateDateValue(fieldVal);
         }
         partitionPath.append(fieldVal);
       }
@@ -291,10 +292,28 @@ public class KeyGenUtils {
     if (hiveStylePartitioning) {
       partitionPath = partitionPathField + "=" + partitionPath;
     }
+    // NOTE: See [[slashSeparateDateValue]] on why a leading dash suppresses the substitution
     if (slashSeparatedDatePartitioning) {
-      partitionPath = partitionPath.replace('-', '/');
+      partitionPath = slashSeparateDateValue(partitionPath);
     }
     return partitionPath;
+  }
+
+  /**
+   * Turns a {@code yyyy-MM-dd} formatted date value into the {@code yyyy/MM/dd} directory structure
+   * requested by {@code hoodie.datasource.write.slash.separated.date.partitioning}.
+   *
+   * <p>A value with a leading dash is returned as-is: substituting would make the partition path
+   * start with {@code "/"}, and an absolute relative-partition-path is resolved inconsistently --
+   * {@link org.apache.hudi.common.fs.FSUtils#constructAbsolutePath(String, String)} chops the
+   * leading {@code "/"} while the {@link org.apache.hudi.storage.StoragePath} overload used by
+   * {@code AbstractTableFileSystemView} lets it URI-resolve away the table base path (a value of
+   * {@code "-5"} lands the writer in {@code "<base>/5"} but the file-system view in {@code "/5"},
+   * and {@code "-"} resolves to the base path itself). Such a value is not a date to begin with,
+   * so nothing is lost by not slashing it.
+   */
+  private static String slashSeparateDateValue(String partitionPath) {
+    return partitionPath.startsWith("-") ? partitionPath : partitionPath.replace('-', '/');
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
@@ -137,24 +137,23 @@ public abstract class PartitionPathFormatterBase<S> {
   protected abstract S replaceDashesWithSlashes(S partitionPathPart);
 
   /**
-   * Whether substituting the dashes in {@code partitionPathPart} would yield a leading, trailing or
-   * doubled path separator, in which case {@link #replaceDashesWithSlashes(Object)} must not be
-   * applied to it. Kept in step with {@code KeyGenUtils#hasPathBreakingDash}, which guards the Avro
-   * write path.
+   * Whether substituting the dashes in {@code partitionPathPart} would yield a path-breaking
+   * segment -- any dash-delimited token that is empty (a leading, trailing or doubled dash),
+   * {@code "."} or {@code ".."} -- in which case {@link #replaceDashesWithSlashes(Object)} must not
+   * be applied to it. Kept in step with {@code KeyGenUtils#hasPathBreakingDash}, which guards the
+   * Avro write path and documents each case.
    *
    * <p>NOTE: This has to be implemented by every sub-class, since the check has to be performed on
    * the concrete string representation {@code S} the formatter operates on.
    *
-   * <p>NOTE: None of the three shapes survives the round trip back from storage. A leading dash
-   * makes the path absolute, and that is resolved inconsistently --
-   * {@code FSUtils#constructAbsolutePath(String, String)} chops the leading "/" while the
-   * {@code StoragePath} overload used by {@code AbstractTableFileSystemView} lets it URI-resolve away
-   * the table base path ({@code "-5"} lands the writer in {@code <base>/5} but the file-system view
-   * in {@code /5}). A trailing dash gives {@code "5/"}, which {@code StoragePath} normalizes back to
-   * {@code "5"}, and a doubled dash gives {@code "a//b"}, which {@code URI.normalize()} collapses to
-   * {@code "a/b"} -- in both cases the writer records a partition string longer than the directory
-   * it resolves to, so {@code FSUtils#getFileName} slices the file name at the wrong offset. None of
-   * these values is a date to begin with, so nothing is lost by not slashing them.
+   * <p>NOTE: None of these shapes survives the round trip back from storage. An empty token turns
+   * the path absolute ({@code "-5"} -> {@code "/5"}, resolved inconsistently by the two
+   * {@code FSUtils#constructAbsolutePath} overloads) or leaves the recorded partition string
+   * longer than the directory it normalizes to ({@code "5-"} -> {@code "5/"},
+   * {@code "a--b"} -> {@code "a//b"}), so {@code FSUtils#getFileName} slices the file name at the
+   * wrong offset. A dot segment is resolved away by {@code URI.normalize()} -- {@code "..-a"}
+   * becomes {@code "../a"} and escapes the table base path entirely. None of these values is a
+   * date to begin with, so nothing is lost by not slashing them.
    */
   protected abstract boolean hasPathBreakingDash(S partitionPathPart);
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
@@ -80,9 +80,9 @@ public abstract class PartitionPathFormatterBase<S> {
             .append(partitionPathPartStr);
       } else if (slashSeparatedDatePartitioning && !hasPathBreakingDash(partitionPathPartStr)) {
         // NOTE: Every part is substituted here, preserving the behaviour this branch had before the
-        //       [[ClassCastException]] fix. Writes reject slash partitioning with more than one
-        //       partition field ([[HoodieWriterUtils#validateTableConfig]]), so this branch only
-        //       serves reads of tables written before that rejection: [[CustomKeyGenerator]] built
+        //       [[ClassCastException]] fix. Spark writes reject slash partitioning with more than
+        //       one partition field ([[HoodieWriterUtils#validateTableConfig]]), so this branch
+        //       mainly serves reads of tables predating that rejection: [[CustomKeyGenerator]] built
         //       one single-field sub-keygen per field, so such tables slashed each field
         //       individually, and [[SparkHoodieTableFileIndex#composeRelativePartitionPath]] has to
         //       land on the same directory when it composes the prefix in one [[combine]] call over
@@ -128,10 +128,11 @@ public abstract class PartitionPathFormatterBase<S> {
    * such tables slashed each field individually, and
    * {@code SparkHoodieTableFileIndex#composeRelativePartitionPath} -- which calls {@link #combine}
    * once over all N columns to compose a listing prefix -- has to name the very same directory, or
-   * the prefix misses and the query silently returns no rows. New writes cannot reach this branch
-   * with slash partitioning enabled: multi-field slash tables produce a layout the extra fragments
-   * leave {@code HoodieSparkUtils#doParsePartitionColumnValues} unable to line up with the
-   * partition columns, so {@code HoodieWriterUtils#validateTableConfig} rejects them at write time.
+   * the prefix misses and the query silently returns no rows. Spark writes cannot reach this
+   * branch with slash partitioning enabled: multi-field slash tables produce a layout the extra
+   * fragments leave {@code HoodieSparkUtils#doParsePartitionColumnValues} unable to line up with
+   * the partition columns, so {@code HoodieWriterUtils#validateTableConfig} rejects them at write
+   * time (a HoodieStreamer first write to a not-yet-existing table bypasses that validation).
    * See HUDI issue #19666.
    */
   protected abstract S replaceDashesWithSlashes(S partitionPathPart);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
@@ -71,8 +71,19 @@ public abstract class PartitionPathFormatterBase<S> {
       //       [[CustomKeyGenerator]] is not an exception to this: it builds one single-field
       //       sub-key-generator per partition field, so every field takes this branch and a
       //       multi-field table does get each of its values slash-separated -- on the Avro,
-      //       [[org.apache.spark.sql.Row]] and [[org.apache.spark.sql.catalyst.InternalRow]] paths alike
-      return slashSeparatedDatePartitioning ? replaceDashesWithSlashes(partitionPathPart) : partitionPathPart;
+      //       [[org.apache.spark.sql.Row]] and [[org.apache.spark.sql.catalyst.InternalRow]] paths alike.
+      //       All three agreeing does not make that layout usable, though: the extra fragments leave
+      //       [[HoodieSparkUtils#doParsePartitionColumnValues]] unable to line the path up with the
+      //       partition columns, so reading such a table back fails. Tracked in HUDI issue #19666
+      // NOTE: A value with a leading dash is left alone: substituting would make the partition path
+      //       start with "/", and an absolute relative-partition-path is resolved inconsistently --
+      //       [[FSUtils#constructAbsolutePath(String, String)]] chops the leading "/" while the
+      //       [[StoragePath]] overload used by [[AbstractTableFileSystemView]] lets it URI-resolve
+      //       away the table base path ("-5" lands the writer in "<base>/5" but the file-system view
+      //       in "/5"). Such a value is not a date to begin with, so nothing is lost by not slashing it
+      return slashSeparatedDatePartitioning && !startsWithDash(partitionPathPart)
+          ? replaceDashesWithSlashes(partitionPathPart)
+          : partitionPathPart;
     }
 
     StringBuilder<S> sb = stringBuilderFactory.get();
@@ -112,6 +123,15 @@ public abstract class PartitionPathFormatterBase<S> {
    * performed on the concrete string representation {@code S} the formatter operates on.
    */
   protected abstract S replaceDashesWithSlashes(S partitionPathPart);
+
+  /**
+   * Whether {@code partitionPathPart} starts with a dash, in which case
+   * {@link #replaceDashesWithSlashes(Object)} must not be applied to it.
+   *
+   * <p>NOTE: This has to be implemented by every sub-class, since the check has to be performed on
+   * the concrete string representation {@code S} the formatter operates on.
+   */
+  protected abstract boolean startsWithDash(S partitionPathPart);
 
   /**
    * This is a generic interface closing the gap and unifying the {@link java.lang.StringBuilder} with

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
@@ -63,25 +63,9 @@ public abstract class PartitionPathFormatterBase<S> {
     // and Hive-style of partitioning is not required
     if (!useHiveStylePartitioning && partitionPathParts.length == 1) {
       S partitionPathPart = tryEncode(handleEmpty(toString(partitionPathParts[0])));
-      // NOTE: For [[SimpleKeyGenerator]]/[[ComplexKeyGenerator]] slash-separated date partitioning
-      //       only kicks in for a table partitioned by a single (date) column, mirroring
-      //       [[KeyGenUtils#getPartitionPath]] (single field) and [[KeyGenUtils#getRecordPartitionPath]]
-      //       (which guards on a single field as well) driving the Avro write-path: both write-paths
-      //       have to derive the very same partition path for a record.
-      //       [[CustomKeyGenerator]] is not an exception to this: it builds one single-field
-      //       sub-key-generator per partition field, so every field takes this branch and a
-      //       multi-field table does get each of its values slash-separated -- on the Avro,
-      //       [[org.apache.spark.sql.Row]] and [[org.apache.spark.sql.catalyst.InternalRow]] paths alike.
-      //       All three agreeing does not make that layout usable, though: the extra fragments leave
-      //       [[HoodieSparkUtils#doParsePartitionColumnValues]] unable to line the path up with the
-      //       partition columns, so reading such a table back fails. Tracked in HUDI issue #19666
-      // NOTE: A value with a leading dash is left alone: substituting would make the partition path
-      //       start with "/", and an absolute relative-partition-path is resolved inconsistently --
-      //       [[FSUtils#constructAbsolutePath(String, String)]] chops the leading "/" while the
-      //       [[StoragePath]] overload used by [[AbstractTableFileSystemView]] lets it URI-resolve
-      //       away the table base path ("-5" lands the writer in "<base>/5" but the file-system view
-      //       in "/5"). Such a value is not a date to begin with, so nothing is lost by not slashing it
-      return slashSeparatedDatePartitioning && !startsWithDash(partitionPathPart)
+      // NOTE: See [[replaceDashesWithSlashes]] on how this lines up with the Avro write path, and
+      //       [[hasPathBreakingDash]] on which dashes suppress the substitution
+      return slashSeparatedDatePartitioning && !hasPathBreakingDash(partitionPathPart)
           ? replaceDashesWithSlashes(partitionPathPart)
           : partitionPathPart;
     }
@@ -92,10 +76,19 @@ public abstract class PartitionPathFormatterBase<S> {
 
       if (useHiveStylePartitioning) {
         sb.appendJava(partitionPathFields.get(i))
-            .appendJava("=");
+            .appendJava("=")
+            .append(partitionPathPartStr);
+      } else if (slashSeparatedDatePartitioning && !hasPathBreakingDash(partitionPathPartStr)) {
+        // NOTE: Every part is substituted here, preserving the behaviour this branch had before the
+        //       [[ClassCastException]] fix. [[CustomKeyGenerator]] builds one single-field sub-keygen
+        //       per field, so its write path slashes each field individually, and
+        //       [[SparkHoodieTableFileIndex#composeRelativePartitionPath]] has to land on the same
+        //       directory when it composes the prefix in one [[combine]] call over all N columns.
+        //       Whether a multi-field table should be slash-separated at all is HUDI issue #19666
+        sb.append(replaceDashesWithSlashes(partitionPathPartStr));
+      } else {
+        sb.append(partitionPathPartStr);
       }
-
-      sb.append(partitionPathPartStr);
 
       if (i < partitionPathParts.length - 1) {
         sb.appendJava(DEFAULT_PARTITION_PATH_SEPARATOR);
@@ -121,17 +114,46 @@ public abstract class PartitionPathFormatterBase<S> {
    *
    * <p>NOTE: This has to be implemented by every sub-class, since the substitution has to be
    * performed on the concrete string representation {@code S} the formatter operates on.
+   *
+   * <p>NOTE: For {@code SimpleKeyGenerator}/{@code ComplexKeyGenerator} the single-part branch of
+   * {@link #combine} routes only a table partitioned by a single (date) column here, mirroring
+   * {@code KeyGenUtils#getPartitionPath} (single field) and {@code KeyGenUtils#getRecordPartitionPath}
+   * (which guards on a single field as well) driving the Avro write-path: both write-paths have to
+   * derive the very same partition path for a record.
+   *
+   * <p>NOTE: The multi-part branch substitutes every part, which {@code CustomKeyGenerator} depends
+   * on: it builds one single-field sub-key-generator per partition field, so its own write path
+   * slashes each field individually, and {@code SparkHoodieTableFileIndex#composeRelativePartitionPath}
+   * -- which calls {@link #combine} once over all N columns to compose a listing prefix -- has to
+   * name the very same directory, or the prefix misses and the query silently returns no rows. For
+   * {@code ComplexKeyGenerator} this leaves the row-writer path slashing where the Avro path does
+   * not, and neither layout reads back: the extra fragments leave
+   * {@code HoodieSparkUtils#doParsePartitionColumnValues} unable to line the path up with the
+   * partition columns. Both are tracked in HUDI issue #19666.
    */
   protected abstract S replaceDashesWithSlashes(S partitionPathPart);
 
   /**
-   * Whether {@code partitionPathPart} starts with a dash, in which case
-   * {@link #replaceDashesWithSlashes(Object)} must not be applied to it.
+   * Whether substituting the dashes in {@code partitionPathPart} would yield a leading, trailing or
+   * doubled path separator, in which case {@link #replaceDashesWithSlashes(Object)} must not be
+   * applied to it. Kept in step with {@code KeyGenUtils#hasPathBreakingDash}, which guards the Avro
+   * write path.
    *
    * <p>NOTE: This has to be implemented by every sub-class, since the check has to be performed on
    * the concrete string representation {@code S} the formatter operates on.
+   *
+   * <p>NOTE: None of the three shapes survives the round trip back from storage. A leading dash
+   * makes the path absolute, and that is resolved inconsistently --
+   * {@code FSUtils#constructAbsolutePath(String, String)} chops the leading "/" while the
+   * {@code StoragePath} overload used by {@code AbstractTableFileSystemView} lets it URI-resolve away
+   * the table base path ({@code "-5"} lands the writer in {@code <base>/5} but the file-system view
+   * in {@code /5}). A trailing dash gives {@code "5/"}, which {@code StoragePath} normalizes back to
+   * {@code "5"}, and a doubled dash gives {@code "a//b"}, which {@code URI.normalize()} collapses to
+   * {@code "a/b"} -- in both cases the writer records a partition string longer than the directory
+   * it resolves to, so {@code FSUtils#getFileName} slices the file name at the wrong offset. None of
+   * these values is a date to begin with, so nothing is lost by not slashing them.
    */
-  protected abstract boolean startsWithDash(S partitionPathPart);
+  protected abstract boolean hasPathBreakingDash(S partitionPathPart);
 
   /**
    * This is a generic interface closing the gap and unifying the {@link java.lang.StringBuilder} with

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
@@ -80,11 +80,13 @@ public abstract class PartitionPathFormatterBase<S> {
             .append(partitionPathPartStr);
       } else if (slashSeparatedDatePartitioning && !hasPathBreakingDash(partitionPathPartStr)) {
         // NOTE: Every part is substituted here, preserving the behaviour this branch had before the
-        //       [[ClassCastException]] fix. [[CustomKeyGenerator]] builds one single-field sub-keygen
-        //       per field, so its write path slashes each field individually, and
-        //       [[SparkHoodieTableFileIndex#composeRelativePartitionPath]] has to land on the same
-        //       directory when it composes the prefix in one [[combine]] call over all N columns.
-        //       Whether a multi-field table should be slash-separated at all is HUDI issue #19666
+        //       [[ClassCastException]] fix. Writes reject slash partitioning with more than one
+        //       partition field ([[HoodieWriterUtils#validateTableConfig]]), so this branch only
+        //       serves reads of tables written before that rejection: [[CustomKeyGenerator]] built
+        //       one single-field sub-keygen per field, so such tables slashed each field
+        //       individually, and [[SparkHoodieTableFileIndex#composeRelativePartitionPath]] has to
+        //       land on the same directory when it composes the prefix in one [[combine]] call over
+        //       all N columns. See HUDI issue #19666
         sb.append(replaceDashesWithSlashes(partitionPathPartStr));
       } else {
         sb.append(partitionPathPartStr);
@@ -121,15 +123,16 @@ public abstract class PartitionPathFormatterBase<S> {
    * (which guards on a single field as well) driving the Avro write-path: both write-paths have to
    * derive the very same partition path for a record.
    *
-   * <p>NOTE: The multi-part branch substitutes every part, which {@code CustomKeyGenerator} depends
-   * on: it builds one single-field sub-key-generator per partition field, so its own write path
-   * slashes each field individually, and {@code SparkHoodieTableFileIndex#composeRelativePartitionPath}
-   * -- which calls {@link #combine} once over all N columns to compose a listing prefix -- has to
-   * name the very same directory, or the prefix misses and the query silently returns no rows. For
-   * {@code ComplexKeyGenerator} this leaves the row-writer path slashing where the Avro path does
-   * not, and neither layout reads back: the extra fragments leave
-   * {@code HoodieSparkUtils#doParsePartitionColumnValues} unable to line the path up with the
-   * partition columns. Both are tracked in HUDI issue #19666.
+   * <p>NOTE: The multi-part branch substitutes every part, which reads of legacy tables depend on:
+   * {@code CustomKeyGenerator} built one single-field sub-key-generator per partition field, so
+   * such tables slashed each field individually, and
+   * {@code SparkHoodieTableFileIndex#composeRelativePartitionPath} -- which calls {@link #combine}
+   * once over all N columns to compose a listing prefix -- has to name the very same directory, or
+   * the prefix misses and the query silently returns no rows. New writes cannot reach this branch
+   * with slash partitioning enabled: multi-field slash tables produce a layout the extra fragments
+   * leave {@code HoodieSparkUtils#doParsePartitionColumnValues} unable to line up with the
+   * partition columns, so {@code HoodieWriterUtils#validateTableConfig} rejects them at write time.
+   * See HUDI issue #19666.
    */
   protected abstract S replaceDashesWithSlashes(S partitionPathPart);
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
@@ -62,11 +62,11 @@ public abstract class PartitionPathFormatterBase<S> {
     // Avoid creating [[StringBuilder]] in case there's just one partition-path part,
     // and Hive-style of partitioning is not required
     if (!useHiveStylePartitioning && partitionPathParts.length == 1) {
-      if (slashSeparatedDatePartitioning) {
-        return ((S) ((String) toString(partitionPathParts[0])).replace('-', '/'));
-      } else {
-        return tryEncode(handleEmpty(toString(partitionPathParts[0])));
-      }
+      S partitionPathPart = tryEncode(handleEmpty(toString(partitionPathParts[0])));
+      // NOTE: Slash-separated date partitioning only kicks in for a table partitioned by a single
+      //       (date) column, mirroring [[KeyGenUtils#getRecordPartitionPath]] used on the Avro
+      //       write-path: both write-paths have to derive the very same partition path for a record
+      return slashSeparatedDatePartitioning ? replaceDashesWithSlashes(partitionPathPart) : partitionPathPart;
     }
 
     StringBuilder<S> sb = stringBuilderFactory.get();
@@ -75,14 +75,10 @@ public abstract class PartitionPathFormatterBase<S> {
 
       if (useHiveStylePartitioning) {
         sb.appendJava(partitionPathFields.get(i))
-            .appendJava("=")
-            .append(partitionPathPartStr);
-      } else if (slashSeparatedDatePartitioning) {
-        String res = ((String) partitionPathPartStr).replace('-', '/');
-        sb.append(((S) res));
-      } else {
-        sb.append(partitionPathPartStr);
+            .appendJava("=");
       }
+
+      sb.append(partitionPathPartStr);
 
       if (i < partitionPathParts.length - 1) {
         sb.appendJava(DEFAULT_PARTITION_PATH_SEPARATOR);
@@ -101,6 +97,15 @@ public abstract class PartitionPathFormatterBase<S> {
   protected abstract S encode(S partitionPathPart);
 
   protected abstract S handleEmpty(S partitionPathPart);
+
+  /**
+   * Turns a {@code yyyy-MM-dd} formatted date value into the {@code yyyy/MM/dd} directory structure
+   * requested by {@code hoodie.datasource.write.slash.separated.date.partitioning}.
+   *
+   * <p>NOTE: This has to be implemented by every sub-class, since the substitution has to be
+   * performed on the concrete string representation {@code S} the formatter operates on.
+   */
+  protected abstract S replaceDashesWithSlashes(S partitionPathPart);
 
   /**
    * This is a generic interface closing the gap and unifying the {@link java.lang.StringBuilder} with

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/PartitionPathFormatterBase.java
@@ -63,9 +63,15 @@ public abstract class PartitionPathFormatterBase<S> {
     // and Hive-style of partitioning is not required
     if (!useHiveStylePartitioning && partitionPathParts.length == 1) {
       S partitionPathPart = tryEncode(handleEmpty(toString(partitionPathParts[0])));
-      // NOTE: Slash-separated date partitioning only kicks in for a table partitioned by a single
-      //       (date) column, mirroring [[KeyGenUtils#getRecordPartitionPath]] used on the Avro
-      //       write-path: both write-paths have to derive the very same partition path for a record
+      // NOTE: For [[SimpleKeyGenerator]]/[[ComplexKeyGenerator]] slash-separated date partitioning
+      //       only kicks in for a table partitioned by a single (date) column, mirroring
+      //       [[KeyGenUtils#getPartitionPath]] (single field) and [[KeyGenUtils#getRecordPartitionPath]]
+      //       (which guards on a single field as well) driving the Avro write-path: both write-paths
+      //       have to derive the very same partition path for a record.
+      //       [[CustomKeyGenerator]] is not an exception to this: it builds one single-field
+      //       sub-key-generator per partition field, so every field takes this branch and a
+      //       multi-field table does get each of its values slash-separated -- on the Avro,
+      //       [[org.apache.spark.sql.Row]] and [[org.apache.spark.sql.catalyst.InternalRow]] paths alike
       return slashSeparatedDatePartitioning ? replaceDashesWithSlashes(partitionPathPart) : partitionPathPart;
     }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/StringPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/StringPartitionPathFormatter.java
@@ -61,6 +61,11 @@ public class StringPartitionPathFormatter extends PartitionPathFormatterBase<Str
     return partitionPathPart.replace('-', '/');
   }
 
+  @Override
+  protected boolean startsWithDash(String partitionPathPart) {
+    return !partitionPathPart.isEmpty() && partitionPathPart.charAt(0) == '-';
+  }
+
   public static class JavaStringBuilder implements PartitionPathFormatterBase.StringBuilder<String> {
     private final java.lang.StringBuilder sb = new java.lang.StringBuilder();
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/StringPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/StringPartitionPathFormatter.java
@@ -62,8 +62,8 @@ public class StringPartitionPathFormatter extends PartitionPathFormatterBase<Str
   }
 
   @Override
-  protected boolean startsWithDash(String partitionPathPart) {
-    return !partitionPathPart.isEmpty() && partitionPathPart.charAt(0) == '-';
+  protected boolean hasPathBreakingDash(String partitionPathPart) {
+    return KeyGenUtils.hasPathBreakingDash(partitionPathPart);
   }
 
   public static class JavaStringBuilder implements PartitionPathFormatterBase.StringBuilder<String> {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/StringPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/StringPartitionPathFormatter.java
@@ -56,6 +56,11 @@ public class StringPartitionPathFormatter extends PartitionPathFormatterBase<Str
     }
   }
 
+  @Override
+  protected String replaceDashesWithSlashes(String partitionPathPart) {
+    return partitionPathPart.replace('-', '/');
+  }
+
   public static class JavaStringBuilder implements PartitionPathFormatterBase.StringBuilder<String> {
     private final java.lang.StringBuilder sb = new java.lang.StringBuilder();
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/UTF8StringPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/UTF8StringPartitionPathFormatter.java
@@ -35,7 +35,6 @@ public class UTF8StringPartitionPathFormatter extends PartitionPathFormatterBase
 
   private static final UTF8String DASH_UTF8 = UTF8String.fromString("-");
   private static final UTF8String SLASH_UTF8 = UTF8String.fromString("/");
-  private static final UTF8String DOUBLE_DASH_UTF8 = UTF8String.fromString("--");
 
   public UTF8StringPartitionPathFormatter(Supplier<StringBuilder<UTF8String>> stringBuilderFactory,
                                           boolean useHiveStylePartitioning,
@@ -70,9 +69,22 @@ public class UTF8StringPartitionPathFormatter extends PartitionPathFormatterBase
 
   @Override
   protected boolean hasPathBreakingDash(UTF8String partitionPathPart) {
-    return partitionPathPart.startsWith(DASH_UTF8)
-        || partitionPathPart.endsWith(DASH_UTF8)
-        || partitionPathPart.contains(DOUBLE_DASH_UTF8);
+    // Byte-wise mirror of KeyGenUtils#hasPathBreakingDash: '-' and '.' are ASCII, so they can
+    // never collide with a UTF-8 continuation byte and a plain byte scan is exact
+    byte[] bytes = partitionPathPart.getBytes();
+    int tokenStart = 0;
+    for (int i = 0; i <= bytes.length; i++) {
+      if (i == bytes.length || bytes[i] == '-') {
+        int tokenLength = i - tokenStart;
+        if (tokenLength == 0
+            || (tokenLength == 1 && bytes[tokenStart] == '.')
+            || (tokenLength == 2 && bytes[tokenStart] == '.' && bytes[tokenStart + 1] == '.')) {
+          return true;
+        }
+        tokenStart = i + 1;
+      }
+    }
+    return false;
   }
 
   public static class UTF8StringBuilder implements StringBuilder<UTF8String> {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/UTF8StringPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/UTF8StringPartitionPathFormatter.java
@@ -35,6 +35,7 @@ public class UTF8StringPartitionPathFormatter extends PartitionPathFormatterBase
 
   private static final UTF8String DASH_UTF8 = UTF8String.fromString("-");
   private static final UTF8String SLASH_UTF8 = UTF8String.fromString("/");
+  private static final UTF8String DOUBLE_DASH_UTF8 = UTF8String.fromString("--");
 
   public UTF8StringPartitionPathFormatter(Supplier<StringBuilder<UTF8String>> stringBuilderFactory,
                                           boolean useHiveStylePartitioning,
@@ -68,8 +69,10 @@ public class UTF8StringPartitionPathFormatter extends PartitionPathFormatterBase
   }
 
   @Override
-  protected boolean startsWithDash(UTF8String partitionPathPart) {
-    return partitionPathPart.startsWith(DASH_UTF8);
+  protected boolean hasPathBreakingDash(UTF8String partitionPathPart) {
+    return partitionPathPart.startsWith(DASH_UTF8)
+        || partitionPathPart.endsWith(DASH_UTF8)
+        || partitionPathPart.contains(DOUBLE_DASH_UTF8);
   }
 
   public static class UTF8StringBuilder implements StringBuilder<UTF8String> {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/UTF8StringPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/UTF8StringPartitionPathFormatter.java
@@ -67,6 +67,11 @@ public class UTF8StringPartitionPathFormatter extends PartitionPathFormatterBase
     return partitionPathPart.replace(DASH_UTF8, SLASH_UTF8);
   }
 
+  @Override
+  protected boolean startsWithDash(UTF8String partitionPathPart) {
+    return partitionPathPart.startsWith(DASH_UTF8);
+  }
+
   public static class UTF8StringBuilder implements StringBuilder<UTF8String> {
     private final org.apache.hudi.unsafe.UTF8StringBuilder sb = new org.apache.hudi.unsafe.UTF8StringBuilder();
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/UTF8StringPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/keygen/UTF8StringPartitionPathFormatter.java
@@ -33,6 +33,9 @@ public class UTF8StringPartitionPathFormatter extends PartitionPathFormatterBase
 
   protected static final UTF8String HUDI_DEFAULT_PARTITION_PATH_UTF8 = UTF8String.fromString(HUDI_DEFAULT_PARTITION_PATH);
 
+  private static final UTF8String DASH_UTF8 = UTF8String.fromString("-");
+  private static final UTF8String SLASH_UTF8 = UTF8String.fromString("/");
+
   public UTF8StringPartitionPathFormatter(Supplier<StringBuilder<UTF8String>> stringBuilderFactory,
                                           boolean useHiveStylePartitioning,
                                           boolean useEncoding,
@@ -57,6 +60,11 @@ public class UTF8StringPartitionPathFormatter extends PartitionPathFormatterBase
     }
 
     return partitionPathPart;
+  }
+
+  @Override
+  protected UTF8String replaceDashesWithSlashes(UTF8String partitionPathPart) {
+    return partitionPathPart.replace(DASH_UTF8, SLASH_UTF8);
   }
 
   public static class UTF8StringBuilder implements StringBuilder<UTF8String> {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestComplexKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestComplexKeyGenerator.java
@@ -245,6 +245,24 @@ public class TestComplexKeyGenerator extends KeyGeneratorTestUtilities {
   }
 
   @Test
+  void testSlashSeparatedDatePartitioningLeavesLeadingDashesAlone() {
+    TypedProperties properties = new TypedProperties();
+    properties.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+    properties.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "timestamp");
+    properties.put(KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING.key(), "true");
+    properties.put(KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE.key(), "false");
+
+    ComplexKeyGenerator keyGenerator = new ComplexKeyGenerator(properties);
+
+    // This is the only production caller of the multi-field KeyGenUtils#getRecordPartitionPath
+    // overload, so the guard on that line is unexercised without this case
+    GenericRecord avroRecord = KeyGeneratorTestUtilities.getRecord();
+    avroRecord.put("timestamp", "-5");
+
+    assertEquals("-5", keyGenerator.getKey(avroRecord).getPartitionPath());
+  }
+
+  @Test
   void testSlashSeparatedDatePartitioningWithAlreadyFormattedInput() {
     TypedProperties properties = new TypedProperties();
     properties.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestCustomKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestCustomKeyGenerator.java
@@ -419,7 +419,9 @@ class TestCustomKeyGenerator extends KeyGeneratorTestUtilities {
   void testSlashSeparatedDatePartitioning() {
     TypedProperties properties = new TypedProperties();
     properties.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
-    properties.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "timestamp:simple");
+    // NOTE: "ts_ms" is the string-typed field of the example schema, "timestamp" is a long, so only
+    //       the former survives the conversion into a [[Row]]/[[InternalRow]]
+    properties.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "ts_ms:simple");
     properties.put(KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING.key(), "true");
     properties.put(KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE.key(), "false");
     properties.put(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), CustomKeyGenerator.class.getName());
@@ -429,12 +431,21 @@ class TestCustomKeyGenerator extends KeyGeneratorTestUtilities {
 
     // Create a record with date in yyyy-MM-dd format
     GenericRecord avroRecord = KeyGeneratorTestUtilities.getRecord();
-    avroRecord.put("timestamp", "2026-01-05");
+    avroRecord.put("ts_ms", "2026-01-05");
 
     // The partition path should be transformed to yyyy/MM/dd format
     HoodieKey key = keyGenerator.getKey(avroRecord);
     assertEquals("key1", key.getRecordKey());
     assertEquals("2026/01/05", key.getPartitionPath());
+
+    // NOTE: [[CustomKeyGenerator]] builds one single-field sub-key-generator per partition field, so
+    //       the row-writer paths have to derive the very same partition path as the Avro one above
+    Row row = KeyGeneratorTestUtilities.getRow(avroRecord);
+    assertEquals("2026/01/05", keyGenerator.getPartitionPath(row));
+
+    InternalRow internalRow = KeyGeneratorTestUtilities.getInternalRow(row);
+    assertEquals(UTF8String.fromString("2026/01/05"),
+        keyGenerator.getPartitionPath(internalRow, row.schema()));
   }
 
   @Test

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
@@ -84,7 +84,7 @@ class TestPartitionPathFormatter {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void testSlashSeparatedDatePartitioningLeavesLeadingDashesAlone(boolean useRowWriterPath) {
+  void testSlashSeparatedDatePartitioningLeavesPathBreakingDashesAlone(boolean useRowWriterPath) {
     // NOTE: Substituting in any of these would yield a partition path that does not survive the
     //       round trip back from storage. A leading "/" is resolved differently by
     //       [[FSUtils#constructAbsolutePath(String, String)]] and the [[StoragePath]] overload used
@@ -97,8 +97,14 @@ class TestPartitionPathFormatter {
     assertEquals("--5", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "--5"));
     assertEquals("5-", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "5-"));
     assertEquals("a--b", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "a--b"));
-    // A single interior dash is still a separator
+    // A dash-delimited "." or ".." would become a URI dot segment: "2026/./05" normalizes to
+    // "2026/05", and "../a" resolves outside the table base path entirely
+    assertEquals("2026-.-05", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "2026-.-05"));
+    assertEquals("a-..-b", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "a-..-b"));
+    assertEquals("..-a", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "..-a"));
+    // A single interior dash is still a separator, and dots inside a token are untouched
     assertEquals("2026/01/05", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "2026-01-05"));
+    assertEquals("v1.2/v3.4", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "v1.2-v3.4"));
   }
 
   @ParameterizedTest

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.hudi.common.util.PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH;
+import static org.apache.hudi.keygen.KeyGenUtils.HUDI_DEFAULT_PARTITION_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -59,16 +59,6 @@ class TestPartitionPathFormatter {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void testSlashSeparatedDatePartitioningSingleField(boolean useRowWriterPath) {
-    assertEquals("2026/01/05",
-        combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "2026-01-05"));
-    // Input that is already slash-separated is left untouched
-    assertEquals("2026/01/05",
-        combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "2026/01/05"));
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
   void testSlashSeparatedDatePartitioningOnlyAppliesToSingleFieldPartitioning(boolean useRowWriterPath) {
     // NOTE: This mirrors [[KeyGenUtils#getRecordPartitionPath]] driving the Avro write-path
     assertEquals("2026-01-05/san-francisco",
@@ -78,9 +68,9 @@ class TestPartitionPathFormatter {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testSlashSeparatedDatePartitioningHandlesNullAndEmptyValues(boolean useRowWriterPath) {
-    assertEquals(DEFAULT_PARTITION_PATH,
+    assertEquals(HUDI_DEFAULT_PARTITION_PATH,
         combine(useRowWriterPath, false, false, true, SINGLE_FIELD, new Object[] {null}));
-    assertEquals(DEFAULT_PARTITION_PATH,
+    assertEquals(HUDI_DEFAULT_PARTITION_PATH,
         combine(useRowWriterPath, false, false, true, SINGLE_FIELD, ""));
   }
 
@@ -90,26 +80,23 @@ class TestPartitionPathFormatter {
     // '?' has to be escaped, while the date separators are turned into directory separators
     assertEquals("2026/01/05", combine(useRowWriterPath, false, true, true, SINGLE_FIELD, "2026-01-05"));
     assertEquals("a%3Fb", combine(useRowWriterPath, false, true, true, SINGLE_FIELD, "a?b"));
+    // Encoding runs before the substitution (parity with KeyGenUtils), so an already slash-separated
+    // value is escaped rather than turned into directories
+    assertEquals("2026%2F01%2F05", combine(useRowWriterPath, false, true, true, SINGLE_FIELD, "2026/01/05"));
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testHiveStylePartitioningTakesPrecedence(boolean useRowWriterPath) {
-    // NOTE: Hive-style partitioning and slash-separated date partitioning are mutually exclusive --
-    //       [[HoodieCatalogTable#extraTableConfig]] rejects a table configuring both -- so this
-    //       combination is unreachable and the formatter deliberately leaves the value alone.
+    // NOTE: Hive-style partitioning and slash-separated date partitioning are documented as mutually
+    //       exclusive ([[KeyGeneratorOptions#SLASH_SEPARATED_DATE_PARTITIONING]]), but only
+    //       [[HoodieCatalogTable#extraTableConfig]] enforces it, and it inspects the SQL options
+    //       alone -- df.write and HoodieStreamer still accept the combination. The formatter
+    //       deliberately leaves the value alone here rather than mirroring the Avro path, which
+    //       produces a layout [[HoodieSparkUtils#doParsePartitionColumnValues]] cannot read back.
     //       This asserts the pre-existing behavior stays put, it is not a statement about what the
     //       combination *should* produce
     assertEquals("date_col=2026-01-05",
         combine(useRowWriterPath, true, false, true, SINGLE_FIELD, "2026-01-05"));
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void testPlainPartitioningIsUnaffected(boolean useRowWriterPath) {
-    assertEquals("2026-01-05",
-        combine(useRowWriterPath, false, false, false, SINGLE_FIELD, "2026-01-05"));
-    assertEquals("2026-01-05/san-francisco",
-        combine(useRowWriterPath, false, false, false, TWO_FIELDS, "2026-01-05", "san-francisco"));
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
@@ -41,13 +41,13 @@ class TestPartitionPathFormatter {
   private static final List<String> SINGLE_FIELD = Collections.singletonList("date_col");
   private static final List<String> TWO_FIELDS = Arrays.asList("date_col", "city");
 
-  private String combine(boolean unsafe,
+  private String combine(boolean useRowWriterPath,
                          boolean hiveStylePartitioning,
                          boolean encode,
                          boolean slashSeparatedDatePartitioning,
                          List<String> fields,
                          Object... parts) {
-    if (unsafe) {
+    if (useRowWriterPath) {
       return new UTF8StringPartitionPathFormatter(
           UTF8StringPartitionPathFormatter.UTF8StringBuilder::new, hiveStylePartitioning, encode,
           slashSeparatedDatePartitioning).combine(fields, parts).toString();
@@ -59,52 +59,57 @@ class TestPartitionPathFormatter {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void testSlashSeparatedDatePartitioningSingleField(boolean unsafe) {
+  void testSlashSeparatedDatePartitioningSingleField(boolean useRowWriterPath) {
     assertEquals("2026/01/05",
-        combine(unsafe, false, false, true, SINGLE_FIELD, "2026-01-05"));
+        combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "2026-01-05"));
     // Input that is already slash-separated is left untouched
     assertEquals("2026/01/05",
-        combine(unsafe, false, false, true, SINGLE_FIELD, "2026/01/05"));
+        combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "2026/01/05"));
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void testSlashSeparatedDatePartitioningOnlyAppliesToSingleFieldPartitioning(boolean unsafe) {
+  void testSlashSeparatedDatePartitioningOnlyAppliesToSingleFieldPartitioning(boolean useRowWriterPath) {
     // NOTE: This mirrors [[KeyGenUtils#getRecordPartitionPath]] driving the Avro write-path
     assertEquals("2026-01-05/san-francisco",
-        combine(unsafe, false, false, true, TWO_FIELDS, "2026-01-05", "san-francisco"));
+        combine(useRowWriterPath, false, false, true, TWO_FIELDS, "2026-01-05", "san-francisco"));
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void testSlashSeparatedDatePartitioningHandlesNullAndEmptyValues(boolean unsafe) {
+  void testSlashSeparatedDatePartitioningHandlesNullAndEmptyValues(boolean useRowWriterPath) {
     assertEquals(DEFAULT_PARTITION_PATH,
-        combine(unsafe, false, false, true, SINGLE_FIELD, new Object[] {null}));
+        combine(useRowWriterPath, false, false, true, SINGLE_FIELD, new Object[] {null}));
     assertEquals(DEFAULT_PARTITION_PATH,
-        combine(unsafe, false, false, true, SINGLE_FIELD, ""));
+        combine(useRowWriterPath, false, false, true, SINGLE_FIELD, ""));
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void testSlashSeparatedDatePartitioningEncodesValues(boolean unsafe) {
+  void testSlashSeparatedDatePartitioningEncodesValues(boolean useRowWriterPath) {
     // '?' has to be escaped, while the date separators are turned into directory separators
-    assertEquals("2026/01/05", combine(unsafe, false, true, true, SINGLE_FIELD, "2026-01-05"));
-    assertEquals("a%3Fb", combine(unsafe, false, true, true, SINGLE_FIELD, "a?b"));
+    assertEquals("2026/01/05", combine(useRowWriterPath, false, true, true, SINGLE_FIELD, "2026-01-05"));
+    assertEquals("a%3Fb", combine(useRowWriterPath, false, true, true, SINGLE_FIELD, "a?b"));
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void testHiveStylePartitioningTakesPrecedence(boolean unsafe) {
+  void testHiveStylePartitioningTakesPrecedence(boolean useRowWriterPath) {
+    // NOTE: Hive-style partitioning and slash-separated date partitioning are mutually exclusive --
+    //       [[HoodieCatalogTable#extraTableConfig]] rejects a table configuring both -- so this
+    //       combination is unreachable and the formatter deliberately leaves the value alone.
+    //       This asserts the pre-existing behavior stays put, it is not a statement about what the
+    //       combination *should* produce
     assertEquals("date_col=2026-01-05",
-        combine(unsafe, true, false, true, SINGLE_FIELD, "2026-01-05"));
+        combine(useRowWriterPath, true, false, true, SINGLE_FIELD, "2026-01-05"));
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void testPlainPartitioningIsUnaffected(boolean unsafe) {
+  void testPlainPartitioningIsUnaffected(boolean useRowWriterPath) {
     assertEquals("2026-01-05",
-        combine(unsafe, false, false, false, SINGLE_FIELD, "2026-01-05"));
+        combine(useRowWriterPath, false, false, false, SINGLE_FIELD, "2026-01-05"));
     assertEquals("2026-01-05/san-francisco",
-        combine(unsafe, false, false, false, TWO_FIELDS, "2026-01-05", "san-francisco"));
+        combine(useRowWriterPath, false, false, false, TWO_FIELDS, "2026-01-05", "san-francisco"));
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.keygen;
+
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.hudi.common.util.PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests the partition-path formatters backing the key generators, making sure that both the
+ * {@link String} (Avro/{@link org.apache.spark.sql.Row} write path) and the {@link UTF8String}
+ * (row-writer/{@link org.apache.spark.sql.catalyst.InternalRow} write path) flavors produce
+ * identical partition paths.
+ */
+class TestPartitionPathFormatter {
+
+  private static final List<String> SINGLE_FIELD = Collections.singletonList("date_col");
+  private static final List<String> TWO_FIELDS = Arrays.asList("date_col", "city");
+
+  private String combine(boolean unsafe,
+                         boolean hiveStylePartitioning,
+                         boolean encode,
+                         boolean slashSeparatedDatePartitioning,
+                         List<String> fields,
+                         Object... parts) {
+    if (unsafe) {
+      return new UTF8StringPartitionPathFormatter(
+          UTF8StringPartitionPathFormatter.UTF8StringBuilder::new, hiveStylePartitioning, encode,
+          slashSeparatedDatePartitioning).combine(fields, parts).toString();
+    }
+    return new StringPartitionPathFormatter(
+        StringPartitionPathFormatter.JavaStringBuilder::new, hiveStylePartitioning, encode,
+        slashSeparatedDatePartitioning).combine(fields, parts);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testSlashSeparatedDatePartitioningSingleField(boolean unsafe) {
+    assertEquals("2026/01/05",
+        combine(unsafe, false, false, true, SINGLE_FIELD, "2026-01-05"));
+    // Input that is already slash-separated is left untouched
+    assertEquals("2026/01/05",
+        combine(unsafe, false, false, true, SINGLE_FIELD, "2026/01/05"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testSlashSeparatedDatePartitioningOnlyAppliesToSingleFieldPartitioning(boolean unsafe) {
+    // NOTE: This mirrors [[KeyGenUtils#getRecordPartitionPath]] driving the Avro write-path
+    assertEquals("2026-01-05/san-francisco",
+        combine(unsafe, false, false, true, TWO_FIELDS, "2026-01-05", "san-francisco"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testSlashSeparatedDatePartitioningHandlesNullAndEmptyValues(boolean unsafe) {
+    assertEquals(DEFAULT_PARTITION_PATH,
+        combine(unsafe, false, false, true, SINGLE_FIELD, new Object[] {null}));
+    assertEquals(DEFAULT_PARTITION_PATH,
+        combine(unsafe, false, false, true, SINGLE_FIELD, ""));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testSlashSeparatedDatePartitioningEncodesValues(boolean unsafe) {
+    // '?' has to be escaped, while the date separators are turned into directory separators
+    assertEquals("2026/01/05", combine(unsafe, false, true, true, SINGLE_FIELD, "2026-01-05"));
+    assertEquals("a%3Fb", combine(unsafe, false, true, true, SINGLE_FIELD, "a?b"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testHiveStylePartitioningTakesPrecedence(boolean unsafe) {
+    assertEquals("date_col=2026-01-05",
+        combine(unsafe, true, false, true, SINGLE_FIELD, "2026-01-05"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testPlainPartitioningIsUnaffected(boolean unsafe) {
+    assertEquals("2026-01-05",
+        combine(unsafe, false, false, false, SINGLE_FIELD, "2026-01-05"));
+    assertEquals("2026-01-05/san-francisco",
+        combine(unsafe, false, false, false, TWO_FIELDS, "2026-01-05", "san-francisco"));
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
@@ -60,11 +60,12 @@ class TestPartitionPathFormatter {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testSlashSeparatedDatePartitioningAppliesToEveryField(boolean useRowWriterPath) {
-    // NOTE: Every part is substituted, which is what [[CustomKeyGenerator]] writes (one single-field
-    //       sub-keygen per field) and what [[SparkHoodieTableFileIndex#composeRelativePartitionPath]]
-    //       has to reproduce when it composes a listing prefix over all N columns in one call.
-    //       [[KeyGenUtils#getRecordPartitionPath]] guards on a single field instead, so for
-    //       [[ComplexKeyGenerator]] the Avro path diverges from this one -- HUDI issue #19666
+    // NOTE: Every part is substituted, which is what legacy [[CustomKeyGenerator]] tables hold on
+    //       disk (one single-field sub-keygen per field) and what
+    //       [[SparkHoodieTableFileIndex#composeRelativePartitionPath]] has to reproduce when it
+    //       composes a listing prefix over all N columns in one call. New writes cannot reach this
+    //       combination -- [[HoodieWriterUtils#validateTableConfig]] rejects slash partitioning
+    //       with more than one partition field. See HUDI issue #19666
     assertEquals("2026/01/05/san/francisco",
         combine(useRowWriterPath, false, false, true, TWO_FIELDS, "2026-01-05", "san-francisco"));
     // The guard applies per part, not just to the first one

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
@@ -76,6 +76,22 @@ class TestPartitionPathFormatter {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
+  void testSlashSeparatedDatePartitioningLeavesLeadingDashesAlone(boolean useRowWriterPath) {
+    // NOTE: Substituting here would yield a partition path starting with "/", which
+    //       [[FSUtils#constructAbsolutePath(String, String)]] and the [[StoragePath]] overload used
+    //       by [[AbstractTableFileSystemView]] resolve differently -- the former chops the leading
+    //       "/", the latter URI-resolves the table base path away -- so the writer and the
+    //       file-system view would disagree on where the partition lives
+    assertEquals("-5", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "-5"));
+    assertEquals("-", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "-"));
+    assertEquals("--5", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "--5"));
+    // A dash anywhere else is still a separator: only a leading one produces an absolute path
+    assertEquals("5/", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "5-"));
+    assertEquals("2026/01/05", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "2026-01-05"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   void testSlashSeparatedDatePartitioningEncodesValues(boolean useRowWriterPath) {
     // '?' has to be escaped, while the date separators are turned into directory separators
     assertEquals("2026/01/05", combine(useRowWriterPath, false, true, true, SINGLE_FIELD, "2026-01-05"));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestPartitionPathFormatter.java
@@ -59,10 +59,17 @@ class TestPartitionPathFormatter {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void testSlashSeparatedDatePartitioningOnlyAppliesToSingleFieldPartitioning(boolean useRowWriterPath) {
-    // NOTE: This mirrors [[KeyGenUtils#getRecordPartitionPath]] driving the Avro write-path
-    assertEquals("2026-01-05/san-francisco",
+  void testSlashSeparatedDatePartitioningAppliesToEveryField(boolean useRowWriterPath) {
+    // NOTE: Every part is substituted, which is what [[CustomKeyGenerator]] writes (one single-field
+    //       sub-keygen per field) and what [[SparkHoodieTableFileIndex#composeRelativePartitionPath]]
+    //       has to reproduce when it composes a listing prefix over all N columns in one call.
+    //       [[KeyGenUtils#getRecordPartitionPath]] guards on a single field instead, so for
+    //       [[ComplexKeyGenerator]] the Avro path diverges from this one -- HUDI issue #19666
+    assertEquals("2026/01/05/san/francisco",
         combine(useRowWriterPath, false, false, true, TWO_FIELDS, "2026-01-05", "san-francisco"));
+    // The guard applies per part, not just to the first one
+    assertEquals("2026/01/05/-5",
+        combine(useRowWriterPath, false, false, true, TWO_FIELDS, "2026-01-05", "-5"));
   }
 
   @ParameterizedTest
@@ -77,16 +84,19 @@ class TestPartitionPathFormatter {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testSlashSeparatedDatePartitioningLeavesLeadingDashesAlone(boolean useRowWriterPath) {
-    // NOTE: Substituting here would yield a partition path starting with "/", which
+    // NOTE: Substituting in any of these would yield a partition path that does not survive the
+    //       round trip back from storage. A leading "/" is resolved differently by
     //       [[FSUtils#constructAbsolutePath(String, String)]] and the [[StoragePath]] overload used
-    //       by [[AbstractTableFileSystemView]] resolve differently -- the former chops the leading
-    //       "/", the latter URI-resolves the table base path away -- so the writer and the
-    //       file-system view would disagree on where the partition lives
+    //       by [[AbstractTableFileSystemView]] -- the former chops it, the latter URI-resolves the
+    //       table base path away. A trailing "/" is normalized off by [[StoragePath#normalize]] and
+    //       a doubled "//" is collapsed by [[java.net.URI#normalize]], leaving the writer recording
+    //       a partition string longer than the directory it actually resolves to
     assertEquals("-5", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "-5"));
     assertEquals("-", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "-"));
     assertEquals("--5", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "--5"));
-    // A dash anywhere else is still a separator: only a leading one produces an absolute path
-    assertEquals("5/", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "5-"));
+    assertEquals("5-", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "5-"));
+    assertEquals("a--b", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "a--b"));
+    // A single interior dash is still a separator
     assertEquals("2026/01/05", combine(useRowWriterPath, false, false, true, SINGLE_FIELD, "2026-01-05"));
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestSimpleKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestSimpleKeyGenerator.java
@@ -29,6 +29,7 @@ import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.CatalystTypeConverters;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Assertions;
@@ -242,5 +243,14 @@ class TestSimpleKeyGenerator extends KeyGeneratorTestUtilities {
 
     Row row = KeyGeneratorTestUtilities.getRow(avroRecord);
     Assertions.assertEquals(HUDI_DEFAULT_PARTITION_PATH, keyGenerator.getPartitionPath(row));
+
+    // NOTE: [[KeyGeneratorTestUtilities#getInternalRow]] builds a flat [[GenericInternalRow]], leaving
+    //       a nested value as a [[Row]], so the conversion has to go through Spark here. "nested_col.prop1"
+    //       is the only nullable field of the example schema, and a null on a non-nullable one is
+    //       rejected by [[org.apache.spark.sql.HoodieUnsafeRowUtils]] before the formatter is reached
+    InternalRow internalRow =
+        (InternalRow) CatalystTypeConverters.createToCatalystConverter(row.schema()).apply(row);
+    Assertions.assertEquals(UTF8String.fromString(HUDI_DEFAULT_PARTITION_PATH),
+        keyGenerator.getPartitionPath(internalRow, row.schema()));
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestSimpleKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestSimpleKeyGenerator.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.stream.Stream;
 
@@ -235,11 +236,13 @@ class TestSimpleKeyGenerator extends KeyGeneratorTestUtilities {
     Assertions.assertEquals("-5", key.getPartitionPath());
   }
 
-  @Test
-  void testSlashSeparatedDatePartitioningOnRowWritingPaths() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testSlashSeparatedDatePartitioningOnRowWritingPaths(boolean urlEncode) {
     TypedProperties properties = getPropsWithSlashSeparatedDatePartitioning();
     // NOTE: "ts_ms" is the string-typed field of the example schema, "timestamp" is a long
     properties.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "ts_ms");
+    properties.put(KeyGeneratorOptions.URL_ENCODE_PARTITIONING.key(), String.valueOf(urlEncode));
     SimpleKeyGenerator keyGenerator = new SimpleKeyGenerator(properties);
 
     GenericRecord avroRecord = getRecord();
@@ -251,6 +254,18 @@ class TestSimpleKeyGenerator extends KeyGeneratorTestUtilities {
     InternalRow internalRow = KeyGeneratorTestUtilities.getInternalRow(row);
     Assertions.assertEquals(UTF8String.fromString("2020/03/21"),
         keyGenerator.getPartitionPath(internalRow, row.schema()));
+
+    // Encoding runs before the substitution on all three write paths, so an escapable character
+    // is escaped while the dash still becomes a directory separator. This pins the ordering at
+    // the KeyGenUtils/Avro level too, which the formatter-level encode test cannot reach
+    avroRecord.put("ts_ms", "a?b-c");
+    String expected = urlEncode ? "a%3Fb/c" : "a?b/c";
+    Assertions.assertEquals(expected, keyGenerator.getPartitionPath(avroRecord));
+
+    Row encodedRow = KeyGeneratorTestUtilities.getRow(avroRecord);
+    Assertions.assertEquals(expected, keyGenerator.getPartitionPath(encodedRow));
+    Assertions.assertEquals(UTF8String.fromString(expected),
+        keyGenerator.getPartitionPath(KeyGeneratorTestUtilities.getInternalRow(encodedRow), encodedRow.schema()));
   }
 
   @Test
@@ -260,6 +275,8 @@ class TestSimpleKeyGenerator extends KeyGeneratorTestUtilities {
     SimpleKeyGenerator keyGenerator = new SimpleKeyGenerator(properties);
 
     GenericRecord avroRecord = getRecord(getNestedColRecord(null, 10L));
+    // The Avro arm covers the HUDI-1888 class (NPE on a null nested partition value) under slash
+    Assertions.assertEquals(HUDI_DEFAULT_PARTITION_PATH, keyGenerator.getPartitionPath(avroRecord));
 
     Row row = KeyGeneratorTestUtilities.getRow(avroRecord);
     Assertions.assertEquals(HUDI_DEFAULT_PARTITION_PATH, keyGenerator.getPartitionPath(row));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestSimpleKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestSimpleKeyGenerator.java
@@ -213,4 +213,34 @@ class TestSimpleKeyGenerator extends KeyGeneratorTestUtilities {
     Assertions.assertEquals("key1", key.getRecordKey());
     Assertions.assertEquals("2026/01/01", key.getPartitionPath());
   }
+
+  @Test
+  void testSlashSeparatedDatePartitioningOnRowWritingPaths() {
+    TypedProperties properties = getPropsWithSlashSeparatedDatePartitioning();
+    // NOTE: "ts_ms" is the string-typed field of the example schema, "timestamp" is a long
+    properties.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "ts_ms");
+    SimpleKeyGenerator keyGenerator = new SimpleKeyGenerator(properties);
+
+    GenericRecord avroRecord = getRecord();
+    Assertions.assertEquals("2020/03/21", keyGenerator.getPartitionPath(avroRecord));
+
+    Row row = KeyGeneratorTestUtilities.getRow(avroRecord);
+    Assertions.assertEquals("2020/03/21", keyGenerator.getPartitionPath(row));
+
+    InternalRow internalRow = KeyGeneratorTestUtilities.getInternalRow(row);
+    Assertions.assertEquals(UTF8String.fromString("2020/03/21"),
+        keyGenerator.getPartitionPath(internalRow, row.schema()));
+  }
+
+  @Test
+  void testSlashSeparatedDatePartitioningWithNullValue() {
+    TypedProperties properties = getPropsWithSlashSeparatedDatePartitioning();
+    properties.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "nested_col.prop1");
+    SimpleKeyGenerator keyGenerator = new SimpleKeyGenerator(properties);
+
+    GenericRecord avroRecord = getRecord(getNestedColRecord(null, 10L));
+
+    Row row = KeyGeneratorTestUtilities.getRow(avroRecord);
+    Assertions.assertEquals(HUDI_DEFAULT_PARTITION_PATH, keyGenerator.getPartitionPath(row));
+  }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestSimpleKeyGenerator.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/keygen/TestSimpleKeyGenerator.java
@@ -216,6 +216,26 @@ class TestSimpleKeyGenerator extends KeyGeneratorTestUtilities {
   }
 
   @Test
+  void testSlashSeparatedDatePartitioningLeavesLeadingDashesAlone() {
+    SimpleKeyGenerator keyGenerator = new SimpleKeyGenerator(getPropsWithSlashSeparatedDatePartitioning());
+
+    // NOTE: Substituting here would yield a partition path starting with "/", which
+    //       [[FSUtils#constructAbsolutePath(String, String)]] and the [[StoragePath]] overload used
+    //       by [[AbstractTableFileSystemView]] resolve differently -- the former chops the leading
+    //       "/", the latter URI-resolves the table base path away -- so the writer and the
+    //       file-system view would disagree on where the partition lives
+    GenericRecord avroRecord = new GenericData.Record(HoodieSchema.parse(KeyGeneratorTestUtilities.EXAMPLE_SCHEMA).getAvroSchema());
+    avroRecord.put("timestamp", "-5");
+    avroRecord.put("_row_key", "key1");
+    avroRecord.put("ts_ms", "-5");
+    avroRecord.put("pii_col", "val1");
+
+    HoodieKey key = keyGenerator.getKey(avroRecord);
+    Assertions.assertEquals("key1", key.getRecordKey());
+    Assertions.assertEquals("-5", key.getPartitionPath());
+  }
+
+  @Test
   void testSlashSeparatedDatePartitioningOnRowWritingPaths() {
     TypedProperties properties = getPropsWithSlashSeparatedDatePartitioning();
     // NOTE: "ts_ms" is the string-typed field of the example schema, "timestamp" is a long

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -283,7 +283,8 @@ object HoodieWriterUtils {
         throw new HoodieException(s"${HoodieTableConfig.SLASH_SEPARATED_DATE_PARTITIONING.key} requires"
           + s" a single partition field, but found $partitionFieldCount: $partitionFields."
           + " The slash-separated layout of a multi-field partition path cannot be read back."
-          + " Use a single date partition field or disable slash-separated date partitioning.")
+          + " Recreate the table with a single date partition field or without this config --"
+          + " an existing table's config cannot be changed in place.")
       }
     }
     // If Overwrite is set as save mode, we don't need to do table config validation.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -262,6 +262,30 @@ object HoodieWriterUtils {
    */
   def validateTableConfig(spark: SparkSession, params: Map[String, String],
                           tableConfig: HoodieTableConfig, isOverWriteMode: Boolean): Unit = {
+    // Fail fast on writes that would produce a slash-separated layout with more than one
+    // partition field. The extra path fragments cannot be lined up with the partition columns on
+    // read (HUDI issue #19666), so without this check the write commits cleanly and every
+    // subsequent read of the table fails. Checked regardless of save mode, since an Overwrite
+    // produces the same layout.
+    val slashSeparatedDatePartitioning =
+      params.get(HoodieTableConfig.SLASH_SEPARATED_DATE_PARTITIONING.key).exists(_.toBoolean) ||
+        (null != tableConfig && tableConfig.getSlashSeparatedDatePartitioning)
+    if (slashSeparatedDatePartitioning) {
+      // The table config is the source of truth for an existing table; for a new one the
+      // datasource value may still carry the CustomKeyGenerator "field:type" format, which the
+      // comma count is insensitive to
+      val partitionFields = Option(tableConfig)
+        .flatMap(tc => Option(HoodieTableConfig.getPartitionFieldProp(tc).orElse(null)))
+        .filter(_.nonEmpty)
+        .getOrElse(params.getOrElse(PARTITIONPATH_FIELD.key(), ""))
+      val partitionFieldCount = partitionFields.split(",").count(_.trim.nonEmpty)
+      if (partitionFieldCount > 1) {
+        throw new HoodieException(s"${HoodieTableConfig.SLASH_SEPARATED_DATE_PARTITIONING.key} requires"
+          + s" a single partition field, but found $partitionFieldCount: $partitionFields."
+          + " The slash-separated layout of a multi-field partition path cannot be read back."
+          + " Use a single date partition field or disable slash-separated date partitioning.")
+      }
+    }
     // If Overwrite is set as save mode, we don't need to do table config validation.
     if (!isOverWriteMode) {
       val resolver = spark.sessionState.conf.resolver

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -267,8 +267,11 @@ object HoodieWriterUtils {
     // read (HUDI issue #19666), so without this check the write commits cleanly and every
     // subsequent read of the table fails. Checked regardless of save mode, since an Overwrite
     // produces the same layout.
+    // NOTE: equalsIgnoreCase rather than toBoolean, since every other reader of this flag goes
+    //       through Boolean.parseBoolean semantics and treats a value like "1" as false, while
+    //       toBoolean would throw on it
     val slashSeparatedDatePartitioning =
-      params.get(HoodieTableConfig.SLASH_SEPARATED_DATE_PARTITIONING.key).exists(_.toBoolean) ||
+      params.get(HoodieTableConfig.SLASH_SEPARATED_DATE_PARTITIONING.key).exists(_.equalsIgnoreCase("true")) ||
         (null != tableConfig && tableConfig.getSlashSeparatedDatePartitioning)
     if (slashSeparatedDatePartitioning) {
       // The table config is the source of truth for an existing table; for a new one the

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -298,6 +298,17 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
         && sqlOptions.contains(KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING.key)),
       s"Table configs cannot contain both ${HIVE_STYLE_PARTITIONING_ENABLE.key} "
         + s"and ${KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING.key}")
+    // Reject slash-separated date partitioning with more than one partition field at table
+    // creation: the resulting layout cannot be read back (HUDI issue #19666).
+    // HoodieWriterUtils#validateTableConfig enforces the same invariant at write time; gated on
+    // !tableExists so a pre-existing table can still be registered in the catalog and read.
+    if (!tableExists
+      && sqlOptions.get(KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING.key).exists(_.toBoolean)) {
+      ValidationUtils.checkArgument(table.partitionColumnNames.size <= 1,
+        s"${KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING.key} requires a single partition"
+          + s" field, but found ${table.partitionColumnNames.size}:"
+          + s" ${table.partitionColumnNames.mkString(",")}")
+    }
     val extraConfig = mutable.Map.empty[String, String]
     if (tableExists) {
       val allPartitionPaths = getPartitionPaths

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -300,10 +300,12 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
         + s"and ${KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING.key}")
     // Reject slash-separated date partitioning with more than one partition field at table
     // creation: the resulting layout cannot be read back (HUDI issue #19666).
-    // HoodieWriterUtils#validateTableConfig enforces the same invariant at write time; gated on
-    // !tableExists so a pre-existing table can still be registered in the catalog and read.
+    // HoodieWriterUtils#validateTableConfig enforces the same invariant at write time and already
+    // rejects a pre-existing table on the tableExists branch (parseSchemaAndConfigs calls it
+    // before reaching here), so the !tableExists gate only avoids a second, differently-worded
+    // error on that path.
     if (!tableExists
-      && sqlOptions.get(KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING.key).exists(_.toBoolean)) {
+      && sqlOptions.get(KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING.key).exists(_.equalsIgnoreCase("true"))) {
       ValidationUtils.checkArgument(table.partitionColumnNames.size <= 1,
         s"${KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING.key} requires a single partition"
           + s" field, but found ${table.partitionColumnNames.size}:"

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieWriterUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieWriterUtils.java
@@ -60,6 +60,24 @@ class TestHoodieWriterUtils extends HoodieClientTestBase {
     assertEquals("randomKey", HoodieWriterUtils.getKeyInTableConfig("randomKey", null));
   }
 
+  @Test
+  void validateTableConfigRejectsMultiFieldSlashPartitioningOnLegacyTable() throws IOException {
+    // A legacy table already holding slash-separated date partitioning with two partition fields:
+    // such a table can no longer be created through SQL or df.write, so the rejection has to fire
+    // off the table config alone, with the write providing no slash or partition configs of its own
+    Properties props = new Properties();
+    props.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), "datestr,city");
+    props.setProperty(HoodieTableConfig.SLASH_SEPARATED_DATE_PARTITIONING.key(), "true");
+    HoodieTableMetaClient tableMetaClient = getMetaClientBuilder(HoodieTableType.COPY_ON_WRITE, props, "")
+        .initTable(storageConf, tempDir.resolve("legacyMultiFieldSlashTable").toString());
+    HoodieTableConfig tableConfig = tableMetaClient.getTableConfig();
+
+    HoodieException ex = assertThrows(HoodieException.class,
+        () -> HoodieWriterUtils.validateTableConfig(
+            sparkSession, JavaScalaConverters.convertJavaPropertiesToScalaMap(new TypedProperties()), tableConfig));
+    assertTrue(ex.getMessage().contains("requires a single partition field"), ex.getMessage());
+  }
+
   /**
    * The meta-fields-mode guard compares normalized modes, not raw legacy property presence. A table
    * written before {@code hoodie.meta.fields.mode} existed is normalized to ALL or NONE when its

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieWriterUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieWriterUtils.java
@@ -78,6 +78,20 @@ class TestHoodieWriterUtils extends HoodieClientTestBase {
     assertTrue(ex.getMessage().contains("requires a single partition field"), ex.getMessage());
   }
 
+  @Test
+  void validateTableConfigRejectsMultiFieldSlashPartitioningOnOverwrite() {
+    // SaveMode.Overwrite nulls the table config, so the rejection has to fire off the params
+    // alone, ahead of the isOverWriteMode gate that skips the rest of the validation
+    TypedProperties writeProps = new TypedProperties();
+    writeProps.put(HoodieTableConfig.SLASH_SEPARATED_DATE_PARTITIONING.key(), "true");
+    writeProps.put("hoodie.datasource.write.partitionpath.field", "datestr,city");
+
+    HoodieException ex = assertThrows(HoodieException.class,
+        () -> HoodieWriterUtils.validateTableConfig(
+            sparkSession, JavaScalaConverters.convertJavaPropertiesToScalaMap(writeProps), null, true));
+    assertTrue(ex.getMessage().contains("requires a single partition field"), ex.getMessage());
+  }
+
   /**
    * The meta-fields-mode guard compares normalized modes, not raw legacy property presence. A table
    * written before {@code hoodie.meta.fields.mode} existed is normalized to ALL or NONE when its

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSlashSeparatedPartitionValue.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSlashSeparatedPartitionValue.scala
@@ -228,12 +228,16 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
     }
   }
 
-  test("Test slash separated date partitions with a multi-field CustomKeyGenerator") {
+  test("Test slash separated date partitioning rejects multiple partition fields at create") {
     withTempDir { tmp =>
       val targetTable = generateTableName
       val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
 
-      spark.sql(
+      // NOTE: A multi-field slash table writes extra path fragments that
+      //       [[HoodieSparkUtils#doParsePartitionColumnValues]] cannot line up with the partition
+      //       columns, so every read of the table fails under the default lazy listing. Rejecting
+      //       the combination up front keeps that layout from ever being written -- HUDI issue #19666
+      checkExceptionContain(
         s"""
            |create table $targetTable (
            |  `id` string,
@@ -252,26 +256,29 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
            | )
            | partitioned by (`datestr`, `city`)
            | location '$tablePath'
-        """.stripMargin)
+        """.stripMargin)("requires a single partition field")
+    }
+  }
 
-      spark.sql(
-        s"""
-           | insert into $targetTable values
-           | (1, 'a1', 1000, "2026-01-05", "NYC")
-        """.stripMargin)
+  test("Test slash separated date partitioning rejects multiple partition fields at write") {
+    withTempDir { tmp =>
+      val tablePath = s"${tmp.getCanonicalPath}/${generateTableName}"
 
-      // NOTE: [[CustomKeyGenerator]] builds one single-field sub-keygen per field, so its write path
-      //       slashes every field. With both partition columns bound
-      //       [[SparkHoodieTableFileIndex#composeRelativePartitionPath]] composes the listing prefix
-      //       in one [[PartitionPathFormatterBase#combine]] call over both columns and short-circuits
-      //       on an `exists` check, so the two have to derive the identical directory -- otherwise
-      //       the prefix misses and the query silently returns no rows rather than failing
-      val metaClient = buildMetaClient(tablePath)
-      assertPartitionDirsExist(metaClient, tablePath, "2026/01/05/NYC")
-
-      checkAnswer(s"select id, name from $targetTable where datestr = '2026-01-05' and city = 'NYC'")(
-        Seq("1", "a1")
-      )
+      // df.write bypasses the catalog-level check, so the rejection has to come from
+      // [[HoodieWriterUtils#validateTableConfig]]
+      val df = spark.sql(
+        "select '1' as id, 'a1' as name, 1000L as ts, '2026-01-05' as datestr, 'NYC' as city")
+      checkExceptionContain(new Runnable {
+        override def run(): Unit = {
+          df.write.format("hudi")
+            .option("hoodie.table.name", "rejected_slash_table")
+            .option("hoodie.datasource.write.recordkey.field", "id")
+            .option("hoodie.datasource.write.partitionpath.field", "datestr,city")
+            .option("hoodie.datasource.write.slash.separated.date.partitioning", "true")
+            .mode("append")
+            .save(tablePath)
+        }
+      })("requires a single partition field")
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSlashSeparatedPartitionValue.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSlashSeparatedPartitionValue.scala
@@ -91,8 +91,7 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
   }
 
   test("Test slash separated date partitions written through the row writer") {
-    withSQLConf("hoodie.sql.bulk.insert.enable" -> "true", "hoodie.sql.insert.mode" -> "non-strict",
-      "hoodie.datasource.write.row.writer.enable" -> "true") {
+    withSQLConf("hoodie.spark.sql.insert.into.operation" -> "bulk_insert") {
       withTempDir { tmp =>
         val targetTable = generateTableName
         val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
@@ -125,10 +124,10 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
              | (3, 'a3', 3000, null)
           """.stripMargin)
 
-        checkAnswer(s"select id, name, ts, _hoodie_partition_path from $targetTable order by id")(
-          Seq("1", "a1", 1000, "2026/01/05"),
-          Seq("2", "a2", 2000, "2026/01/06"),
-          Seq("3", "a3", 3000, "__HIVE_DEFAULT_PARTITION__")
+        checkAnswer(s"select id, name, ts, _hoodie_partition_path, datestr from $targetTable order by id")(
+          Seq("1", "a1", 1000, "2026/01/05", "2026-01-05"),
+          Seq("2", "a2", 2000, "2026/01/06", "2026-01-06"),
+          Seq("3", "a3", 3000, "__HIVE_DEFAULT_PARTITION__", null)
         )
 
         val metaClient = HoodieTableMetaClient.builder()
@@ -141,6 +140,59 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
           s"Partition path 2026/01/06 should exist")
         assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "__HIVE_DEFAULT_PARTITION__")),
           s"Partition path __HIVE_DEFAULT_PARTITION__ should exist")
+      }
+    }
+  }
+
+  test("Test slash separated date partitions on a DATE typed partition column") {
+    Seq("insert", "bulk_insert").foreach { operation =>
+      withSQLConf("hoodie.spark.sql.insert.into.operation" -> operation) {
+        withTempDir { tmp =>
+          val targetTable = generateTableName
+          val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
+
+          spark.sql(
+            s"""
+               |create table $targetTable (
+               |  `id` string,
+               |  `name` string,
+               |  `ts` bigint,
+               |  `datestr` DATE
+               |) using hudi
+               | tblproperties (
+               |  'primaryKey' = 'id',
+               |  'type' = 'COW',
+               |  'preCombineField'='ts',
+               |  'hoodie.datasource.write.slash.separated.date.partitioning'='true'
+               | )
+               | partitioned by (`datestr`)
+               | location '$tablePath'
+            """.stripMargin)
+
+          // NOTE: A DATE partition value is rendered through [[BuiltinKeyGenerator#convertToLogicalDataType]]
+          //       on the row-writer paths and [[HoodieAvroUtils#convertValueForAvroLogicalTypes]] on the
+          //       Avro one, so all three have to land in the very same directory
+          spark.sql(
+            s"""
+               | insert into $targetTable values
+               | (1, 'a1', 1000, date'2026-01-05'),
+               | (2, 'a2', 2000, date'2026-01-06')
+            """.stripMargin)
+
+          checkAnswer(s"select id, name, ts, _hoodie_partition_path, datestr from $targetTable order by id")(
+            Seq("1", "a1", 1000, "2026/01/05", java.sql.Date.valueOf("2026-01-05")),
+            Seq("2", "a2", 2000, "2026/01/06", java.sql.Date.valueOf("2026-01-06"))
+          )
+
+          val metaClient = HoodieTableMetaClient.builder()
+            .setConf(HadoopFSUtils.getStorageConfWithCopy(spark.sparkContext.hadoopConfiguration))
+            .setBasePath(tablePath)
+            .build()
+          assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/05")),
+            s"Partition path 2026/01/05 should exist for operation $operation")
+          assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/06")),
+            s"Partition path 2026/01/06 should exist for operation $operation")
+        }
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSlashSeparatedPartitionValue.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSlashSeparatedPartitionValue.scala
@@ -90,6 +90,61 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
     }
   }
 
+  test("Test slash separated date partitions written through the row writer") {
+    withSQLConf("hoodie.sql.bulk.insert.enable" -> "true", "hoodie.sql.insert.mode" -> "non-strict",
+      "hoodie.datasource.write.row.writer.enable" -> "true") {
+      withTempDir { tmp =>
+        val targetTable = generateTableName
+        val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
+
+        spark.sql(
+          s"""
+             |create table $targetTable (
+             |  `id` string,
+             |  `name` string,
+             |  `ts` bigint,
+             |  `datestr` STRING
+             |) using hudi
+             | tblproperties (
+             |  'primaryKey' = 'id',
+             |  'type' = 'COW',
+             |  'preCombineField'='ts',
+             |  'hoodie.datasource.write.slash.separated.date.partitioning'='true'
+             | )
+             | partitioned by (`datestr`)
+             | location '$tablePath'
+          """.stripMargin)
+
+        // NOTE: The row writer derives the partition path off of an [[InternalRow]], which used to
+        //       blow up with a [[ClassCastException]]; a null partition value used to NPE
+        spark.sql(
+          s"""
+             | insert into $targetTable values
+             | (1, 'a1', 1000, "2026-01-05"),
+             | (2, 'a2', 2000, "2026-01-06"),
+             | (3, 'a3', 3000, null)
+          """.stripMargin)
+
+        checkAnswer(s"select id, name, ts, _hoodie_partition_path from $targetTable order by id")(
+          Seq("1", "a1", 1000, "2026/01/05"),
+          Seq("2", "a2", 2000, "2026/01/06"),
+          Seq("3", "a3", 3000, "__HIVE_DEFAULT_PARTITION__")
+        )
+
+        val metaClient = HoodieTableMetaClient.builder()
+          .setConf(HadoopFSUtils.getStorageConfWithCopy(spark.sparkContext.hadoopConfiguration))
+          .setBasePath(tablePath)
+          .build()
+        assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/05")),
+          s"Partition path 2026/01/05 should exist")
+        assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/06")),
+          s"Partition path 2026/01/06 should exist")
+        assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "__HIVE_DEFAULT_PARTITION__")),
+          s"Partition path __HIVE_DEFAULT_PARTITION__ should exist")
+      }
+    }
+  }
+
   test("Test slash separated date partitions with already formatted input") {
     Seq(true, false).foreach { slashSeparatedPartitioning =>
       withTempDir { tmp =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSlashSeparatedPartitionValue.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSlashSeparatedPartitionValue.scala
@@ -22,34 +22,82 @@ import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.metadata.HoodieBackedTableMetadata
-import org.apache.hudi.storage.{HoodieStorage, StoragePath}
+import org.apache.hudi.storage.StoragePath
 
 import org.junit.jupiter.api.Assertions.assertTrue
 
 class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
+
+  private def createSlashPartitionedTable(targetTable: String,
+                                          tablePath: String,
+                                          partitionColumnType: String = "STRING",
+                                          tableType: String = "COW",
+                                          slashSeparatedPartitioning: Boolean = true): Unit = {
+    spark.sql(
+      s"""
+         |create table $targetTable (
+         |  `id` string,
+         |  `name` string,
+         |  `ts` bigint,
+         |  `datestr` $partitionColumnType
+         |) using hudi
+         | tblproperties (
+         |  'primaryKey' = 'id',
+         |  'type' = '$tableType',
+         |  'preCombineField'='ts',
+         |  'hoodie.datasource.write.slash.separated.date.partitioning'='$slashSeparatedPartitioning'
+         | )
+         | partitioned by (`datestr`)
+         | location '$tablePath'
+      """.stripMargin)
+  }
+
+  private def buildMetaClient(tablePath: String): HoodieTableMetaClient = {
+    HoodieTableMetaClient.builder()
+      .setConf(HadoopFSUtils.getStorageConfWithCopy(spark.sparkContext.hadoopConfiguration))
+      .setBasePath(tablePath)
+      .build()
+  }
+
+  private def assertPartitionDirsExist(metaClient: HoodieTableMetaClient,
+                                       tablePath: String,
+                                       partitions: String*): Unit = {
+    partitions.foreach { partition =>
+      assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, partition)),
+        s"Partition path $partition should exist")
+    }
+  }
+
+  /**
+   * Asserts that the metadata table names the very same directories the writer created. The
+   * `_hoodie_partition_path` column and an `exists` check on storage both still pass when the
+   * writer-recorded partition string and the metadata-table entry disagree, so this is the
+   * assertion that actually pins the two together.
+   */
+  private def assertMetadataTablePartitions(metaClient: HoodieTableMetaClient,
+                                            tablePath: String,
+                                            partitions: String*): Unit = {
+    val engine = new HoodieSparkEngineContext(spark.sparkContext)
+    val metadataConfig = HoodieMetadataConfig.newBuilder().build()
+    val metadataTable =
+      new HoodieBackedTableMetadata(engine, metaClient.getStorage, metadataConfig, tablePath)
+    try {
+      val partitionPaths = metadataTable.getAllPartitionPaths
+      partitions.foreach { partition =>
+        assertTrue(partitionPaths.contains(partition),
+          s"Metadata table should list partition $partition")
+      }
+    } finally {
+      metadataTable.close()
+    }
+  }
 
   test("Test slash separated date partitions") {
     withTempDir { tmp =>
       val targetTable = generateTableName
       val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
 
-      spark.sql(
-        s"""
-           |create table $targetTable (
-           |  `id` string,
-           |  `name` string,
-           |  `ts` bigint,
-           |  `datestr` STRING
-           |) using hudi
-           | tblproperties (
-           |  'primaryKey' = 'id',
-           |  'type' = 'COW',
-           |  'preCombineField'='ts',
-           |  'hoodie.datasource.write.slash.separated.date.partitioning'='true'
-           | )
-           | partitioned by (`datestr`)
-           | location '$tablePath'
-        """.stripMargin)
+      createSlashPartitionedTable(targetTable, tablePath)
 
       spark.sql(
         s"""
@@ -58,35 +106,17 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
            | (2, 'a2', 2000, "2026-01-06")
         """.stripMargin)
 
-      // check result after insert and merge data into target table
       checkAnswer(s"select id, name, ts, _hoodie_partition_path, datestr from $targetTable limit 10")(
         Seq("1", "a1", 1000, "2026/01/05", "2026-01-05"),
         Seq("2", "a2", 2000, "2026/01/06", "2026-01-06")
       )
 
-      // Verify table config has slash separated date partitioning enabled
-      val metaClient = HoodieTableMetaClient.builder()
-        .setConf(HadoopFSUtils.getStorageConfWithCopy(spark.sparkContext.hadoopConfiguration))
-        .setBasePath(tablePath)
-        .build()
-      val tableConfig = metaClient.getTableConfig
-      assertTrue(tableConfig.getSlashSeparatedDatePartitioning,
+      val metaClient = buildMetaClient(tablePath)
+      assertTrue(metaClient.getTableConfig.getSlashSeparatedDatePartitioning,
         "Table config should have slash separated date partitioning enabled")
 
-      // Verify that partition paths are created with slash separated date format (yyyy/MM/dd)
-      assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/05")),
-        s"Partition path 2026/01/05 should exist")
-      assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/06")),
-        s"Partition path 2026/01/06 should exist")
-
-      val engine = new HoodieSparkEngineContext(spark.sparkContext)
-      val storage = metaClient.getStorage()
-      val metadataConfig = HoodieMetadataConfig.newBuilder().build()
-      val metadataTable = new HoodieBackedTableMetadata(engine, storage, metadataConfig, tablePath)
-      val partitionPaths = metadataTable.getAllPartitionPaths
-      assertTrue(partitionPaths.contains("2026/01/05"))
-      assertTrue(partitionPaths.contains("2026/01/06"))
-      metadataTable.close()
+      assertPartitionDirsExist(metaClient, tablePath, "2026/01/05", "2026/01/06")
+      assertMetadataTablePartitions(metaClient, tablePath, "2026/01/05", "2026/01/06")
     }
   }
 
@@ -96,23 +126,7 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
         val targetTable = generateTableName
         val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
 
-        spark.sql(
-          s"""
-             |create table $targetTable (
-             |  `id` string,
-             |  `name` string,
-             |  `ts` bigint,
-             |  `datestr` STRING
-             |) using hudi
-             | tblproperties (
-             |  'primaryKey' = 'id',
-             |  'type' = 'COW',
-             |  'preCombineField'='ts',
-             |  'hoodie.datasource.write.slash.separated.date.partitioning'='true'
-             | )
-             | partitioned by (`datestr`)
-             | location '$tablePath'
-          """.stripMargin)
+        createSlashPartitionedTable(targetTable, tablePath)
 
         // NOTE: The row writer derives the partition path off of an [[InternalRow]], which used to
         //       blow up with a [[ClassCastException]]; a null partition value used to NPE
@@ -130,70 +144,134 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
           Seq("3", "a3", 3000, "__HIVE_DEFAULT_PARTITION__", null)
         )
 
-        val metaClient = HoodieTableMetaClient.builder()
-          .setConf(HadoopFSUtils.getStorageConfWithCopy(spark.sparkContext.hadoopConfiguration))
-          .setBasePath(tablePath)
-          .build()
-        assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/05")),
-          s"Partition path 2026/01/05 should exist")
-        assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/06")),
-          s"Partition path 2026/01/06 should exist")
-        assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "__HIVE_DEFAULT_PARTITION__")),
-          s"Partition path __HIVE_DEFAULT_PARTITION__ should exist")
+        val metaClient = buildMetaClient(tablePath)
+        assertPartitionDirsExist(metaClient, tablePath,
+          "2026/01/05", "2026/01/06", "__HIVE_DEFAULT_PARTITION__")
+        assertMetadataTablePartitions(metaClient, tablePath,
+          "2026/01/05", "2026/01/06", "__HIVE_DEFAULT_PARTITION__")
       }
     }
   }
 
   test("Test slash separated date partitions on a DATE typed partition column") {
-    Seq("insert", "bulk_insert").foreach { operation =>
-      withSQLConf("hoodie.spark.sql.insert.into.operation" -> operation) {
-        withTempDir { tmp =>
-          val targetTable = generateTableName
-          val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
+    // NOTE: Only bulk_insert exercises the row-writer rendering this fixes -- the insert path on a
+    //       DATE column is already covered by [[TestTypedPartitionValues]]
+    withSQLConf("hoodie.spark.sql.insert.into.operation" -> "bulk_insert") {
+      withTempDir { tmp =>
+        val targetTable = generateTableName
+        val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
 
-          spark.sql(
-            s"""
-               |create table $targetTable (
-               |  `id` string,
-               |  `name` string,
-               |  `ts` bigint,
-               |  `datestr` DATE
-               |) using hudi
-               | tblproperties (
-               |  'primaryKey' = 'id',
-               |  'type' = 'COW',
-               |  'preCombineField'='ts',
-               |  'hoodie.datasource.write.slash.separated.date.partitioning'='true'
-               | )
-               | partitioned by (`datestr`)
-               | location '$tablePath'
-            """.stripMargin)
+        createSlashPartitionedTable(targetTable, tablePath, partitionColumnType = "DATE")
 
-          // NOTE: A DATE partition value is rendered through [[BuiltinKeyGenerator#convertToLogicalDataType]]
-          //       on the row-writer paths and [[HoodieAvroUtils#convertValueForAvroLogicalTypes]] on the
-          //       Avro one, so all three have to land in the very same directory
-          spark.sql(
-            s"""
-               | insert into $targetTable values
-               | (1, 'a1', 1000, date'2026-01-05'),
-               | (2, 'a2', 2000, date'2026-01-06')
-            """.stripMargin)
+        // NOTE: A DATE partition value is rendered through [[BuiltinKeyGenerator#convertToLogicalDataType]]
+        //       on the row-writer paths and [[HoodieAvroUtils#convertValueForAvroLogicalTypes]] on the
+        //       Avro one, so all three have to land in the very same directory
+        spark.sql(
+          s"""
+             | insert into $targetTable values
+             | (1, 'a1', 1000, date'2026-01-05'),
+             | (2, 'a2', 2000, date'2026-01-06')
+          """.stripMargin)
 
-          checkAnswer(s"select id, name, ts, _hoodie_partition_path, datestr from $targetTable order by id")(
-            Seq("1", "a1", 1000, "2026/01/05", java.sql.Date.valueOf("2026-01-05")),
-            Seq("2", "a2", 2000, "2026/01/06", java.sql.Date.valueOf("2026-01-06"))
-          )
+        checkAnswer(s"select id, name, ts, _hoodie_partition_path, datestr from $targetTable order by id")(
+          Seq("1", "a1", 1000, "2026/01/05", java.sql.Date.valueOf("2026-01-05")),
+          Seq("2", "a2", 2000, "2026/01/06", java.sql.Date.valueOf("2026-01-06"))
+        )
 
-          val metaClient = HoodieTableMetaClient.builder()
-            .setConf(HadoopFSUtils.getStorageConfWithCopy(spark.sparkContext.hadoopConfiguration))
-            .setBasePath(tablePath)
-            .build()
-          assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/05")),
-            s"Partition path 2026/01/05 should exist for operation $operation")
-          assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/06")),
-            s"Partition path 2026/01/06 should exist for operation $operation")
-        }
+        // Partition pruning evaluates the predicate against the recovered partition value
+        checkAnswer(s"select id from $targetTable where datestr = date'2026-01-06'")(Seq("2"))
+        checkAnswer(s"select id from $targetTable where datestr < date'2026-01-06'")(Seq("1"))
+
+        val metaClient = buildMetaClient(tablePath)
+        assertPartitionDirsExist(metaClient, tablePath, "2026/01/05", "2026/01/06")
+        assertMetadataTablePartitions(metaClient, tablePath, "2026/01/05", "2026/01/06")
       }
+    }
+  }
+
+  test("Test upsert into a slash separated date partition") {
+    Seq("COW", "MOR").foreach { tableType =>
+      withTempDir { tmp =>
+        val targetTable = generateTableName
+        val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
+
+        createSlashPartitionedTable(targetTable, tablePath, tableType = tableType)
+
+        spark.sql(
+          s"""
+             | insert into $targetTable values
+             | (1, 'a1', 1000, "2026-01-05")
+          """.stripMargin)
+
+        // NOTE: The index and the file-system view have to agree on the slash partition path for
+        //       the second write to be recognised as an update. When they disagree the record is
+        //       inserted a second time instead, which surfaces as a duplicate rather than an error
+        spark.sql(
+          s"""
+             | merge into $targetTable as t
+             | using (select '1' as id, 'a1_updated' as name, 2000L as ts, cast("2026-01-05" as string) as datestr) as s
+             | on t.id = s.id
+             | when matched then update set *
+             | when not matched then insert *
+          """.stripMargin)
+
+        checkAnswer(s"select id, name, ts, _hoodie_partition_path, datestr from $targetTable")(
+          Seq("1", "a1_updated", 2000, "2026/01/05", "2026-01-05")
+        )
+
+        val metaClient = buildMetaClient(tablePath)
+        assertPartitionDirsExist(metaClient, tablePath, "2026/01/05")
+        assertMetadataTablePartitions(metaClient, tablePath, "2026/01/05")
+        assertTrue(!metaClient.getStorage.exists(new StoragePath(tablePath, "2026-01-05")),
+          s"No second directory should be created for table type $tableType")
+      }
+    }
+  }
+
+  test("Test slash separated date partitions with a multi-field CustomKeyGenerator") {
+    withTempDir { tmp =>
+      val targetTable = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
+
+      spark.sql(
+        s"""
+           |create table $targetTable (
+           |  `id` string,
+           |  `name` string,
+           |  `ts` bigint,
+           |  `datestr` STRING,
+           |  `city` STRING
+           |) using hudi
+           | tblproperties (
+           |  'primaryKey' = 'id',
+           |  'type' = 'COW',
+           |  'preCombineField'='ts',
+           |  'hoodie.datasource.write.keygenerator.class'='org.apache.hudi.keygen.CustomKeyGenerator',
+           |  'hoodie.datasource.write.partitionpath.field'='datestr:simple,city:simple',
+           |  'hoodie.datasource.write.slash.separated.date.partitioning'='true'
+           | )
+           | partitioned by (`datestr`, `city`)
+           | location '$tablePath'
+        """.stripMargin)
+
+      spark.sql(
+        s"""
+           | insert into $targetTable values
+           | (1, 'a1', 1000, "2026-01-05", "NYC")
+        """.stripMargin)
+
+      // NOTE: [[CustomKeyGenerator]] builds one single-field sub-keygen per field, so its write path
+      //       slashes every field. With both partition columns bound
+      //       [[SparkHoodieTableFileIndex#composeRelativePartitionPath]] composes the listing prefix
+      //       in one [[PartitionPathFormatterBase#combine]] call over both columns and short-circuits
+      //       on an `exists` check, so the two have to derive the identical directory -- otherwise
+      //       the prefix misses and the query silently returns no rows rather than failing
+      val metaClient = buildMetaClient(tablePath)
+      assertPartitionDirsExist(metaClient, tablePath, "2026/01/05/NYC")
+
+      checkAnswer(s"select id, name from $targetTable where datestr = '2026-01-05' and city = 'NYC'")(
+        Seq("1", "a1")
+      )
     }
   }
 
@@ -203,23 +281,8 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
         val targetTable = generateTableName
         val tablePath = s"${tmp.getCanonicalPath}/$targetTable"
 
-        spark.sql(
-          s"""
-             |create table $targetTable (
-             |  `id` string,
-             |  `name` string,
-             |  `ts` bigint,
-             |  `datestr` STRING
-             |) using hudi
-             | tblproperties (
-             |  'primaryKey' = 'id',
-             |  'type' = 'COW',
-             |  'preCombineField'='ts',
-             |  'hoodie.datasource.write.slash.separated.date.partitioning'='$slashSeparatedPartitioning'
-             | )
-             | partitioned by (`datestr`)
-             | location '$tablePath'
-          """.stripMargin)
+        createSlashPartitionedTable(targetTable, tablePath,
+          slashSeparatedPartitioning = slashSeparatedPartitioning)
 
         spark.sql(
           s"""
@@ -239,29 +302,12 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
           Seq("2", "a2", 2000, "2026/01/02", secondPartitionValue)
         )
 
-        // Verify table config
-        val metaClient = HoodieTableMetaClient.builder()
-          .setConf(HadoopFSUtils.getStorageConfWithCopy(spark.sparkContext.hadoopConfiguration))
-          .setBasePath(tablePath)
-          .build()
-        val tableConfig = metaClient.getTableConfig
-        assertTrue(tableConfig.getSlashSeparatedDatePartitioning == slashSeparatedPartitioning,
+        val metaClient = buildMetaClient(tablePath)
+        assertTrue(metaClient.getTableConfig.getSlashSeparatedDatePartitioning == slashSeparatedPartitioning,
           s"Table config should have slash separated date partitioning set to $slashSeparatedPartitioning")
 
-        // Verify that partition paths are created with slash separated date format (yyyy/MM/dd)
-        assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/01")),
-          s"Partition path 2026/01/01 should exist")
-        assertTrue(metaClient.getStorage.exists(new StoragePath(tablePath, "2026/01/02")),
-          s"Partition path 2026/01/02 should exist")
-
-        val engine = new HoodieSparkEngineContext(spark.sparkContext)
-        val storage = metaClient.getStorage()
-        val metadataConfig = HoodieMetadataConfig.newBuilder().build()
-        val metadataTable = new HoodieBackedTableMetadata(engine, storage, metadataConfig, tablePath)
-        val partitionPaths = metadataTable.getAllPartitionPaths
-        assertTrue(partitionPaths.contains("2026/01/01"))
-        assertTrue(partitionPaths.contains("2026/01/02"))
-        metadataTable.close()
+        assertPartitionDirsExist(metaClient, tablePath, "2026/01/01", "2026/01/02")
+        assertMetadataTablePartitions(metaClient, tablePath, "2026/01/01", "2026/01/02")
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSlashSeparatedPartitionValue.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSlashSeparatedPartitionValue.scala
@@ -178,10 +178,6 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
           Seq("2", "a2", 2000, "2026/01/06", java.sql.Date.valueOf("2026-01-06"))
         )
 
-        // Partition pruning evaluates the predicate against the recovered partition value
-        checkAnswer(s"select id from $targetTable where datestr = date'2026-01-06'")(Seq("2"))
-        checkAnswer(s"select id from $targetTable where datestr < date'2026-01-06'")(Seq("1"))
-
         val metaClient = buildMetaClient(tablePath)
         assertPartitionDirsExist(metaClient, tablePath, "2026/01/05", "2026/01/06")
         assertMetadataTablePartitions(metaClient, tablePath, "2026/01/05", "2026/01/06")
@@ -220,8 +216,6 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
         )
 
         val metaClient = buildMetaClient(tablePath)
-        assertPartitionDirsExist(metaClient, tablePath, "2026/01/05")
-        assertMetadataTablePartitions(metaClient, tablePath, "2026/01/05")
         assertTrue(!metaClient.getStorage.exists(new StoragePath(tablePath, "2026-01-05")),
           s"No second directory should be created for table type $tableType")
       }
@@ -256,7 +250,7 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
            | )
            | partitioned by (`datestr`, `city`)
            | location '$tablePath'
-        """.stripMargin)("requires a single partition field")
+        """.stripMargin)("but found 2: datestr,city")
     }
   }
 
@@ -268,17 +262,15 @@ class TestSlashSeparatedPartitionValue extends HoodieSparkSqlTestBase {
       // [[HoodieWriterUtils#validateTableConfig]]
       val df = spark.sql(
         "select '1' as id, 'a1' as name, 1000L as ts, '2026-01-05' as datestr, 'NYC' as city")
-      checkExceptionContain(new Runnable {
-        override def run(): Unit = {
-          df.write.format("hudi")
-            .option("hoodie.table.name", "rejected_slash_table")
-            .option("hoodie.datasource.write.recordkey.field", "id")
-            .option("hoodie.datasource.write.partitionpath.field", "datestr,city")
-            .option("hoodie.datasource.write.slash.separated.date.partitioning", "true")
-            .mode("append")
-            .save(tablePath)
-        }
-      })("requires a single partition field")
+      checkExceptionContain(() =>
+        df.write.format("hudi")
+          .option("hoodie.table.name", "rejected_slash_table")
+          .option("hoodie.datasource.write.recordkey.field", "id")
+          .option("hoodie.datasource.write.partitionpath.field", "datestr,city")
+          .option("hoodie.datasource.write.slash.separated.date.partitioning", "true")
+          .mode("append")
+          .save(tablePath)
+      )("cannot be read back")
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19647.

Slash-separated date partitioning did not work on the Spark row-writer path. The single-field
fast path in `PartitionPathFormatterBase#combine` cast the value to `String` before substituting
dashes, so the `UTF8String` formatter backing the `InternalRow` write path threw a
`ClassCastException`, and a null partition value threw a `NullPointerException` on both string
flavors because the branch bypassed `handleEmpty`.

### Summary and Changelog

* `PartitionPathFormatterBase#combine` now runs the single-field value through `handleEmpty` and
  `tryEncode` like every other branch, and delegates the substitution to a new
  `replaceDashesWithSlashes` implemented by each formatter on its own string representation --
  `String#replace(char, char)` and `UTF8String#replace` -- instead of casting.
* Slash-separated date partitioning with more than one partition field is now rejected, at table
  creation (`HoodieCatalogTable#extraTableConfig`) and at write time
  (`HoodieWriterUtils#validateTableConfig`, covering `df.write` and SQL writes alike). The
  multi-field layout writes extra path fragments that
  `HoodieSparkUtils#doParsePartitionColumnValues` cannot line up with the partition columns, so
  without the check the write commits cleanly and every subsequent read of the table fails --
  failing the write fast keeps the error at the write, instead of surfacing days later when a read
  first touches the table. Raised in review by @voonhous; the read-side symptoms are #19666.
* The multi-field branch of `combine` keeps substituting every part, as it did before this fix
  through the `(String)` cast. New writes cannot reach it with slash partitioning enabled (see
  above); it remains for reads of legacy multi-field tables, where
  `SparkHoodieTableFileIndex#composeRelativePartitionPath` has to reproduce the directory the
  per-field `CustomKeyGenerator` sub-key-generators wrote.
* A partition value whose dash-delimited tokens would turn into a path-breaking segment -- an
  empty token (leading, trailing or doubled dash), `.` or `..` -- is no longer slash-separated, on
  the Avro path (`KeyGenUtils#getPartitionPath`/`#getRecordPartitionPath`) as well as the two
  formatters, through one shared predicate `KeyGenUtils#hasPathBreakingDash`. Substituting turned
  the relative partition path absolute, left it longer than the directory it normalizes to, or let
  it escape the table entirely. `-5` wrote to `<base>/5` but was looked up under `/5`, because the
  two `FSUtils#constructAbsolutePath` overloads resolve an absolute child differently; `-`
  collapsed the partition onto the table root; `5-` and `a--b` normalized back to `5` and `a/b`,
  so `FSUtils#getFileName` sliced the file name at the wrong offset; and `..-a` became `../a`,
  which URI-resolves outside the table base path (url-encoding does not neutralize it, since
  `escapePathName` leaves dots and dashes alone). Raised in review by @voonhous.
* On the Avro path the substitution now runs before the hive-style `field=` prefix, so the guard
  inspects the bare value the way the formatter does. Otherwise behaviour-preserving, since `"dt="`
  holds no dash.
* Tests: a new `TestPartitionPathFormatter` asserting both formatters agree across
  slash/encode/hive-style/null combinations and on the three path-breaking dash shapes; dash-guard
  cases in `TestSimpleKeyGenerator` and `TestComplexKeyGenerator` covering both Avro overloads;
  keygen-level Row and InternalRow asserts in `TestSimpleKeyGenerator` and `TestCustomKeyGenerator`;
  and in `TestSlashSeparatedPartitionValue` row-writer, DATE-typed partition column and upsert (COW
  and MOR) cases, multi-field rejection asserts at create and at write, and every test in the suite
  now asserting the metadata table names the very same directories the writer created;
  `TestHoodieWriterUtils` cases pin the rejection firing off the table config alone (the legacy
  shape no new table can reach) and under `SaveMode.Overwrite` (params alone, ahead of the
  overwrite gate); and the SimpleKeyGenerator row-writing test is parameterized over url-encoding
  so encode-before-substitute is pinned on the Avro path as well as the formatters.

No code was copied.

### Impact

Records with a null or empty date partition value, and every record written through the row
writer, no longer fail on a slash-partitioned table.

* `SparkHoodieTableFileIndex#composeRelativePartitionPath` (query-side prefix pruning) and
  `RowRecordKeyExtractor` (bucket routing) previously skipped `handleEmpty` and `tryEncode` on the
  single-field slash path, while `KeyGenUtils` always applied both. Both now agree with what the
  Avro writer has always produced, rather than changing any layout.
* No on-disk layout changes for existing tables: every slash partition directory in existence was
  written by the Avro path, since the row-writer path could not produce one at all.
* Behavior change, multi-field slash tables: creating one, writing to one, or registering a legacy
  one in the SQL catalog now fails with a clear error instead of being accepted. Such tables were
  already broken -- `CustomKeyGenerator` layouts throw on every read under the default lazy
  listing, and `SimpleKeyGenerator`/`ComplexKeyGenerator` layouts silently return zero rows on any
  partition-filtered query -- so the check turns existing silent corruption loud rather than
  removing a working configuration. Legacy tables already registered in the catalog remain
  readable, since no read path runs the validation.
* The path-breaking dash guard only changes values whose current output is already unreadable --
  the writer and the file-system view disagree on where such a partition lives -- so no layout that
  works today moves. Values matching `yyyy-MM-dd` are unaffected.

Scope is Spark-only -- no Flink or Java-client code reads
`hoodie.datasource.write.slash.separated.date.partitioning`. HoodieStreamer runs
`validateTableConfig` at init when the target table exists, so streamer writes to an existing
multi-field slash table fail fast as well.

No public API, config or storage-format change.

### Risk Level

low

The formatter is exercised by the new unit tests across both string flavors, and the SQL-level
suite covers insert, bulk_insert, upsert on COW and MOR, null values, DATE partition columns and
the multi-field rejection at create and write time. Follow-ups filed during review for the
configurations this PR deliberately does not change: #19666 (reads of legacy multi-field tables),
#19667 (TIMESTAMP), #19668 (hive sync of the default-partition directory) and #19669 (hive-style
plus slash outside SQL DDL).

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
