### PR TITLE
fix(common): honor configured ordering field in Debezium payloads when merging against storage

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
 import lombok.extern.slf4j.Slf4j;
@@ -125,37 +124,20 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
   protected abstract boolean shouldPickCurrentRecord(IndexedRecord currentRecord, IndexedRecord insertRecord, Schema schema) throws IOException;
 
   /**
-   * The connector-hardcoded ordering column (e.g. LSN / seq) whose comparison semantics
-   * {@link #shouldPickCurrentRecord(IndexedRecord, IndexedRecord, Schema)} implements.
-   */
-  protected abstract String getConnectorOrderingField();
-
-  /**
-   * Resolves the configured ordering field(s) to dispatch on, or empty to use the connector-hardcoded
-   * ordering: nothing configured, or a single field equal to the connector's own column (MySQL's
-   * "file.pos" seq needs segment-wise numeric compare; a plain Comparable is lexicographic). Values are
-   * trimmed so stray whitespace in user config cannot silently reroute the comparison. A composite
-   * (multi-field) ordering is supported element-wise, but must not include the connector column — its
-   * encoded representation cannot participate in a plain Comparable composite — and fails loudly if it does.
+   * Resolves the configured ordering field(s) to dispatch on, or empty when nothing is configured — in
+   * which case the connector-hardcoded ordering ({@link #shouldPickCurrentRecord}) applies. Values are
+   * trimmed so stray whitespace in user config cannot silently change which field is compared. A
+   * composite (multi-field) ordering is supported element-wise.
    */
   private Option<String[]> getConfiguredOrderingFields(Properties properties) {
     String[] orderingFields = ConfigUtils.getOrderingFields(properties);
-    if (orderingFields == null) {
+    if (orderingFields == null || orderingFields.length == 0
+        || (orderingFields.length == 1 && orderingFields[0].trim().isEmpty())) {
       return Option.empty();
     }
     String[] trimmedFields = new String[orderingFields.length];
     for (int i = 0; i < orderingFields.length; i++) {
       trimmedFields[i] = orderingFields[i].trim();
-    }
-    if (trimmedFields.length == 1) {
-      return trimmedFields[0].isEmpty() || trimmedFields[0].equals(getConnectorOrderingField())
-          ? Option.empty() : Option.of(trimmedFields);
-    }
-    for (String field : trimmedFields) {
-      if (field.equals(getConnectorOrderingField())) {
-        throw new HoodieException(String.format("Debezium composite ordering cannot include the connector ordering column %s, found: %s",
-            getConnectorOrderingField(), String.join(",", trimmedFields)));
-      }
     }
     return Option.of(trimmedFields);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -19,7 +19,9 @@
 package org.apache.hudi.common.model.debezium;
 
 import org.apache.hudi.common.avro.HoodieAvroUtils;
+import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
+import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
 
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +30,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
+import java.util.Properties;
 
 /**
  * Base class that provides support for seamlessly applying changes captured via Debezium.
@@ -42,7 +45,7 @@ import java.io.IOException;
  * This payload implementation will issue matching insert, delete, updates against the hudi table
  */
 @Slf4j
-public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvroPayload {
+public abstract class AbstractDebeziumAvroPayload extends DefaultHoodieRecordPayload {
 
   public AbstractDebeziumAvroPayload(GenericRecord record, Comparable orderingVal) {
     super(record, orderingVal);
@@ -73,14 +76,36 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
   }
 
   @Override
+  public Option<IndexedRecord> getInsertValue(Schema schema, Properties properties) throws IOException {
+    // Pin to the Debezium delete-op handling; DefaultHoodieRecordPayload's properties-aware variant
+    // (event-time tracking, DELETE_KEY/DELETE_MARKER) must not replace it
+    return getInsertValue(schema);
+  }
+
+  @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
+    return combineAndGetUpdateValue(currentValue, schema, new Properties());
+  }
+
+  @Override
+  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema, Properties properties) throws IOException {
     // Step 1: If the time occurrence of the current record in storage is higher than the time occurrence of the
     // insert record (including a delete record), pick the current record.
     Option<IndexedRecord> insertValue = getRecord(schema);
     if (!insertValue.isPresent()) {
       return Option.empty();
     }
-    if (shouldPickCurrentRecord(currentValue, insertValue.get(), schema)) {
+    String[] orderingFields = ConfigUtils.getOrderingFields(properties);
+    boolean pickCurrentRecord;
+    if (orderingFields == null || orderingFields.length != 1 || orderingFields[0].equals(getConnectorOrderingField())) {
+      // No ordering field configured, a composite ordering (not supported yet), or the connector's own column:
+      // use the connector-specific comparison (MySQL's "file.pos" seq needs segment-wise numeric compare;
+      // a plain Comparable is lexicographic)
+      pickCurrentRecord = shouldPickCurrentRecord(currentValue, insertValue.get(), schema);
+    } else {
+      pickCurrentRecord = !needUpdatingPersistedRecord(currentValue, insertValue, properties);
+    }
+    if (pickCurrentRecord) {
       return Option.of(currentValue);
     }
     // Step 2: Pick the insert record (as a delete record if it is a deleted event)
@@ -88,6 +113,12 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
   }
 
   protected abstract boolean shouldPickCurrentRecord(IndexedRecord currentRecord, IndexedRecord insertRecord, Schema schema) throws IOException;
+
+  /**
+   * The connector-hardcoded ordering column (e.g. LSN / seq) whose comparison semantics
+   * {@link #shouldPickCurrentRecord(IndexedRecord, IndexedRecord, Schema)} implements.
+   */
+  protected abstract String getConnectorOrderingField();
 
   private Option<IndexedRecord> handleDeleteOperation(IndexedRecord insertRecord) {
     boolean delete = false;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -133,11 +133,12 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
         || (orderingFields.length == 1 && orderingFields[0].trim().isEmpty())) {
       return Option.empty();
     }
-    String[] trimmedFields = new String[orderingFields.length];
+    // Trim in place: ConfigUtils returns a freshly split array on every call, so mutating it is safe
+    // and avoids a second per-record array allocation on the merge path.
     for (int i = 0; i < orderingFields.length; i++) {
-      trimmedFields[i] = orderingFields[i].trim();
+      orderingFields[i] = orderingFields[i].trim();
     }
-    return Option.of(trimmedFields);
+    return Option.of(orderingFields);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -65,6 +65,18 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
     if (!getConfiguredOrderingFields(properties).isPresent()) {
       return preCombine(oldValue);
     }
+    // Deliberately bypasses any connector-specific preCombine(oldValue) override: with ordering fields
+    // configured, dedup must use the plain orderingVal comparison. The helper is private so the bypass
+    // cannot be undone by a subclass override.
+    return pickByOrderingValue(oldValue);
+  }
+
+  @Override
+  public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload oldValue) {
+    return pickByOrderingValue(oldValue);
+  }
+
+  private OverwriteWithLatestAvroPayload pickByOrderingValue(OverwriteWithLatestAvroPayload oldValue) {
     if (oldValue.getRecordBytes().length == 0) {
       // use natural order for delete record
       return this;
@@ -74,20 +86,6 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
       return oldValue;
     }
     return this;
-  }
-
-  @Override
-  public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload oldValue) {
-    if (oldValue.getRecordBytes().length == 0) {
-      // use natural order for delete record
-      return this;
-    }
-    if (((Comparable) oldValue.getOrderingValue()).compareTo(orderingVal) > 0) {
-      // pick the payload with greatest ordering value
-      return oldValue;
-    } else {
-      return this;
-    }
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -59,9 +59,9 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
 
   @Override
   public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload oldValue, Properties properties) {
-    // Same dispatch as combineAndGetUpdateValue: intra-batch dedup must order by the same column as the
-    // against-storage merge, or a configured non-connector ordering field would still be parsed as a
-    // connector seq/LSN here (MySQL's "file.pos" parser throws on plain values).
+    // Same dispatch as combineAndGetUpdateValue: intra-batch dedup must order by the same column(s) as
+    // the against-storage merge. Without this, a configured ordering field would still be fed into the
+    // connector-specific preCombine (MySQL's "file.pos" seq parser, which throws on plain values).
     if (!getConfiguredOrderingFields(properties).isPresent()) {
       return preCombine(oldValue);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -19,10 +19,10 @@
 package org.apache.hudi.common.model.debezium;
 
 import org.apache.hudi.common.avro.HoodieAvroUtils;
-import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
@@ -45,7 +45,7 @@ import java.util.Properties;
  * This payload implementation will issue matching insert, delete, updates against the hudi table
  */
 @Slf4j
-public abstract class AbstractDebeziumAvroPayload extends DefaultHoodieRecordPayload {
+public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvroPayload {
 
   public AbstractDebeziumAvroPayload(GenericRecord record, Comparable orderingVal) {
     super(record, orderingVal);
@@ -96,13 +96,6 @@ public abstract class AbstractDebeziumAvroPayload extends DefaultHoodieRecordPay
   }
 
   @Override
-  public Option<IndexedRecord> getInsertValue(Schema schema, Properties properties) throws IOException {
-    // Pin to the Debezium delete-op handling; DefaultHoodieRecordPayload's properties-aware variant
-    // (event-time tracking, DELETE_KEY/DELETE_MARKER) must not replace it
-    return getInsertValue(schema);
-  }
-
-  @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
     return combineAndGetUpdateValue(currentValue, schema, new Properties());
   }
@@ -123,7 +116,7 @@ public abstract class AbstractDebeziumAvroPayload extends DefaultHoodieRecordPay
       // a plain Comparable is lexicographic)
       pickCurrentRecord = shouldPickCurrentRecord(currentValue, insertValue.get(), schema);
     } else {
-      pickCurrentRecord = !needUpdatingPersistedRecord(currentValue, insertValue, properties);
+      pickCurrentRecord = !needUpdatingPersistedRecord(currentValue, insertValue.get(), properties);
     }
     if (pickCurrentRecord) {
       return Option.of(currentValue);
@@ -139,6 +132,27 @@ public abstract class AbstractDebeziumAvroPayload extends DefaultHoodieRecordPay
    * {@link #shouldPickCurrentRecord(IndexedRecord, IndexedRecord, Schema)} implements.
    */
   protected abstract String getConnectorOrderingField();
+
+  /**
+   * Mirrors {@code DefaultHoodieRecordPayload#needUpdatingPersistedRecord}: the record in storage needs
+   * updating unless its configured ordering value is strictly greater than the incoming record's
+   * (ties go to the incoming record; a null persisted value, e.g. bootstrapped rows, takes the incoming).
+   */
+  protected boolean needUpdatingPersistedRecord(IndexedRecord currentValue, IndexedRecord incomingRecord, Properties properties) {
+    String[] orderingFields = ConfigUtils.getOrderingFields(properties);
+    if (orderingFields == null || orderingFields.length != 1) {
+      return true;
+    }
+    String orderingField = orderingFields[0];
+    boolean consistentLogicalTimestampEnabled = Boolean.parseBoolean(properties.getProperty(
+        KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
+        KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()));
+    Object persistedOrderingVal = HoodieAvroUtils.getNestedFieldVal((GenericRecord) currentValue,
+        orderingField, true, consistentLogicalTimestampEnabled);
+    Comparable incomingOrderingVal = (Comparable) HoodieAvroUtils.getNestedFieldVal((GenericRecord) incomingRecord,
+        orderingField, true, consistentLogicalTimestampEnabled);
+    return persistedOrderingVal == null || ((Comparable) persistedOrderingVal).compareTo(incomingOrderingVal) <= 0;
+  }
 
   private Option<IndexedRecord> handleDeleteOperation(IndexedRecord insertRecord) {
     boolean delete = false;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -127,7 +127,7 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
    * trimmed so stray whitespace in user config cannot silently change which field is compared. A
    * composite (multi-field) ordering is supported element-wise.
    */
-  private Option<String[]> getConfiguredOrderingFields(Properties properties) {
+  protected Option<String[]> getConfiguredOrderingFields(Properties properties) {
     String[] orderingFields = ConfigUtils.getOrderingFields(properties);
     if (orderingFields == null || orderingFields.length == 0
         || (orderingFields.length == 1 && orderingFields[0].trim().isEmpty())) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -155,8 +155,8 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
    * A null incoming ordering value fails loudly with the record in the message, matching the connector
    * paths, instead of surfacing as a bare NPE.
    */
-  protected boolean needUpdatingPersistedRecord(IndexedRecord currentValue, IndexedRecord incomingRecord,
-                                                String orderingField, Properties properties) throws HoodieDebeziumAvroPayloadException {
+  private boolean needUpdatingPersistedRecord(IndexedRecord currentValue, IndexedRecord incomingRecord,
+                                              String orderingField, Properties properties) throws HoodieDebeziumAvroPayloadException {
     boolean consistentLogicalTimestampEnabled = Boolean.parseBoolean(properties.getProperty(
         KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
         KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()));

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
 import lombok.extern.slf4j.Slf4j;
@@ -62,7 +63,7 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
     // Same dispatch as combineAndGetUpdateValue: intra-batch dedup must order by the same column as the
     // against-storage merge, or a configured non-connector ordering field would still be parsed as a
     // connector seq/LSN here (MySQL's "file.pos" parser throws on plain values).
-    if (!getConfiguredOrderingField(properties).isPresent()) {
+    if (!getConfiguredOrderingFields(properties).isPresent()) {
       return preCombine(oldValue);
     }
     if (oldValue.getRecordBytes().length == 0) {
@@ -109,9 +110,9 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
     if (!insertValue.isPresent()) {
       return Option.empty();
     }
-    Option<String> orderingField = getConfiguredOrderingField(properties);
-    boolean pickCurrentRecord = orderingField.isPresent()
-        ? !needUpdatingPersistedRecord(currentValue, insertValue.get(), orderingField.get(), properties)
+    Option<String[]> orderingFields = getConfiguredOrderingFields(properties);
+    boolean pickCurrentRecord = orderingFields.isPresent()
+        ? !needUpdatingPersistedRecord(currentValue, insertValue.get(), orderingFields.get(), properties)
         : shouldPickCurrentRecord(currentValue, insertValue.get(), schema);
     if (pickCurrentRecord) {
       return Option.of(currentValue);
@@ -130,45 +131,70 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
   protected abstract String getConnectorOrderingField();
 
   /**
-   * Resolves the single configured ordering field to dispatch on, or empty to use the connector-hardcoded
-   * ordering: nothing configured, a composite (multi-field) ordering (not supported yet), or the
-   * connector's own column (MySQL's "file.pos" seq needs segment-wise numeric compare; a plain Comparable
-   * is lexicographic). The value is trimmed so stray whitespace in user config cannot silently reroute
-   * the comparison.
+   * Resolves the configured ordering field(s) to dispatch on, or empty to use the connector-hardcoded
+   * ordering: nothing configured, or a single field equal to the connector's own column (MySQL's
+   * "file.pos" seq needs segment-wise numeric compare; a plain Comparable is lexicographic). Values are
+   * trimmed so stray whitespace in user config cannot silently reroute the comparison. A composite
+   * (multi-field) ordering is supported element-wise, but must not include the connector column — its
+   * encoded representation cannot participate in a plain Comparable composite — and fails loudly if it does.
    */
-  private Option<String> getConfiguredOrderingField(Properties properties) {
+  private Option<String[]> getConfiguredOrderingFields(Properties properties) {
     String[] orderingFields = ConfigUtils.getOrderingFields(properties);
-    if (orderingFields == null || orderingFields.length != 1) {
+    if (orderingFields == null) {
       return Option.empty();
     }
-    String orderingField = orderingFields[0].trim();
-    if (orderingField.isEmpty() || orderingField.equals(getConnectorOrderingField())) {
-      return Option.empty();
+    String[] trimmedFields = new String[orderingFields.length];
+    for (int i = 0; i < orderingFields.length; i++) {
+      trimmedFields[i] = orderingFields[i].trim();
     }
-    return Option.of(orderingField);
+    if (trimmedFields.length == 1) {
+      return trimmedFields[0].isEmpty() || trimmedFields[0].equals(getConnectorOrderingField())
+          ? Option.empty() : Option.of(trimmedFields);
+    }
+    for (String field : trimmedFields) {
+      if (field.equals(getConnectorOrderingField())) {
+        throw new HoodieException(String.format("Debezium composite ordering cannot include the connector ordering column %s, found: %s",
+            getConnectorOrderingField(), String.join(",", trimmedFields)));
+      }
+    }
+    return Option.of(trimmedFields);
   }
 
   /**
-   * Mirrors {@code DefaultHoodieRecordPayload#needUpdatingPersistedRecord}: the record in storage needs
-   * updating unless its configured ordering value is strictly greater than the incoming record's
-   * (ties go to the incoming record; a null persisted value, e.g. bootstrapped rows, takes the incoming).
-   * A null incoming ordering value fails loudly with the record in the message, matching the connector
-   * paths, instead of surfacing as a bare NPE.
+   * Mirrors {@code DefaultHoodieRecordPayload#needUpdatingPersistedRecord}, extended to composite ordering:
+   * fields are compared element-wise and the first non-equal field decides; the record in storage needs
+   * updating unless its ordering is strictly greater than the incoming record's (ties go to the incoming
+   * record; a null persisted value, e.g. bootstrapped rows, takes the incoming). A null incoming ordering
+   * value fails loudly with the field and record in the message, matching the connector paths, instead of
+   * surfacing as a bare NPE.
    */
   private boolean needUpdatingPersistedRecord(IndexedRecord currentValue, IndexedRecord incomingRecord,
-                                              String orderingField, Properties properties) throws HoodieDebeziumAvroPayloadException {
+                                              String[] orderingFields, Properties properties) throws HoodieDebeziumAvroPayloadException {
     boolean consistentLogicalTimestampEnabled = Boolean.parseBoolean(properties.getProperty(
         KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
         KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()));
-    Comparable incomingOrderingVal = (Comparable) HoodieAvroUtils.getNestedFieldVal((GenericRecord) incomingRecord,
-        orderingField, true, consistentLogicalTimestampEnabled);
-    if (incomingOrderingVal == null) {
-      throw new HoodieDebeziumAvroPayloadException(String.format("ordering field %s cannot be null in insert record: %s",
-          orderingField, incomingRecord));
+    Comparable[] incomingOrderingVals = new Comparable[orderingFields.length];
+    for (int i = 0; i < orderingFields.length; i++) {
+      incomingOrderingVals[i] = (Comparable) HoodieAvroUtils.getNestedFieldVal((GenericRecord) incomingRecord,
+          orderingFields[i], true, consistentLogicalTimestampEnabled);
+      if (incomingOrderingVals[i] == null) {
+        throw new HoodieDebeziumAvroPayloadException(String.format("ordering field %s cannot be null in insert record: %s",
+            orderingFields[i], incomingRecord));
+      }
     }
-    Object persistedOrderingVal = HoodieAvroUtils.getNestedFieldVal((GenericRecord) currentValue,
-        orderingField, true, consistentLogicalTimestampEnabled);
-    return persistedOrderingVal == null || ((Comparable) persistedOrderingVal).compareTo(incomingOrderingVal) <= 0;
+    for (int i = 0; i < orderingFields.length; i++) {
+      Object persistedOrderingVal = HoodieAvroUtils.getNestedFieldVal((GenericRecord) currentValue,
+          orderingFields[i], true, consistentLogicalTimestampEnabled);
+      if (persistedOrderingVal == null) {
+        return true;
+      }
+      int comparison = ((Comparable) persistedOrderingVal).compareTo(incomingOrderingVals[i]);
+      if (comparison != 0) {
+        return comparison < 0;
+      }
+    }
+    // all ordering fields equal: tie goes to the incoming record
+    return true;
   }
 
   private Option<IndexedRecord> handleDeleteOperation(IndexedRecord insertRecord) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -20,8 +20,10 @@ package org.apache.hudi.common.model.debezium;
 
 import org.apache.hudi.common.avro.HoodieAvroUtils;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
+import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
 import lombok.extern.slf4j.Slf4j;
@@ -60,8 +62,7 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
     // Same dispatch as combineAndGetUpdateValue: intra-batch dedup must order by the same column as the
     // against-storage merge, or a configured non-connector ordering field would still be parsed as a
     // connector seq/LSN here (MySQL's "file.pos" parser throws on plain values).
-    String[] orderingFields = ConfigUtils.getOrderingFields(properties);
-    if (orderingFields == null || orderingFields.length != 1 || orderingFields[0].equals(getConnectorOrderingField())) {
+    if (!getConfiguredOrderingField(properties).isPresent()) {
       return preCombine(oldValue);
     }
     if (oldValue.getRecordBytes().length == 0) {
@@ -97,7 +98,7 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
 
   @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
-    return combineAndGetUpdateValue(currentValue, schema, new Properties());
+    return combineAndGetUpdateValue(currentValue, schema, CollectionUtils.emptyProps());
   }
 
   @Override
@@ -108,21 +109,16 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
     if (!insertValue.isPresent()) {
       return Option.empty();
     }
-    String[] orderingFields = ConfigUtils.getOrderingFields(properties);
-    boolean pickCurrentRecord;
-    if (orderingFields == null || orderingFields.length != 1 || orderingFields[0].equals(getConnectorOrderingField())) {
-      // No ordering field configured, a composite ordering (not supported yet), or the connector's own column:
-      // use the connector-specific comparison (MySQL's "file.pos" seq needs segment-wise numeric compare;
-      // a plain Comparable is lexicographic)
-      pickCurrentRecord = shouldPickCurrentRecord(currentValue, insertValue.get(), schema);
-    } else {
-      pickCurrentRecord = !needUpdatingPersistedRecord(currentValue, insertValue.get(), properties);
-    }
+    Option<String> orderingField = getConfiguredOrderingField(properties);
+    boolean pickCurrentRecord = orderingField.isPresent()
+        ? !needUpdatingPersistedRecord(currentValue, insertValue.get(), orderingField.get(), properties)
+        : shouldPickCurrentRecord(currentValue, insertValue.get(), schema);
     if (pickCurrentRecord) {
       return Option.of(currentValue);
     }
-    // Step 2: Pick the insert record (as a delete record if it is a deleted event)
-    return getInsertValue(schema);
+    // Step 2: Pick the insert record (as a delete record if it is a deleted event), reusing the record
+    // deserialized for step 1; keep the base class's deleted-record short-circuit from getInsertValue
+    return isDeletedRecord ? Option.empty() : handleDeleteOperation(insertValue.get());
   }
 
   protected abstract boolean shouldPickCurrentRecord(IndexedRecord currentRecord, IndexedRecord insertRecord, Schema schema) throws IOException;
@@ -134,22 +130,43 @@ public abstract class AbstractDebeziumAvroPayload extends OverwriteWithLatestAvr
   protected abstract String getConnectorOrderingField();
 
   /**
+   * Resolves the single configured ordering field to dispatch on, or empty to use the connector-hardcoded
+   * ordering: nothing configured, a composite (multi-field) ordering (not supported yet), or the
+   * connector's own column (MySQL's "file.pos" seq needs segment-wise numeric compare; a plain Comparable
+   * is lexicographic). The value is trimmed so stray whitespace in user config cannot silently reroute
+   * the comparison.
+   */
+  private Option<String> getConfiguredOrderingField(Properties properties) {
+    String[] orderingFields = ConfigUtils.getOrderingFields(properties);
+    if (orderingFields == null || orderingFields.length != 1) {
+      return Option.empty();
+    }
+    String orderingField = orderingFields[0].trim();
+    if (orderingField.isEmpty() || orderingField.equals(getConnectorOrderingField())) {
+      return Option.empty();
+    }
+    return Option.of(orderingField);
+  }
+
+  /**
    * Mirrors {@code DefaultHoodieRecordPayload#needUpdatingPersistedRecord}: the record in storage needs
    * updating unless its configured ordering value is strictly greater than the incoming record's
    * (ties go to the incoming record; a null persisted value, e.g. bootstrapped rows, takes the incoming).
+   * A null incoming ordering value fails loudly with the record in the message, matching the connector
+   * paths, instead of surfacing as a bare NPE.
    */
-  protected boolean needUpdatingPersistedRecord(IndexedRecord currentValue, IndexedRecord incomingRecord, Properties properties) {
-    String[] orderingFields = ConfigUtils.getOrderingFields(properties);
-    if (orderingFields == null || orderingFields.length != 1) {
-      return true;
-    }
-    String orderingField = orderingFields[0];
+  protected boolean needUpdatingPersistedRecord(IndexedRecord currentValue, IndexedRecord incomingRecord,
+                                                String orderingField, Properties properties) throws HoodieDebeziumAvroPayloadException {
     boolean consistentLogicalTimestampEnabled = Boolean.parseBoolean(properties.getProperty(
         KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
         KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()));
-    Object persistedOrderingVal = HoodieAvroUtils.getNestedFieldVal((GenericRecord) currentValue,
-        orderingField, true, consistentLogicalTimestampEnabled);
     Comparable incomingOrderingVal = (Comparable) HoodieAvroUtils.getNestedFieldVal((GenericRecord) incomingRecord,
+        orderingField, true, consistentLogicalTimestampEnabled);
+    if (incomingOrderingVal == null) {
+      throw new HoodieDebeziumAvroPayloadException(String.format("ordering field %s cannot be null in insert record: %s",
+          orderingField, incomingRecord));
+    }
+    Object persistedOrderingVal = HoodieAvroUtils.getNestedFieldVal((GenericRecord) currentValue,
         orderingField, true, consistentLogicalTimestampEnabled);
     return persistedOrderingVal == null || ((Comparable) persistedOrderingVal).compareTo(incomingOrderingVal) <= 0;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/AbstractDebeziumAvroPayload.java
@@ -56,6 +56,26 @@ public abstract class AbstractDebeziumAvroPayload extends DefaultHoodieRecordPay
   }
 
   @Override
+  public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload oldValue, Properties properties) {
+    // Same dispatch as combineAndGetUpdateValue: intra-batch dedup must order by the same column as the
+    // against-storage merge, or a configured non-connector ordering field would still be parsed as a
+    // connector seq/LSN here (MySQL's "file.pos" parser throws on plain values).
+    String[] orderingFields = ConfigUtils.getOrderingFields(properties);
+    if (orderingFields == null || orderingFields.length != 1 || orderingFields[0].equals(getConnectorOrderingField())) {
+      return preCombine(oldValue);
+    }
+    if (oldValue.getRecordBytes().length == 0) {
+      // use natural order for delete record
+      return this;
+    }
+    if (((Comparable) oldValue.getOrderingValue()).compareTo(orderingVal) > 0) {
+      // pick the payload with greatest ordering value
+      return oldValue;
+    }
+    return this;
+  }
+
+  @Override
   public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload oldValue) {
     if (oldValue.getRecordBytes().length == 0) {
       // use natural order for delete record

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
@@ -30,6 +30,7 @@ import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Properties;
 
 import static org.apache.hudi.common.model.debezium.DebeziumConstants.FLATTENED_FILE_COL_NAME;
 import static org.apache.hudi.common.model.debezium.DebeziumConstants.FLATTENED_POS_COL_NAME;
@@ -77,6 +78,20 @@ public class MySqlDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
       return false;
     }
     return isCurrentSeqLatest(currentSourceSeqOpt.get(), insertSourceSeq);
+  }
+
+  @Override
+  protected Option<String[]> getConfiguredOrderingFields(Properties properties) {
+    Option<String[]> orderingFields = super.getConfiguredOrderingFields(properties);
+    // v8 tables carry ORDERING_FIELDS = _event_seq until the v9 upgrade rewrites it to
+    // "_event_bin_file,_event_pos". The seq's "file.pos" encoding needs the segment-wise numeric
+    // parser; a plain Comparable compare is lexicographic ("9.1" > "10.1"). Route that single
+    // legacy field to the connector comparison instead of the generic one.
+    if (orderingFields.isPresent() && orderingFields.get().length == 1
+        && DebeziumConstants.ADDED_SEQ_COL_NAME.equals(orderingFields.get()[0])) {
+      return Option.empty();
+    }
+    return orderingFields;
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
@@ -80,6 +80,13 @@ public class MySqlDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
   }
 
   @Override
+  protected String getConnectorOrderingField() {
+    // The seq's "file.pos" encoding needs the segment-wise numeric comparison above;
+    // a plain Comparable compare is lexicographic and wrong for unpadded positions
+    return DebeziumConstants.ADDED_SEQ_COL_NAME;
+  }
+
+  @Override
   public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload oldValue) {
     if (oldValue.getRecordBytes().length == 0) {
       // use natural order for delete record

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/MySqlDebeziumAvroPayload.java
@@ -80,13 +80,6 @@ public class MySqlDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
   }
 
   @Override
-  protected String getConnectorOrderingField() {
-    // The seq's "file.pos" encoding needs the segment-wise numeric comparison above;
-    // a plain Comparable compare is lexicographic and wrong for unpadded positions
-    return DebeziumConstants.ADDED_SEQ_COL_NAME;
-  }
-
-  @Override
   public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload oldValue) {
     if (oldValue.getRecordBytes().length == 0) {
       // use natural order for delete record

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
@@ -76,11 +76,6 @@ public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
   }
 
   @Override
-  protected String getConnectorOrderingField() {
-    return DebeziumConstants.FLATTENED_LSN_COL_NAME;
-  }
-
-  @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema, Properties properties) throws IOException {
     // Specific to Postgres: If the updated record has TOASTED columns,
     // we will need to keep the previous value for those columns

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
@@ -76,6 +76,11 @@ public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
   }
 
   @Override
+  protected String getConnectorOrderingField() {
+    return DebeziumConstants.FLATTENED_LSN_COL_NAME;
+  }
+
+  @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema, Properties properties) throws IOException {
     // Specific to Postgres: If the updated record has TOASTED columns,
     // we will need to keep the previous value for those columns

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/DebeziumOrderingTestFixtures.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/DebeziumOrderingTestFixtures.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model.debezium;
+
+import org.apache.hudi.common.model.HoodiePayloadProps;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Shared fixtures for the Debezium payload configured-ordering tests: one schema/record/props/assert
+ * builder set, parameterized by the connector ordering column, so the MySQL and Postgres suites
+ * cannot drift.
+ */
+final class DebeziumOrderingTestFixtures {
+
+  static final String KEY_FIELD = "Key";
+  static final String ORDERING_FIELD = "event_ts";
+
+  private DebeziumOrderingTestFixtures() {
+  }
+
+  static Schema schemaWithOrderingField(String connectorColumn, Schema.Type connectorType) {
+    return Schema.createRecord("test_ordering", null, "test_namespace", false, Arrays.asList(
+        new Schema.Field(KEY_FIELD, Schema.create(Schema.Type.INT), "", 0),
+        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
+        new Schema.Field(connectorColumn,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(connectorType)), "", null),
+        new Schema.Field(ORDERING_FIELD,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null)
+    ));
+  }
+
+  static GenericRecord recordWithOrdering(Schema schema, int key, @Nullable Object op, String connectorColumn,
+                                          @Nullable Object connectorValue, @Nullable Long orderingValue) {
+    GenericRecord record = new GenericData.Record(schema);
+    record.put(KEY_FIELD, key);
+    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, Objects.toString(op, null));
+    record.put(connectorColumn, connectorValue);
+    record.put(ORDERING_FIELD, orderingValue);
+    return record;
+  }
+
+  static Properties orderingProps(String orderingField) {
+    Properties props = new Properties();
+    props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingField);
+    return props;
+  }
+
+  /**
+   * Asserts every field of a merged ordering-schema record, so a regression that returns the right
+   * ordering value on the wrong row (wrong key / op / connector value) cannot pass.
+   */
+  static void validateOrderingRecord(Option<IndexedRecord> merged, int key, @Nullable Object op, String connectorColumn,
+                                     @Nullable Object connectorValue, @Nullable Long orderingValue) {
+    GenericRecord record = (GenericRecord) merged.get();
+    assertEquals(key, record.get(KEY_FIELD));
+    assertEquals(Objects.toString(op, null), Objects.toString(record.get(DebeziumConstants.FLATTENED_OP_COL_NAME), null));
+    assertEquals(Objects.toString(connectorValue, null), Objects.toString(record.get(connectorColumn), null));
+    assertEquals(orderingValue, record.get(ORDERING_FIELD));
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/DebeziumOrderingTestFixtures.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/DebeziumOrderingTestFixtures.java
@@ -43,6 +43,7 @@ final class DebeziumOrderingTestFixtures {
 
   static final String KEY_FIELD = "Key";
   static final String ORDERING_FIELD = "event_ts";
+  static final String SECOND_ORDERING_FIELD = "event_ts2";
 
   private DebeziumOrderingTestFixtures() {
   }
@@ -55,6 +56,8 @@ final class DebeziumOrderingTestFixtures {
         new Schema.Field(connectorColumn,
             Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(connectorType)), "", null),
         new Schema.Field(ORDERING_FIELD,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null),
+        new Schema.Field(SECOND_ORDERING_FIELD,
             Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null)
     ));
   }
@@ -66,6 +69,14 @@ final class DebeziumOrderingTestFixtures {
     record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, Objects.toString(op, null));
     record.put(connectorColumn, connectorValue);
     record.put(ORDERING_FIELD, orderingValue);
+    return record;
+  }
+
+  static GenericRecord recordWithCompositeOrdering(Schema schema, int key, @Nullable Object op, String connectorColumn,
+                                                   @Nullable Object connectorValue, @Nullable Long orderingValue,
+                                                   @Nullable Long secondOrderingValue) {
+    GenericRecord record = recordWithOrdering(schema, key, op, connectorColumn, connectorValue, orderingValue);
+    record.put(SECOND_ORDERING_FIELD, secondOrderingValue);
     return record;
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/DebeziumOrderingTestFixtures.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/DebeziumOrderingTestFixtures.java
@@ -98,4 +98,16 @@ final class DebeziumOrderingTestFixtures {
     assertEquals(Objects.toString(connectorValue, null), Objects.toString(record.get(connectorColumn), null));
     assertEquals(orderingValue, record.get(ORDERING_FIELD));
   }
+
+  /**
+   * Composite variant: additionally asserts {@link #SECOND_ORDERING_FIELD}, the field the composite
+   * tests turn on — without it, a merge that picked the right row by the first ordering field and the
+   * wrong second one would pass.
+   */
+  static void validateOrderingRecord(Option<IndexedRecord> merged, int key, @Nullable Object op, String connectorColumn,
+                                     @Nullable Object connectorValue, @Nullable Long orderingValue,
+                                     @Nullable Long secondOrderingValue) {
+    validateOrderingRecord(merged, key, op, connectorColumn, connectorValue, orderingValue);
+    assertEquals(secondOrderingValue, ((GenericRecord) merged.get()).get(SECOND_ORDERING_FIELD));
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -196,6 +196,29 @@ public class TestMySqlDebeziumAvroPayload {
   }
 
   @Test
+  public void testMergeWithWhitespacePaddedSeqOrderingFieldStaysOnSeqCompare() throws IOException {
+    // Whitespace in the configured field must not silently reroute the connector column
+    // into the generic Comparable compare (lexicographic, wrong for "file.pos").
+    Properties props = orderingProps(" " + DebeziumConstants.ADDED_SEQ_COL_NAME + " ");
+    GenericRecord incoming = createRecord(2, Operation.UPDATE, "2.11");
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, "2.11");
+    GenericRecord existing = createRecord(2, Operation.INSERT, "10.111");
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, avroSchema, props);
+    validateRecord(merged, 2, Operation.INSERT, "10.111");
+  }
+
+  @Test
+  public void testMergeWithCompositeOrderingFieldFallsBackToSeq() throws IOException {
+    // Composite (comma-separated) ordering is not supported yet: fall back to the connector seq compare.
+    Properties props = orderingProps("event_ts," + DebeziumConstants.ADDED_SEQ_COL_NAME);
+    GenericRecord incoming = createRecord(2, Operation.UPDATE, "2.11");
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, "2.11");
+    GenericRecord existing = createRecord(2, Operation.INSERT, "10.111");
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, avroSchema, props);
+    validateRecord(merged, 2, Operation.INSERT, "10.111");
+  }
+
+  @Test
   public void testMergeWithoutOrderingFieldFallsBackToSeq() throws IOException {
     // Properties present but no ordering field configured -> legacy hardcoded seq comparison.
     GenericRecord lateRecord = createRecord(3, Operation.UPDATE, "00000.222");

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -26,6 +26,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.util.Utf8;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -186,9 +187,8 @@ public class TestMySqlDebeziumAvroPayload {
   @Test
   public void testMergeWithWhitespacePaddedConfiguredOrderingFieldIsTrimmed() throws IOException {
     Schema schema = createSchemaWithOrderingField();
-    // The other trimming direction: a padded NON-connector field must route to the configured-field
-    // compare. Without the trim, " event_ts " resolves no field (null ordering value) and throws,
-    // so this asserts the trim rather than accidentally passing through the connector path.
+    // Trimming is what keeps a padded configured field resolving to a real column: without it,
+    // " event_ts " resolves no field (null ordering value) and the null-incoming guard throws.
     MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00005.100", 50L), 50L);
     GenericRecord existing = createRecordWithOrdering(schema, 1, Operation.INSERT, "00001.100", 99L);
     Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps(" event_ts "));
@@ -197,22 +197,78 @@ public class TestMySqlDebeziumAvroPayload {
   }
 
   @Test
-  public void testMergeWithCompositeOrderingFieldsComparesElementWise() throws IOException {
+  public void testMergeWithCompositeOrderingFieldsSecondFieldDecides() throws IOException {
     Schema schema = createSchemaWithOrderingField();
-    Properties props = orderingProps("event_ts,event_ts2");
     // First ordering field ties (99 == 99); the second decides (7 > 5) -> incoming wins,
     // even though the seq order (00001 < 00005) says otherwise.
     MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(
         DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00001.100", 99L, 7L), 99L);
     GenericRecord existing = DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00005.100", 99L, 5L);
-    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, props);
-    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00001.100", 99L);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps("event_ts,event_ts2"));
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00001.100", 99L, 7L);
+  }
 
-    // First ordering field decides outright when it differs (98 < 99) -> stored record kept.
-    MySqlDebeziumAvroPayload older = new MySqlDebeziumAvroPayload(
+  @Test
+  public void testMergeWithCompositeOrderingFieldsFirstFieldDecides() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
+    // First ordering field decides outright when it differs (98 < 99) -> stored record kept,
+    // regardless of the second field (100 > 5 would say otherwise).
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(
         DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00009.100", 98L, 100L), 98L);
-    merged = older.combineAndGetUpdateValue(existing, schema, props);
-    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00005.100", 99L);
+    GenericRecord existing = DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00005.100", 99L, 5L);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps("event_ts,event_ts2"));
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00005.100", 99L, 5L);
+  }
+
+  @Test
+  public void testMergeWithCompositeOrderingNullPersistedSecondFieldFirstDecides() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
+    // Persisted second element is null but the FIRST field strictly decides (stored 99 > incoming 98):
+    // the element-wise loop returns at the first field without ever touching the null.
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(
+        DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00009.100", 98L, 100L), 98L);
+    GenericRecord existing = DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00005.100", 99L, null);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps("event_ts,event_ts2"));
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00005.100", 99L, null);
+  }
+
+  @Test
+  public void testMergeWithCompositeOrderingNullPersistedSecondFieldOnTieTakesIncoming() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
+    // First field ties and the persisted second element is null (e.g. bootstrapped rows): the incoming
+    // record wins — the null-persisted rule applies per element, no NPE.
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(
+        DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00001.100", 99L, 7L), 99L);
+    GenericRecord existing = DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00005.100", 99L, null);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps("event_ts,event_ts2"));
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00001.100", 99L, 7L);
+  }
+
+  @Test
+  public void testMergeWithMySqlNativeCompositeOrderingPosDecides() throws IOException {
+    Schema schema = createMySqlNativeOrderingSchema();
+    // The composite every MySQL table actually configures (ORDERING_FIELDS = _event_bin_file,_event_pos):
+    // mixed element types (String file, long pos). Same binlog file -> the numeric pos decides.
+    GenericRecord incoming = createMySqlNativeOrderingRecord(schema, 1, Operation.UPDATE, "mysql-bin.000001", 200L);
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, 200L);
+    GenericRecord existing = createMySqlNativeOrderingRecord(schema, 1, Operation.INSERT, "mysql-bin.000001", 100L);
+    GenericRecord merged = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema,
+        orderingProps(MySqlDebeziumAvroPayload.ORDERING_FIELDS)).get();
+    assertEquals(200L, merged.get(DebeziumConstants.FLATTENED_POS_COL_NAME));
+    assertEquals(Operation.UPDATE.op, merged.get(DebeziumConstants.FLATTENED_OP_COL_NAME).toString());
+  }
+
+  @Test
+  public void testMergeWithMySqlNativeCompositeOrderingFileDecides() throws IOException {
+    Schema schema = createMySqlNativeOrderingSchema();
+    // Binlog file differs -> the String file name decides before pos is consulted; stored record kept.
+    GenericRecord incoming = createMySqlNativeOrderingRecord(schema, 1, Operation.UPDATE, "mysql-bin.000001", 999L);
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, 999L);
+    GenericRecord existing = createMySqlNativeOrderingRecord(schema, 1, Operation.INSERT, "mysql-bin.000002", 5L);
+    GenericRecord merged = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema,
+        orderingProps(MySqlDebeziumAvroPayload.ORDERING_FIELDS)).get();
+    assertEquals(5L, merged.get(DebeziumConstants.FLATTENED_POS_COL_NAME));
+    assertEquals(Operation.INSERT.op, merged.get(DebeziumConstants.FLATTENED_OP_COL_NAME).toString());
   }
 
   @Test
@@ -231,17 +287,21 @@ public class TestMySqlDebeziumAvroPayload {
   }
 
   @Test
-  public void testMergeWithoutOrderingFieldFallsBackToSeq() throws IOException {
+  public void testMergeWithoutOrderingFieldLateRecordLosesOnSeq() throws IOException {
     // Properties present but no ordering field configured -> legacy hardcoded seq comparison.
     GenericRecord lateRecord = createRecord(3, Operation.UPDATE, "00000.222");
     MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(lateRecord, "00000.222");
     GenericRecord existingRecord = createRecord(3, Operation.INSERT, "00001.111");
     Option<IndexedRecord> mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema, new Properties());
     validateRecord(mergedRecord, 3, Operation.INSERT, "00001.111");
+  }
 
+  @Test
+  public void testMergeWithoutOrderingFieldFreshRecordWinsOnSeq() throws IOException {
     GenericRecord freshRecord = createRecord(3, Operation.UPDATE, "00002.11");
-    payload = new MySqlDebeziumAvroPayload(freshRecord, "00002.11");
-    mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema, new Properties());
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(freshRecord, "00002.11");
+    GenericRecord existingRecord = createRecord(3, Operation.INSERT, "00001.111");
+    Option<IndexedRecord> mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema, new Properties());
     validateRecord(mergedRecord, 3, Operation.UPDATE, "00002.11");
   }
 
@@ -283,6 +343,28 @@ public class TestMySqlDebeziumAvroPayload {
     MySqlDebeziumAvroPayload olderSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.INSERT, "00001.111", 99L), "00001.111");
     MySqlDebeziumAvroPayload newerSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00002.111", 99L), "00002.111");
     assertEquals(newerSeq, newerSeq.preCombine(olderSeq, new Properties()));
+  }
+
+  private Schema createMySqlNativeOrderingSchema() {
+    return Schema.createRecord("test_mysql_native_ordering", null, "test_namespace", false, Arrays.asList(
+        new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),
+        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
+        new Schema.Field(DebeziumConstants.FLATTENED_FILE_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
+        new Schema.Field(DebeziumConstants.FLATTENED_POS_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null)
+    ));
+  }
+
+  private GenericRecord createMySqlNativeOrderingRecord(Schema schema, int key, Operation op, String binlogFile, Long pos) {
+    GenericRecord record = new GenericData.Record(schema);
+    record.put(KEY_FIELD_NAME, key);
+    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, Objects.toString(op, null));
+    // Utf8, matching what the persisted side carries in production (both sides come from Avro decoding)
+    record.put(DebeziumConstants.FLATTENED_FILE_COL_NAME, new Utf8(binlogFile));
+    record.put(DebeziumConstants.FLATTENED_POS_COL_NAME, pos);
+    return record;
   }
 
   private Schema createSchemaWithOrderingField() {

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -345,6 +345,29 @@ public class TestMySqlDebeziumAvroPayload {
     assertEquals(newerSeq, newerSeq.preCombine(olderSeq, new Properties()));
   }
 
+  @Test
+  public void testMergeWithSeqOrderingFieldKeepsNumericCompare() throws IOException {
+    // Legacy config: ordering field = _event_seq (v8 tables / precombine convention). The "file.pos"
+    // segments must be compared numerically. Unpadded values discriminate: lexicographically
+    // "2.11" > "10.111", numerically file 2 < file 10 -> the stored record must win.
+    Properties props = orderingProps(DebeziumConstants.ADDED_SEQ_COL_NAME);
+    GenericRecord incoming = createRecord(2, Operation.UPDATE, "2.11");
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, "2.11");
+    GenericRecord existing = createRecord(2, Operation.INSERT, "10.111");
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, avroSchema, props);
+    validateRecord(merged, 2, Operation.INSERT, "10.111");
+  }
+
+  @Test
+  public void testPreCombineWithSeqOrderingFieldKeepsNumericCompare() {
+    // Same carve-out on the dedup path: orderingVal carries seq strings when precombine = _event_seq.
+    // Numerically file 10 > file 9 -> newer wins; lexicographic "9.111" > "10.2" would invert it.
+    Schema schema = createSchemaWithOrderingField();
+    MySqlDebeziumAvroPayload olderSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.INSERT, "9.111", 99L), "9.111");
+    MySqlDebeziumAvroPayload newerSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "10.2", 99L), "10.2");
+    assertEquals(newerSeq, newerSeq.preCombine(olderSeq, orderingProps(DebeziumConstants.ADDED_SEQ_COL_NAME)));
+  }
+
   private Schema createMySqlNativeOrderingSchema() {
     return Schema.createRecord("test_mysql_native_ordering", null, "test_namespace", false, Arrays.asList(
         new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.common.model.debezium;
 
-import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
 
@@ -163,23 +162,24 @@ public class TestMySqlDebeziumAvroPayload {
   }
 
   @Test
-  public void testMergeWithConfiguredOrderingFieldOverridesSeq() throws IOException {
+  public void testMergeWithConfiguredOrderingFieldStoredRecordWins() throws IOException {
     Schema schema = createSchemaWithOrderingField();
-    Properties props = orderingProps("event_ts");
-
     // Incoming has a HIGHER seq but a LOWER configured ordering value -> stored record must win,
     // proving the configured field (not the hardcoded seq) decides.
-    GenericRecord incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, "00005.100", 50L);
-    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, "00005.100");
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00005.100", 50L), 50L);
     GenericRecord existing = createRecordWithOrdering(schema, 1, Operation.INSERT, "00001.100", 99L);
-    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, props);
-    assertEquals(99L, (long) ((GenericRecord) merged.get()).get("event_ts"));
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps("event_ts"));
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00001.100", 99L);
+  }
 
