### PR TITLE
[DNM] fix(spark): do not hold the deprecated populate.meta.fields against a…

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -181,6 +181,14 @@ object HoodieWriterUtils {
     ignoreConfig = ignoreConfig || (key.equals(PAYLOAD_CLASS_NAME.key()) && shouldIgnorePayloadValidation(value, tableConfig))
     // If hoodie.database.name is empty, ignore validation.
     ignoreConfig = ignoreConfig || (key.equals(HoodieTableConfig.DATABASE_NAME.key()) && isNullOrEmpty(getStringFromTableConfigWithAlternatives(tableConfig, key)))
+    // Once a table carries hoodie.meta.fields.mode, the mode is the source of truth and the deprecated
+    // hoodie.populate.meta.fields boolean is consulted only when the mode is absent. Tables below
+    // version 10 persist the derived boolean next to the mode for unpatched readers, so a writer that
+    // still states the legacy boolean must not trip a conflict against that persisted copy; the mode
+    // comparison below and BaseHoodieWriteClient#validateAgainstTableProperties enforce agreement on
+    // the resolved mode. Tables that predate the mode property keep the boolean comparison.
+    ignoreConfig = ignoreConfig || (key.equals(HoodieTableConfig.POPULATE_META_FIELDS.key())
+      && tableConfig != null && tableConfig.contains(HoodieTableConfig.META_FIELDS_MODE))
     ignoreConfig
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieWriterUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieWriterUtils.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Properties;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getMetaClientBuilder;
@@ -118,6 +119,62 @@ class TestHoodieWriterUtils extends HoodieClientTestBase {
     // Narrowing is still a disagreement here: hoodie.properties would keep advertising ALL while the
     // writer stopped populating the columns.
     assertModeAgainstTable("NONE", MetaFieldsMode.ALL, "metaModeNoneOnAll", true);
+  }
+
+  /**
+   * Below table version 10 a table persists the deprecated {@code hoodie.populate.meta.fields} next to
+   * {@code hoodie.meta.fields.mode} (see {@code HoodieTableMetaClient.TableBuilder}). The key-by-key
+   * conflict loop must not hold a writer that still states the legacy boolean against that persisted
+   * copy: the mode is the source of truth and the boolean is consulted only when the mode is absent.
+   * Version 10 tables never hit this branch because they do not persist the boolean at all.
+   */
+  @Test
+  void validateTableConfigIgnoresTheLegacyBooleanOnceTheTableCarriesAMode() throws IOException {
+    for (MetaFieldsMode tableMode : new MetaFieldsMode[] {MetaFieldsMode.NONE, MetaFieldsMode.ALL}) {
+      HoodieTableConfig tableConfig = initTableBelowVersionTen(tableMode, "legacyBooleanIgnored-" + tableMode).getTableConfig();
+      assertEquals(String.valueOf(tableMode.toLegacyPopulateMetaFields()),
+          tableConfig.getProps().getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+          "precondition: a table below v10 persists the derived boolean next to the mode");
+
+      // The writer states the opposite of what the table persisted, and nothing about the mode.
+      TypedProperties writeProps = TypedProperties.copy(tableConfig.getProps());
+      writeProps.remove(HoodieTableConfig.META_FIELDS_MODE.key());
+      writeProps.put(HoodieTableConfig.POPULATE_META_FIELDS.key(),
+          String.valueOf(!tableMode.toLegacyPopulateMetaFields()));
+      Assertions.assertDoesNotThrow(() -> HoodieWriterUtils.validateTableConfig(
+          sparkSession, JavaScalaConverters.convertJavaPropertiesToScalaMap(writeProps), tableConfig),
+          "the deprecated boolean must not override a table that carries " + tableMode);
+    }
+  }
+
+  /**
+   * A table written before the mode property existed carries only the boolean, so the boolean is still
+   * the only statement of its meta-field layout and a contradicting writer must keep being rejected.
+   */
+  @Test
+  void validateTableConfigStillRejectsTheLegacyBooleanOnATableWithoutAMode() throws IOException {
+    HoodieTableMetaClient metaClient = initTableBelowVersionTen(MetaFieldsMode.NONE, "legacyBooleanRejected");
+    // Strip the mode the builder wrote, leaving the legacy shape: populate.meta.fields=false only.
+    HoodieTableConfig.delete(metaClient.getStorage(), metaClient.getMetaPath(),
+        Collections.singleton(HoodieTableConfig.META_FIELDS_MODE.key()));
+    HoodieTableConfig legacyTableConfig = HoodieTableMetaClient.reload(metaClient).getTableConfig();
+    assertFalse(legacyTableConfig.getProps().containsKey(HoodieTableConfig.META_FIELDS_MODE.key()),
+        "precondition: the table must carry only the legacy boolean");
+    assertEquals(MetaFieldsMode.NONE, legacyTableConfig.getMetaFieldsMode());
+
+    TypedProperties writeProps = TypedProperties.copy(legacyTableConfig.getProps());
+    writeProps.put(HoodieTableConfig.POPULATE_META_FIELDS.key(), "true");
+    HoodieException ex = assertThrows(HoodieException.class, () -> HoodieWriterUtils.validateTableConfig(
+        sparkSession, JavaScalaConverters.convertJavaPropertiesToScalaMap(writeProps), legacyTableConfig));
+    assertTrue(ex.getMessage().contains(HoodieTableConfig.POPULATE_META_FIELDS.key()), ex.getMessage());
+  }
+
+  private HoodieTableMetaClient initTableBelowVersionTen(MetaFieldsMode mode, String tableDir) throws IOException {
+    Properties tableProps = new Properties();
+    tableProps.put(HoodieTableConfig.META_FIELDS_MODE.key(), mode.name());
+    return getMetaClientBuilder(HoodieTableType.COPY_ON_WRITE, tableProps, "")
+        .setTableVersion(HoodieTableVersion.NINE.versionCode())
+        .initTable(storageConf, tempDir.resolve(tableDir).toString());
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -22,7 +22,7 @@ import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.common.config.{HoodieConfig, HoodieMetadataConfig, RecordMergeMode}
 import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, HoodieFileFormat, HoodieRecord, HoodieRecordPayload, HoodieReplaceCommitMetadata, HoodieTableType, MetaFieldsMode, WriteOperationType}
 import org.apache.hudi.common.schema.HoodieSchema
-import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, TableSchemaResolver}
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion, TableSchemaResolver}
 import org.apache.hudi.common.table.timeline.{HoodieTimeline, TimelineUtils}
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.config.{HoodieBootstrapConfig, HoodieIndexConfig, HoodieWriteConfig}
@@ -67,13 +67,15 @@ class TestHoodieSparkSqlWriter extends HoodieSparkWriterTestBase {
    * @param sortMode           Bulk insert sort mode
    * @param populateMetaFields Flag for populating meta fields
    */
-  def testBulkInsertWithSortMode(sortMode: BulkInsertSortMode, populateMetaFields: Boolean = true, enableOCCConfigs: Boolean = false): Unit = {
+  def testBulkInsertWithSortMode(sortMode: BulkInsertSortMode, populateMetaFields: Boolean = true, enableOCCConfigs: Boolean = false,
+                                 tableVersion: Int = HoodieTableVersion.current().versionCode()): Unit = {
     //create a new table
     var fooTableModifier = commonTableModifier.updated("hoodie.bulkinsert.shuffle.parallelism", "4")
       .updated(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL)
       .updated(DataSourceWriteOptions.ENABLE_ROW_WRITER.key, "true")
       .updated(HoodieTableConfig.POPULATE_META_FIELDS.key(), String.valueOf(populateMetaFields))
       .updated(HoodieWriteConfig.BULK_INSERT_SORT_MODE.key(), sortMode.name())
+      .updated(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), tableVersion.toString)
 
     if (enableOCCConfigs) {
       fooTableModifier = fooTableModifier
@@ -338,15 +340,20 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
   /**
    * Test case for disable and enable meta fields.
    */
-  @Test
-  def testLegacyBooleanDoesNotOverrideDisabledMetaFields(): Unit = {
-    testBulkInsertWithSortMode(BulkInsertSortMode.NONE, populateMetaFields = false)
+  @ParameterizedTest
+  @ValueSource(ints = Array(6, 8, 9, 10))
+  def testLegacyBooleanDoesNotOverrideDisabledMetaFields(tableVersion: Int): Unit = {
+    // Every writable table version: below 10 the table persists the deprecated boolean next to the
+    // mode, from 10 it carries the mode alone. The legacy boolean must not override the mode in
+    // either shape, and the persisted copy below 10 must not be held against the writer either.
+    testBulkInsertWithSortMode(BulkInsertSortMode.NONE, populateMetaFields = false, tableVersion = tableVersion)
     //create a new table
     val fooTableModifier = commonTableModifier.updated("hoodie.bulkinsert.shuffle.parallelism", "4")
       .updated(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL)
       .updated(DataSourceWriteOptions.ENABLE_ROW_WRITER.key, "true")
       .updated(HoodieWriteConfig.BULK_INSERT_SORT_MODE.key(), BulkInsertSortMode.NONE.name())
       .updated(HoodieTableConfig.POPULATE_META_FIELDS.key(), "true")
+      .updated(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), tableVersion.toString)
 
     // generate the inserts
     val schema = DataSourceTestUtils.getStructTypeExampleSchema

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala
@@ -22,7 +22,7 @@ import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.common.config.{HoodieMetadataConfig, RecordMergeMode}
 import org.apache.hudi.common.model._
 import org.apache.hudi.common.schema.HoodieSchema
-import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, TableSchemaResolver}
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion, TableSchemaResolver}
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.config.{HoodieBootstrapConfig, HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.HoodieException
@@ -65,13 +65,15 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
    * @param sortMode           Bulk insert sort mode
    * @param populateMetaFields Flag for populating meta fields
    */
-  def testBulkInsertWithSortMode(sortMode: BulkInsertSortMode, populateMetaFields: Boolean = true, enableOCCConfigs: Boolean = false): Unit = {
+  def testBulkInsertWithSortMode(sortMode: BulkInsertSortMode, populateMetaFields: Boolean = true, enableOCCConfigs: Boolean = false,
+                                 tableVersion: Int = HoodieTableVersion.current().versionCode()): Unit = {
     //create a new table
     var fooTableModifier = commonTableModifier.updated("hoodie.bulkinsert.shuffle.parallelism", "4")
       .updated(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL)
       .updated(DataSourceWriteOptions.ENABLE_ROW_WRITER.key, "true")
       .updated(HoodieTableConfig.POPULATE_META_FIELDS.key(), String.valueOf(populateMetaFields))
       .updated(HoodieWriteConfig.BULK_INSERT_SORT_MODE.key(), sortMode.name())
+      .updated(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), tableVersion.toString)
       .updated(HoodieTableConfig.TABLE_FORMAT.key, "test-format")
 
     if (enableOCCConfigs) {
@@ -204,15 +206,22 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
   /**
    * Test case for disable and enable meta fields.
    */
-  @Test
-  def testLegacyBooleanDoesNotOverrideDisabledMetaFields(): Unit = {
-    testBulkInsertWithSortMode(BulkInsertSortMode.NONE, populateMetaFields = false)
+  @ParameterizedTest
+  @ValueSource(ints = Array(8, 9, 10))
+  def testLegacyBooleanDoesNotOverrideDisabledMetaFields(tableVersion: Int): Unit = {
+    // Below 10 the table persists the deprecated boolean next to the mode, from 10 it carries the
+    // mode alone. The legacy boolean must not override the mode in either shape, and the persisted
+    // copy below 10 must not be held against the writer either. Version 6 is covered by the plain
+    // TestHoodieSparkSqlWriter: the test table format writes layout-v2 instant names that a v6
+    // (layout-v1) timeline cannot parse.
+    testBulkInsertWithSortMode(BulkInsertSortMode.NONE, populateMetaFields = false, tableVersion = tableVersion)
     //create a new table
     val fooTableModifier = commonTableModifier.updated("hoodie.bulkinsert.shuffle.parallelism", "4")
       .updated(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL)
       .updated(DataSourceWriteOptions.ENABLE_ROW_WRITER.key, "true")
       .updated(HoodieWriteConfig.BULK_INSERT_SORT_MODE.key(), BulkInsertSortMode.NONE.name())
       .updated(HoodieTableConfig.POPULATE_META_FIELDS.key(), "true")
+      .updated(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), tableVersion.toString)
       .updated(HoodieTableConfig.TABLE_FORMAT.key, "test-format")
 
     // generate the inserts


### PR DESCRIPTION
… table that carries a mode

### Describe the issue this Pull Request addresses

#19205 made `hoodie.meta.fields.mode` the source of truth for meta-column population; the deprecated `hoodie.populate.meta.fields` boolean is consulted only when the mode is absent. That contract is honored for table version 10, which persists the mode alone, but not below it.

Tables below v10 that carry a mode also persist the derived boolean next to it, for readers that only know the boolean. `HoodieWriterUtils.validateTableConfig` compares the writer's options key by key against `hoodie.properties` before any mode logic runs, so a writer that still states `hoodie.populate.meta.fields=true` against such a `NONE` table is rejected with a generic `Config conflict`, while the identical write against a v10 table is accepted and the boolean correctly ignored.

Who is affected:
- Only tables that carry `hoodie.meta.fields.mode` and sit below v10: tables created after #19205 with `hoodie.write.table.version` pinned to 6/8/9 (or with auto-upgrade disabled), and tables migrated via the hudi-cli `set-meta-fields-mode` command. On a release branch whose current version is 9, that is every newly created table.
- Not affected: pre-existing tables that carry only the boolean. Nothing backfills the mode on a regular write, so they behave exactly as before #19205 (flipping the boolean on them was rejected then and still is), and v10 tables.

The existing test for this contract only ran at the default (v10) version, so the gap was invisible.

### Summary and Changelog

- `HoodieWriterUtils.shouldIgnoreConfig`: skip `hoodie.populate.meta.fields` in the key-by-key loop once the table carries `hoodie.meta.fields.mode`. The mode comparison in the same method and `BaseHoodieWriteClient#validateAgainstTableProperties` still enforce agreement on the resolved mode. Tables that predate the mode property (boolean only) keep the boolean comparison.
- `TestHoodieWriterUtils`: a v9 table (mode + persisted boolean) accepts a contradicting legacy boolean for both `NONE` and `ALL`; a legacy-shaped table (boolean only) still rejects it.
- `testLegacyBooleanDoesNotOverrideDisabledMetaFields` in `TestHoodieSparkSqlWriter` and `TestHoodieSparkSqlWriterWithTestFormat` is parameterized over every writable table version and pins the version on both writes: 6/8/9/10 (8/9/10 in the test-format suite, whose fixture writes layout-v2 instant names a v6 timeline cannot parse). Without the fix the sub-10 parameters fail and 10 passes.

### Impact

Behavior change only for tables below v10 that carry a mode: a writer stating the deprecated boolean no longer conflicts against the persisted copy; the mode wins, matching v10 behavior. Pre-existing boolean-only tables are unchanged. No API or config changes.

### Risk Level

low. The skip is scoped to one key and only when the table already carries a mode; mode agreement is still enforced downstream. Covered by the new unit tests and the version-parameterized writer tests (red without the fix, green with it).

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
