### PR TITLE
fix(spark): return partition values in Catalyst's internal representation

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
@@ -248,7 +248,7 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
       Array.fill(partitionColumns.length)(UTF8String.fromString(partitionPath))
     } else if(usePartitionValueExtractorOnRead && !StringUtils.isNullOrEmpty(partitionValueExtractorClass)) {
       parsePartitionValuesBasedOnPartitionValueExtractor(partitionValueExtractorClass, partitionPath,
-        partitionColumns, tableSchema)
+        partitionColumns, tableSchema, timeZoneId)
     } else {
       doParsePartitionColumnValues(partitionColumns, partitionPath, tableBasePath, tableSchema, timeZoneId,
         shouldValidatePartitionColumns, tableConfig.getSlashSeparatedDatePartitioning)
@@ -268,7 +268,8 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
       partitionValueExtractorClass: String,
       partitionPath: String,
       partitionColumns: Array[String],
-      tableSchema: StructType): Array[Object] = {
+      tableSchema: StructType,
+      timeZoneId: String): Array[Object] = {
     try {
       val partitionValueExtractor = Class.forName(partitionValueExtractorClass)
         .getDeclaredConstructor()
@@ -277,7 +278,7 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
       val partitionValues = partitionValueExtractor.extractPartitionValuesInPath(partitionPath).asScala.toArray
       val partitionSchema = buildPartitionSchemaForNestedFields(tableSchema, partitionColumns)
       val typedValues = partitionValues.zip(partitionSchema.fields).map { case (stringValue, field) =>
-        castStringToType(stringValue, field.dataType)
+        castStringToType(stringValue, field.dataType, timeZoneId)
       }
       typedValues.map(_.asInstanceOf[Object])
     } catch {
@@ -314,7 +315,7 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
           }
           val partitionSchema = buildPartitionSchemaForNestedFields(schema, partitionColumns)
           val typedValue = if (partitionSchema.fields.nonEmpty) {
-            castStringToType(partitionValue, partitionSchema.fields.head.dataType)
+            castStringToType(partitionValue, partitionSchema.fields.head.dataType, timeZoneId)
           } else {
             UTF8String.fromString(partitionValue)
           }
@@ -325,7 +326,7 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
             val partitionValues = splitHiveSlashPartitions(partitionFragments, partitionColumns.length)
             val partitionSchema = buildPartitionSchemaForNestedFields(schema, partitionColumns)
             val typedValues = partitionValues.zip(partitionSchema.fields).map { case (stringValue, field) =>
-              castStringToType(stringValue, field.dataType)
+              castStringToType(stringValue, field.dataType, timeZoneId)
             }
             typedValues.map(_.asInstanceOf[Object])
           } else {
@@ -405,38 +406,30 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
     traverseSchema(schema, pathParts.toList, fieldPath)
   }
 