+  @Test
+  public void testMergeWithConfiguredOrderingFieldIncomingRecordWins() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
     // Incoming has a LOWER seq but a HIGHER configured ordering value -> incoming wins.
-    incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, "00000.100", 120L);
-    payload = new MySqlDebeziumAvroPayload(incoming, "00000.100");
-    merged = payload.combineAndGetUpdateValue(existing, schema, props);
-    assertEquals(120L, (long) ((GenericRecord) merged.get()).get("event_ts"));
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00000.100", 120L), 120L);
+    GenericRecord existing = createRecordWithOrdering(schema, 1, Operation.INSERT, "00001.100", 99L);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps("event_ts"));
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00000.100", 120L);
   }
 
   @Test
@@ -234,27 +234,37 @@ public class TestMySqlDebeziumAvroPayload {
   }
 
   @Test
-  public void testPreCombineWithConfiguredOrderingField() {
+  public void testPreCombineEqualConfiguredOrderingValuesTieGoesToNewer() {
     Schema schema = createSchemaWithOrderingField();
-    Properties props = orderingProps("event_ts");
-
     // Two records with EQUAL configured ordering values: the seq parser would throw here
-    // ("99".split("\\.") has no position segment -> ArrayIndexOutOfBoundsException); the
+    // ("99".split(".") has no position segment -> ArrayIndexOutOfBoundsException); the
     // configured-field compare must not throw, and the newer payload wins the tie.
     MySqlDebeziumAvroPayload older = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.INSERT, "00001.111", 99L), 99L);
     MySqlDebeziumAvroPayload newer = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00002.111", 99L), 99L);
