### PR TITLE
feat: Add debugging metadata (hudi.version, engine) to all instant types (#417)

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -581,6 +581,9 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       replaceCommitMetadata.addWriteStat(writeStat.getPartitionPath(), writeStat);
     }
     HoodieClusteringPlan clusteringPlan = ClusteringUtils.getPendingClusteringPlan(table.getMetaClient(), clusteringCommitTime);
+    if (clusteringPlan.getExtraMetadata() != null) {
+      clusteringPlan.getExtraMetadata().forEach(replaceCommitMetadata::addMetadata);
+    }
     Map<String, List<String>> partitionToReplaceFileIds = CommonClientUtils.getPartitionToReplacedFileIds(clusteringPlan, clusteringWriteMetadata, config);
     clusteringWriteMetadata.setPartitionToReplaceFileIds(partitionToReplaceFileIds);
     replaceCommitMetadata.setPartitionToReplaceFileIds(partitionToReplaceFileIds);
@@ -729,7 +732,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
     if (tableServiceType == TableServiceType.CLEAN) {
       // Cleaning is a frequent operation that does not conflict with other operations and is idempotent,
       // so it is handled differently to avoid locking for planning.
-      return scheduleCleaning(createTable(config, storageConf), providedInstantTime);
+      return scheduleCleaning(createTable(config, storageConf), providedInstantTime, updateExtraMetadata(extraMetadata));
     }
     // Only enrich metadata after early-return checks, when we're actually going to use it
     extraMetadata = updateExtraMetadata(extraMetadata);
@@ -883,7 +886,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       log.info("Cleaner started for table {}", config.getBasePath());
       // proceed only if multiple clean schedules are enabled or if there are no pending cleans.
       if (scheduleInline) {
-        cleanInstantTime = scheduleCleaning(table, suppliedCleanInstant);
+        cleanInstantTime = scheduleCleaning(table, suppliedCleanInstant, updateExtraMetadata(Option.empty()));
       }
 
       if (shouldDelegateToTableServiceManager(config, ActionType.clean)) {
@@ -918,8 +921,9 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
    * @param suppliedCleanInstant Optional supplied clean instant time that overrides the generated time. This can only be used for testing.
    * @return the requested instant time if the service was scheduled
    */
-  private Option<String> scheduleCleaning(HoodieTable<?, ?, ?, ?> table, Option<String> suppliedCleanInstant) {
-    Option<HoodieCleanerPlan> cleanerPlan = table.createCleanerPlan(context, Option.empty());
+  private Option<String> scheduleCleaning(HoodieTable<?, ?, ?, ?> table, Option<String> suppliedCleanInstant,
+                                          Option<Map<String, String>> extraMetadata) {
+    Option<HoodieCleanerPlan> cleanerPlan = table.createCleanerPlan(context, extraMetadata);
     if (cleanerPlan.isPresent()) {
       txnManager.beginStateChange(Option.empty(), Option.empty());
       try {
@@ -1383,8 +1387,9 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       String newRollbackInstantTime = suppliedRollbackInstantTime.orElseGet(() -> createNewInstantTime(false));
       HoodieInstant rollbackInstant = new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.ROLLBACK_ACTION, newRollbackInstantTime,
           table.getMetaClient().getTimelineLayout().getInstantComparator().requestedTimeOrderedComparator());
+      Option<Map<String, String>> rollbackExtraMetadata = updateExtraMetadata(Option.empty());
       Option<HoodieRollbackPlan> rollbackPlan = table.scheduleRollback(context, newRollbackInstantTime, commitInstantOpt.get(),
-          false, config.shouldRollbackUsingMarkers(), false);
+          false, config.shouldRollbackUsingMarkers(), false, rollbackExtraMetadata);
       return Option.of(Pair.of(rollbackInstant, rollbackPlan));
     } finally {
       if (!skipLocking) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1023,7 +1023,8 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     txnManager.beginStateChange(Option.empty(), Option.empty());
     try {
       final String restoreInstantTimestamp = createNewInstantTime(false);
-      return Pair.of(restoreInstantTimestamp, table.scheduleRestore(context, restoreInstantTimestamp, savepointToRestoreTimestamp));
+      Option<Map<String, String>> extraMetadata = updateExtraMetadata(Option.empty());
+      return Pair.of(restoreInstantTimestamp, table.scheduleRestore(context, restoreInstantTimestamp, savepointToRestoreTimestamp, extraMetadata));
     } finally {
       txnManager.endStateChange(Option.empty());
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -565,13 +565,15 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
    * @param instantTime Instant Time for scheduling rollback
    * @param instantToRollback instant to be rolled back
    * @param shouldRollbackUsingMarkers uses marker based rollback strategy when set to true. uses list based rollback when false.
+   * @param extraMetadata additional metadata to be stored in the rollback plan.
    * @return HoodieRollbackPlan containing info on rollback.
    */
   public abstract Option<HoodieRollbackPlan> scheduleRollback(HoodieEngineContext context,
                                                               String instantTime,
                                                               HoodieInstant instantToRollback,
                                                               boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers,
-                                                              boolean isRestore);
+                                                              boolean isRestore,
+                                                              Option<Map<String, String>> extraMetadata);
 
   /**
    * Rollback the (inflight/committed) record changes with the given commit time.
@@ -632,7 +634,8 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
    */
   public abstract Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context,
                                                     String restoreInstantTimestamp,
-                                                    String savepointToRestoreTimestamp);
+                                                    String savepointToRestoreTimestamp,
+                                                    Option<Map<String, String>> extraMetadata);
 
   public void rollbackInflightCompaction(HoodieInstant inflightInstant, TransactionManager transactionManager) {
     rollbackInflightCompaction(inflightInstant, s -> Option.empty(), transactionManager);
@@ -703,7 +706,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
       transactionManager.beginStateChange(Option.empty(), Option.empty());
       try {
         instantTime = getMetaClient().createNewInstantTime(false);
-        scheduleRollback(context, instantTime, inflightInstant, false, config.shouldRollbackUsingMarkers(), false);
+        scheduleRollback(context, instantTime, inflightInstant, false, config.shouldRollbackUsingMarkers(), false, Option.empty());
       } finally {
         transactionManager.endStateChange(Option.empty());
       }
@@ -731,7 +734,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
               -> entry.getRollbackInstant().requestedTime())
           .orElseGet(() -> getMetaClient().createNewInstantTime(false));
       scheduleRollback(context, commitTime, inflightInstant, false, config.shouldRollbackUsingMarkers(),
-          false);
+          false, Option.empty());
     } finally {
       transactionManager.endStateChange(Option.empty());
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/BaseRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/BaseRestoreActionExecutor.java
@@ -76,7 +76,8 @@ public abstract class BaseRestoreActionExecutor<T, I, K, O> extends BaseActionEx
       throw new HoodieRollbackException("No pending restore instants found to execute restore");
     }
     try {
-      List<HoodieInstant> instantsToRollback = getInstantsToRollback(restoreInstant.get());
+      HoodieRestorePlan restorePlan = RestoreUtils.getRestorePlan(table.getMetaClient(), restoreInstant.get());
+      List<HoodieInstant> instantsToRollback = getInstantsToRollback(restorePlan);
       ValidationUtils.checkArgument(restoreInstant.get().getState().equals(HoodieInstant.State.REQUESTED)
           || restoreInstant.get().getState().equals(HoodieInstant.State.INFLIGHT));
       Map<String, List<HoodieRollbackMetadata>> instantToMetadata = new HashMap<>();
@@ -91,16 +92,16 @@ public abstract class BaseRestoreActionExecutor<T, I, K, O> extends BaseActionEx
 
       return finishRestore(instantToMetadata,
           instantsToRollback,
-          restoreTimer.endTimer()
+          restoreTimer.endTimer(),
+          restorePlan.getExtraMetadata()
       );
     } catch (IOException io) {
       throw new HoodieRestoreException("unable to Restore instant " + restoreInstant.get(), io);
     }
   }
 