-  def castStringToType(value: String, dataType: org.apache.spark.sql.types.DataType): Any = {
-    import org.apache.spark.sql.types._
+  /**
+   * Converts a raw partition-path value into the Catalyst-internal representation of
+   * {@code dataType}, so that it can be held in the [[InternalRow]] of partition values.
+   *
+   * NOTE: This delegates to the very same [[SparkParsePartitionUtil#castPartValueToDesiredType]]
+   *       backing [[parsePartitionPath]], so that a partition value parsed through this (fallback)
+   *       flow is identical to the one parsed when the partition fragments line up with the
+   *       partition columns. Rolling our own conversion here previously handed back values in the
+   *       external representation ([[UTF8String]] for date/timestamp, [[java.math.BigDecimal]] for
+   *       decimal), which blows up with a [[ClassCastException]] as soon as Spark reads the
+   *       partition row.
+   */
+  def castStringToType(value: String, dataType: org.apache.spark.sql.types.DataType): Any =
+    castStringToType(value, dataType, SQLConf.get.sessionLocalTimeZone)
 
-    // handling cases where the value contains path separators or is complex
-    if (value.contains("/") || value.contains("=")) {
-      // For complex paths, falling back to string representation
-      logWarning(s"Cannot convert complex partition path '$value' to $dataType, keeping as string")
-      return UTF8String.fromString(value)
-    }
-
+  def castStringToType(value: String,
+                       dataType: org.apache.spark.sql.types.DataType,
+                       timeZoneId: String): Any = {
     try {
-      dataType match {
-        case LongType => value.toLong
-        case IntegerType => value.toInt
-        case ShortType => value.toShort
-        case ByteType => value.toByte
-        case FloatType => value.toFloat
-        case DoubleType => value.toDouble
-        case BooleanType => value.toBoolean
-        case _: DecimalType => new java.math.BigDecimal(value)
-        case StringType => UTF8String.fromString(value)
-        case _: TimestampType =>
-          UTF8String.fromString(value)
-        case _: DateType =>
-          UTF8String.fromString(value)
-        case _ => UTF8String.fromString(value)
-      }
+      SparkParsePartitionUtil.castPartValueToDesiredType(dataType, value, getTimeZone(timeZoneId).toZoneId)
     } catch {
-      case _: NumberFormatException =>
-        logWarning(s"Failed to convert '$value' to $dataType, keeping as string")
-        UTF8String.fromString(value)
       case _: Exception =>
+        // NOTE: A partition path that cannot be converted is left in its string representation,
+        //       preserving the long-standing lenient behavior for malformed paths
         logWarning(s"Error converting '$value' to $dataType, keeping as string")
         UTF8String.fromString(value)
     }

--- a/hudi-client/hudi-spark-client/src/test/scala/org/apache/hudi/TestHoodieSparkUtilsPartitionValues.scala
+++ b/hudi-client/hudi-spark-client/src/test/scala/org/apache/hudi/TestHoodieSparkUtilsPartitionValues.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi
+
+import org.apache.hudi.storage.StoragePath
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNull}
+import org.junit.jupiter.api.Test
+
+import java.time.{LocalDateTime, ZoneOffset}
+
+/**
+ * Tests that partition values recovered from a partition path are handed back in Catalyst's
+ * internal representation, so that they can be held in the [[InternalRow]] of partition values
+ * that partition pruning and the file index evaluate against.
+ */
+class TestHoodieSparkUtilsPartitionValues {
+
+  private val UTC = "UTC"
+
+  @Test
+  def testCastStringToTypeReturnsCatalystInternalValues(): Unit = {
+    // Date is represented as the number of days since the epoch, not as a string
+    assertEquals(DateTimeUtils.fromJavaDate(java.sql.Date.valueOf("2023-03-01")),
+      HoodieSparkUtils.castStringToType("2023-03-01", DateType, UTC))
+    // Timestamp is represented as micros since the epoch, resolved against the given time zone
+    val expectedMicros = LocalDateTime.of(2023, 3, 1, 1, 2, 3).toInstant(ZoneOffset.UTC)
+      .getEpochSecond * 1000000L
+    assertEquals(expectedMicros,
+      HoodieSparkUtils.castStringToType("2023-03-01 01:02:03", TimestampType, UTC))
+    // ... and the time zone is honored: Asia/Kolkata is a fixed +05:30 off UTC
+    assertEquals(expectedMicros - 19800L * 1000000L,
+      HoodieSparkUtils.castStringToType("2023-03-01 01:02:03", TimestampType, "Asia/Kolkata"))
+    // Decimal is represented as [[Decimal]], not as [[java.math.BigDecimal]]
+    assertEquals(Decimal(new java.math.BigDecimal("1.50")),
+      HoodieSparkUtils.castStringToType("1.50", DecimalType(10, 2), UTC))
+
+    // Types that were already handled keep working
+    assertEquals(5, HoodieSparkUtils.castStringToType("5", IntegerType, UTC))
+    assertEquals(5L, HoodieSparkUtils.castStringToType("5", LongType, UTC))
+    assertEquals(true, HoodieSparkUtils.castStringToType("true", BooleanType, UTC))
+    assertEquals(UTF8String.fromString("abc"),
+      HoodieSparkUtils.castStringToType("abc", StringType, UTC))
+  }
+
+  @Test
+  def testCastStringToTypeMapsDefaultPartitionToNull(): Unit = {
+    Seq(StringType, IntegerType, DateType, TimestampType).foreach { dataType =>
+      assertNull(HoodieSparkUtils.castStringToType("__HIVE_DEFAULT_PARTITION__", dataType, UTC),
+        s"the default partition stands for a null value of $dataType")
+    }
+  }
+
+  @Test
+  def testCastStringToTypeUnescapesValues(): Unit = {
+    assertEquals(UTF8String.fromString("a=b"),
+      HoodieSparkUtils.castStringToType("a%3Db", StringType, UTC))
+  }
+
+  @Test
+  def testParsePartitionValuesForSlashSeparatedDatePartitioning(): Unit = {
+    // A single date partition column laid out as yyyy/MM/dd does not line up with the partition
+    // columns, so it falls back onto [[castStringToType]]
+    val schema = StructType(Seq(StructField("id", IntegerType), StructField("grass_date", DateType)))
+    val values = HoodieSparkUtils.doParsePartitionColumnValues(
+      Array("grass_date"), "2023/03/01", new StoragePath("/tmp/table"), schema, UTC,
+      shouldValidatePartitionCols = false, slashSeparatedDatePartitioning = true)
+
+    assertEquals(1, values.length)
+    assertEquals(DateTimeUtils.fromJavaDate(java.sql.Date.valueOf("2023-03-01")), values.head)
+    // The partition row has to be readable through the accessor matching the column's data type
+    assertEquals(DateTimeUtils.fromJavaDate(java.sql.Date.valueOf("2023-03-01")),
+      InternalRow.fromSeq(values.toSeq).getInt(0))
+  }
+
+  @Test
+  def testParsePartitionValuesForHiveStyleValueHoldingSlash(): Unit = {
+    // "san/francisco" spills over into an extra path fragment, so the fragments do not line up
+    // with the partition columns and parsing falls back onto [[castStringToType]]
+    val schema = StructType(Seq(
+      StructField("id", IntegerType), StructField("dt", DateType), StructField("city", StringType)))
+    val values = HoodieSparkUtils.doParsePartitionColumnValues(
+      Array("dt", "city"), "dt=2023-03-01/city=san/francisco", new StoragePath("/tmp/table"), schema,
+      UTC, shouldValidatePartitionCols = false, slashSeparatedDatePartitioning = false)
+
+    assertEquals(2, values.length)
+    assertEquals(DateTimeUtils.fromJavaDate(java.sql.Date.valueOf("2023-03-01")), values.head)
+    assertEquals(UTF8String.fromString("san/francisco"), values(1))
+    assertEquals(DateTimeUtils.fromJavaDate(java.sql.Date.valueOf("2023-03-01")),
+      InternalRow.fromSeq(values.toSeq).getInt(0))
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestTypedPartitionValues.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestTypedPartitionValues.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.common
+
+/**
+ * Covers reading tables whose partition path does not line up one-to-one with the partition
+ * columns, so that the partition values have to be recovered through
+ * [[org.apache.hudi.HoodieSparkUtils#castStringToType]] rather than through Spark's partition
+ * parser.
+ */
+class TestTypedPartitionValues extends HoodieSparkSqlTestBase {
+
+  test("Test reading a date partition column laid out as yyyy/MM/dd") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  ts long,
+           |  grass_date date
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  orderingFields = 'ts',
+           |  'hoodie.datasource.write.slash.separated.date.partitioning' = 'true'
+           | )
+           | partitioned by (grass_date)
+         """.stripMargin)
+
+      spark.sql(s"insert into $tableName values(1, 'a1', 1000, date'2023-02-27')")
+      spark.sql(s"insert into $tableName values(2, 'a2', 1000, date'2023-03-01')")
+
+      // NOTE: The partition path holds three fragments for a single partition column, so the
+      //       partition value is recovered through [[castStringToType]]. Handing it back as a
+      //       string used to fail every read of the table with a [[ClassCastException]]
+      checkAnswer(s"select id, name, grass_date, _hoodie_partition_path from $tableName order by id")(
+        Seq(1, "a1", java.sql.Date.valueOf("2023-02-27"), "2023/02/27"),
+        Seq(2, "a2", java.sql.Date.valueOf("2023-03-01"), "2023/03/01")
+      )
+
+      // Partition pruning evaluates the predicate against the recovered partition value
+      checkAnswer(s"select id from $tableName where grass_date = date'2023-03-01'")(
+        Seq(2)
+      )
+      checkAnswer(s"select id from $tableName where grass_date < date'2023-03-01'")(
+        Seq(1)
+      )
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19651.

A table partitioned by a `date` column whose partition path does not line up one-to-one with the
partition columns writes successfully but cannot be read at all — every query, including an
unfiltered `select *`, fails with `ClassCastException: UTF8String cannot be cast to
java.lang.Integer`.

When the partition fragments do not line up with the partition columns,
`HoodieSparkUtils#doParsePartitionColumnValues` falls back onto `castStringToType`, which returned
partition values in their *external* representation instead of Catalyst's *internal* one. Those
values are placed directly into the `InternalRow` of partition values that `SparkHoodieTableFileIndex`
and `HoodieFileIndex` evaluate against, so Spark reads a `UTF8String` through `InternalRow#getInt`
and throws.

Five problems in that one method:

| input | expected | before this PR |
|---|---|---|
| `"2023-03-01"` as `DateType` | `Int` epoch days | `UTF8String` |
| `"2023-03-01 01:02:03"` as `TimestampType` | `Long` micros | `UTF8String` |
| `"1.50"` as `DecimalType(10,2)` | `Decimal` | `java.math.BigDecimal` |
| `"__HIVE_DEFAULT_PARTITION__"` | `null` | the literal sentinel string |
| `"a%3Db"` as `StringType` | `a=b` | `a%3Db` |

The last two also diverged from the non-fallback path: when the fragments do line up, parsing goes
through Spark's partition parser, which maps the default partition to `null` and unescapes values.
The same table therefore produced different partition values depending on which branch parsed the
path.

### Summary and Changelog

Partition values recovered from a partition path are now in Catalyst's internal representation, so
tables with a `date`/`timestamp`/`decimal` partition column whose path does not line up with the
partition columns are readable and prune correctly.

- `HoodieSparkUtils#castStringToType` now delegates to
  `SparkParsePartitionUtil#castPartValueToDesiredType` — the same function already backing
  `parsePartitionPath` on the aligned path, so both paths converge by construction instead of
  through a second hand-rolled conversion. This is what fixes all five rows of the table above; the
  hand-rolled `match` is deleted.
- Threaded the configured `timeZoneId` down to the conversion, so timestamp partition values are
  resolved against the session/reader time zone (as the aligned path already did) rather than the
  JVM default. `castStringToType` keeps its original two-argument form as an overload defaulting to
  the session-local time zone, so the existing signature stays binary compatible.
- Kept the pre-existing lenient fallback: a value that cannot be converted is still logged and left
  in its string representation, so genuinely malformed paths behave as before.
- Tests: new `TestHoodieSparkUtilsPartitionValues` covering the internal representations, the
  default-partition-to-null mapping, unescaping, time-zone handling, and both fallback shapes
  (single date column laid out as `yyyy/MM/dd`, and a hive-style value spilling over a `/`); new
  end-to-end `TestTypedPartitionValues` reading a `date`-partitioned table and pruning on it.

Verified that the new tests fail on `master` with the `ClassCastException` above and pass with the
fix.

### Impact

Fixes a total read failure for affected tables. Data already written is fine — only the read path
was broken, so the fix makes existing tables readable again without any migration.

Affects 1.2.0 and master.

Behavior changes, both bringing the fallback path in line with the aligned path:
- A partition value of `__HIVE_DEFAULT_PARTITION__` now reads back as `null` rather than as the
  literal string.
- String partition values are now URL-unescaped, so a value written as `a%3Db` reads back as `a=b`.

`castStringToType` is public; its existing two-argument signature is preserved as an overload.

### Risk Level

low

The change replaces a hand-rolled conversion with the conversion helper Spark and Hudi already use
for the aligned path, in the same module. The previously broken paths threw before producing any
result, and the two behavior changes above make the fallback agree with the parser that already
governs the majority of tables. Verified against the new unit and end-to-end tests plus the
`hudi-spark-client` key-generator/datasource suites and the `TestHoodieFileIndex`,
`TestLazyPartitionPathFetching`, `TestSlashSeparatedPartitionValue` and `TestShowPartitions` Spark
suites, all green.

### Documentation Update

none — no new configs and no change to any documented behavior.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