-    assertEquals(newer, newer.preCombine(older, props));
+    assertEquals(newer, newer.preCombine(older, orderingProps("event_ts")));
+  }
 
-    // The configured field decides, even when the seq order says otherwise.
+  @Test
+  public void testPreCombineConfiguredOrderingFieldOverridesSeq() {
+    Schema schema = createSchemaWithOrderingField();
+    // The configured field decides, in both directions, even when the seq order says otherwise.
     MySqlDebeziumAvroPayload lowerTsHigherSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00005.100", 50L), 50L);
     MySqlDebeziumAvroPayload higherTsLowerSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00000.100", 120L), 120L);
-    assertEquals(higherTsLowerSeq, higherTsLowerSeq.preCombine(lowerTsHigherSeq, props));
-    assertEquals(higherTsLowerSeq, lowerTsHigherSeq.preCombine(higherTsLowerSeq, props));
+    assertEquals(higherTsLowerSeq, higherTsLowerSeq.preCombine(lowerTsHigherSeq, orderingProps("event_ts")));
+    assertEquals(higherTsLowerSeq, lowerTsHigherSeq.preCombine(higherTsLowerSeq, orderingProps("event_ts")));
+  }
 
-    // Delete record (empty payload) keeps natural order.
+  @Test
+  public void testPreCombineDeleteRecordKeepsNaturalOrder() {
+    Schema schema = createSchemaWithOrderingField();
+    MySqlDebeziumAvroPayload newer = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00002.111", 99L), 99L);
     MySqlDebeziumAvroPayload empty = new MySqlDebeziumAvroPayload(Option.empty());
-    assertEquals(newer, newer.preCombine(empty, props));
+    assertEquals(newer, newer.preCombine(empty, orderingProps("event_ts")));
+  }
 
