### PR TITLE
feat(utilities): select more than one file extension in cloud incremental sources

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -131,9 +131,11 @@ public class CloudSourceConfig extends HoodieConfig {
       .noDefaultValue()
       .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.select.file.extension")
       .markAdvanced()
-      .withDocumentation("Only match files with this extension. Accepts a comma separated list, "
-          + "in which case a file matching any one of the extensions is selected, e.g. \"json,jsonl\". "
-          + "By default, this is the same as hoodie.streamer.source.hoodieincr.file.format");
+      .withDocumentation("Only select objects whose key ends with this extension. Accepts a comma "
+          + "separated list, e.g. \"json,jsonl\", where an object matching any one of them is selected. "
+          + "With no usable extension configured, falls back to "
+          + "hoodie.streamer.source.cloud.data.datafile.format, then to "
+          + "hoodie.streamer.source.hoodieincr.file.format (parquet).");
 
   public static final ConfigProperty<String> DATAFILE_FORMAT = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.datafile.format")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -131,7 +131,9 @@ public class CloudSourceConfig extends HoodieConfig {
       .noDefaultValue()
       .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.select.file.extension")
       .markAdvanced()
-      .withDocumentation("Only match files with this extension. By default, this is the same as hoodie.streamer.source.hoodieincr.file.format");
+      .withDocumentation("Only match files with this extension. Accepts a comma separated list, "
+          + "in which case a file matching any one of the extensions is selected, e.g. \"json,jsonl\". "
+          + "By default, this is the same as hoodie.streamer.source.hoodieincr.file.format");
 
   public static final ConfigProperty<String> DATAFILE_FORMAT = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.datafile.format")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -302,11 +302,31 @@ public class CloudObjectsSelectorCommon {
       filter.append(SPACE_DELIMTER).append(String.format("and %s not like '%%%s%%'", objectKey, ignoreRelativePathSubStr.get()));
     }
 
-    // Match files with a given extension, or use the fileFormat as the default.
+    // Match files with any of the given extensions, or use the fileFormat as the default.
     getPropVal(props, CLOUD_DATAFILE_EXTENSION).or(() -> Option.of(fileFormat))
-        .map(val -> filter.append(SPACE_DELIMTER).append(String.format("and %s like '%%%s'", objectKey, val)));
+        .map(extensions -> filter.append(extensionClause(objectKey, extensions)));
 
     return filter.toString();
+  }
+
+  /**
+   * Renders the file extension predicate. A comma separated value matches any one of the
+   * extensions, so a prefix holding more than one file type can be selected in a single sync;
+   * a single value renders exactly the predicate it always did. Empty when no usable extension
+   * is configured, which leaves the filter unchanged.
+   */
+  private static String extensionClause(String objectKey, String extensions) {
+    List<String> predicates = Arrays.stream(extensions.split(","))
+        .map(String::trim)
+        .filter(extension -> !extension.isEmpty())
+        .map(extension -> String.format("%s like '%%%s'", objectKey, extension))
+        .collect(Collectors.toList());
+    if (predicates.isEmpty()) {
+      return "";
+    }
+    return predicates.size() == 1
+        ? SPACE_DELIMTER + "and " + predicates.get(0)
+        : SPACE_DELIMTER + "and (" + String.join(" or ", predicates) + ")";
   }
 
   /**

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -293,6 +294,57 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
     assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("avro"));
     assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(""));
     assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(null));
+  }
+
+  @Test
+  void extensionFilterKeepsASinglePredicateForOneExtension() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), "json");
+    assertEquals("s3.object.size > 0 and s3.object.key like '%json'",
+        CloudObjectsSelectorCommon.generateFilter(CloudObjectsSelectorCommon.Type.S3, props));
+  }
+
+  @Test
+  void extensionFilterMatchesAnyOneOfSeveralExtensions() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), "pdf,docx,html");
+    assertEquals("s3.object.size > 0 and (s3.object.key like '%pdf' or s3.object.key like '%docx'"
+            + " or s3.object.key like '%html')",
+        CloudObjectsSelectorCommon.generateFilter(CloudObjectsSelectorCommon.Type.S3, props));
+  }
+
+  @Test
+  void extensionFilterTrimsBlanksAndDropsEmptyEntries() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), " pdf , ,docx, ");
+    assertEquals("s3.object.size > 0 and (s3.object.key like '%pdf' or s3.object.key like '%docx')",
+        CloudObjectsSelectorCommon.generateFilter(CloudObjectsSelectorCommon.Type.S3, props));
+  }
+
+  @Test
+  void extensionFilterFallsBackToTheDataFileFormat() {
+    // pins long-standing behaviour: with nothing configured the filter selects parquet only
+    assertEquals("s3.object.size > 0 and s3.object.key like '%parquet'",
+        CloudObjectsSelectorCommon.generateFilter(
+            CloudObjectsSelectorCommon.Type.S3, new TypedProperties()));
+  }
+
+  @Test
+  void extensionFilterUsesTheGcsObjectKeyAndSizeColumns() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), "pdf,png");
+    assertEquals("size > 0 and (name like '%pdf' or name like '%png')",
+        CloudObjectsSelectorCommon.generateFilter(CloudObjectsSelectorCommon.Type.GCS, props));
+  }
+
+  @Test
+  void extensionFilterComposesWithThePathPrefixFilter() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.SELECT_RELATIVE_PATH_PREFIX.key(), "docs/");
+    props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), "pdf,docx");
+    assertEquals("s3.object.size > 0 and s3.object.key like 'docs/%'"
+            + " and (s3.object.key like '%pdf' or s3.object.key like '%docx')",
+        CloudObjectsSelectorCommon.generateFilter(CloudObjectsSelectorCommon.Type.S3, props));
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

closes #19671

`hoodie.streamer.source.cloud.data.select.file.extension` is interpolated into a single SQL predicate, so a bucket holding more than one file type cannot be ingested by one streamer. Setting a list looks like it should work and fails quietly: `select.file.extension=json,jsonl` generates `s3.object.key like '%json,jsonl'`, a literal match on the joined string that selects nothing, and the job then commits nothing without reporting an error.

### Summary and Changelog

A comma separated value now renders one `like` predicate per extension, OR'd inside parentheses so it composes correctly with the size and relative-path predicates. A single value renders exactly the predicate it did before, and the fallback to the data file format when the config is unset is unchanged. `generateFilter` had no test coverage, so six cases were added to the existing suite: single and multiple extensions, blank and empty list entries, the format fallback, the GCS column names, and composition with the path prefix filter.

### Impact

Additive and backwards compatible. Existing single-extension pipelines produce a byte-identical filter, and the config keeps its current default. Users with mixed-extension buckets can now select them in one pipeline instead of running one per extension.

### Risk Level

low. The change is confined to rendering one config value into a filter string, and the previously untested single-value and format-fallback behaviours are now pinned by tests. Verified by running the new cases against the unmodified code first, where the four multiple-extension cases fail as expected (`expected: ...like '%pdf' or ...like '%docx'` but `was: ...like '%pdf,docx'`) while the two backwards-compatibility cases pass both before and after. `TestCloudObjectsSelectorCommon` (27), `TestS3EventsHoodieIncrSource` (16), `TestGcsEventsHoodieIncrSource` (11), `TestCloudObjectsSelector` (50) and `TestDeprecatedCloudIngestionConfigs` (3) all pass, with checkstyle clean.

### Documentation Update

The config documentation on `CLOUD_DATAFILE_EXTENSION` is updated in this PR and the reference tables generate from it, so no separate website change is needed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