-  private List<HoodieInstant> getInstantsToRollback(HoodieInstant restoreInstant) throws IOException {
+  private List<HoodieInstant> getInstantsToRollback(HoodieRestorePlan restorePlan) {
     List<HoodieInstant> instantsToRollback = new ArrayList<>();
-    HoodieRestorePlan restorePlan = RestoreUtils.getRestorePlan(table.getMetaClient(), restoreInstant);
     for (HoodieInstantInfo instantInfo : restorePlan.getInstantsToRollback()) {
       // If restore crashed midway, there are chances that some commits are already rolled back,
       // but some are not. so, we can ignore those commits which are fully rolledback in previous attempt if any.
@@ -119,10 +120,11 @@ public abstract class BaseRestoreActionExecutor<T, I, K, O> extends BaseActionEx
 
   private HoodieRestoreMetadata finishRestore(Map<String, List<HoodieRollbackMetadata>> instantToMetadata,
                                               List<HoodieInstant> instantsRolledBack,
-                                              long durationInMs) throws IOException {
+                                              long durationInMs,
+                                              Map<String, String> extraMetadata) throws IOException {
 
     HoodieRestoreMetadata restoreMetadata = TimelineMetadataUtils.convertRestoreMetadata(
-        instantTime, durationInMs, instantsRolledBack, instantToMetadata);
+        instantTime, durationInMs, instantsRolledBack, instantToMetadata, extraMetadata);
     HoodieInstant restoreInflightInstant = instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.RESTORE_ACTION, instantTime);
     writeToMetadata(restoreMetadata, restoreInflightInstant);
     table.getActiveTimeline().saveAsComplete(

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/CopyOnWriteRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/CopyOnWriteRestoreActionExecutor.java
@@ -53,7 +53,7 @@ public class CopyOnWriteRestoreActionExecutor<T, I, K, O>
       transactionManager.beginStateChange(Option.empty(), Option.empty());
       try {
         newInstantTime = table.getMetaClient().createNewInstantTime(false);
-        table.scheduleRollback(context, newInstantTime, instantToRollback, false, false, true);
+        table.scheduleRollback(context, newInstantTime, instantToRollback, false, false, true, Option.empty());
       } finally {
         transactionManager.endStateChange(Option.empty());
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/MergeOnReadRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/MergeOnReadRestoreActionExecutor.java
@@ -57,7 +57,7 @@ public class MergeOnReadRestoreActionExecutor<T, I, K, O>
       transactionManager.beginStateChange(Option.empty(), Option.empty());
       try {
         newInstantTime = table.getMetaClient().createNewInstantTime(false);
-        table.scheduleRollback(context, newInstantTime, instantToRollback, false, false, true);
+        table.scheduleRollback(context, newInstantTime, instantToRollback, false, false, true, Option.empty());
       } finally {
         transactionManager.endStateChange(Option.empty());
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
@@ -119,7 +119,8 @@ public abstract class BaseRollbackActionExecutor<T, I, K, O> extends BaseActionE
         instantTime,
         Option.of(rollbackTimer.endTimer()),
         Collections.singletonList(instantToRollback),
-        stats);
+        stats,
+        rollbackPlan.getExtraMetadata());
     finishRollback(inflightInstant, rollbackMetadata);
 
     // Finally, remove the markers post rollback.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackPlanActionExecutor.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Base rollback plan action executor to assist in scheduling rollback requests. This phase serialized {@link HoodieRollbackPlan}
@@ -47,6 +48,7 @@ public class BaseRollbackPlanActionExecutor<T, I, K, O> extends BaseActionExecut
   private final boolean skipTimelinePublish;
   private final boolean shouldRollbackUsingMarkers;
   protected final Boolean isRestore;
+  private final Option<Map<String, String>> extraMetadata;
 
   public static final Integer ROLLBACK_PLAN_VERSION_1 = 1;
   public static final Integer LATEST_ROLLBACK_PLAN_VERSION = ROLLBACK_PLAN_VERSION_1;
@@ -58,12 +60,14 @@ public class BaseRollbackPlanActionExecutor<T, I, K, O> extends BaseActionExecut
                                         HoodieInstant instantToRollback,
                                         boolean skipTimelinePublish,
                                         boolean shouldRollbackUsingMarkers,
-                                        boolean isRestore) {
+                                        boolean isRestore,
+                                        Option<Map<String, String>> extraMetadata) {
     super(context, config, table, instantTime);
     this.instantToRollback = instantToRollback;
     this.skipTimelinePublish = skipTimelinePublish;
     this.shouldRollbackUsingMarkers = shouldRollbackUsingMarkers && !instantToRollback.isCompleted();
     this.isRestore = isRestore;
+    this.extraMetadata = extraMetadata;
   }
 
   /**
@@ -107,7 +111,7 @@ public class BaseRollbackPlanActionExecutor<T, I, K, O> extends BaseActionExecut
         rollbackRequests.addAll(getRollbackStrategy().getRollbackRequests(instantToRollback));
       }
       HoodieRollbackPlan rollbackPlan = new HoodieRollbackPlan(new HoodieInstantInfo(instantToRollback.requestedTime(),
-          instantToRollback.getAction()), rollbackRequests, LATEST_ROLLBACK_PLAN_VERSION);
+          instantToRollback.getAction()), rollbackRequests, LATEST_ROLLBACK_PLAN_VERSION, extraMetadata.orElse(null));
       if (!skipTimelinePublish) {
         if (table.getRollbackTimeline().filterInflightsAndRequested().containsInstant(rollbackInstant.requestedTime())) {
           log.info("Request Rollback found with instant time {}, hence skipping scheduling rollback", rollbackInstant);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RestorePlanActionExecutor.java
@@ -38,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -55,14 +56,17 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
   public static final Integer RESTORE_PLAN_VERSION_2 = 2;
   public static final Integer LATEST_RESTORE_PLAN_VERSION = RESTORE_PLAN_VERSION_2;
   private final String savepointToRestoreTimestamp;
+  private final Option<Map<String, String>> extraMetadata;
 
   public RestorePlanActionExecutor(HoodieEngineContext context,
                                    HoodieWriteConfig config,
                                    HoodieTable<T, I, K, O> table,
                                    String instantTime,
-                                   String savepointToRestoreTimestamp) {
+                                   String savepointToRestoreTimestamp,
+                                   Option<Map<String, String>> extraMetadata) {
     super(context, config, table, instantTime);
     this.savepointToRestoreTimestamp = savepointToRestoreTimestamp;
+    this.extraMetadata = extraMetadata;
   }
 
   @Override
@@ -100,7 +104,7 @@ public class RestorePlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T,
             .map(entry -> new HoodieInstantInfo(entry.requestedTime(), entry.getAction()))
             .collect(Collectors.toList());
       }
-      HoodieRestorePlan restorePlan = new HoodieRestorePlan(instantsToRollback, LATEST_RESTORE_PLAN_VERSION, savepointToRestoreTimestamp);
+      HoodieRestorePlan restorePlan = new HoodieRestorePlan(instantsToRollback, LATEST_RESTORE_PLAN_VERSION, savepointToRestoreTimestamp, extraMetadata.orElse(null));
       table.getActiveTimeline().saveToRestoreRequested(restoreInstant, restorePlan);
       table.getMetaClient().reloadActiveTimeline();
       log.info("Requesting Restore with instant time {}", restoreInstant);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/savepoint/SavepointActionExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.table.action.savepoint;
 
 import org.apache.hudi.avro.model.HoodieSavepointMetadata;
+import org.apache.hudi.client.CommitMetadataProperties;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieLogFile;
@@ -122,7 +123,8 @@ public class SavepointActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
         }, null);
       }
 
-      HoodieSavepointMetadata metadata = TimelineMetadataUtils.convertSavepointMetadata(user, comment, latestFilesMap);
+      Map<String, String> enrichedMetadata = CommitMetadataProperties.enrich(Option.empty(), config, context).orElse(null);
+      HoodieSavepointMetadata metadata = TimelineMetadataUtils.convertSavepointMetadata(user, comment, latestFilesMap, enrichedMetadata);
       // Nothing to save in the savepoint
       table.getActiveTimeline().createNewInstant(
           instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.SAVEPOINT_ACTION, instantTime));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieTableServiceClient.java
@@ -190,12 +190,12 @@ class TestBaseHoodieTableServiceClient extends HoodieCommonTestHarness {
     HoodieCleanMetadata metadata;
     if (generatesPlan) {
       HoodieCleanerPlan plan = new HoodieCleanerPlan();
-      when(mockTable.createCleanerPlan(any(), eq(Option.empty()))).thenReturn(Option.of(plan));
+      when(mockTable.createCleanerPlan(any(), any())).thenReturn(Option.of(plan));
       // create default clean metadata
       metadata = new HoodieCleanMetadata();
       when(mockTable.clean(any(), eq(cleanInstantTime))).thenReturn(metadata);
     } else {
-      when(mockTable.createCleanerPlan(any(), eq(Option.empty()))).thenReturn(Option.empty());
+      when(mockTable.createCleanerPlan(any(), any())).thenReturn(Option.empty());
       metadata = null;
     }
 
@@ -243,14 +243,14 @@ class TestBaseHoodieTableServiceClient extends HoodieCommonTestHarness {
     when(mockTable.getActiveTimeline().getCleanerTimeline().filterInflightsAndRequested().firstInstant()).thenReturn(Option.of(inflightCleaning));
     // mock planning
     HoodieCleanerPlan plan = new HoodieCleanerPlan();
-    when(mockTable.createCleanerPlan(any(), eq(Option.empty()))).thenReturn(Option.of(plan));
+    when(mockTable.createCleanerPlan(any(), any())).thenReturn(Option.of(plan));
     // create default clean metadata
     HoodieCleanMetadata metadata = new HoodieCleanMetadata();
     when(mockTable.clean(any(), eq(cleanInstantTime))).thenReturn(metadata);
 
     TestTableServiceClient tableServiceClient = new TestTableServiceClient(writeConfig, Collections.singletonList(mockTable).iterator(), Option.empty(), expectedRollbackInfo,
         Collections.singletonList(cleanInstantTime).iterator());
-    assertEquals(metadata, tableServiceClient.clean(Option.empty(), true));
+    assertSame(metadata, tableServiceClient.clean(Option.empty(), true));
     verify(mockMetaClient).reloadActiveTimeline();
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestCommitMetadataProperties.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestCommitMetadataProperties.java
@@ -18,8 +18,17 @@
 
 package org.apache.hudi.client;
 
+import org.apache.hudi.avro.model.HoodieInstantInfo;
+import org.apache.hudi.avro.model.HoodieRestoreMetadata;
+import org.apache.hudi.avro.model.HoodieRestorePlan;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackPlan;
+import org.apache.hudi.avro.model.HoodieSavepointMetadata;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.TimelineMetadataUtils;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 
@@ -153,6 +162,120 @@ class TestCommitMetadataProperties {
     assertEquals("caller.value1", result.get("caller.key1"));
     assertEquals("caller.value2", result.get("caller.key2"));
     assertNotNull(result.get(HUDI_VERSION_KEY));
+  }
+
+  // ---- Tests for extraMetadata in all instant types ----
+
+  @Test
+  void rollbackPlan_extraMetadataFieldPresent() {
+    Map<String, String> extraMetadata = new HashMap<>();
+    extraMetadata.put(HUDI_VERSION_KEY, "1.2.0");
+    extraMetadata.put(ENGINE_KEY, "SPARK");
+
+    HoodieRollbackPlan plan = new HoodieRollbackPlan(
+        new HoodieInstantInfo("001", "commit"),
+        Collections.emptyList(), 1, extraMetadata);
+
+    assertEquals("1.2.0", plan.getExtraMetadata().get(HUDI_VERSION_KEY));
+    assertEquals("SPARK", plan.getExtraMetadata().get(ENGINE_KEY));
+  }
+
+  @Test
+  void rollbackPlan_extraMetadataNullByDefault() {
+    HoodieRollbackPlan plan = new HoodieRollbackPlan(
+        new HoodieInstantInfo("001", "commit"),
+        Collections.emptyList(), 1, null);
+
+    assertEquals(null, plan.getExtraMetadata());
+  }
+
+  @Test
+  void rollbackMetadata_extraMetadataViaConvertMethod() {
+    Map<String, String> extraMetadata = new HashMap<>();
+    extraMetadata.put(HUDI_VERSION_KEY, "1.2.0");
+    extraMetadata.put(ENGINE_KEY, "SPARK");
+    extraMetadata.put("spark.application.id", "app-123");
+
+    HoodieInstant instant = new HoodieInstant(HoodieInstant.State.INFLIGHT, "commit", "001",
+        HoodieTestUtils.INSTANT_COMPARATOR.requestedTimeOrderedComparator());
+    HoodieRollbackMetadata metadata = TimelineMetadataUtils.convertRollbackMetadata(
+        "002", Option.of(100L), Collections.singletonList(instant), Collections.emptyList(), extraMetadata);
+
+    assertNotNull(metadata.getExtraMetadata());
+    assertEquals("1.2.0", metadata.getExtraMetadata().get(HUDI_VERSION_KEY));
+    assertEquals("SPARK", metadata.getExtraMetadata().get(ENGINE_KEY));
+    assertEquals("app-123", metadata.getExtraMetadata().get("spark.application.id"));
+  }
+
+  @Test
+  void rollbackMetadata_noExtraMetadataByDefault() {
+    HoodieInstant instant = new HoodieInstant(HoodieInstant.State.INFLIGHT, "commit", "001",
+        HoodieTestUtils.INSTANT_COMPARATOR.requestedTimeOrderedComparator());
+    HoodieRollbackMetadata metadata = TimelineMetadataUtils.convertRollbackMetadata(
+        "002", Option.of(100L), Collections.singletonList(instant), Collections.emptyList());
+
+    assertEquals(null, metadata.getExtraMetadata());
+  }
+
+  @Test
+  void savepointMetadata_extraMetadataViaConvertMethod() {
+    Map<String, String> extraMetadata = new HashMap<>();
+    extraMetadata.put(HUDI_VERSION_KEY, "1.2.0");
+    extraMetadata.put(ENGINE_KEY, "JAVA");
+
+    HoodieSavepointMetadata metadata = TimelineMetadataUtils.convertSavepointMetadata(
+        "user", "test comment", Collections.emptyMap(), extraMetadata);
+
+    assertNotNull(metadata.getExtraMetadata());
+    assertEquals("1.2.0", metadata.getExtraMetadata().get(HUDI_VERSION_KEY));
+    assertEquals("JAVA", metadata.getExtraMetadata().get(ENGINE_KEY));
+  }
+
+  @Test
+  void savepointMetadata_noExtraMetadataByDefault() {
+    HoodieSavepointMetadata metadata = TimelineMetadataUtils.convertSavepointMetadata(
+        "user", "test comment", Collections.emptyMap());
+
+    assertEquals(null, metadata.getExtraMetadata());
+  }
+
+  @Test
+  void restorePlan_extraMetadataFieldPresent() {
+    Map<String, String> extraMetadata = new HashMap<>();
+    extraMetadata.put(HUDI_VERSION_KEY, "1.2.0");
+    extraMetadata.put(ENGINE_KEY, "FLINK");
+
+    HoodieRestorePlan plan = new HoodieRestorePlan(
+        Collections.emptyList(), 2, "savepoint-001", extraMetadata);
+
+    assertEquals("1.2.0", plan.getExtraMetadata().get(HUDI_VERSION_KEY));
+    assertEquals("FLINK", plan.getExtraMetadata().get(ENGINE_KEY));
+  }
+
+  @Test
+  void restoreMetadata_extraMetadataViaConvertMethod() {
+    Map<String, String> extraMetadata = new HashMap<>();
+    extraMetadata.put(HUDI_VERSION_KEY, "1.2.0");
+    extraMetadata.put(ENGINE_KEY, "SPARK");
+
+    HoodieInstant instant = new HoodieInstant(HoodieInstant.State.COMPLETED, "commit", "001",
+        HoodieTestUtils.INSTANT_COMPARATOR.requestedTimeOrderedComparator());
+    HoodieRestoreMetadata metadata = TimelineMetadataUtils.convertRestoreMetadata(
+        "002", 100L, Collections.singletonList(instant), Collections.emptyMap(), extraMetadata);
+
+    assertNotNull(metadata.getExtraMetadata());
+    assertEquals("1.2.0", metadata.getExtraMetadata().get(HUDI_VERSION_KEY));
+    assertEquals("SPARK", metadata.getExtraMetadata().get(ENGINE_KEY));
+  }
+
+  @Test
+  void restoreMetadata_noExtraMetadataByDefault() {
+    HoodieInstant instant = new HoodieInstant(HoodieInstant.State.COMPLETED, "commit", "001",
+        HoodieTestUtils.INSTANT_COMPARATOR.requestedTimeOrderedComparator());
+    HoodieRestoreMetadata metadata = TimelineMetadataUtils.convertRestoreMetadata(
+        "002", 100L, Collections.singletonList(instant), Collections.emptyMap());
+
+    assertEquals(null, metadata.getExtraMetadata());
   }
 
   private static HoodieWriteConfig newConfig(Properties overrides) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/TestBaseHoodieTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/TestBaseHoodieTable.java
@@ -130,7 +130,8 @@ public class TestBaseHoodieTable extends HoodieTable {
 
   @Override
   public Option<HoodieRollbackPlan> scheduleRollback(HoodieEngineContext context, String instantTime, HoodieInstant instantToRollback,
-                                                     boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers, boolean isRestore) {
+                                                     boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers, boolean isRestore,
+                                                     Option extraMetadata) {
     countOfScheduleRollbackFunctionCalls++;
     return null;
   }
@@ -161,7 +162,8 @@ public class TestBaseHoodieTable extends HoodieTable {
   }
 
   @Override
-  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp) {
+  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp,
+                                                    Option extraMetadata) {
     return null;
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/TestCleanPlanner.java
@@ -596,7 +596,7 @@ public class TestCleanPlanner {
     Map<String, HoodieSavepointPartitionMetadata> partitionMetadata = new HashMap<>();
     List<String> fileNames = paths.stream().map(path -> path.substring(path.lastIndexOf("/") + 1)).collect(Collectors.toList());
     partitionMetadata.put(partition, new HoodieSavepointPartitionMetadata(partition, fileNames));
-    return new HoodieSavepointMetadata("user", 1L, "comments", partitionMetadata, 1);
+    return new HoodieSavepointMetadata("user", 1L, "comments", partitionMetadata, 1, null);
   }
 
   private static HoodieCleanMetadata getCleanCommitMetadata(List<String> partitions, String instantTime, String earliestCommitToRetain,
@@ -613,7 +613,7 @@ public class TestCleanPlanner {
   private static HoodieSavepointMetadata getSavepointMetadata(List<String> partitions) {
     Map<String, HoodieSavepointPartitionMetadata> partitionMetadata = new HashMap<>();
     partitions.forEach(partition -> partitionMetadata.put(partition, new HoodieSavepointPartitionMetadata(partition, Collections.emptyList())));
-    return new HoodieSavepointMetadata("user", 1L, "comments", partitionMetadata, 1);
+    return new HoodieSavepointMetadata("user", 1L, "comments", partitionMetadata, 1, null);
   }
 
   private static HoodieCleanerPlan mockLastCleanCommit(HoodieTable hoodieTable, String timestamp, String earliestCommitToRetain, HoodieActiveTimeline activeTimeline,

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkCopyOnWriteTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkCopyOnWriteTable.java
@@ -355,9 +355,10 @@ public class HoodieFlinkCopyOnWriteTable<T>
 
   @Override
   public Option<HoodieRollbackPlan> scheduleRollback(HoodieEngineContext context, String instantTime, HoodieInstant instantToRollback,
-                                                     boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers, boolean isRestore) {
+                                                     boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers, boolean isRestore,
+                                                     Option<Map<String, String>> extraMetadata) {
     return new BaseRollbackPlanActionExecutor(context, config, this, instantTime, instantToRollback, skipTimelinePublish,
-        shouldRollbackUsingMarkers, isRestore).execute();
+        shouldRollbackUsingMarkers, isRestore, extraMetadata).execute();
   }
 
   @Override
@@ -387,7 +388,8 @@ public class HoodieFlinkCopyOnWriteTable<T>
   }
 
   @Override
-  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp) {
+  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp,
+                                                    Option<Map<String, String>> extraMetadata) {
     throw new HoodieNotSupportedException("Restore is not supported yet");
   }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkMergeOnReadTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkMergeOnReadTable.java
@@ -154,9 +154,10 @@ public class HoodieFlinkMergeOnReadTable<T>
 
   @Override
   public Option<HoodieRollbackPlan> scheduleRollback(HoodieEngineContext context, String instantTime, HoodieInstant instantToRollback,
-                                                     boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers, boolean isRestore) {
+                                                     boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers, boolean isRestore,
+                                                     Option<Map<String, String>> extraMetadata) {
     return new BaseRollbackPlanActionExecutor(context, config, this, instantTime, instantToRollback, skipTimelinePublish,
-        shouldRollbackUsingMarkers, isRestore).execute();
+        shouldRollbackUsingMarkers, isRestore, extraMetadata).execute();
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaCopyOnWriteTable.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/HoodieJavaCopyOnWriteTable.java
@@ -217,9 +217,10 @@ public class HoodieJavaCopyOnWriteTable<T>
 
   @Override
   public Option<HoodieRollbackPlan> scheduleRollback(HoodieEngineContext context, String instantTime, HoodieInstant instantToRollback,
-                                                     boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers, boolean isRestore) {
+                                                     boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers, boolean isRestore,
+                                                     Option<Map<String, String>> extraMetadata) {
     return new BaseRollbackPlanActionExecutor(context, config, this, instantTime, instantToRollback, skipTimelinePublish,
-        shouldRollbackUsingMarkers, isRestore).execute();
+        shouldRollbackUsingMarkers, isRestore, extraMetadata).execute();
   }
 
   @Override
@@ -263,8 +264,9 @@ public class HoodieJavaCopyOnWriteTable<T>
   }
 
   @Override
-  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp) {
-    return new RestorePlanActionExecutor(context, config, this, restoreInstantTimestamp, savepointToRestoreTimestamp).execute();
+  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp,
+                                                    Option<Map<String, String>> extraMetadata) {
+    return new RestorePlanActionExecutor(context, config, this, restoreInstantTimestamp, savepointToRestoreTimestamp, extraMetadata).execute();
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkCopyOnWriteTable.java
@@ -206,7 +206,7 @@ public class HoodieSparkCopyOnWriteTable<T>
     } catch (HoodieMetadataException e) {
       throw new HoodieException("Failed to delete metadata table.", e);
     }
-    new RestorePlanActionExecutor<>(context, config, this, instantTime, HoodieTimeline.INIT_INSTANT_TS).execute();
+    new RestorePlanActionExecutor<>(context, config, this, instantTime, HoodieTimeline.INIT_INSTANT_TS, Option.empty()).execute();
     new CopyOnWriteRestoreActionExecutor<>(context, config, this, instantTime, HoodieTimeline.INIT_INSTANT_TS).execute();
   }
 
@@ -219,9 +219,9 @@ public class HoodieSparkCopyOnWriteTable<T>
   public Option<HoodieRollbackPlan> scheduleRollback(HoodieEngineContext context,
                                                      String instantTime,
                                                      HoodieInstant instantToRollback, boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers,
-                                                     boolean isRestore) {
+                                                     boolean isRestore, Option<Map<String, String>> extraMetadata) {
     return new BaseRollbackPlanActionExecutor<>(context, config, this, instantTime, instantToRollback, skipTimelinePublish,
-        shouldRollbackUsingMarkers, isRestore).execute();
+        shouldRollbackUsingMarkers, isRestore, extraMetadata).execute();
   }
 
   /**
@@ -310,8 +310,9 @@ public class HoodieSparkCopyOnWriteTable<T>
   }
 
   @Override
-  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp) {
-    return new RestorePlanActionExecutor<>(context, config, this, restoreInstantTimestamp, savepointToRestoreTimestamp).execute();
+  public Option<HoodieRestorePlan> scheduleRestore(HoodieEngineContext context, String restoreInstantTimestamp, String savepointToRestoreTimestamp,
+                                                    Option<Map<String, String>> extraMetadata) {
+    return new RestorePlanActionExecutor<>(context, config, this, restoreInstantTimestamp, savepointToRestoreTimestamp, extraMetadata).execute();
   }
 
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadTable.java
@@ -186,7 +186,7 @@ public class HoodieSparkMergeOnReadTable<T> extends HoodieSparkCopyOnWriteTable<
       throw new HoodieException("Failed to delete metadata table.", e);
     }
 
-    new RestorePlanActionExecutor<>(context, config, this, instantTime, HoodieTimeline.INIT_INSTANT_TS).execute();
+    new RestorePlanActionExecutor<>(context, config, this, instantTime, HoodieTimeline.INIT_INSTANT_TS, Option.empty()).execute();
     new MergeOnReadRestoreActionExecutor<>(context, config, this, instantTime, HoodieTimeline.INIT_INSTANT_TS).execute();
   }
 
@@ -194,9 +194,9 @@ public class HoodieSparkMergeOnReadTable<T> extends HoodieSparkCopyOnWriteTable<
   public Option<HoodieRollbackPlan> scheduleRollback(HoodieEngineContext context,
                                                      String instantTime,
                                                      HoodieInstant instantToRollback, boolean skipTimelinePublish, boolean shouldRollbackUsingMarkers,
-                                                     boolean isRestore) {
+                                                     boolean isRestore, Option<Map<String, String>> extraMetadata) {
     return new BaseRollbackPlanActionExecutor<>(context, config, this, instantTime, instantToRollback, skipTimelinePublish,
-        shouldRollbackUsingMarkers, isRestore).execute();
+        shouldRollbackUsingMarkers, isRestore, extraMetadata).execute();
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkCommitActionExecutor.java
@@ -155,7 +155,7 @@ public abstract class BaseSparkCommitActionExecutor<T> extends
           String commitTime;
           try {
             commitTime = table.getMetaClient().createNewInstantTime(false);
-            table.scheduleRollback(context, commitTime, instant, false, config.shouldRollbackUsingMarkers(), false);
+            table.scheduleRollback(context, commitTime, instant, false, config.shouldRollbackUsingMarkers(), false, Option.empty());
           } finally {
             transactionManager.endStateChange(Option.empty());
           }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreCopyOnWrite.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreCopyOnWrite.java
@@ -207,7 +207,7 @@ public class TestSavepointRestoreCopyOnWrite extends HoodieClientTestBase {
         HoodieInstant pendingInstant = metaClient.getActiveTimeline().filterPendingExcludingCompaction()
             .lastInstant().orElseThrow(() -> new HoodieException("Pending instant does not exist"));
         HoodieSparkTable.create(client.getConfig(), context)
-            .scheduleRollback(context, WriteClientTestUtils.createNewInstantTime(), pendingInstant, false, true, false);
+            .scheduleRollback(context, WriteClientTestUtils.createNewInstantTime(), pendingInstant, false, true, false, Option.empty());
       }
       Option<String> rollbackInstant = metaClient.reloadActiveTimeline().getRollbackTimeline().lastInstant().map(HoodieInstant::requestedTime);
       assertTrue(rollbackInstant.isPresent(), "The latest instant should be a rollback");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreCopyOnWriteWithTestFormat.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreCopyOnWriteWithTestFormat.java
@@ -197,7 +197,7 @@ public class TestSavepointRestoreCopyOnWriteWithTestFormat extends HoodieClientT
         HoodieInstant pendingInstant = metaClient.getActiveTimeline().filterPendingExcludingCompaction()
             .lastInstant().orElseThrow(() -> new HoodieException("Pending instant does not exist"));
         HoodieSparkTable.create(client.getConfig(), context)
-            .scheduleRollback(context, WriteClientTestUtils.createNewInstantTime(), pendingInstant, false, true, false);
+            .scheduleRollback(context, WriteClientTestUtils.createNewInstantTime(), pendingInstant, false, true, false, Option.empty());
       }
       Option<String> rollbackInstant = metaClient.reloadActiveTimeline().getRollbackTimeline().lastInstant().map(HoodieInstant::requestedTime);
       assertTrue(rollbackInstant.isPresent(), "The latest instant should be a rollback");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -907,7 +907,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
         INSTANT_GENERATOR.createNewInstant(State.REQUESTED, COMMIT_ACTION, "001"), Option.empty());
     metaClient.reloadActiveTimeline();
     HoodieInstant rollbackInstant = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, COMMIT_ACTION, "001");
-    table.scheduleRollback(context, "002", rollbackInstant, false, config.shouldRollbackUsingMarkers(), false);
+    table.scheduleRollback(context, "002", rollbackInstant, false, config.shouldRollbackUsingMarkers(), false, Option.empty());
     table.rollback(context, "002", rollbackInstant, true, false);
     final int numTempFilesAfter = testTable.listAllFilesInTempFolder().length;
     assertEquals(0, numTempFilesAfter, "All temp files are deleted.");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestMarkerBasedRollbackStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestMarkerBasedRollbackStrategy.java
@@ -389,7 +389,7 @@ public class TestMarkerBasedRollbackStrategy extends HoodieClientTestBase {
         rollbackRequests.size());
     HoodieRollbackPlan rollbackPlan = new HoodieRollbackPlan(
         new HoodieInstantInfo(instantTime3, HoodieTimeline.DELTA_COMMIT_ACTION),
-        rollbackRequests, LATEST_ROLLBACK_PLAN_VERSION);
+        rollbackRequests, LATEST_ROLLBACK_PLAN_VERSION, null);
     EmbeddedTimelineService timelineServer =
         EmbeddedTimelineServerHelper.createEmbeddedTimelineService(context, writeConfig);
     writeConfig.setViewStorageConfig(timelineServer.getRemoteFileSystemViewConfig(writeConfig));

--- a/hudi-common/src/main/avro/HoodieRestoreMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieRestoreMetadata.avsc
@@ -44,6 +44,14 @@
          "default": null,
          "items": "HoodieInstantInfo"
        }
+     },
+     {
+        "name":"extraMetadata",
+        "type":["null", {
+           "type":"map",
+           "values":"string"
+        }],
+        "default": null
      }
  ]
 }

--- a/hudi-common/src/main/avro/HoodieRestorePlan.avsc
+++ b/hudi-common/src/main/avro/HoodieRestorePlan.avsc
@@ -38,6 +38,14 @@
            "name": "savepointToRestoreTimestamp",
            "type": ["null", "string"],
            "default": null
+    },
+    {
+           "name":"extraMetadata",
+           "type":["null", {
+              "type":"map",
+              "values":"string"
+           }],
+           "default": null
     }
     ]
 }

--- a/hudi-common/src/main/avro/HoodieRollbackMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieRollbackMetadata.avsc
@@ -66,6 +66,14 @@
           "default": [],
           "items": "HoodieInstantInfo"
        }
+     },
+     {
+        "name":"extraMetadata",
+        "type":["null", {
+           "type":"map",
+           "values":"string"
+        }],
+        "default": null
      }
  ]
 }

--- a/hudi-common/src/main/avro/HoodieRollbackPlan.avsc
+++ b/hudi-common/src/main/avro/HoodieRollbackPlan.avsc
@@ -71,6 +71,14 @@
        "name":"version",
        "type":["int", "null"],
        "default": 1
+    },
+    {
+       "name":"extraMetadata",
+       "type":["null", {
+          "type":"map",
+          "values":"string"
+       }],
+       "default": null
     }
   ]
 }

--- a/hudi-common/src/main/avro/HoodieSavePointMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieSavePointMetadata.avsc
@@ -37,6 +37,14 @@
         "name":"version",
         "type":["int", "null"],
         "default": 1
+     },
+     {
+        "name":"extraMetadata",
+        "type":["null", {
+           "type":"map",
+           "values":"string"
+        }],
+        "default": null
      }
  ]
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineMetadataUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineMetadataUtils.java
@@ -76,14 +76,29 @@ public class TimelineMetadataUtils {
                                                              long durationInMs,
                                                              List<HoodieInstant> instants,
                                                              Map<String, List<HoodieRollbackMetadata>> instantToRollbackMetadata) {
+    return convertRestoreMetadata(startRestoreTime, durationInMs, instants, instantToRollbackMetadata, null);
+  }
+
+  public static HoodieRestoreMetadata convertRestoreMetadata(String startRestoreTime,
+                                                             long durationInMs,
+                                                             List<HoodieInstant> instants,
+                                                             Map<String, List<HoodieRollbackMetadata>> instantToRollbackMetadata,
+                                                             Map<String, String> extraMetadata) {
     return new HoodieRestoreMetadata(startRestoreTime, durationInMs,
         instants.stream().map(HoodieInstant::requestedTime).collect(Collectors.toList()),
         Collections.unmodifiableMap(instantToRollbackMetadata), DEFAULT_VERSION,
-        instants.stream().map(instant -> new HoodieInstantInfo(instant.requestedTime(), instant.getAction())).collect(Collectors.toList()));
+        instants.stream().map(instant -> new HoodieInstantInfo(instant.requestedTime(), instant.getAction())).collect(Collectors.toList()),
+        extraMetadata);
   }
 
   public static HoodieRollbackMetadata convertRollbackMetadata(String startRollbackTime, Option<Long> durationInMs,
                                                                List<HoodieInstant> instants, List<HoodieRollbackStat> rollbackStats) {
+    return convertRollbackMetadata(startRollbackTime, durationInMs, instants, rollbackStats, null);
+  }
+
+  public static HoodieRollbackMetadata convertRollbackMetadata(String startRollbackTime, Option<Long> durationInMs,
+                                                               List<HoodieInstant> instants, List<HoodieRollbackStat> rollbackStats,
+                                                               Map<String, String> extraMetadata) {
     Map<String, HoodieRollbackPartitionMetadata> partitionMetadataBuilder = new HashMap<>();
     int totalDeleted = 0;
     for (HoodieRollbackStat stat : rollbackStats) {
@@ -98,18 +113,25 @@ public class TimelineMetadataUtils {
     return new HoodieRollbackMetadata(startRollbackTime, durationInMs.orElseGet(() -> -1L), totalDeleted,
         instants.stream().map(HoodieInstant::requestedTime).collect(Collectors.toList()),
         Collections.unmodifiableMap(partitionMetadataBuilder), DEFAULT_VERSION,
-        instants.stream().map(instant -> new HoodieInstantInfo(instant.requestedTime(), instant.getAction())).collect(Collectors.toList()));
+        instants.stream().map(instant -> new HoodieInstantInfo(instant.requestedTime(), instant.getAction())).collect(Collectors.toList()),
+        extraMetadata);
   }
 
   public static HoodieSavepointMetadata convertSavepointMetadata(String user, String comment,
                                                                  Map<String, List<String>> latestFiles) {
+    return convertSavepointMetadata(user, comment, latestFiles, null);
+  }
+
+  public static HoodieSavepointMetadata convertSavepointMetadata(String user, String comment,
+                                                                 Map<String, List<String>> latestFiles,
+                                                                 Map<String, String> extraMetadata) {
     Map<String, HoodieSavepointPartitionMetadata> partitionMetadataBuilder = new HashMap<>();
     for (Map.Entry<String, List<String>> stat : latestFiles.entrySet()) {
       HoodieSavepointPartitionMetadata metadata = new HoodieSavepointPartitionMetadata(stat.getKey(), stat.getValue());
       partitionMetadataBuilder.put(stat.getKey(), metadata);
     }
     return new HoodieSavepointMetadata(user, System.currentTimeMillis(), comment,
-        Collections.unmodifiableMap(partitionMetadataBuilder), DEFAULT_VERSION);
+        Collections.unmodifiableMap(partitionMetadataBuilder), DEFAULT_VERSION, extraMetadata);
   }
 
   public static <T extends SpecificRecordBase> Option<byte[]> serializeAvroMetadata(T metadata, Class<T> clazz)

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
@@ -125,7 +125,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     // execute CopyOnWriteRollbackActionExecutor with filelisting mode
     BaseRollbackPlanActionExecutor copyOnWriteRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, table.getConfig(), table, rollbackInstant, needRollBackInstant, false,
-            table.getConfig().shouldRollbackUsingMarkers(), false);
+            table.getConfig().shouldRollbackUsingMarkers(), false, Option.empty());
     HoodieRollbackPlan rollbackPlan = (HoodieRollbackPlan) copyOnWriteRollbackPlanActionExecutor.execute().get();
     CopyOnWriteRollbackActionExecutor copyOnWriteRollbackActionExecutor = new CopyOnWriteRollbackActionExecutor(context, table.getConfig(), table, "003", needRollBackInstant, true,
         false);
@@ -290,7 +290,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     // Schedule rollback
     BaseRollbackPlanActionExecutor copyOnWriteRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, table.getConfig(), table, "003", needRollBackInstant, false,
-            table.getConfig().shouldRollbackUsingMarkers(), false);
+            table.getConfig().shouldRollbackUsingMarkers(), false, Option.empty());
     HoodieRollbackPlan hoodieRollbackPlan = (HoodieRollbackPlan) copyOnWriteRollbackPlanActionExecutor.execute().get();
 
     // execute CopyOnWriteRollbackActionExecutor with filelisting mode
@@ -315,7 +315,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
 
     BaseRollbackPlanActionExecutor copyOnWriteRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, table.getConfig(), table, "003", commitInstant, false,
-            table.getConfig().shouldRollbackUsingMarkers(), false);
+            table.getConfig().shouldRollbackUsingMarkers(), false, Option.empty());
     HoodieRollbackPlan hoodieRollbackPlan = (HoodieRollbackPlan) copyOnWriteRollbackPlanActionExecutor.execute().get();
     CopyOnWriteRollbackActionExecutor copyOnWriteRollbackActionExecutor = new CopyOnWriteRollbackActionExecutor(context, cfg, table, "003", commitInstant, false,
         false);
@@ -391,7 +391,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     BaseRollbackPlanActionExecutor copyOnWriteRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, table.getConfig(), table, "003",
             needRollBackInstant, false,
-            table.getConfig().shouldRollbackUsingMarkers(), false);
+            table.getConfig().shouldRollbackUsingMarkers(), false, Option.empty());
     copyOnWriteRollbackPlanActionExecutor.execute();
 
     CopyOnWriteRollbackActionExecutor copyOnWriteRollbackActionExecutor =
@@ -519,7 +519,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     // Schedule rollback
     BaseRollbackPlanActionExecutor copyOnWriteRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, table.getConfig(), table, "007", needRollBackInstant, false,
-            table.getConfig().shouldRollbackUsingMarkers(), false);
+            table.getConfig().shouldRollbackUsingMarkers(), false, Option.empty());
     HoodieRollbackPlan hoodieRollbackPlan = (HoodieRollbackPlan) copyOnWriteRollbackPlanActionExecutor.execute().get();
 
     // execute CopyOnWriteRollbackActionExecutor with filelisting mode
@@ -601,7 +601,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     String rollbackInstant = WriteClientTestUtils.createNewInstantTime();
     BaseRollbackPlanActionExecutor copyOnWriteRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, table.getConfig(), table, rollbackInstant, needRollBackInstant, false,
-            !table.getConfig().shouldRollbackUsingMarkers(), false);
+            table.getConfig().shouldRollbackUsingMarkers(), false, Option.empty());
     copyOnWriteRollbackPlanActionExecutor.execute().get();
 
     // execute CopyOnWriteRollbackActionExecutor with filelisting mode
@@ -614,7 +614,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     rollbackInstant = WriteClientTestUtils.createNewInstantTime();
     copyOnWriteRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, table.getConfig(), table, rollbackInstant, needRollBackInstant, false,
-            table.getConfig().shouldRollbackUsingMarkers(), false);
+            table.getConfig().shouldRollbackUsingMarkers(), false, Option.empty());
     HoodieRollbackPlan rollbackPlan = (HoodieRollbackPlan) copyOnWriteRollbackPlanActionExecutor.execute().get();
 
     // execute CopyOnWriteRollbackActionExecutor with filelisting mode

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestMergeOnReadRollbackActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestMergeOnReadRollbackActionExecutor.java
@@ -139,7 +139,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
         HoodieTimeline.DELTA_COMMIT_ACTION, timestampToRollback);
     BaseRollbackPlanActionExecutor mergeOnReadRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, cfg, table, rollbackTime, rollBackInstant, false,
-            cfg.shouldRollbackUsingMarkers(), false);
+            cfg.shouldRollbackUsingMarkers(), false, Option.empty());
     mergeOnReadRollbackPlanActionExecutor.execute().get();
     MergeOnReadRollbackActionExecutor mergeOnReadRollbackActionExecutor = new MergeOnReadRollbackActionExecutor(
         context,
@@ -236,7 +236,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
       String rollbackTime = InProcessTimeGenerator.createNewInstantTime();
       BaseRollbackPlanActionExecutor mergeOnReadRollbackPlanActionExecutor =
           new BaseRollbackPlanActionExecutor(context, cfg, table, rollbackTime, rollBackInstant, false,
-              cfg.shouldRollbackUsingMarkers(), false);
+              cfg.shouldRollbackUsingMarkers(), false, Option.empty());
       mergeOnReadRollbackPlanActionExecutor.execute().get();
       MergeOnReadRollbackActionExecutor mergeOnReadRollbackActionExecutor = new MergeOnReadRollbackActionExecutor(
           context,
@@ -326,7 +326,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
         HoodieTimeline.DELTA_COMMIT_ACTION, timestampToRollback);
     BaseRollbackPlanActionExecutor mergeOnReadRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, cfg, table, rollbackTime, rollBackInstant, false,
-            cfg.shouldRollbackUsingMarkers(), true);
+            cfg.shouldRollbackUsingMarkers(), true, Option.empty());
     mergeOnReadRollbackPlanActionExecutor.execute().get();
     MergeOnReadRollbackActionExecutor mergeOnReadRollbackActionExecutor = new MergeOnReadRollbackActionExecutor(
         context,
@@ -348,7 +348,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
         HoodieTimeline.DELTA_COMMIT_ACTION, timestampToRollback);
     BaseRollbackPlanActionExecutor mergeOnReadRollbackPlanActionExecutor1 =
         new BaseRollbackPlanActionExecutor(context, cfg, table, rollbackTime, rollBackInstant1, false,
-            cfg.shouldRollbackUsingMarkers(), true);
+            cfg.shouldRollbackUsingMarkers(), true, Option.empty());
     mergeOnReadRollbackPlanActionExecutor1.execute().get();
     MergeOnReadRollbackActionExecutor mergeOnReadRollbackActionExecutor1 = new MergeOnReadRollbackActionExecutor(
         context,
@@ -457,7 +457,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
     String rollbackTimestamp = InProcessTimeGenerator.createNewInstantTime();
     BaseRollbackPlanActionExecutor mergeOnReadRollbackPlanActionExecutor =
         new BaseRollbackPlanActionExecutor(context, cfg, table, rollbackTimestamp, rollBackInstant, false,
-            cfg.shouldRollbackUsingMarkers(), false);
+            cfg.shouldRollbackUsingMarkers(), false, Option.empty());
     mergeOnReadRollbackPlanActionExecutor.execute().get();
     MergeOnReadRollbackActionExecutor mergeOnReadRollbackActionExecutor = new MergeOnReadRollbackActionExecutor(
         context,

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
@@ -462,7 +462,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
         HoodieInstant failedDeltaCommitInstant = activeTimeline.getDeltaCommitTimeline().lastInstant().get();
         assertEquals(commitTime1, failedDeltaCommitInstant.requestedTime());
         Option<HoodieRollbackPlan> rollbackPlan = hoodieTable.scheduleRollback(hoodieTable.getContext(), rollbackInstantTime,
-            failedDeltaCommitInstant, false, secondClient.getConfig().shouldRollbackUsingMarkers(), false);
+            failedDeltaCommitInstant, false, secondClient.getConfig().shouldRollbackUsingMarkers(), false, Option.empty());
         assertTrue(rollbackPlan.isPresent());
 
         MergeOnReadRollbackActionExecutor rollbackExecutor = new MergeOnReadRollbackActionExecutor<>(hoodieTable.getContext(),


### PR DESCRIPTION
Extend CommitMetadataProperties.enrich() to clean, rollback, savepoint, and restore instants so post-hoc debugging can identify which writer produced any instant on the timeline.

- Add nullable extraMetadata field to 5 Avro schemas (HoodieRollbackPlan, HoodieRollbackMetadata, HoodieSavePointMetadata, HoodieRestorePlan, HoodieRestoreMetadata)
- Wire enrich() into clean scheduling (was hardcoded Option.empty())
- Wire extraMetadata through rollback plan->completed metadata flow
- Wire extraMetadata through restore plan->completed metadata flow
- Call enrich() in SavepointActionExecutor for completed savepoints
- Fix clustering bug: plan extraMetadata not re-merged into completed HoodieReplaceCommitMetadata
- Add TimelineMetadataUtils overloads with extraMetadata parameter
- 10 new unit tests in TestCommitMetadataProperties

Jira Issues: T3-HUDI-9605

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