+  @Test
+  public void testPreCombineWithoutOrderingFieldUsesSeqCompare() {
+    Schema schema = createSchemaWithOrderingField();
     // No ordering field configured, or configured to the connector seq column ->
     // the legacy numeric seq comparison still applies. On this path real ingestion sets
     // orderingVal from the seq column (precombine = _event_seq), so construct accordingly.
@@ -265,31 +275,16 @@ public class TestMySqlDebeziumAvroPayload {
   }
 
   private Schema createSchemaWithOrderingField() {
-    return Schema.createRecord("test_ordering", null, "test_namespace", false, Arrays.asList(
-        new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),
-        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME,
-            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
-        new Schema.Field(DebeziumConstants.ADDED_SEQ_COL_NAME,
-            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
-        new Schema.Field("event_ts",
-            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null)
-    ));
+    return DebeziumOrderingTestFixtures.schemaWithOrderingField(DebeziumConstants.ADDED_SEQ_COL_NAME, Schema.Type.STRING);
   }
 
   private GenericRecord createRecordWithOrdering(Schema schema, int primaryKeyValue, @Nullable Operation op,
                                                  @Nullable String seqValue, @Nullable Long orderingValue) {
-    GenericRecord record = new GenericData.Record(schema);
-    record.put(KEY_FIELD_NAME, primaryKeyValue);
-    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, Objects.toString(op, null));
-    record.put(DebeziumConstants.ADDED_SEQ_COL_NAME, seqValue);
-    record.put("event_ts", orderingValue);
-    return record;
+    return DebeziumOrderingTestFixtures.recordWithOrdering(schema, primaryKeyValue, op, DebeziumConstants.ADDED_SEQ_COL_NAME, seqValue, orderingValue);
   }
 
   private Properties orderingProps(String orderingField) {
-    Properties props = new Properties();
-    props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingField);
-    return props;
+    return DebeziumOrderingTestFixtures.orderingProps(orderingField);
   }
 
   private GenericRecord createRecord(int primaryKeyValue, @Nullable Operation op, @Nullable String seqValue) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.model.debezium;
 
