### PR TITLE
fix(spark): make new schema evolution fields nullable

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -77,14 +77,11 @@ public class HoodieCommonConfig extends HoodieConfig {
   public static final ConfigProperty<String> SET_NULL_FOR_MISSING_COLUMNS = ConfigProperty
       .key("hoodie.write.set.null.for.missing.columns")
       .defaultValue("false")
-      .withAlternatives("hoodie.datasource.write.new.columns.nullable")
       .markAdvanced()
       .sinceVersion("0.14.1")
-      .withDocumentation("Controls whether schema reconciliation may use null to backfill fields that are absent on "
-          + "one side of schema evolution. When enabled, existing nullable fields missing from an incoming batch are "
-          + "filled with null, and newly added fields are made nullable with a null default so existing records can "
-          + "be read with the evolved schema. The legacy key hoodie.datasource.write.new.columns.nullable is "
-          + "supported as an alternative.");
+      .withDocumentation("When a nullable column is missing from incoming batch during a write operation, the write "
+          + " operation will fail schema compatibility check. Set this option to true will make the missing "
+          + " column be filled with null values to successfully complete the write operation.");
 
   public static final ConfigProperty<String> TIMESTAMP_LOGICAL_TYPE_OVERRIDES = ConfigProperty
       .key("hoodie.write.timestamp.logical.type.overrides")

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieCommonConfig.java
@@ -77,11 +77,14 @@ public class HoodieCommonConfig extends HoodieConfig {
   public static final ConfigProperty<String> SET_NULL_FOR_MISSING_COLUMNS = ConfigProperty
       .key("hoodie.write.set.null.for.missing.columns")
       .defaultValue("false")
+      .withAlternatives("hoodie.datasource.write.new.columns.nullable")
       .markAdvanced()
       .sinceVersion("0.14.1")
-      .withDocumentation("When a nullable column is missing from incoming batch during a write operation, the write "
-          + " operation will fail schema compatibility check. Set this option to true will make the missing "
-          + " column be filled with null values to successfully complete the write operation.");
+      .withDocumentation("Controls whether schema reconciliation may use null to backfill fields that are absent on "
+          + "one side of schema evolution. When enabled, existing nullable fields missing from an incoming batch are "
+          + "filled with null, and newly added fields are made nullable with a null default so existing records can "
+          + "be read with the evolved schema. The legacy key hoodie.datasource.write.new.columns.nullable is "
+          + "supported as an alternative.");
 
   public static final ConfigProperty<String> TIMESTAMP_LOGICAL_TYPE_OVERRIDES = ConfigProperty
       .key("hoodie.write.timestamp.logical.type.overrides")

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/utils/AvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/utils/AvroSchemaEvolutionUtils.java
@@ -302,18 +302,19 @@ public class AvroSchemaEvolutionUtils {
    * {@code target} one. Source is considered to be new incoming schema, while target could refer to prev table schema.
    * For example,
    * if colA in source is non-nullable, but is nullable in target, output schema will have colA as nullable.
-   * if null backfill is enabled and colB is present in source, but not in target, output schema will have colB as nullable.
+   * if colB is present in source, but not in target, output schema will have colB as nullable. If colB is a complex
+   * type, its existing descendants retain their nullability constraints.
    * if colC has different data type in source schema compared to target schema and if its promotable, (say source is int,
    * and target is long and since int can be promoted to long), colC will be long data type in output schema.
    *
    *
    * @param sourceSchema source schema that needs reconciliation
    * @param targetSchema target schema that source schema will be reconciled against
-   * @param makeNewColumnsNullable whether fields newly introduced by the source schema should be made nullable
+   * @param shouldReorderColumns whether fields should be reordered to match the target schema
    * @return schema (based off {@code source} one) that has nullability constraints and datatypes reconciled
    */
   public static HoodieSchema reconcileSchemaRequirements(HoodieSchema sourceSchema, HoodieSchema targetSchema,
-                                                          boolean shouldReorderColumns, boolean makeNewColumnsNullable) {
+                                                          boolean shouldReorderColumns) {
     if (targetSchema.isSchemaNull() || targetSchema.getFields().isEmpty()) {
       return sourceSchema;
     }
@@ -331,10 +332,28 @@ public class AvroSchemaEvolutionUtils {
 
     List<String> nullableUpdateColsInSource = new ArrayList<>();
     List<String> typeUpdateColsInSource = new ArrayList<>();
+
+    // Only relax the topmost field in a wholly new subtree. Relaxing every descendant would alter the
+    // element/field constraints supplied by the writer instead of only making the evolved field backfillable.
+    Set<String> visitedNewColumns = new HashSet<>();
+    colNamesSourceSchema.stream()
+        .filter(field -> !colNamesTargetSchema.contains(field))
+        .filter(field -> !META_FIELD_NAMES.contains(field))
+        .sorted()
+        .forEach(field -> {
+          String parent = TableChangesHelper.getParentName(field);
+          if (!visitedNewColumns.contains(parent)) {
+            nullableUpdateColsInSource.add(field);
+          }
+          visitedNewColumns.add(field);
+        });
+
     colNamesSourceSchema.forEach(field -> {
-      // handle columns that needs to be made nullable
-      if ((makeNewColumnsNullable && !colNamesTargetSchema.contains(field))
-          || (colNamesTargetSchema.contains(field) && sourceInternalSchema.findField(field).isOptional() != targetInternalSchema.findField(field).isOptional())) {
+      // Reconcile nullability only for existing user columns. Metadata fields may be present in the source even
+      // though the target schema used for canonicalization has intentionally stripped them.
+      if (colNamesTargetSchema.contains(field)
+          && !META_FIELD_NAMES.contains(field)
+          && sourceInternalSchema.findField(field).isOptional() != targetInternalSchema.findField(field).isOptional()) {
         nullableUpdateColsInSource.add(field);
       }
       // handle columns that needs type to be updated
@@ -364,10 +383,5 @@ public class AvroSchemaEvolutionUtils {
 
 
     return convert(SchemaChangeUtils.applyTableChanges2Schema(sourceInternalSchema, schemaChange), sourceSchema.getFullName());
-  }
-
-  public static HoodieSchema reconcileSchemaRequirements(HoodieSchema sourceSchema, HoodieSchema targetSchema,
-                                                          boolean shouldReorderColumns) {
-    return reconcileSchemaRequirements(sourceSchema, targetSchema, shouldReorderColumns, false);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/utils/AvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/utils/AvroSchemaEvolutionUtils.java
@@ -302,17 +302,18 @@ public class AvroSchemaEvolutionUtils {
    * {@code target} one. Source is considered to be new incoming schema, while target could refer to prev table schema.
    * For example,
    * if colA in source is non-nullable, but is nullable in target, output schema will have colA as nullable.
-   * if "hoodie.datasource.write.new.columns.nullable" is set to true and if colB is not present in source, but
-   * is present in target, output schema will have colB as nullable.
+   * if null backfill is enabled and colB is present in source, but not in target, output schema will have colB as nullable.
    * if colC has different data type in source schema compared to target schema and if its promotable, (say source is int,
    * and target is long and since int can be promoted to long), colC will be long data type in output schema.
    *
    *
    * @param sourceSchema source schema that needs reconciliation
    * @param targetSchema target schema that source schema will be reconciled against
+   * @param makeNewColumnsNullable whether fields newly introduced by the source schema should be made nullable
    * @return schema (based off {@code source} one) that has nullability constraints and datatypes reconciled
    */
-  public static HoodieSchema reconcileSchemaRequirements(HoodieSchema sourceSchema, HoodieSchema targetSchema, boolean shouldReorderColumns) {
+  public static HoodieSchema reconcileSchemaRequirements(HoodieSchema sourceSchema, HoodieSchema targetSchema,
+                                                          boolean shouldReorderColumns, boolean makeNewColumnsNullable) {
     if (targetSchema.isSchemaNull() || targetSchema.getFields().isEmpty()) {
       return sourceSchema;
     }
@@ -332,7 +333,8 @@ public class AvroSchemaEvolutionUtils {
     List<String> typeUpdateColsInSource = new ArrayList<>();
     colNamesSourceSchema.forEach(field -> {
       // handle columns that needs to be made nullable
-      if (colNamesTargetSchema.contains(field) && sourceInternalSchema.findField(field).isOptional() != targetInternalSchema.findField(field).isOptional()) {
+      if ((makeNewColumnsNullable && !colNamesTargetSchema.contains(field))
+          || (colNamesTargetSchema.contains(field) && sourceInternalSchema.findField(field).isOptional() != targetInternalSchema.findField(field).isOptional())) {
         nullableUpdateColsInSource.add(field);
       }
       // handle columns that needs type to be updated
@@ -363,5 +365,9 @@ public class AvroSchemaEvolutionUtils {
 
     return convert(SchemaChangeUtils.applyTableChanges2Schema(sourceInternalSchema, schemaChange), sourceSchema.getFullName());
   }
-}
 
+  public static HoodieSchema reconcileSchemaRequirements(HoodieSchema sourceSchema, HoodieSchema targetSchema,
+                                                          boolean shouldReorderColumns) {
+    return reconcileSchemaRequirements(sourceSchema, targetSchema, shouldReorderColumns, false);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/utils/AvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/utils/AvroSchemaEvolutionUtils.java
@@ -329,6 +329,9 @@ public class AvroSchemaEvolutionUtils {
 
     List<String> colNamesSourceSchema = sourceInternalSchema.getAllColsFullName();
     List<String> colNamesTargetSchema = targetInternalSchema.getAllColsFullName();
+    List<String> userColNamesSourceSchema = colNamesSourceSchema.stream()
+        .filter(field -> !META_FIELD_NAMES.contains(field))
+        .collect(Collectors.toList());
 
     List<String> nullableUpdateColsInSource = new ArrayList<>();
     List<String> typeUpdateColsInSource = new ArrayList<>();
@@ -336,9 +339,8 @@ public class AvroSchemaEvolutionUtils {
     // Only relax the topmost field in a wholly new subtree. Relaxing every descendant would alter the
     // element/field constraints supplied by the writer instead of only making the evolved field backfillable.
     Set<String> visitedNewColumns = new HashSet<>();
-    colNamesSourceSchema.stream()
+    userColNamesSourceSchema.stream()
         .filter(field -> !colNamesTargetSchema.contains(field))
-        .filter(field -> !META_FIELD_NAMES.contains(field))
         .sorted()
         .forEach(field -> {
           String parent = TableChangesHelper.getParentName(field);
@@ -348,11 +350,8 @@ public class AvroSchemaEvolutionUtils {
           visitedNewColumns.add(field);
         });
 
-    colNamesSourceSchema.forEach(field -> {
-      // Reconcile nullability only for existing user columns. Metadata fields may be present in the source even
-      // though the target schema used for canonicalization has intentionally stripped them.
+    userColNamesSourceSchema.forEach(field -> {
       if (colNamesTargetSchema.contains(field)
-          && !META_FIELD_NAMES.contains(field)
           && sourceInternalSchema.findField(field).isOptional() != targetInternalSchema.findField(field).isOptional()) {
         nullableUpdateColsInSource.add(field);
       }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSchemaUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSchemaUtils.scala
@@ -32,7 +32,6 @@ import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.ConfigUtils
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.{HoodieException, SchemaCompatibilityException}
-import org.apache.hudi.util.SparkConfigUtils
 
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
@@ -138,7 +137,7 @@ object HoodieSchemaUtils {
         val shouldReconcileSchema = opts.getOrElse(DataSourceWriteOptions.RECONCILE_SCHEMA.key(),
           DataSourceWriteOptions.RECONCILE_SCHEMA.defaultValue().toString).toBoolean
         val canonicalizedSourceSchema = if (shouldCanonicalizeSchema) {
-          canonicalizeSchema(sourceSchema, latestTableSchema, opts, !shouldReconcileSchema)
+          canonicalizeSchema(sourceSchema, latestTableSchema, !shouldReconcileSchema)
         } else {
           InternalSchemaConverter.fixNullOrdering(sourceSchema)
         }
@@ -186,7 +185,8 @@ object HoodieSchemaUtils {
       HoodieWriteConfig.AVRO_SCHEMA_VALIDATE_ENABLE.defaultValue).toBoolean
     val allowAutoEvolutionColumnDrop = opts.getOrElse(HoodieWriteConfig.SCHEMA_ALLOW_AUTO_EVOLUTION_COLUMN_DROP.key,
       HoodieWriteConfig.SCHEMA_ALLOW_AUTO_EVOLUTION_COLUMN_DROP.defaultValue).toBoolean
-    val setNullForMissingColumns = shouldSetNullForMissingColumns(opts)
+    val setNullForMissingColumns = opts.getOrElse(DataSourceWriteOptions.SET_NULL_FOR_MISSING_COLUMNS.key(),
+      DataSourceWriteOptions.SET_NULL_FOR_MISSING_COLUMNS.defaultValue).toBoolean
 
     if (!mergeIntoWrites && !shouldValidateSchemasCompatibility && !allowAutoEvolutionColumnDrop) {
       // Default behaviour
@@ -223,7 +223,8 @@ object HoodieSchemaUtils {
     internalSchemaOpt match {
       case Some(internalSchema) =>
         // Apply schema evolution, by auto-merging write schema and read schema
-        val setNullForMissingColumns = shouldSetNullForMissingColumns(opts)
+        val setNullForMissingColumns = opts.getOrElse(HoodieCommonConfig.SET_NULL_FOR_MISSING_COLUMNS.key(),
+          HoodieCommonConfig.SET_NULL_FOR_MISSING_COLUMNS.defaultValue()).toBoolean
         val mergedInternalSchema = AvroSchemaEvolutionUtils.reconcileSchema(canonicalizedSourceSchema, internalSchema,
           setNullForMissingColumns, timestampLogicalTypeOverrides)
         val evolvedSchema = InternalSchemaConverter.convert(mergedInternalSchema, latestTableSchema.getFullName)
@@ -275,16 +276,10 @@ object HoodieSchemaUtils {
    *
    * TODO support casing reconciliation
    */
-  private def canonicalizeSchema(sourceSchema: HoodieSchema, latestTableSchema: HoodieSchema, opts : Map[String, String],
+  private def canonicalizeSchema(sourceSchema: HoodieSchema, latestTableSchema: HoodieSchema,
                                  shouldReorderColumns: Boolean): HoodieSchema = {
-    reconcileSchemaRequirements(sourceSchema, latestTableSchema, shouldReorderColumns,
-      shouldSetNullForMissingColumns(opts))
+    reconcileSchemaRequirements(sourceSchema, latestTableSchema, shouldReorderColumns)
   }
-
-  private def shouldSetNullForMissingColumns(opts: Map[String, String]): Boolean = {
-    SparkConfigUtils.getStringWithAltKeys(opts, HoodieCommonConfig.SET_NULL_FOR_MISSING_COLUMNS).toBoolean
-  }
-
 
   private def reconcileSchemasLegacy(tableSchema: HoodieSchema, newSchema: HoodieSchema): (HoodieSchema, Boolean) = {
     // Legacy reconciliation implements following semantic

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSchemaUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSchemaUtils.scala
@@ -32,6 +32,7 @@ import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.ConfigUtils
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.{HoodieException, SchemaCompatibilityException}
+import org.apache.hudi.util.SparkConfigUtils
 
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
@@ -185,8 +186,7 @@ object HoodieSchemaUtils {
       HoodieWriteConfig.AVRO_SCHEMA_VALIDATE_ENABLE.defaultValue).toBoolean
     val allowAutoEvolutionColumnDrop = opts.getOrElse(HoodieWriteConfig.SCHEMA_ALLOW_AUTO_EVOLUTION_COLUMN_DROP.key,
       HoodieWriteConfig.SCHEMA_ALLOW_AUTO_EVOLUTION_COLUMN_DROP.defaultValue).toBoolean
-    val setNullForMissingColumns = opts.getOrElse(DataSourceWriteOptions.SET_NULL_FOR_MISSING_COLUMNS.key(),
-      DataSourceWriteOptions.SET_NULL_FOR_MISSING_COLUMNS.defaultValue).toBoolean
+    val setNullForMissingColumns = shouldSetNullForMissingColumns(opts)
 
     if (!mergeIntoWrites && !shouldValidateSchemasCompatibility && !allowAutoEvolutionColumnDrop) {
       // Default behaviour
@@ -223,8 +223,7 @@ object HoodieSchemaUtils {
     internalSchemaOpt match {
       case Some(internalSchema) =>
         // Apply schema evolution, by auto-merging write schema and read schema
-        val setNullForMissingColumns = opts.getOrElse(HoodieCommonConfig.SET_NULL_FOR_MISSING_COLUMNS.key(),
-          HoodieCommonConfig.SET_NULL_FOR_MISSING_COLUMNS.defaultValue()).toBoolean
+        val setNullForMissingColumns = shouldSetNullForMissingColumns(opts)
         val mergedInternalSchema = AvroSchemaEvolutionUtils.reconcileSchema(canonicalizedSourceSchema, internalSchema,
           setNullForMissingColumns, timestampLogicalTypeOverrides)
         val evolvedSchema = InternalSchemaConverter.convert(mergedInternalSchema, latestTableSchema.getFullName)
@@ -278,7 +277,12 @@ object HoodieSchemaUtils {
    */
   private def canonicalizeSchema(sourceSchema: HoodieSchema, latestTableSchema: HoodieSchema, opts : Map[String, String],
                                  shouldReorderColumns: Boolean): HoodieSchema = {
-    reconcileSchemaRequirements(sourceSchema, latestTableSchema, shouldReorderColumns)
+    reconcileSchemaRequirements(sourceSchema, latestTableSchema, shouldReorderColumns,
+      shouldSetNullForMissingColumns(opts))
+  }
+
+  private def shouldSetNullForMissingColumns(opts: Map[String, String]): Boolean = {
+    SparkConfigUtils.getStringWithAltKeys(opts, HoodieCommonConfig.SET_NULL_FOR_MISSING_COLUMNS).toBoolean
   }
 
 

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieSchemaUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieSchemaUtils.java
@@ -21,11 +21,12 @@ package org.apache.hudi;
 
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.schema.HoodieSchemaCompatibilityChecker.SchemaIncompatibilityType;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.schema.internal.convert.InternalSchemaConverter;
+import org.apache.hudi.common.schema.internal.utils.AvroSchemaEvolutionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieNullSchemaTypeException;
@@ -346,13 +347,11 @@ public class TestHoodieSchemaUtils {
 
   @ParameterizedTest
   @CsvSource({
-      "false,false,hoodie.write.set.null.for.missing.columns",
-      "true,false,hoodie.write.set.null.for.missing.columns",
-      "true,true,hoodie.write.set.null.for.missing.columns",
-      "true,false,hoodie.datasource.write.new.columns.nullable"
+      "false,false",
+      "true,false",
+      "true,true"
   })
-  void testNullBackfillMakesNewColumnsNullable(boolean reconcileSchema, boolean useInternalSchema,
-                                               String nullBackfillConfigKey) {
+  void testNewColumnsAreNullableAcrossReconciliationPaths(boolean reconcileSchema, boolean useInternalSchema) {
     HoodieSchema table = createRecord("newColumns",
         createPrimitiveField("id", HoodieSchemaType.INT),
         HoodieSchemaField.of("address", createRecord("address",
@@ -362,10 +361,13 @@ public class TestHoodieSchemaUtils {
         HoodieSchemaField.of("address", createRecord("address",
             createPrimitiveField("city", HoodieSchemaType.STRING),
             createPrimitiveField("country", HoodieSchemaType.STRING)), null, null),
-        createPrimitiveField("phone", HoodieSchemaType.STRING));
+        createPrimitiveField("phone", HoodieSchemaType.STRING),
+        HoodieSchemaField.of("profile", createRecord("profile",
+            createPrimitiveField("name", HoodieSchemaType.STRING)), null, null),
+        createArrayField("items", createRecord("item",
+            createPrimitiveField("sku", HoodieSchemaType.STRING))));
     TypedProperties properties = new TypedProperties();
     properties.setProperty(HoodieCommonConfig.RECONCILE_SCHEMA.key(), Boolean.toString(reconcileSchema));
-    properties.setProperty(nullBackfillConfigKey, "true");
 
     HoodieSchema actual = HoodieSchemaUtils.deduceWriterSchema(
         incoming,
@@ -376,20 +378,26 @@ public class TestHoodieSchemaUtils {
     assertFalse(actual.getNestedField("address.city").get().getRight().isNullable());
     assertNewFieldIsNullableWithNullDefault(actual.getNestedField("address.country").get().getRight());
     assertNewFieldIsNullableWithNullDefault(actual.getField("phone").get());
+    HoodieSchemaField profile = actual.getField("profile").get();
+    assertNewFieldIsNullableWithNullDefault(profile);
+    assertFalse(profile.schema().getNonNullType().getField("name").get().isNullable());
+    HoodieSchemaField items = actual.getField("items").get();
+    assertNewFieldIsNullableWithNullDefault(items);
+    HoodieSchema itemElement = items.schema().getNonNullType().getElementType();
+    assertFalse(itemElement.isNullable());
+    assertFalse(itemElement.getField("sku").get().isNullable());
   }
 
   @Test
-  void testNewColumnsRemainRequiredWithoutNullBackfill() {
-    HoodieSchema table = createRecord("newColumns",
-        createPrimitiveField("id", HoodieSchemaType.INT));
-    HoodieSchema incoming = createRecord("newColumns",
+  void testMetadataFieldsAreExcludedFromNewColumnNullability() {
+    HoodieSchema table = createRecord("metadata", createPrimitiveField("id", HoodieSchemaType.INT));
+    HoodieSchema incoming = createRecord("metadata",
         createPrimitiveField("id", HoodieSchemaType.INT),
-        createPrimitiveField("phone", HoodieSchemaType.STRING));
+        createPrimitiveField(HoodieRecord.COMMIT_TIME_METADATA_FIELD, HoodieSchemaType.STRING));
 
-    Throwable throwable = assertThrows(SchemaBackwardsCompatibilityException.class,
-        () -> deduceWriterSchema(incoming, table, false));
-    assertTrue(throwable.getMessage().contains(
-        SchemaIncompatibilityType.READER_FIELD_MISSING_DEFAULT_VALUE.name()));
+    HoodieSchema actual = AvroSchemaEvolutionUtils.reconcileSchemaRequirements(incoming, table, false);
+
+    assertFalse(actual.getField(HoodieRecord.COMMIT_TIME_METADATA_FIELD).get().isNullable());
   }
 
   private static void assertNewFieldIsNullableWithNullDefault(HoodieSchemaField field) {

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieSchemaUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieSchemaUtils.java
@@ -22,7 +22,10 @@ package org.apache.hudi;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaCompatibilityChecker.SchemaIncompatibilityType;
+import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.schema.internal.convert.InternalSchemaConverter;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieNullSchemaTypeException;
@@ -31,6 +34,7 @@ import org.apache.hudi.exception.SchemaBackwardsCompatibilityException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.EnumMap;
@@ -338,6 +342,60 @@ public class TestHoodieSchemaUtils {
         createPrimitiveField("field1", HoodieSchemaType.INT),
         createNullablePrimitiveField("field2", HoodieSchemaType.BOOLEAN));
     assertEquals(expected, deduceWriterSchema(incoming, table, setNullForMissingColumns));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "false,false,hoodie.write.set.null.for.missing.columns",
+      "true,false,hoodie.write.set.null.for.missing.columns",
+      "true,true,hoodie.write.set.null.for.missing.columns",
+      "true,false,hoodie.datasource.write.new.columns.nullable"
+  })
+  void testNullBackfillMakesNewColumnsNullable(boolean reconcileSchema, boolean useInternalSchema,
+                                               String nullBackfillConfigKey) {
+    HoodieSchema table = createRecord("newColumns",
+        createPrimitiveField("id", HoodieSchemaType.INT),
+        HoodieSchemaField.of("address", createRecord("address",
+            createPrimitiveField("city", HoodieSchemaType.STRING)), null, null));
+    HoodieSchema incoming = createRecord("newColumns",
+        createPrimitiveField("id", HoodieSchemaType.INT),
+        HoodieSchemaField.of("address", createRecord("address",
+            createPrimitiveField("city", HoodieSchemaType.STRING),
+            createPrimitiveField("country", HoodieSchemaType.STRING)), null, null),
+        createPrimitiveField("phone", HoodieSchemaType.STRING));
+    TypedProperties properties = new TypedProperties();
+    properties.setProperty(HoodieCommonConfig.RECONCILE_SCHEMA.key(), Boolean.toString(reconcileSchema));
+    properties.setProperty(nullBackfillConfigKey, "true");
+
+    HoodieSchema actual = HoodieSchemaUtils.deduceWriterSchema(
+        incoming,
+        Option.of(table),
+        useInternalSchema ? Option.of(InternalSchemaConverter.convert(table)) : Option.empty(),
+        properties);
+
+    assertFalse(actual.getNestedField("address.city").get().getRight().isNullable());
+    assertNewFieldIsNullableWithNullDefault(actual.getNestedField("address.country").get().getRight());
+    assertNewFieldIsNullableWithNullDefault(actual.getField("phone").get());
+  }
+
+  @Test
+  void testNewColumnsRemainRequiredWithoutNullBackfill() {
+    HoodieSchema table = createRecord("newColumns",
+        createPrimitiveField("id", HoodieSchemaType.INT));
+    HoodieSchema incoming = createRecord("newColumns",
+        createPrimitiveField("id", HoodieSchemaType.INT),
+        createPrimitiveField("phone", HoodieSchemaType.STRING));
+
+    Throwable throwable = assertThrows(SchemaBackwardsCompatibilityException.class,
+        () -> deduceWriterSchema(incoming, table, false));
+    assertTrue(throwable.getMessage().contains(
+        SchemaIncompatibilityType.READER_FIELD_MISSING_DEFAULT_VALUE.name()));
+  }
+
+  private static void assertNewFieldIsNullableWithNullDefault(HoodieSchemaField field) {
+    assertTrue(field.isNullable());
+    assertTrue(field.hasDefaultValue());
+    assertEquals(HoodieSchema.NULL_VALUE, field.defaultVal().get());
   }
 
   private static HoodieSchema deduceWriterSchema(HoodieSchema incomingSchema, HoodieSchema latestTableSchema) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -1937,7 +1937,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
       (3, "3", "2021-01-05"))
     val rdd = spark.sparkContext.parallelize(data)
     val df = spark.createDataFrame(rdd).toDF(columns: _*)
-    val hudiOptions = Map[String, String](
+    var hudiOptions = Map[String, String](
       HoodieWriteConfig.TBL_NAME.key() -> "tbl",
       DataSourceWriteOptions.OPERATION.key() -> "insert",
       DataSourceWriteOptions.TABLE_TYPE.key() -> "COPY_ON_WRITE",
@@ -1971,7 +1971,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
   def testSchemaEvolutionWithNewColumns(schemaOnRead: Boolean): Unit = {
     val df1 = spark.sql(
       "select '1' as event_id, '2' as ts, '3' as version, named_struct('city', 'Paris') as address")
-    var hudiOptions = Map[String, String](
+    val hudiOptions = Map[String, String](
       HoodieWriteConfig.TBL_NAME.key() -> "test_hudi_merger",
       KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key() -> "event_id",
       KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key() -> "version",

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -1967,8 +1967,8 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = Array(false, true))
-  def testSchemaEvolutionWithNewColumns(schemaOnRead: Boolean): Unit = {
+  @CsvSource(value = Array("false,false", "false,true", "true,false", "true,true"))
+  def testSchemaEvolutionWithNewColumns(schemaOnRead: Boolean, reconcileSchema: Boolean): Unit = {
     val df1 = spark.sql(
       "select '1' as event_id, '2' as ts, '3' as version, named_struct('city', 'Paris') as address")
     val hudiOptions = Map[String, String](
@@ -1981,7 +1981,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
       KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE.key() -> "true",
       HiveSyncConfigHolder.HIVE_SYNC_ENABLED.key() -> "false",
       HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key() -> "org.apache.hudi.DefaultSparkRecordMerger",
-      HoodieCommonConfig.RECONCILE_SCHEMA.key() -> "true",
+      HoodieCommonConfig.RECONCILE_SCHEMA.key() -> reconcileSchema.toString,
       HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE.key() -> schemaOnRead.toString
     )
     df1.write.format("hudi").options(hudiOptions).mode(SaveMode.Append).save(basePath)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -1937,7 +1937,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
       (3, "3", "2021-01-05"))
     val rdd = spark.sparkContext.parallelize(data)
     val df = spark.createDataFrame(rdd).toDF(columns: _*)
-    var hudiOptions = Map[String, String](
+    val hudiOptions = Map[String, String](
       HoodieWriteConfig.TBL_NAME.key() -> "tbl",
       DataSourceWriteOptions.OPERATION.key() -> "insert",
       DataSourceWriteOptions.TABLE_TYPE.key() -> "COPY_ON_WRITE",
@@ -1967,11 +1967,8 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
   }
 
   @ParameterizedTest
-  @CsvSource(value = Array(
-    "false,hoodie.write.set.null.for.missing.columns",
-    "true,hoodie.write.set.null.for.missing.columns",
-    "false,hoodie.datasource.write.new.columns.nullable"))
-  def testSchemaEvolutionWithNewColumns(schemaOnRead: Boolean, nullBackfillConfigKey: String): Unit = {
+  @ValueSource(booleans = Array(false, true))
+  def testSchemaEvolutionWithNewColumns(schemaOnRead: Boolean): Unit = {
     val df1 = spark.sql(
       "select '1' as event_id, '2' as ts, '3' as version, named_struct('city', 'Paris') as address")
     var hudiOptions = Map[String, String](
@@ -1993,7 +1990,6 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
       "select '2' as event_id, '2' as ts, '3' as version, "
         + "named_struct('city', 'Berlin', 'country', 'DE') as address, '123' as phone")
 
-    hudiOptions = hudiOptions + (nullBackfillConfigKey -> "true")
     df2.write.format("hudi").options(hudiOptions).mode("append").save(basePath)
 
     val metaClient = createMetaClient(basePath)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -27,9 +27,9 @@ import org.apache.hudi.common.config.{HoodieCommonConfig, HoodieMetadataConfig, 
 import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT, TIMESTAMP_TIMEZONE_FORMAT, TIMESTAMP_TYPE_FIELD}
 import org.apache.hudi.common.config.metrics.HoodieMetricsConfig
 import org.apache.hudi.common.fs.FSUtils
-import org.apache.hudi.common.model.{HoodieRecord, HoodieReplaceCommitMetadata, WriteOperationType}
+import org.apache.hudi.common.model.{HoodieCommitMetadata, HoodieRecord, HoodieReplaceCommitMetadata, WriteOperationType}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
-import org.apache.hudi.common.schema.HoodieSchemaCompatibilityChecker.SchemaIncompatibilityType
+import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion, TableSchemaResolver}
 import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline, TimelineUtils}
 import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestUtils}
@@ -37,7 +37,7 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator.{deleteRecordsTo
 import org.apache.hudi.common.testutils.HoodieTestUtils.{INSTANT_FILE_NAME_GENERATOR, INSTANT_GENERATOR}
 import org.apache.hudi.common.util.{ClusteringUtils, Option}
 import org.apache.hudi.config.HoodieWriteConfig
-import org.apache.hudi.exception.{HoodieException, SchemaBackwardsCompatibilityException}
+import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.hive.HiveSyncConfigHolder
 import org.apache.hudi.keygen.{ComplexKeyGenerator, CustomKeyGenerator, GlobalDeleteKeyGenerator, NonpartitionedKeyGenerator, SimpleKeyGenerator, TimestampBasedKeyGenerator}
 import org.apache.hudi.keygen.constant.{KeyGeneratorOptions, KeyGeneratorType}
@@ -1966,10 +1966,14 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
     assertEquals(0, result.filter(result("id") === 1).count())
   }
 
-  /** Test case to verify MAKE_NEW_COLUMNS_NULLABLE config parameter. */
-  @Test
-  def testSchemaEvolutionWithNewColumn(): Unit = {
-    val df1 = spark.sql("select '1' as event_id, '2' as ts, '3' as version, 'foo' as event_date")
+  @ParameterizedTest
+  @CsvSource(value = Array(
+    "false,hoodie.write.set.null.for.missing.columns",
+    "true,hoodie.write.set.null.for.missing.columns",
+    "false,hoodie.datasource.write.new.columns.nullable"))
+  def testSchemaEvolutionWithNewColumns(schemaOnRead: Boolean, nullBackfillConfigKey: String): Unit = {
+    val df1 = spark.sql(
+      "select '1' as event_id, '2' as ts, '3' as version, named_struct('city', 'Paris') as address")
     var hudiOptions = Map[String, String](
       HoodieWriteConfig.TBL_NAME.key() -> "test_hudi_merger",
       KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key() -> "event_id",
@@ -1979,35 +1983,40 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
       HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key() -> "org.apache.hudi.keygen.ComplexKeyGenerator",
       KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE.key() -> "true",
       HiveSyncConfigHolder.HIVE_SYNC_ENABLED.key() -> "false",
-      HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key() -> "org.apache.hudi.DefaultSparkRecordMerger"
+      HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key() -> "org.apache.hudi.DefaultSparkRecordMerger",
+      HoodieCommonConfig.RECONCILE_SCHEMA.key() -> "true",
+      HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE.key() -> schemaOnRead.toString
     )
     df1.write.format("hudi").options(hudiOptions).mode(SaveMode.Append).save(basePath)
 
-    // Try adding a string column. This operation is expected to throw 'schema not compatible' exception since
-    // 'MAKE_NEW_COLUMNS_NULLABLE' parameter is 'false' by default.
-    val df2 = spark.sql("select '2' as event_id, '2' as ts, '3' as version, 'foo' as event_date, 'bar' as add_col")
-    try {
-      (df2.write.format("hudi").options(hudiOptions).mode("append").save(basePath))
-      fail("Option succeeded, but was expected to fail.")
-    } catch {
-      case ex: SchemaBackwardsCompatibilityException => {
-        assertTrue(ex.getMessage.contains(SchemaIncompatibilityType.READER_FIELD_MISSING_DEFAULT_VALUE.name()))
-      }
-      case ex: Exception => {
-        fail(ex)
-      }
+    val df2 = spark.sql(
+      "select '2' as event_id, '2' as ts, '3' as version, "
+        + "named_struct('city', 'Berlin', 'country', 'DE') as address, '123' as phone")
+
+    hudiOptions = hudiOptions + (nullBackfillConfigKey -> "true")
+    df2.write.format("hudi").options(hudiOptions).mode("append").save(basePath)
+
+    val metaClient = createMetaClient(basePath)
+    val timeline = metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants()
+    val commitMetadata = timeline.readCommitMetadata(timeline.lastInstant().get())
+    val committedSchema = HoodieSchema.parse(commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY))
+    val phoneField = committedSchema.getField("phone").get()
+    val countryField = committedSchema.getNestedField("address.country").get().getRight
+    Seq(phoneField, countryField).foreach { field =>
+      assertTrue(field.isNullable)
+      assertTrue(field.hasDefaultValue)
+      assertEquals(HoodieSchema.NULL_VALUE, field.defaultVal().get())
     }
 
-    // Try adding the string column again. This operation is expected to succeed since 'MAKE_NEW_COLUMNS_NULLABLE'
-    // parameter has been set to 'true'.
-    hudiOptions = hudiOptions + (HoodieCommonConfig.SET_NULL_FOR_MISSING_COLUMNS.key() -> "true")
-    try {
-      (df2.write.format("hudi").options(hudiOptions).mode("append").save(basePath))
-    } catch {
-      case ex: Exception => {
-        fail(ex)
-      }
-    }
+    val rows = spark.read.format("hudi").load(basePath)
+      .select("event_id", "phone", "address")
+      .orderBy("event_id")
+      .collect()
+    assertEquals(2, rows.length)
+    assertEquals(null, rows(0).getAs[String]("phone"))
+    assertEquals(null, rows(0).getAs[Row]("address").getAs[String]("country"))
+    assertEquals("123", rows(1).getAs[String]("phone"))
+    assertEquals("DE", rows(1).getAs[Row]("address").getAs[String]("country"))
   }
 
   def assertLastCommitIsUpsert(): Boolean = {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19654.

Adding a required top-level or nested field to a table that already contains records produces an Avro reader field with neither a value in old records nor a default. Hudi 0.14.1 handled this by making newly evolved fields nullable with a `null` default, but removal of that behavior caused an upgrade regression.

`hoodie.write.set.null.for.missing.columns` solves the separate case where an incoming batch omits an existing table column. It should not control whether newly evolved fields can be backfilled. The current schema canonicalization also needs to behave consistently in the legacy reconciliation path and the InternalSchema/schema-on-read path.

### Summary and Changelog

Newly evolved fields are now made nullable with a `null` default during schema canonicalization, before either reconciliation path is selected. Avro's validation for genuinely incompatible schemas remains unchanged.

#### Commit 1: Restore nullable schema evolution for new fields (`dc1cd5f3df4c`)

- Canonicalize newly added top-level and nested fields before legacy or InternalSchema reconciliation.
- Add functional assertions for the committed schema, old-row null values, and new-row values.

#### Commit 2: Address schema evolution review feedback (`8e1ba38b300c`)

- Keep `hoodie.write.set.null.for.missing.columns` limited to missing existing columns; no compatibility alias is added.
- Exclude Hudi metadata fields from new-field nullability reconciliation.
- Relax only the topmost field of a wholly new struct or array subtree, preserving descendant constraints.
- Cover schema-on-read enabled and disabled paths, metadata fields, nested additions, and wholly new struct and array fields.

#### Commit 3: Fix mutable test options declaration (`2b2048642dab`)

- Restore mutability only in the existing test that reassigns its options map, fixing the Scala test compilation failure.

#### Commit 4: Address follow-up review feedback (`4ed8c66ff60a`)

- Filter Hudi metadata fields once before new-field and existing-field schema reconciliation.
- Exercise all four combinations of schema reconciliation and schema-on-read in the functional regression test.

No code was copied.

### Impact

Spark writes can evolve required top-level and nested fields over existing records without a separate null-backfill option. The newly introduced field becomes nullable with a `null` default; descendants of a newly introduced complex field retain the writer's nullability constraints.

This changes the default behavior for newly added required fields: such an evolution previously failed with `SchemaBackwardsCompatibilityException(READER_FIELD_MISSING_DEFAULT_VALUE)` and now succeeds by widening the new field to nullable. There is no public API, configuration, storage-format, or expected performance impact. The meaning and default of `hoodie.write.set.null.for.missing.columns` are unchanged.

### Risk Level

medium. This changes the default canonical writer schema for newly added fields. The risk is mitigated by 15 focused `TestHoodieSchemaUtils` unit cases and four `TestCOWDataSource#testSchemaEvolutionWithNewColumns` functional cases covering every combination of schema reconciliation and schema-on-read. The functional test verifies commit metadata, old-row `null` values, and new-row values.

### Documentation Update

required. The release notes for the first release containing this change should call out the default-behavior change: adding a required field previously failed with `SchemaBackwardsCompatibilityException(READER_FIELD_MISSING_DEFAULT_VALUE)`; after this change, Hudi widens the newly added field to nullable with a `null` default.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
