### PR TITLE
fix(storage-format): ignore temporary LSM timeline manifests

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/LSMTimeline.java
@@ -109,8 +109,7 @@ public class LSMTimeline {
 
   private static final String VERSION_FILE_NAME = "_version_";    // _version_
   private static final String MANIFEST_FILE_PREFIX = "manifest_"; // manifest_[N]
-
-  private static final String TEMP_FILE_SUFFIX = ".tmp";
+  private static final Pattern MANIFEST_FILE_PATTERN = Pattern.compile("^" + MANIFEST_FILE_PREFIX + "(\\d+)$");
 
   private static final Pattern ARCHIVE_FILE_PATTERN =
       Pattern.compile("^(\\d+)_(\\d+)_(\\d)\\.parquet");
@@ -241,7 +240,11 @@ public class LSMTimeline {
    * Parse the snapshot version from the manifest file name.
    */
   public static int getManifestVersion(String fileName) {
-    return Integer.parseInt(fileName.split("_")[1]);
+    Matcher fileMatcher = MANIFEST_FILE_PATTERN.matcher(fileName);
+    if (fileMatcher.matches()) {
+      return Integer.parseInt(fileMatcher.group(1));
+    }
+    throw new HoodieException("Unexpected manifest file name: " + fileName);
   }
 
   /**
@@ -297,6 +300,6 @@ public class LSMTimeline {
    * Returns a path filter for the manifest files.
    */
   public static StoragePathFilter getManifestFilePathFilter() {
-    return path -> path.getName().startsWith(MANIFEST_FILE_PREFIX) && !path.getName().endsWith(TEMP_FILE_SUFFIX);
+    return path -> MANIFEST_FILE_PATTERN.matcher(path.getName()).matches();
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestLSMTimeline.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestLSMTimeline.java
@@ -19,13 +19,30 @@
 
 package org.apache.hudi.common.table.timeline;
 
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathFilter;
+import org.apache.hudi.storage.StoragePathInfo;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test cases for {@link LSMTimeline}.
@@ -53,5 +70,46 @@ public class TestLSMTimeline {
     int layer = LSMTimeline.getFileLayer(fileName);
     assertThat(layer, is(0));
     assertThat("for invalid file name, returns 0", LSMTimeline.getFileLayer("invalid_file_name.parquet"), is(0));
+  }
+
+  @Test
+  void testManifestFileValidation() {
+    StoragePathFilter filter = LSMTimeline.getManifestFilePathFilter();
+
+    assertTrue(filter.accept(new StoragePath("manifest_1")));
+    assertTrue(filter.accept(new StoragePath("manifest_114")));
+    assertThat(LSMTimeline.getManifestVersion("manifest_114"), is(114));
+
+    assertFalse(filter.accept(new StoragePath("manifest_114.tmp")));
+    assertFalse(filter.accept(new StoragePath("manifest_114.a5e022a6-e5c9-4450-b9e5-9296262329b5")));
+    assertFalse(filter.accept(new StoragePath("manifest_invalid")));
+    assertFalse(filter.accept(new StoragePath("manifest_")));
+    assertThrows(HoodieException.class,
+        () -> LSMTimeline.getManifestVersion("manifest_114.a5e022a6-e5c9-4450-b9e5-9296262329b5"));
+  }
+
+  @Test
+  void testLatestSnapshotVersionFallbackIgnoresTemporaryManifest() throws IOException {
+    StoragePath archivePath = new StoragePath("/table/.hoodie/timeline/history");
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    List<StoragePathInfo> manifestFiles = Arrays.asList(
+        manifestFile(archivePath, "manifest_113"),
+        manifestFile(archivePath, "manifest_114"),
+        manifestFile(archivePath, "manifest_114.a5e022a6-e5c9-4450-b9e5-9296262329b5"));
+
+    when(metaClient.getStorage()).thenReturn(storage);
+    when(storage.open(LSMTimeline.getVersionFilePath(archivePath))).thenThrow(new FileNotFoundException());
+    when(storage.listDirectEntries(eq(archivePath), any(StoragePathFilter.class))).thenAnswer(invocation -> {
+      StoragePathFilter filter = invocation.getArgument(1);
+      return manifestFiles.stream().filter(file -> filter.accept(file.getPath())).collect(Collectors.toList());
+    });
+
+    assertThat(LSMTimeline.latestSnapshotVersion(metaClient, archivePath), is(114));
+    assertThat(LSMTimeline.allSnapshotVersions(metaClient, archivePath), is(Arrays.asList(113, 114)));
+  }
+
+  private static StoragePathInfo manifestFile(StoragePath archivePath, String fileName) {
+    return new StoragePathInfo(new StoragePath(archivePath, fileName), 0, false, (short) 1, 0, 0);
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/storage/hadoop/TestHoodieHadoopStorage.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/storage/hadoop/TestHoodieHadoopStorage.java
@@ -19,17 +19,26 @@
 
 package org.apache.hudi.storage.hadoop;
 
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.io.storage.TestHoodieStorageBase;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.Test;
 
+import java.io.FilterOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link HoodieHadoopStorage}.
@@ -69,5 +78,40 @@ public class TestHoodieHadoopStorage extends TestHoodieStorageBase {
     // which can be caught here.
     assertSame(fileSystem, storage.getFileSystem());
     assertSame(fileSystem, HadoopFSUtils.getFs(getTempDir(), conf, true));
+  }
+
+  @Test
+  void testCreateImmutableFileCleansTemporaryFileAfterCloseFailure() throws IOException {
+    Configuration conf = new Configuration();
+    FileSystem fileSystem = HadoopFSUtils.getFs(getTempDir(), conf, true);
+    HoodieStorage storage = new CloseFailingHoodieHadoopStorage(fileSystem);
+    StoragePath directory = new StoragePath(getTempDir(), "testImmutableFileCloseFailure");
+    StoragePath path = new StoragePath(directory, "1.file");
+    storage.createDirectory(directory);
+
+    HoodieIOException exception = assertThrows(HoodieIOException.class,
+        () -> storage.createImmutableFileInPath(path,
+            Option.of(HoodieInstantWriter.convertByteArrayToWriter(new byte[] {42}))));
+
+    assertTrue(exception.getMessage().startsWith("Failed to close file "));
+    assertFalse(storage.exists(path));
+    assertTrue(storage.listDirectEntries(directory).isEmpty());
+  }
+
+  private static class CloseFailingHoodieHadoopStorage extends HoodieHadoopStorage {
+    CloseFailingHoodieHadoopStorage(FileSystem fileSystem) {
+      super(fileSystem);
+    }
+
+    @Override
+    public OutputStream create(StoragePath path, boolean overwrite) throws IOException {
+      return new FilterOutputStream(super.create(path, overwrite)) {
+        @Override
+        public void close() throws IOException {
+          super.close();
+          throw new IOException("close failure");
+        }
+      };
+    }
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/storage/hadoop/TestHoodieHadoopStorage.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/storage/hadoop/TestHoodieHadoopStorage.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.storage.hadoop;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.io.storage.TestHoodieStorageBase;
@@ -35,6 +36,7 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -93,9 +95,51 @@ public class TestHoodieHadoopStorage extends TestHoodieStorageBase {
         () -> storage.createImmutableFileInPath(path,
             Option.of(HoodieInstantWriter.convertByteArrayToWriter(new byte[] {42}))));
 
-    assertTrue(exception.getMessage().startsWith("Failed to close file "));
+    assertTrue(exception.getMessage().startsWith("Failed to create immutable file "));
     assertFalse(storage.exists(path));
     assertTrue(storage.listDirectEntries(directory).isEmpty());
+  }
+
+  @Test
+  void testCreateImmutableFileCleansTemporaryFileAfterUncheckedRenameFailure() throws IOException {
+    Configuration conf = new Configuration();
+    FileSystem fileSystem = HadoopFSUtils.getFs(getTempDir(), conf, true);
+    HoodieStorage storage = new RenameFailingHoodieHadoopStorage(fileSystem);
+    StoragePath directory = new StoragePath(getTempDir(), "testImmutableFileRenameFailure");
+    StoragePath path = new StoragePath(directory, "1.file");
+    storage.createDirectory(directory);
+
+    HoodieException exception = assertThrows(HoodieException.class,
+        () -> storage.createImmutableFileInPath(path,
+            Option.of(HoodieInstantWriter.convertByteArrayToWriter(new byte[] {42}))));
+
+    assertEquals("rename failure", exception.getMessage());
+    assertFalse(storage.exists(path));
+    assertTrue(storage.listDirectEntries(directory).isEmpty());
+  }
+
+  @Test
+  void testCreateImmutableFileSuppressesUncheckedCleanupFailure() throws IOException {
+    Configuration conf = new Configuration();
+    FileSystem fileSystem = HadoopFSUtils.getFs(getTempDir(), conf, true);
+    CleanupFailingHoodieHadoopStorage storage = new CleanupFailingHoodieHadoopStorage(fileSystem);
+    StoragePath directory = new StoragePath(getTempDir(), "testImmutableFileCleanupFailure");
+    StoragePath path = new StoragePath(directory, "1.file");
+    storage.createDirectory(directory);
+
+    HoodieIOException exception = assertThrows(HoodieIOException.class,
+        () -> storage.createImmutableFileInPath(path, Option.of(outputStream -> {
+          outputStream.write(42);
+          throw new IOException("write failure");
+        })));
+
+    assertEquals("write failure", exception.getCause().getMessage());
+    assertEquals(1, exception.getSuppressed().length);
+    assertEquals("cleanup failure", exception.getSuppressed()[0].getMessage());
+    assertFalse(storage.exists(path));
+    assertEquals(1, storage.listDirectEntries(directory).size());
+    StoragePath temporaryPath = storage.listDirectEntries(directory).get(0).getPath();
+    storage.deleteTemporaryFileAfterTest(temporaryPath);
   }
 
   private static class CloseFailingHoodieHadoopStorage extends HoodieHadoopStorage {
@@ -112,6 +156,32 @@ public class TestHoodieHadoopStorage extends TestHoodieStorageBase {
           throw new IOException("close failure");
         }
       };
+    }
+  }
+
+  private static class RenameFailingHoodieHadoopStorage extends HoodieHadoopStorage {
+    RenameFailingHoodieHadoopStorage(FileSystem fileSystem) {
+      super(fileSystem);
+    }
+
+    @Override
+    public boolean rename(StoragePath oldPath, StoragePath newPath) {
+      throw new HoodieException("rename failure");
+    }
+  }
+
+  private static class CleanupFailingHoodieHadoopStorage extends HoodieHadoopStorage {
+    CleanupFailingHoodieHadoopStorage(FileSystem fileSystem) {
+      super(fileSystem);
+    }
+
+    @Override
+    public boolean deleteFile(StoragePath path) {
+      throw new HoodieIOException("cleanup failure");
+    }
+
+    void deleteTemporaryFileAfterTest(StoragePath path) throws IOException {
+      super.deleteFile(path);
     }
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -329,56 +329,55 @@ public abstract class HoodieStorage implements Closeable {
   public final void createImmutableFileInPath(StoragePath path,
                                               Option<HoodieInstantWriter> contentWriter,
                                               boolean needTempFile) throws HoodieIOException {
-    OutputStream fsout = null;
     StoragePath tmpPath = null;
+    StoragePath pathToCreate = path;
+    if (contentWriter.isPresent() && needTempFile) {
+      StoragePath parent = path.getParent();
+      tmpPath = new StoragePath(parent, path.getName() + "." + UUID.randomUUID());
+      pathToCreate = tmpPath;
+    }
+
+    boolean writeSucceeded = false;
+    try (OutputStream fsout = create(pathToCreate, false)) {
+      if (contentWriter.isPresent()) {
+        contentWriter.get().writeToStream(fsout);
+      }
+      writeSucceeded = true;
+    } catch (IOException e) {
+      String errorMsg = (writeSucceeded ? "Failed to close file " : "Failed to create file ") + pathToCreate;
+      HoodieIOException failure = new HoodieIOException(errorMsg, e);
+      deleteTemporaryFile(tmpPath, failure);
+      throw failure;
+    }
+
+    if (tmpPath != null) {
+      try {
+        if (!rename(tmpPath, path)) {
+          deleteTemporaryFile(tmpPath, null);
+          LOG.debug("Failed to rename {} to {}; target file may already exist", tmpPath, path);
+        }
+      } catch (IOException e) {
+        HoodieIOException failure = new HoodieIOException(
+            "Failed to rename " + tmpPath + " to the target " + path, e);
+        deleteTemporaryFile(tmpPath, failure);
+        throw failure;
+      }
+    }
+  }
+
+  private void deleteTemporaryFile(StoragePath tmpPath, HoodieIOException primaryFailure) {
+    if (tmpPath == null) {
+      return;
+    }
 
     try {
-      if (!contentWriter.isPresent()) {
-        fsout = create(path, false);
-      }
-
-      if (contentWriter.isPresent() && needTempFile) {
-        StoragePath parent = path.getParent();
-        tmpPath = new StoragePath(parent, path.getName() + "." + UUID.randomUUID());
-        fsout = create(tmpPath, false);
-        contentWriter.get().writeToStream(fsout);
-      }
-
-      if (contentWriter.isPresent() && !needTempFile) {
-        fsout = create(path, false);
-        contentWriter.get().writeToStream(fsout);
-      }
+      deleteFile(tmpPath);
     } catch (IOException e) {
-      String errorMsg = "Failed to create file " + (tmpPath != null ? tmpPath : path);
-      throw new HoodieIOException(errorMsg, e);
-    } finally {
-      try {
-        if (null != fsout) {
-          fsout.close();
-        }
-      } catch (IOException e) {
-        String errorMsg = "Failed to close file " + (needTempFile ? tmpPath : path);
-        throw new HoodieIOException(errorMsg, e);
-      }
-
-      boolean renameSuccess = false;
-      try {
-        if (null != tmpPath) {
-          renameSuccess = rename(tmpPath, path);
-        }
-      } catch (IOException e) {
-        throw new HoodieIOException(
-            "Failed to rename " + tmpPath + " to the target " + path,
-            e);
-      } finally {
-        if (!renameSuccess && null != tmpPath) {
-          try {
-            deleteFile(tmpPath);
-            LOG.debug("Failed to rename {} to {}, target file exists: {}", tmpPath, path, exists(path));
-          } catch (IOException e) {
-            throw new HoodieIOException("Failed to delete tmp file " + tmpPath, e);
-          }
-        }
+      HoodieIOException cleanupFailure = new HoodieIOException("Failed to delete tmp file " + tmpPath, e);
+      if (primaryFailure != null) {
+        primaryFailure.addSuppressed(cleanupFailure);
+      } else {
+        throw cleanupFailure;
       }
     }
   }

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -23,6 +23,7 @@ import org.apache.hudi.ApiMaturityLevel;
 import org.apache.hudi.PublicAPIClass;
 import org.apache.hudi.PublicAPIMethod;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.io.SeekableDataInputStream;
 
@@ -337,48 +338,40 @@ public abstract class HoodieStorage implements Closeable {
       pathToCreate = tmpPath;
     }
 
-    boolean writeSucceeded = false;
-    try (OutputStream fsout = create(pathToCreate, false)) {
-      if (contentWriter.isPresent()) {
-        contentWriter.get().writeToStream(fsout);
-      }
-      writeSucceeded = true;
-    } catch (IOException e) {
-      String errorMsg = (writeSucceeded ? "Failed to close file " : "Failed to create file ") + pathToCreate;
-      HoodieIOException failure = new HoodieIOException(errorMsg, e);
-      deleteTemporaryFile(tmpPath, failure);
-      throw failure;
-    }
-
-    if (tmpPath != null) {
-      try {
-        if (!rename(tmpPath, path)) {
-          deleteTemporaryFile(tmpPath, null);
-          LOG.debug("Failed to rename {} to {}; target file may already exist", tmpPath, path);
-        }
-      } catch (IOException e) {
-        HoodieIOException failure = new HoodieIOException(
-            "Failed to rename " + tmpPath + " to the target " + path, e);
-        deleteTemporaryFile(tmpPath, failure);
-        throw failure;
-      }
-    }
-  }
-
-  private void deleteTemporaryFile(StoragePath tmpPath, HoodieIOException primaryFailure) {
-    if (tmpPath == null) {
-      return;
-    }
-
+    boolean fileCreated = false;
+    HoodieException failure = null;
     try {
-      deleteFile(tmpPath);
-    } catch (IOException e) {
-      HoodieIOException cleanupFailure = new HoodieIOException("Failed to delete tmp file " + tmpPath, e);
-      if (primaryFailure != null) {
-        primaryFailure.addSuppressed(cleanupFailure);
-      } else {
-        throw cleanupFailure;
+      try (OutputStream fsout = create(pathToCreate, false)) {
+        if (contentWriter.isPresent()) {
+          contentWriter.get().writeToStream(fsout);
+        }
       }
+      fileCreated = tmpPath == null || rename(tmpPath, path);
+    } catch (Throwable t) {
+      if (t instanceof HoodieException) {
+        failure = (HoodieException) t;
+      } else if (t instanceof IOException) {
+        failure = new HoodieIOException("Failed to create immutable file " + path, (IOException) t);
+      } else {
+        failure = new HoodieException("Failed to create immutable file " + path, t);
+      }
+      throw failure;
+    } finally {
+      if (tmpPath != null && !fileCreated) {
+        try {
+          deleteFile(tmpPath);
+        } catch (Throwable t) {
+          if (failure != null) {
+            failure.addSuppressed(t);
+          } else {
+            throw new HoodieException("Failed to delete temporary file " + tmpPath, t);
+          }
+        }
+      }
+    }
+
+    if (!fileCreated) {
+      LOG.debug("Failed to rename {} to {}; target file may already exist", tmpPath, path);
     }
   }
 

--- a/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageBase.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.io.storage;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.io.SeekableDataInputStream;
 import org.apache.hudi.io.util.FileIOUtils;
 import org.apache.hudi.storage.HoodieInstantWriter;
@@ -149,6 +150,24 @@ public abstract class TestHoodieStorageBase {
     assertTrue(storage.createDirectory(path4));
     validatePathInfo(storage, path4, EMPTY_BYTES, true);
     assertTrue(storage.createDirectory(path4));
+  }
+
+  @Test
+  public void testImmutableFileIsNotPublishedOnWriteFailure() throws IOException {
+    HoodieStorage storage = getStorage();
+    StoragePath directory = new StoragePath(getTempDir(), "testImmutableFileWriteFailure");
+    StoragePath path = new StoragePath(directory, "1.file");
+    storage.createDirectory(directory);
+
+    HoodieIOException exception = assertThrows(HoodieIOException.class,
+        () -> storage.createImmutableFileInPath(path, Option.of(outputStream -> {
+          outputStream.write(42);
+          throw new IOException("write failure");
+        })));
+
+    assertEquals("write failure", exception.getCause().getMessage());
+    assertFalse(storage.exists(path));
+    assertTrue(storage.listDirectEntries(directory).isEmpty());
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19649.

LSM timeline manifest discovery accepted every file starting with `manifest_` except files ending in `.tmp`. Immutable HDFS writes now use UUID-suffixed temporary files, so a failed close could leave `manifest_<version>.<uuid>` behind. Timeline cleaning, or timeline loading while `_version_` is unavailable, then attempted to parse the UUID suffix as part of the numeric manifest version and failed persistently.

The immutable-file write path also ran its rename logic from a `finally` block. A close failure skipped temporary-file cleanup, while a write failure followed by a successful close could publish partial content.

### Summary and Changelog

This change prevents temporary LSM timeline manifests from blocking archival and archived-timeline loading after a transient storage failure.

- Accept only finalized LSM manifest names matching `manifest_<numeric-version>` and use the same pattern for version parsing.
- Close immutable files successfully before renaming their temporary paths.
- Attempt to remove temporary files after write, close, or rename exceptions without hiding the primary failure.
- Add regression coverage for missing-`_version_` fallback with a UUID temporary manifest and for immutable-file write/close failures.

No code was copied from another source.

Validation:

- `mvn -Punit-tests -Dtest=TestLSMTimeline,TestHoodieHadoopStorage -Dsurefire.failIfNoSpecifiedTests=false -pl hudi-common,hudi-hadoop-common -am test -Dcheckstyle.skip=true -Drat.skip=true`
- `mvn -pl hudi-io,hudi-common,hudi-hadoop-common -am -DskipTests -Drat.skip=true org.apache.maven.plugins:maven-checkstyle-plugin:3.6.0:check`

### Impact

No public API, configuration, or on-disk format changes. Existing UUID-suffixed temporary manifests are ignored during discovery, and future failed immutable writes make a best-effort cleanup of their temporary paths. The successful write path retains the existing create-close-rename behavior with no material performance impact.

### Risk Level

low. The manifest change narrows discovery to the documented finalized filename format. The shared immutable-file change only restructures failure handling and is covered by injected write- and close-failure tests in addition to the existing storage tests.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