+import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
 
@@ -159,6 +160,82 @@ public class TestMySqlDebeziumAvroPayload {
       "'00001.100', '00001.100', false"})
   public void testIsCurrentSeqLatest(String currentSeq, String newSeq, boolean expectedResult) {
     assertEquals(expectedResult, MySqlDebeziumAvroPayload.isCurrentSeqLatest(currentSeq, newSeq));
+  }
+
+  @Test
+  public void testMergeWithConfiguredOrderingFieldOverridesSeq() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
+    Properties props = orderingProps("event_ts");
+
+    // Incoming has a HIGHER seq but a LOWER configured ordering value -> stored record must win,
+    // proving the configured field (not the hardcoded seq) decides.
+    GenericRecord incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, "00005.100", 50L);
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, "00005.100");
+    GenericRecord existing = createRecordWithOrdering(schema, 1, Operation.INSERT, "00001.100", 99L);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, props);
+    assertEquals(99L, (long) ((GenericRecord) merged.get()).get("event_ts"));
+
+    // Incoming has a LOWER seq but a HIGHER configured ordering value -> incoming wins.
+    incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, "00000.100", 120L);
+    payload = new MySqlDebeziumAvroPayload(incoming, "00000.100");
+    merged = payload.combineAndGetUpdateValue(existing, schema, props);
+    assertEquals(120L, (long) ((GenericRecord) merged.get()).get("event_ts"));
+  }
+
+  @Test
+  public void testMergeWithSeqOrderingFieldKeepsNumericCompare() throws IOException {
+    // Ordering field configured to the connector seq column: the "file.pos" segments must still be
+    // compared numerically. Unpadded values discriminate: lexicographically "2.11" > "10.111",
+    // numerically file 2 < file 10 -> the stored record must win.
+    Properties props = orderingProps(DebeziumConstants.ADDED_SEQ_COL_NAME);
+    GenericRecord incoming = createRecord(2, Operation.UPDATE, "2.11");
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, "2.11");
+    GenericRecord existing = createRecord(2, Operation.INSERT, "10.111");
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, avroSchema, props);
+    validateRecord(merged, 2, Operation.INSERT, "10.111");
+  }
+
+  @Test
+  public void testMergeWithoutOrderingFieldFallsBackToSeq() throws IOException {
+    // Properties present but no ordering field configured -> legacy hardcoded seq comparison.
+    GenericRecord lateRecord = createRecord(3, Operation.UPDATE, "00000.222");
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(lateRecord, "00000.222");
+    GenericRecord existingRecord = createRecord(3, Operation.INSERT, "00001.111");
+    Option<IndexedRecord> mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema, new Properties());
+    validateRecord(mergedRecord, 3, Operation.INSERT, "00001.111");
+
+    GenericRecord freshRecord = createRecord(3, Operation.UPDATE, "00002.11");
+    payload = new MySqlDebeziumAvroPayload(freshRecord, "00002.11");
+    mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema, new Properties());
+    validateRecord(mergedRecord, 3, Operation.UPDATE, "00002.11");
+  }
+
+  private Schema createSchemaWithOrderingField() {
+    return Schema.createRecord("test_ordering", null, "test_namespace", false, Arrays.asList(
+        new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),
+        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
+        new Schema.Field(DebeziumConstants.ADDED_SEQ_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
+        new Schema.Field("event_ts",
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null)
+    ));
+  }
+
+  private GenericRecord createRecordWithOrdering(Schema schema, int primaryKeyValue, @Nullable Operation op,
+                                                 @Nullable String seqValue, @Nullable Long orderingValue) {
+    GenericRecord record = new GenericData.Record(schema);
+    record.put(KEY_FIELD_NAME, primaryKeyValue);
+    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, Objects.toString(op, null));
+    record.put(DebeziumConstants.ADDED_SEQ_COL_NAME, seqValue);
+    record.put("event_ts", orderingValue);
+    return record;
+  }
+
+  private Properties orderingProps(String orderingField) {
+    Properties props = new Properties();
+    props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingField);
+    return props;
   }
 
   private GenericRecord createRecord(int primaryKeyValue, @Nullable Operation op, @Nullable String seqValue) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -208,6 +208,19 @@ public class TestMySqlDebeziumAvroPayload {
   }
 
   @Test
