### PR TITLE
docs(tech-specs): secondary index and index versions for table version 9

### DIFF
--- a/website/learn/tech-specs.md
+++ b/website/learn/tech-specs.md
@@ -614,9 +614,11 @@ read as `V1` while indexes created afterwards on the same table use `V2`.
 
 *   A secondary index may be defined on **exactly one column**. Attempting more fails with
     `Only one column can be indexed for functional or secondary index.`
-*   The indexed column must be one of `string`, `int`, `long`, `float`, `double`, `date`, `time`, or a
-    **UTC-adjusted** `timestamp`. Local-timestamp columns and all other types are rejected. A nullable column is
-    supported when its non-null branch is one of these types.
+*   The indexed column must resolve to one of the schema types `string`, `int`, `long`, `float`, `double`, `date`,
+    `time`, or a **UTC-adjusted** `timestamp`. In Spark SQL terms that covers `string`, `tinyint`, `smallint`, `int`,
+    `bigint`, `float`, `double`, `date` and `timestamp`, since `tinyint` and `smallint` are represented as `int`.
+    Rejected are `decimal`, `boolean`, `binary`, the nested types `array`, `map` and `struct`, and local
+    (non-UTC-adjusted) timestamps. A nullable column is supported when its non-null branch is a supported type.
 *   The **type of an indexed column cannot be changed** while the index exists. Both a SQL
     `ALTER TABLE ... ALTER COLUMN ... TYPE ...` and a write that evolves the column through schema-on-read fail with
     `Column '<column>' has secondary index '<index>' and cannot evolve from schema '<old>' to '<new>'`. Drop the index,

--- a/website/learn/tech-specs.md
+++ b/website/learn/tech-specs.md
@@ -463,6 +463,70 @@ The other fields can also be optional for writers depending on whether protectio
 ### Naming
 Indexes are stored under `.hoodie/metadata` storage path, with separate partitions of the  form `<index_type>_<index_name>`.
 
+### Index Definitions
+
+Every index carries a definition, serialized to JSON under the path in `hoodie.table.index.defs.path`
+(default `.hoodie/.index_defs/index.json`). All definitions for a table live in a single file, keyed by the
+metadata-table partition name:
+
+```json
+{
+  "indexDefinitions": {
+    "<partition_name>": {
+      "indexName": "<partition_name>",
+      "indexType": "<index_type>",
+      "indexFunction": "<index_function>",
+      "version": "<index_version>",
+      "sourceFields": ["<column_1>", "<column_2>"],
+      "indexOptions": {}
+    }
+  }
+}
+```
+
+*   `indexType` is one of `files`, `column_stats`, `partition_stats`, `bloom_filters`, `record_index`,
+    `secondary_index` or `expr_index`.
+*   `indexFunction` is the transform applied to the source column, `identity` unless the index is an expression index.
+*   `sourceFields` are the data-table columns the index is derived from. Metadata columns are permitted.
+*   `indexOptions` carries index-type-specific options, such as the expression-index function arguments.
+*   `version` is the storage-layout version of the index, described below.
+
+#### Index Versions
+
+`version` holds a `HoodieIndexVersion`, an index-level attribute introduced in table version 9. It allows the physical
+layout of an index to change without forcing a table-version upgrade or downgrade, so that readers and writers built
+against different releases agree on how to interpret a given index partition. Values take the form `V1`, `V2` and so on.
+
+A table version 8 definition may omit `version` entirely. From table version 9 onward a definition without a version is
+rejected as invalid, and secondary indexes on a table still at version 8 must be `V1`.
+
+Which version a newly created index gets depends on the index type and the table version:
+
+| Index type | Table version 8 | Table version 9 |
+|---|---|---|
+| `secondary_index` | `V1` | **`V2`** |
+| `column_stats` | `V1` | **`V2`** |
+| `partition_stats` | `V1` | **`V2`** |
+| `expr_index` | `V1` | **`V2`** |
+| `record_index` | `V1` | `V1` |
+| `bloom_filters` | `V1` | `V1` |
+| `files` | `V1` | `V1` |
+
+Only the layout changes; the logical contents of an index are unaffected by its version.
+
+#### Table Upgrade and Downgrade
+
+Index versions are reconciled when the table version changes.
+
+*   **Upgrading from table version 8 to 9** does not rebuild or drop any index. Definitions that carry no `version` are
+    stamped `V1`, so existing indexes keep their on-disk layout and continue to be read as `V1`. Indexes created after
+    the upgrade pick up the table version 9 defaults above.
+*   **Downgrading from table version 9 to 8** drops every metadata partition whose index version is newer than `V1`,
+    because table version 8 readers cannot interpret those layouts. Additionally, if a `V2` `column_stats` partition is
+    dropped, `partition_stats` is dropped with it, since partition stats may have no definition of their own to inspect.
+
+Dropped indexes have to be rebuilt after the downgrade.
+
 ### Bloom Filter Index
 
 The bloom filter index is used to accelerate 'presence checks' — validating whether a particular record is present in a file — which is used during merging, hash-based joins, point-lookup queries, etc.
