### PR TITLE
fix(flink): sort ClientIds heartbeat files numerically instead of lexicographically

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/ClientIds.java
@@ -186,7 +186,7 @@ public class ClientIds implements AutoCloseable, Serializable {
       }
       List<Path> sortedPaths = Arrays.stream(fs.listStatus(heartbeatFolderPath))
           .map(FileStatus::getPath)
-          .sorted(Comparator.comparing(Path::getName))
+          .sorted(Comparator.comparingInt(path -> getClientIdSortKey(getClientId(path))))
           .collect(Collectors.toList());
       if (sortedPaths.isEmpty()) {
         return INIT_CLIENT_ID;
@@ -217,6 +217,14 @@ public class ClientIds implements AutoCloseable, Serializable {
   private static String getClientId(Path path) {
     String[] splits = path.getName().split(HEARTBEAT_FILE_NAME_PREFIX);
     return splits.length > 1 ? splits[1] : INIT_CLIENT_ID;
+  }
+
+  /**
+   * Returns a sort key so heartbeat files order numerically instead of lexicographically.
+   * The base heartbeat file (empty client id) always sorts first.
+   */
+  private static int getClientIdSortKey(String clientId) {
+    return StringUtils.isNullOrEmpty(clientId) ? -1 : Integer.parseInt(clientId);
   }
 
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestClientIds.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestClientIds.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.hudi.configuration.FlinkOptions;
+
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link ClientIds}.
+ */
+public class TestClientIds {
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  public void testNextIdSortsNumericallyAcrossDoubleDigitIds() throws IOException {
+    createHeartbeatFiles("", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
+    Configuration conf = confForBasePath();
+
+    String nextId = ClientIds.builder().conf(conf).build().nextId(conf);
+
+    assertEquals("11", nextId);
+  }
+
+  @Test
+  public void testNextIdSingleDigitIdsStillWork() throws IOException {
+    createHeartbeatFiles("", "1", "2");
+    Configuration conf = confForBasePath();
+
+    String nextId = ClientIds.builder().conf(conf).build().nextId(conf);
+
+    assertEquals("3", nextId);
+  }
+
+  private void createHeartbeatFiles(String... clientIds) throws IOException {
+    Path heartbeatDir = tempDir.resolve(".hoodie").resolve(".aux").resolve(".ids");
+    Files.createDirectories(heartbeatDir);
+    for (String clientId : clientIds) {
+      Files.createFile(heartbeatDir.resolve("_" + clientId));
+    }
+  }
+
+  private Configuration confForBasePath() {
+    String uri = tempDir.toUri().toString();
+    String basePath = uri.endsWith("/") ? uri.substring(0, uri.length() - 1) : uri;
+    Configuration conf = new Configuration();
+    conf.set(FlinkOptions.PATH, basePath);
+    return conf;
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19619.

`ClientIds#nextId` sorts heartbeat client-id files with `Comparator.comparing(Path::getName)`, a plain lexicographic string sort. Once double-digit ids exist, `_10` sorts before `_2` (comparing `'1'` vs `'2'` at the second character), so the file the code treats as "largest" (the last one after sorting) is wrong. `nextId()` then reissues an id that's already in use — for example it returns `10` again instead of `11` when `_1` through `_10` already exist.

### Summary and Changelog

Replaced the comparator with one that parses each heartbeat file's numeric client id and compares on that, and added a `getClientIdSortKey` helper that returns `-1` for the base file (empty id) so it still sorts first, matching the existing `INIT_CLIENT_ID` handling a few lines below. This also corrects the zombie-reuse branch just above the auto-increment logic, which reads from the same sorted list and could pick the wrong "smallest" zombie once double-digit ids existed.

Added `TestClientIds` with two cases: the exact repro from the issue (heartbeat files `_`, `_1`...`_10`, asserting `nextId()` returns `"11"`) and a sanity check that ordinary single-digit ids still work as before.

### Impact

No public API change. User-facing effect is limited to correct next-client-id generation under Flink multi-writer mode once more than 9 concurrent writers have registered — previously this could silently assign a duplicate id. No performance impact: same O(n log n) sort, only the comparator changed.

### Risk Level

low. The change is isolated to the sort comparator used internally by `ClientIds#nextId`; the id-generation and zombie-cleanup logic downstream of the sort is unchanged.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