+  public void testMergeWithWhitespacePaddedConfiguredOrderingFieldIsTrimmed() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
+    // The other trimming direction: a padded NON-connector field must route to the configured-field
+    // compare. Without the trim, " event_ts " resolves no field (null ordering value) and throws,
+    // so this asserts the trim rather than accidentally passing through the connector path.
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00005.100", 50L), 50L);
+    GenericRecord existing = createRecordWithOrdering(schema, 1, Operation.INSERT, "00001.100", 99L);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps(" event_ts "));
+    // Stored row wins on event_ts (99 > 50); the seq order (00005 > 00001) would have picked the incoming
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00001.100", 99L);
+  }
+
+  @Test
   public void testMergeWithCompositeOrderingFieldFallsBackToSeq() throws IOException {
     // Composite (comma-separated) ordering is not supported yet: fall back to the connector seq compare.
     Properties props = orderingProps("event_ts," + DebeziumConstants.ADDED_SEQ_COL_NAME);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -19,7 +19,9 @@
 package org.apache.hudi.common.model.debezium;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
+import org.apache.hudi.exception.HoodieException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -221,14 +223,50 @@ public class TestMySqlDebeziumAvroPayload {
   }
 
   @Test
-  public void testMergeWithCompositeOrderingFieldFallsBackToSeq() throws IOException {
-    // Composite (comma-separated) ordering is not supported yet: fall back to the connector seq compare.
+  public void testMergeWithCompositeOrderingFieldsComparesElementWise() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
+    Properties props = orderingProps("event_ts,event_ts2");
+    // First ordering field ties (99 == 99); the second decides (7 > 5) -> incoming wins,
+    // even though the seq order (00001 < 00005) says otherwise.
+    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(
+        DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00001.100", 99L, 7L), 99L);
+    GenericRecord existing = DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00005.100", 99L, 5L);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, props);
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00001.100", 99L);
+
+    // First ordering field decides outright when it differs (98 < 99) -> stored record kept.
+    MySqlDebeziumAvroPayload older = new MySqlDebeziumAvroPayload(
+        DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00009.100", 98L, 100L), 98L);
+    merged = older.combineAndGetUpdateValue(existing, schema, props);
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00005.100", 99L);
+  }
+
+  @Test
+  public void testPreCombineWithCompositeOrderingFields() {
+    Schema schema = createSchemaWithOrderingField();
+    Properties props = orderingProps("event_ts,event_ts2");
+    // Composite orderingVal, first field tied: the second field decides the dedup winner.
+    MySqlDebeziumAvroPayload lower = new MySqlDebeziumAvroPayload(
+        DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.INSERT, DebeziumConstants.ADDED_SEQ_COL_NAME, "00005.100", 99L, 5L),
+        OrderingValues.create(new Comparable[] {99L, 5L}));
+    MySqlDebeziumAvroPayload higher = new MySqlDebeziumAvroPayload(
+        DebeziumOrderingTestFixtures.recordWithCompositeOrdering(schema, 1, Operation.UPDATE, DebeziumConstants.ADDED_SEQ_COL_NAME, "00001.100", 99L, 7L),
+        OrderingValues.create(new Comparable[] {99L, 7L}));
+    assertEquals(higher, higher.preCombine(lower, props));
+    assertEquals(higher, lower.preCombine(higher, props));
+  }
+
+  @Test
+  public void testCompositeOrderingIncludingConnectorColumnIsRejected() {
+    // The connector column's encoded "file.pos" representation cannot participate in a plain
+    // Comparable composite: reject loudly on both entry points instead of mis-ordering.
     Properties props = orderingProps("event_ts," + DebeziumConstants.ADDED_SEQ_COL_NAME);
     GenericRecord incoming = createRecord(2, Operation.UPDATE, "2.11");
     MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, "2.11");
     GenericRecord existing = createRecord(2, Operation.INSERT, "10.111");
-    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, avroSchema, props);
-    validateRecord(merged, 2, Operation.INSERT, "10.111");
+    assertThrows(HoodieException.class, () -> payload.combineAndGetUpdateValue(existing, avroSchema, props));
+    MySqlDebeziumAvroPayload other = new MySqlDebeziumAvroPayload(createRecord(2, Operation.INSERT, "1.11"), "1.11");
+    assertThrows(HoodieException.class, () -> payload.preCombine(other, props));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -21,7 +21,6 @@ package org.apache.hudi.common.model.debezium;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
-import org.apache.hudi.exception.HoodieException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -185,31 +184,6 @@ public class TestMySqlDebeziumAvroPayload {
   }
 
   @Test
-  public void testMergeWithSeqOrderingFieldKeepsNumericCompare() throws IOException {
-    // Ordering field configured to the connector seq column: the "file.pos" segments must still be
-    // compared numerically. Unpadded values discriminate: lexicographically "2.11" > "10.111",
-    // numerically file 2 < file 10 -> the stored record must win.
-    Properties props = orderingProps(DebeziumConstants.ADDED_SEQ_COL_NAME);
-    GenericRecord incoming = createRecord(2, Operation.UPDATE, "2.11");
-    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, "2.11");
-    GenericRecord existing = createRecord(2, Operation.INSERT, "10.111");
-    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, avroSchema, props);
-    validateRecord(merged, 2, Operation.INSERT, "10.111");
-  }
-
-  @Test
-  public void testMergeWithWhitespacePaddedSeqOrderingFieldStaysOnSeqCompare() throws IOException {
-    // Whitespace in the configured field must not silently reroute the connector column
-    // into the generic Comparable compare (lexicographic, wrong for "file.pos").
-    Properties props = orderingProps(" " + DebeziumConstants.ADDED_SEQ_COL_NAME + " ");
-    GenericRecord incoming = createRecord(2, Operation.UPDATE, "2.11");
-    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, "2.11");
-    GenericRecord existing = createRecord(2, Operation.INSERT, "10.111");
-    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, avroSchema, props);
-    validateRecord(merged, 2, Operation.INSERT, "10.111");
-  }
-
-  @Test
   public void testMergeWithWhitespacePaddedConfiguredOrderingFieldIsTrimmed() throws IOException {
     Schema schema = createSchemaWithOrderingField();
     // The other trimming direction: a padded NON-connector field must route to the configured-field
@@ -254,19 +228,6 @@ public class TestMySqlDebeziumAvroPayload {
         OrderingValues.create(new Comparable[] {99L, 7L}));
     assertEquals(higher, higher.preCombine(lower, props));
     assertEquals(higher, lower.preCombine(higher, props));
-  }
-
-  @Test
-  public void testCompositeOrderingIncludingConnectorColumnIsRejected() {
-    // The connector column's encoded "file.pos" representation cannot participate in a plain
-    // Comparable composite: reject loudly on both entry points instead of mis-ordering.
-    Properties props = orderingProps("event_ts," + DebeziumConstants.ADDED_SEQ_COL_NAME);
-    GenericRecord incoming = createRecord(2, Operation.UPDATE, "2.11");
-    MySqlDebeziumAvroPayload payload = new MySqlDebeziumAvroPayload(incoming, "2.11");
-    GenericRecord existing = createRecord(2, Operation.INSERT, "10.111");
-    assertThrows(HoodieException.class, () -> payload.combineAndGetUpdateValue(existing, avroSchema, props));
-    MySqlDebeziumAvroPayload other = new MySqlDebeziumAvroPayload(createRecord(2, Operation.INSERT, "1.11"), "1.11");
-    assertThrows(HoodieException.class, () -> payload.preCombine(other, props));
   }
 
   @Test