@@ -506,7 +570,7 @@ Hudi supports near-standard [SQL syntax](/docs/sql_ddl#create-index) for creatin
 via Spark SQL, along with an asynchronous indexing table service that builds indexes without interrupting writers.
 
 A secondary index definition is serialized to JSON and saved at the path specified by `hoodie.table.index.defs.path`
-(see [Indexing Functions / Index Definitions](#indexing-functions) for the on-disk shape).
+(see [Index Definitions](#index-definitions) for the on-disk shape).
 The index itself is stored in the Hudi metadata table under the partition `secondary_index_<index_name>`. As with other
 metadata partitions the entry is a key/value, but the encoding is a little more nuanced.
 
@@ -532,12 +596,32 @@ For example, a secondary index on the `city` column, for a record with `city = C
 chennai$id1 -> {"isDeleted": false}
 ```
 
-Each secondary-index partition is tagged with a `HoodieIndexVersion` (stored on the corresponding `HoodieIndexDefinition`).
-Table version 8 constrained every secondary-index partition to `V1` (the encoding described above). Table version 9
-introduces `V2`, which shards records by the primary (record) key rather than by the secondary key. This makes secondary-index
-updates cheaper on writes with skewed secondary values, at the cost of secondary-key range scans having to visit more file
-groups. Readers pick their scan strategy from the per-partition `HoodieIndexVersion`. New tables created on version 9
-default to `V2` for secondary indexes; existing `V1` partitions from upgraded tables continue to be read with the V1 encoding.
+**Partitioning** decides which file group of the index partition an entry is written to. Hudi hashes a portion of the
+record key and takes that value modulo the number of file groups. Which portion is hashed is governed by the
+[`HoodieIndexVersion`](#index-versions) recorded on the index's `HoodieIndexDefinition`:
+
+*   **`V1`**, the default for table version 8, hashes the whole `<escaped-secondary-key>$<escaped-primary-key>` key.
+    Entries sharing a secondary value are distributed across all file groups, so resolving a secondary value to its
+    records reads every file group unless the primary key is already known.
+*   **`V2`**, the default for table version 9, hashes only the leading `<escaped-secondary-key>$` portion. All entries
+    sharing a secondary value therefore reside in one file group, and a lookup by secondary value alone reads that
+    single file group.
+
+The strategy is selected per partition from its recorded version, so `V1` partitions on an upgraded table continue to be
+read as `V1` while indexes created afterwards on the same table use `V2`.
+
+#### Limitations
+
+*   A secondary index may be defined on **exactly one column**. Attempting more fails with
+    `Only one column can be indexed for functional or secondary index.`
+*   The indexed column must be one of `string`, `int`, `long`, `float`, `double`, `date`, `time`, or a
+    **UTC-adjusted** `timestamp`. Local-timestamp columns and all other types are rejected. A nullable column is
+    supported when its non-null branch is one of these types.
+*   The **type of an indexed column cannot be changed** while the index exists. Both a SQL
+    `ALTER TABLE ... ALTER COLUMN ... TYPE ...` and a write that evolves the column through schema-on-read fail with
+    `Column '<column>' has secondary index '<index>' and cannot evolve from schema '<old>' to '<new>'`. Drop the index,
+    change the type, then rebuild the index. Changing only a column's nullability is permitted and does not require
+    dropping the index.
 
 ### Expression Indexes
 

--- a/website/learn/tech-specs.md
+++ b/website/learn/tech-specs.md
@@ -486,7 +486,11 @@ metadata-table partition name:
 
 *   `indexType` is one of `files`, `column_stats`, `partition_stats`, `bloom_filters`, `record_index`,
     `secondary_index` or `expr_index`.
-*   `indexFunction` is the transform applied to the source column, `identity` unless the index is an expression index.
+*   `indexFunction` carries the transform for an expression index, and defaults to `identity` when an expression index
+    is created without an explicit function. For every other index type the field is not meaningful, and the value it
+    ends up with depends on the code path that registered the definition: empty when the built-in initialisation path
+    registers it, `identity` for a secondary index created through SQL `CREATE INDEX`, and the partition name for the
+    column-stats registration path. Use `indexType` to identify an index, not this field.
 *   `sourceFields` are the data-table columns the index is derived from. Metadata columns are permitted.
 *   `indexOptions` carries index-type-specific options, such as the expression-index function arguments.
 *   `version` is the storage-layout version of the index, described below.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17068. (JIRA: [HUDI-9550](https://issues.apache.org/jira/browse/HUDI-9550).)

The issue asks for the tech spec to cover four table version 9 index changes: the new internal `indexVersion` field, the
new secondary index partition scheme, null value handling, and what upgrade/downgrade does to indexes.

While working through it I found that the page does not merely omit the new partition scheme — **it currently describes it
backwards**. Fixing that is the most important change here, so it goes first.

### The correction

`learn/tech-specs.md` says today:

> Table version 9 introduces `V2`, which **shards records by the primary (record) key rather than by the secondary key**.
> This makes secondary-index updates cheaper on writes with skewed secondary values, **at the cost of secondary-key range
> scans having to visit more file groups**.

Both halves are inverted. The dispatch is unambiguous:

```java
// MetadataPartitionType.java (SECONDARY_INDEX)
public SerializableBiFunction<String, Integer, Integer> getFileGroupMappingFunction(HoodieIndexVersion indexVersion) {
  return HoodieTableMetadataUtil.getSecondaryKeyToFileGroupMappingFunction(indexVersion.greaterThanOrEquals(HoodieIndexVersion.V2));
}
```

```java
// HoodieTableMetadataUtil.java
public static SerializableBiFunction<String, Integer, Integer> getSecondaryKeyToFileGroupMappingFunction(boolean needsSecondaryKeyExtraction) {
  if (needsSecondaryKeyExtraction) {
    String secondaryKey = SecondaryIndexKeyUtils.getUnescapedSecondaryKeyPrefixFromSecondaryIndexKey(recordKey);
    return mapRecordKeyToFileGroupIndex(secondaryKey, numFileGroups);
  }
  return HoodieTableMetadataUtil::mapRecordKeyToFileGroupIndex;
}
```

and its javadoc states it plainly: *"For secondary index partitions (version >= 2) … the unescaped secondary key portion
is used for hashing. Otherwise, the full record key is used."*

So `V1` hashes the whole `<secondary>$<primary>` key, scattering one secondary value across every file group; `V2` hashes
only the `<secondary>$` prefix, so all entries for a secondary value sit in one file group and a lookup by secondary value
alone reads exactly one. `V2` is the improvement for secondary-key lookups, and the published text says the opposite.

<img width="897" height="743" alt="image" src="https://github.com/user-attachments/assets/54211c61-5727-4867-ac01-7c8c2f5fb134" />

### Summary and Changelog

One file, `website/learn/tech-specs.md` (+96/−10). `learn/` is an unversioned Docusaurus plugin, so there is a single copy
and no versioned duplicates; the page therefore has to describe both table version 8 and 9 behaviour, which it now does.

**1. Index Definitions.** The definition path and the `hoodie.table.index.defs.path` property were already documented, but
the JSON schema was not, and the secondary index section pointed at `#indexing-functions` for "the on-disk shape" — a
two-line RFC stub. That dangling cross-reference now resolves to this new section.

<img width="899" height="599" alt="image" src="https://github.com/user-attachments/assets/58848b7b-86d8-42d8-afd0-15dbf289d5ba" />

**2. Index Versions.** `version` holds a `HoodieIndexVersion`, introduced at table version 9, which lets an index's
physical layout change without a table-version upgrade. Worth stating explicitly that this is **not** secondary-index
specific: `column_stats`, `partition_stats` and `expr_index` also default to `V2` at table version 9, while
`record_index`, `bloom_filters` and `files` stay `V1`. Also that a table version 8 definition may omit `version`, but from
version 9 a definition without one is invalid.

<img width="903" height="652" alt="image" src="https://github.com/user-attachments/assets/ac10072b-47da-452a-88d9-949d33674193" />

**3. Table Upgrade and Downgrade.** The issue phrases this as "downgrade/upgrade will drop new/old SI index", but only
downgrade drops anything:

- Upgrading 8 → 9 rebuilds and drops nothing. `EightToNineUpgradeHandler#populateIndexVersionIfMissing` stamps
  version-less definitions with `V1`, so existing indexes keep their layout.
- Downgrading 9 → 8 drops every partition whose version is above `V1`
  (`UpgradeDowngradeUtils#dropNonV1IndexPartitions`), plus `partition_stats` when a `V2` `column_stats` partition is
  dropped, since partition stats may have no definition of their own to inspect.

<img width="904" height="290" alt="image" src="https://github.com/user-attachments/assets/683e5421-59a7-486b-ba5a-f1c5fce03427" />

**4. Secondary index limitations.** One indexed column; the supported column types; and the column-type-change
restriction.

**Null handling** (issue item 3) needed no change — the page already documents `\0` escaping correctly.

### Relationship to the abandoned PR #13713

#13713 is the open PR linked from the issue. It is **CONFLICTING/DIRTY** and untouched since Feb 2026. The reason it
conflicts is worth recording: its target file `website/src/pages/tech-specs-1point0.md` **no longer exists**. Commit
`34f4d7bd9433` (#14221) moved tech specs to `website/learn/tech-specs.md`. So it cannot simply be rebased; the content has
to be re-applied against the current file, which is what this PR does.

I used it as a reference, not as the answer, and re-derived every fact. Two of its statements do not hold on
`release-1.2.0`:

| #13713 says | Verified behaviour |
|---|---|
| SI supports "string, double, timestamp and any integral types" | `HoodieIndexUtils#isSecondaryIndexSupportedType` admits `string, int, long, float, double, date, time`, and `timestamp` **only when `isUtcAdjusted`**. Local timestamps are rejected. Its list omits float/date/time and misses the timestamp caveat. |
| "We don't allow schema evolution on columns with a secondary index" | `HoodieTable` throws `SchemaCompatibilityException` on a column **type** change, but explicitly `continue`s when only nullability differs. So the restriction is narrower than stated. |

Also not carried over: its `.gitignore` change (`.vscode/`, `.metals/`), which is unrelated to the docs, and its
`## Indexes` → `## Indices` rename, which introduced typos ("Indicies", "speciffies", "compatibiity").

**On its review feedback**, being precise rather than implying there was more than there was: #13713 has exactly **one**
reviewer comment and **zero** inline threads (confirmed via the GraphQL `reviewThreads` API, including resolved and
outdated ones):

> **@vinothchandar:** *"lets remove the release notes .md file.. and notify the RM.. @yihua on the update."*

The author replied "done" and the file is absent from that diff. This PR honours it by adding no release-notes file, and
the second half is the reason @yihua is tagged below.

### Verification

`npm run build` passes with the warning block **byte-identical** to a baseline built from the same base commit
(`eaa8dfd89a38`), 13,265 lines each. Rendered under `npm run serve` and checked over HTTP: all four new headings resolve
with correct anchors, 7 TOC entries are generated, the `index.json` block and per-index-type table render, and the
inverted `"shards records by the primary"` sentence is confirmed gone. The screenshots above are from that local render.

Every claim was checked against `release-1.2.0` source rather than carried over: `HoodieIndexVersion`,
`HoodieIndexDefinition`, `SecondaryIndexKeyUtils`, `HoodieTableMetadataUtil`, `MetadataPartitionType`,
`EightToNineUpgradeHandler`, `NineToEightDowngradeHandler`, `UpgradeDowngradeUtils`, `HoodieIndexUtils` and `HoodieTable`.

One limitation worth stating: this is verified by reading source, not by running an upgrade/downgrade against a real
table. A committer confirming the upgrade/downgrade wording in particular would be valuable, since that is the part users
will act on.

### Impact

Documentation only. No code, config, or behaviour change. It does correct a statement that is currently misleading about
which layout is better for secondary-key lookups.

### Risk Level

none

### Documentation Update

This PR is the documentation update — the tech spec, https://hudi.apache.org/learn/tech-specs.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

cc @yihua (per the RM notification asked for on #13713), @Davis-Zhang-Onehouse (author of #13713), @vinothchandar