@@ -316,13 +277,12 @@ public class TestMySqlDebeziumAvroPayload {
   @Test
   public void testPreCombineWithoutOrderingFieldUsesSeqCompare() {
     Schema schema = createSchemaWithOrderingField();
-    // No ordering field configured, or configured to the connector seq column ->
-    // the legacy numeric seq comparison still applies. On this path real ingestion sets
-    // orderingVal from the seq column (precombine = _event_seq), so construct accordingly.
+    // No ordering field configured -> the legacy numeric seq comparison still applies. On this
+    // path real ingestion sets orderingVal from the seq column (precombine = _event_seq), so
+    // construct accordingly.
     MySqlDebeziumAvroPayload olderSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.INSERT, "00001.111", 99L), "00001.111");
     MySqlDebeziumAvroPayload newerSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00002.111", 99L), "00002.111");
     assertEquals(newerSeq, newerSeq.preCombine(olderSeq, new Properties()));
-    assertEquals(newerSeq, newerSeq.preCombine(olderSeq, orderingProps(DebeziumConstants.ADDED_SEQ_COL_NAME)));
   }
 
   private Schema createSchemaWithOrderingField() {

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestMySqlDebeziumAvroPayload.java
@@ -210,6 +210,37 @@ public class TestMySqlDebeziumAvroPayload {
     validateRecord(mergedRecord, 3, Operation.UPDATE, "00002.11");
   }
 
+  @Test
+  public void testPreCombineWithConfiguredOrderingField() {
+    Schema schema = createSchemaWithOrderingField();
+    Properties props = orderingProps("event_ts");
+
+    // Two records with EQUAL configured ordering values: the seq parser would throw here
+    // ("99".split("\\.") has no position segment -> ArrayIndexOutOfBoundsException); the
+    // configured-field compare must not throw, and the newer payload wins the tie.
+    MySqlDebeziumAvroPayload older = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.INSERT, "00001.111", 99L), 99L);
+    MySqlDebeziumAvroPayload newer = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00002.111", 99L), 99L);
+    assertEquals(newer, newer.preCombine(older, props));
+
+    // The configured field decides, even when the seq order says otherwise.
+    MySqlDebeziumAvroPayload lowerTsHigherSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00005.100", 50L), 50L);
+    MySqlDebeziumAvroPayload higherTsLowerSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00000.100", 120L), 120L);
+    assertEquals(higherTsLowerSeq, higherTsLowerSeq.preCombine(lowerTsHigherSeq, props));
+    assertEquals(higherTsLowerSeq, lowerTsHigherSeq.preCombine(higherTsLowerSeq, props));
+
+    // Delete record (empty payload) keeps natural order.
+    MySqlDebeziumAvroPayload empty = new MySqlDebeziumAvroPayload(Option.empty());
+    assertEquals(newer, newer.preCombine(empty, props));
+
+    // No ordering field configured, or configured to the connector seq column ->
+    // the legacy numeric seq comparison still applies. On this path real ingestion sets
+    // orderingVal from the seq column (precombine = _event_seq), so construct accordingly.
+    MySqlDebeziumAvroPayload olderSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.INSERT, "00001.111", 99L), "00001.111");
+    MySqlDebeziumAvroPayload newerSeq = new MySqlDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, "00002.111", 99L), "00002.111");
+    assertEquals(newerSeq, newerSeq.preCombine(olderSeq, new Properties()));
+    assertEquals(newerSeq, newerSeq.preCombine(olderSeq, orderingProps(DebeziumConstants.ADDED_SEQ_COL_NAME)));
+  }
+
   private Schema createSchemaWithOrderingField() {
     return Schema.createRecord("test_ordering", null, "test_namespace", false, Arrays.asList(
         new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -194,6 +194,17 @@ public class TestPostgresDebeziumAvroPayload {
   }
 
   @Test
+  public void testMergeWithConfiguredOrderingFieldNullIncomingThrows() {
+    Schema schema = createSchemaWithOrderingField();
+    GenericRecord incoming = createRecordWithOrdering(schema, 2, Operation.UPDATE, 200L, null);
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(incoming, 0L);
+    GenericRecord existing = createRecordWithOrdering(schema, 2, Operation.INSERT, 100L, 99L);
+    assertThrows(HoodieDebeziumAvroPayloadException.class,
+        () -> payload.combineAndGetUpdateValue(existing, schema, orderingProps("event_ts")),
+        "null configured ordering value in the incoming record must fail loudly, not NPE");
+  }
+
+  @Test
   public void testMergeWithoutOrderingFieldFallsBackToLsn() throws IOException {
     // Properties present but no ordering field configured -> legacy hardcoded LSN comparison.
     GenericRecord lateRecord = createRecord(3, Operation.UPDATE, 98L);

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -21,6 +21,7 @@ package org.apache.hudi.common.model.debezium;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
@@ -157,6 +158,114 @@ public class TestPostgresDebeziumAvroPayload {
     assertThrows(HoodieDebeziumAvroPayloadException.class,
         () -> payload.combineAndGetUpdateValue(existingRecord, avroSchema),
         "should have thrown because LSN value of the incoming record is null");
+  }
+
+  @Test
+  public void testMergeWithConfiguredOrderingFieldOverridesLsn() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
+    Properties props = orderingProps("event_ts");
+
+    // Incoming has a HIGHER LSN but a LOWER configured ordering value -> stored record must win,
+    // proving the configured field (not the hardcoded LSN) decides.
+    GenericRecord incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, 200L, 50L);
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(incoming, 50L);
+    GenericRecord existing = createRecordWithOrdering(schema, 1, Operation.INSERT, 100L, 99L);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, props);
+    assertEquals(99L, (long) ((GenericRecord) merged.get()).get("event_ts"));
+
+    // Incoming has a LOWER LSN but a HIGHER configured ordering value -> incoming wins.
+    incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, 90L, 120L);
+    payload = new PostgresDebeziumAvroPayload(incoming, 120L);
+    merged = payload.combineAndGetUpdateValue(existing, schema, props);
+    assertEquals(120L, (long) ((GenericRecord) merged.get()).get("event_ts"));
+
+    // Tie on the configured ordering value -> incoming wins (mirrors legacy LSN tie semantics).
+    incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, 90L, 99L);
+    payload = new PostgresDebeziumAvroPayload(incoming, 99L);
+    merged = payload.combineAndGetUpdateValue(existing, schema, props);
+    assertEquals(Operation.UPDATE.op, ((GenericRecord) merged.get()).get(DebeziumConstants.FLATTENED_OP_COL_NAME).toString());
+
+    // Stored record has a null ordering value (e.g. bootstrapped rows) -> incoming wins.
+    GenericRecord bootstrapped = createRecordWithOrdering(schema, 1, null, null, null);
+    incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, 90L, 10L);
+    payload = new PostgresDebeziumAvroPayload(incoming, 10L);
+    merged = payload.combineAndGetUpdateValue(bootstrapped, schema, props);
+    assertEquals(10L, (long) ((GenericRecord) merged.get()).get("event_ts"));
+  }
+
+  @Test
+  public void testMergeWithoutOrderingFieldFallsBackToLsn() throws IOException {
+    // Properties present but no ordering field configured -> legacy hardcoded LSN comparison.
+    GenericRecord lateRecord = createRecord(3, Operation.UPDATE, 98L);
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(lateRecord, 98L);
+    GenericRecord existingRecord = createRecord(3, Operation.INSERT, 99L);
+    Option<IndexedRecord> mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema, new Properties());
+    validateRecord(mergedRecord, 3, Operation.INSERT, 99L);
+
+    GenericRecord freshRecord = createRecord(3, Operation.UPDATE, 100L);
+    payload = new PostgresDebeziumAvroPayload(freshRecord, 100L);
+    mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema, new Properties());
+    validateRecord(mergedRecord, 3, Operation.UPDATE, 100L);
+  }
+
+  @Test
+  public void testMergeWithToastedValuesUnderConfiguredOrdering() throws IOException {
+    // Toast-column merging must keep working when the ordering decision goes through the
+    // configured ordering field instead of the hardcoded LSN.
+    Schema schema = SchemaBuilder.builder()
+        .record("test_toast_ordering")
+        .namespace("test_namespace")
+        .fields()
+        .name(DebeziumConstants.FLATTENED_LSN_COL_NAME).type().longType().noDefault()
+        .name("event_ts").type().longType().noDefault()
+        .name("string_col").type().stringType().noDefault()
+        .endRecord();
+
+    GenericRecord oldVal = new GenericData.Record(schema);
+    oldVal.put(DebeziumConstants.FLATTENED_LSN_COL_NAME, 100L);
+    oldVal.put("event_ts", 1L);
+    oldVal.put("string_col", "valid string value");
+
+    // Incoming loses on LSN but wins on the configured ordering field, and carries a toasted column
+    GenericRecord newVal = new GenericData.Record(schema);
+    newVal.put(DebeziumConstants.FLATTENED_LSN_COL_NAME, 90L);
+    newVal.put("event_ts", 2L);
+    newVal.put("string_col", PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE);
+
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(Option.of(newVal));
+    GenericRecord merged = (GenericRecord) payload
+        .combineAndGetUpdateValue(oldVal, schema, orderingProps("event_ts")).get();
+
+    assertEquals(2L, (long) merged.get("event_ts"));
+    assertEquals("valid string value", merged.get("string_col"));
+  }
+
+  private Schema createSchemaWithOrderingField() {
+    return Schema.createRecord("test_ordering", null, "test_namespace", false, Arrays.asList(
+        new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),
+        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
+        new Schema.Field(DebeziumConstants.FLATTENED_LSN_COL_NAME,
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null),
+        new Schema.Field("event_ts",
+            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null)
+    ));
+  }
+
+  private GenericRecord createRecordWithOrdering(Schema schema, int primaryKeyValue, @Nullable Operation op,
+                                                 @Nullable Long lsnValue, @Nullable Long orderingValue) {
+    GenericRecord record = new GenericData.Record(schema);
+    record.put(KEY_FIELD_NAME, primaryKeyValue);
+    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, Objects.toString(op, null));
+    record.put(DebeziumConstants.FLATTENED_LSN_COL_NAME, lsnValue);
+    record.put("event_ts", orderingValue);
+    return record;
+  }
+
+  private Properties orderingProps(String orderingField) {
+    Properties props = new Properties();
+    props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingField);
+    return props;
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -21,7 +21,6 @@ package org.apache.hudi.common.model.debezium;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
-import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
@@ -161,36 +160,44 @@ public class TestPostgresDebeziumAvroPayload {
   }
 
   @Test
-  public void testMergeWithConfiguredOrderingFieldOverridesLsn() throws IOException {
+  public void testMergeWithConfiguredOrderingFieldStoredRecordWins() throws IOException {
     Schema schema = createSchemaWithOrderingField();
-    Properties props = orderingProps("event_ts");
-
     // Incoming has a HIGHER LSN but a LOWER configured ordering value -> stored record must win,
     // proving the configured field (not the hardcoded LSN) decides.
-    GenericRecord incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, 200L, 50L);
-    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(incoming, 50L);
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, 200L, 50L), 50L);
     GenericRecord existing = createRecordWithOrdering(schema, 1, Operation.INSERT, 100L, 99L);
-    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, props);
-    assertEquals(99L, (long) ((GenericRecord) merged.get()).get("event_ts"));
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps("event_ts"));
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.INSERT, DebeziumConstants.FLATTENED_LSN_COL_NAME, 100L, 99L);
+  }
 
+  @Test
+  public void testMergeWithConfiguredOrderingFieldIncomingRecordWins() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
     // Incoming has a LOWER LSN but a HIGHER configured ordering value -> incoming wins.
-    incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, 90L, 120L);
-    payload = new PostgresDebeziumAvroPayload(incoming, 120L);
-    merged = payload.combineAndGetUpdateValue(existing, schema, props);
-    assertEquals(120L, (long) ((GenericRecord) merged.get()).get("event_ts"));
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, 90L, 120L), 120L);
+    GenericRecord existing = createRecordWithOrdering(schema, 1, Operation.INSERT, 100L, 99L);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps("event_ts"));
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.UPDATE, DebeziumConstants.FLATTENED_LSN_COL_NAME, 90L, 120L);
+  }
 
+  @Test
+  public void testMergeWithConfiguredOrderingFieldTieGoesToIncoming() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
     // Tie on the configured ordering value -> incoming wins (mirrors legacy LSN tie semantics).
-    incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, 90L, 99L);
-    payload = new PostgresDebeziumAvroPayload(incoming, 99L);
-    merged = payload.combineAndGetUpdateValue(existing, schema, props);
-    assertEquals(Operation.UPDATE.op, ((GenericRecord) merged.get()).get(DebeziumConstants.FLATTENED_OP_COL_NAME).toString());
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, 90L, 99L), 99L);
+    GenericRecord existing = createRecordWithOrdering(schema, 1, Operation.INSERT, 100L, 99L);
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(existing, schema, orderingProps("event_ts"));
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.UPDATE, DebeziumConstants.FLATTENED_LSN_COL_NAME, 90L, 99L);
+  }
 
+  @Test
+  public void testMergeWithConfiguredOrderingFieldNullPersistedTakesIncoming() throws IOException {
+    Schema schema = createSchemaWithOrderingField();
     // Stored record has a null ordering value (e.g. bootstrapped rows) -> incoming wins.
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(createRecordWithOrdering(schema, 1, Operation.UPDATE, 90L, 10L), 10L);
     GenericRecord bootstrapped = createRecordWithOrdering(schema, 1, null, null, null);
-    incoming = createRecordWithOrdering(schema, 1, Operation.UPDATE, 90L, 10L);
-    payload = new PostgresDebeziumAvroPayload(incoming, 10L);
-    merged = payload.combineAndGetUpdateValue(bootstrapped, schema, props);
-    assertEquals(10L, (long) ((GenericRecord) merged.get()).get("event_ts"));
+    Option<IndexedRecord> merged = payload.combineAndGetUpdateValue(bootstrapped, schema, orderingProps("event_ts"));
+    DebeziumOrderingTestFixtures.validateOrderingRecord(merged, 1, Operation.UPDATE, DebeziumConstants.FLATTENED_LSN_COL_NAME, 90L, 10L);
   }
 
   @Test
@@ -252,31 +259,16 @@ public class TestPostgresDebeziumAvroPayload {
   }
 
   private Schema createSchemaWithOrderingField() {
-    return Schema.createRecord("test_ordering", null, "test_namespace", false, Arrays.asList(
-        new Schema.Field(KEY_FIELD_NAME, Schema.create(Schema.Type.INT), "", 0),
-        new Schema.Field(DebeziumConstants.FLATTENED_OP_COL_NAME,
-            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), "", null),
-        new Schema.Field(DebeziumConstants.FLATTENED_LSN_COL_NAME,
-            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null),
-        new Schema.Field("event_ts",
-            Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null)
-    ));
+    return DebeziumOrderingTestFixtures.schemaWithOrderingField(DebeziumConstants.FLATTENED_LSN_COL_NAME, Schema.Type.LONG);
   }
 
   private GenericRecord createRecordWithOrdering(Schema schema, int primaryKeyValue, @Nullable Operation op,
                                                  @Nullable Long lsnValue, @Nullable Long orderingValue) {
-    GenericRecord record = new GenericData.Record(schema);
-    record.put(KEY_FIELD_NAME, primaryKeyValue);
-    record.put(DebeziumConstants.FLATTENED_OP_COL_NAME, Objects.toString(op, null));
-    record.put(DebeziumConstants.FLATTENED_LSN_COL_NAME, lsnValue);
-    record.put("event_ts", orderingValue);
-    return record;
+    return DebeziumOrderingTestFixtures.recordWithOrdering(schema, primaryKeyValue, op, DebeziumConstants.FLATTENED_LSN_COL_NAME, lsnValue, orderingValue);
   }
 
   private Properties orderingProps(String orderingField) {
-    Properties props = new Properties();
-    props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingField);
-    return props;
+    return DebeziumOrderingTestFixtures.orderingProps(orderingField);
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestPostgresDebeziumAvroPayload.java
@@ -212,17 +212,21 @@ public class TestPostgresDebeziumAvroPayload {
   }
 
   @Test
-  public void testMergeWithoutOrderingFieldFallsBackToLsn() throws IOException {
+  public void testMergeWithoutOrderingFieldLateRecordLosesOnLsn() throws IOException {
     // Properties present but no ordering field configured -> legacy hardcoded LSN comparison.
     GenericRecord lateRecord = createRecord(3, Operation.UPDATE, 98L);
     PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(lateRecord, 98L);
     GenericRecord existingRecord = createRecord(3, Operation.INSERT, 99L);
     Option<IndexedRecord> mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema, new Properties());
     validateRecord(mergedRecord, 3, Operation.INSERT, 99L);
+  }
 
+  @Test
+  public void testMergeWithoutOrderingFieldFreshRecordWinsOnLsn() throws IOException {
     GenericRecord freshRecord = createRecord(3, Operation.UPDATE, 100L);
-    payload = new PostgresDebeziumAvroPayload(freshRecord, 100L);
-    mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema, new Properties());
+    PostgresDebeziumAvroPayload payload = new PostgresDebeziumAvroPayload(freshRecord, 100L);
+    GenericRecord existingRecord = createRecord(3, Operation.INSERT, 99L);
+    Option<IndexedRecord> mergedRecord = payload.combineAndGetUpdateValue(existingRecord, avroSchema, new Properties());
     validateRecord(mergedRecord, 3, Operation.UPDATE, 100L);
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Debezium payloads order records with two different mechanisms. `preCombine` (intra-batch dedup) compares `orderingVal` — the value of the configured precombine field captured at payload construction — while `combineAndGetUpdateValue` (incoming vs stored record) drops the payload `Properties` and always compares the connector-hardcoded column (`_event_lsn` for Postgres, `_event_seq` for MySQL) via `shouldPickCurrentRecord`: the 3-arg `combineAndGetUpdateValue(current, schema, properties)` funnels into the props-less template, so `Properties` never reaches the ordering decision.

The two agree only by convention (precombine set to the connector column). Any table where precombine differs silently orders against storage by a column the user never configured.

### Summary and Changelog

Debezium payloads now honor the configured ordering field(s) when merging against storage, matching what `preCombine` already does within a batch.

- `AbstractDebeziumAvroPayload` keeps `OverwriteWithLatestAvroPayload` as its parent and adds a `Properties`-aware `combineAndGetUpdateValue` template (the 2-arg overload delegates with `CollectionUtils.emptyProps()`) which dispatches the ordering decision:
  - ordering fields absent → the connector-specific `shouldPickCurrentRecord` (unchanged, original 3-arg signature);
  - any configured ordering is used as-is, single or composite (multi-field, element-wise: the first non-equal field decides, ties go to the incoming record) via `needUpdatingPersistedRecord`, implemented in the abstract class mirroring `DefaultHoodieRecordPayload`'s comparison (kept local rather than reusing `OrderingValues` because a null persisted element after a tied element must take the incoming record instead of throwing; keeping the parent unchanged also avoids inheriting `Default`'s per-record-deserializing `isDeleted` and its `DELETE_KEY` handling — `isDeleted`/`getInsertValue` behavior is byte-identical to before this PR).
- One compatibility carve-out, owned by `MySqlDebeziumAvroPayload`: the single legacy ordering field `_event_seq` (what v8 tables carry until the v9 upgrade rewrites it to `_event_bin_file,_event_pos`) routes to the connector's segment-wise numeric seq parser — a plain `Comparable` compare of the encoded `"file.pos"` string is lexicographic (`"9.1" > "10.1"`) and flips merge winners for unpadded positions (caught by `TestPayloadDeprecationFlow`).
- `preCombine(oldValue, properties)` applies the same dispatch, so intra-batch dedup (`hoodie.combine.before.upsert`) and the against-storage merge order by the same column(s) — a configured non-connector field previously crashed MySQL's seq parser on the first repeated key in a batch (NFE for non-numerics, AIOOBE for equal plain values). The props-less `preCombine` overrides (MySQL seq compare, delete natural-order) are untouched; Postgres toast-column merging is unchanged and covered by a test through the configured-ordering path.
- A null incoming ordering value on the configured path throws `HoodieDebeziumAvroPayloadException` naming the field and record; a null persisted value (e.g. bootstrapped rows) takes the incoming record; ties go to the incoming record in every path, matching the legacy strict comparisons. Configured values are trimmed. No code was copied from external sources.

### Impact

| Table config | Before | After |
|---|---|---|
| precombine = connector column | connector ordering | identical (numeric seq compare preserved for MySQL via the carve-out; plain `Comparable` on the LSN is the same ordering for Postgres) |
| precombine = other field | `preCombine` by config field, `combineAndGetUpdateValue` by connector column | both by config field |
| composite ordering (e.g. `_event_bin_file,_event_pos`) | connector column only | element-wise composite |
| no ordering props passed | connector ordering | identical |

No public API change; behavior-preserving for the conventional configurations.

### Risk Level

low

Behavior-preserving for the common configuration (precombine = connector column) and for callers that pass no ordering properties. Verification: `TestPostgresDebeziumAvroPayload` 16/16 and `TestMySqlDebeziumAvroPayload` 31/31, including tests where the configured field contradicts the connector ordering, tie/null-persisted/null-incoming cases, whitespace-trim discriminators, mixed-type composite tests bound to `MySqlDebeziumAvroPayload.ORDERING_FIELDS` with real binlog shapes, unpadded-seq discriminators where lexicographic ordering inverts the winner, and toast-column merging through the configured-ordering path. `TestPayloadDeprecationFlow` covers the v8→v9 upgrade flow for every built-in payload.

### Documentation Update

none — the payloads honor `hoodie.payload.ordering.field` / precombine as already documented for `DefaultHoodieRecordPayload`.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
