### PR TITLE
fix(utilities): ship Tika's parsers in the bundle and fail when they are absent

### DIFF
--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -115,7 +115,6 @@
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers-standard-package</artifactId>
       <version>${tika.version}</version>
-      <scope>test</scope>
     </dependency>
     <!-- POI (Office formats via tika-parsers) needs commons-compress >= 1.24; the
          hadoop/spark-provided 1.23 would otherwise shadow it on the test classpath.

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -103,9 +103,11 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Apache Tika: embedded document parsing for UnstructuredFileDFSSource.
-         Only tika-core ships in the bundles; parser modules (PDF, Office, ...) are
-         supplied at runtime via spark-submit packages (org.apache.tika:tika-parsers-standard-package) -->
+    <!-- Apache Tika: embedded document parsing for the unstructured file sources.
+         Only tika-core is compiled against, and only it ships in hudi-utilities-bundle.
+         The format parser modules are discovered at runtime through Tika's ServiceLoader,
+         so they are needed for tests and at runtime but never at compile time; they ship
+         in hudi-tika-bundle, which is passed alongside the utilities bundle. -->
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
@@ -115,6 +117,7 @@
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers-standard-package</artifactId>
       <version>${tika.version}</version>
+      <scope>test</scope>
     </dependency>
     <!-- POI (Office formats via tika-parsers) needs commons-compress >= 1.24; the
          hadoop/spark-provided 1.23 would otherwise shadow it on the test classpath.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/UnstructuredFileSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/UnstructuredFileSourceConfig.java
@@ -122,6 +122,15 @@ public class UnstructuredFileSourceConfig extends HoodieConfig {
       .sinceVersion("1.2.0")
       .withDocumentation("Number of characters consecutive chunks overlap by.");
 
+  public static final ConfigProperty<Integer> MAX_FILES_PER_BATCH = ConfigProperty
+      .key(PREFIX + "max.files.per.batch")
+      .defaultValue(10000)
+      .sinceVersion("1.3.0")
+      .withDocumentation("Maximum number of files a single sync ingests. --source-limit bounds "
+          + "bytes but never file count, and file count is what drives driver memory and task "
+          + "count, so a folder of many small files can otherwise pull an entire corpus into one "
+          + "batch. Files beyond the cap are picked up by the next sync.");
+
   public static final ConfigProperty<Integer> LISTING_PARALLELISM = ConfigProperty
       .key(PREFIX + "listing.parallelism")
       .defaultValue(0)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/UnstructuredFileDFSSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/UnstructuredFileDFSSource.java
@@ -28,7 +28,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.utilities.schema.SchemaProvider;
-import org.apache.hudi.utilities.sources.helpers.DFSPathSelector;
+import org.apache.hudi.utilities.sources.helpers.unstructured.UnstructuredFilePathSelector;
 import org.apache.hudi.utilities.sources.helpers.unstructured.UnstructuredFileRecordBuilder;
 
 import org.apache.hadoop.fs.FileSystem;
@@ -112,7 +112,7 @@ public class UnstructuredFileDFSSource extends RowSource {
       DataTypes.createStructField("parse_status", DataTypes.StringType, false),
       DataTypes.createStructField("parse_error", DataTypes.StringType, true)});
 
-  private final DFSPathSelector pathSelector;
+  private final UnstructuredFilePathSelector pathSelector;
   private final UnstructuredFileRecordBuilder recordBuilder;
   private final Set<String> allowedExtensions;
   private final Set<String> ignoredExtensions;
@@ -121,7 +121,7 @@ public class UnstructuredFileDFSSource extends RowSource {
   public UnstructuredFileDFSSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
       SchemaProvider schemaProvider) {
     super(props, sparkContext, sparkSession, schemaProvider);
-    this.pathSelector = DFSPathSelector.createSourceSelector(props, sparkContext.hadoopConfiguration());
+    this.pathSelector = new UnstructuredFilePathSelector(props, sparkContext.hadoopConfiguration());
     this.recordBuilder = new UnstructuredFileRecordBuilder(props);
     this.allowedExtensions = parseExtensions(getStringWithAltKeys(props, FILE_EXTENSIONS, true));
     this.ignoredExtensions = parseExtensions(getStringWithAltKeys(props, FILE_EXTENSIONS_IGNORE, true));
@@ -146,36 +146,35 @@ public class UnstructuredFileDFSSource extends RowSource {
 
   @Override
   public Pair<Option<Dataset<Row>>, Checkpoint> fetchNextBatch(Option<Checkpoint> lastCheckpoint, long sourceLimit) {
-    Pair<Option<String>, Checkpoint> selected =
-        pathSelector.getNextFilePathsAndMaxModificationTime(sparkContext, lastCheckpoint, sourceLimit);
-    return selected.getLeft()
-        .map(pathStr -> Pair.of(Option.of(fromFiles(pathStr)), selected.getRight()))
-        .orElseGet(() -> Pair.of(Option.empty(), selected.getRight()));
+    UnstructuredFilePathSelector.Batch batch = pathSelector.selectNextBatch(lastCheckpoint, sourceLimit);
+    List<UnstructuredFilePathSelector.FileEntry> eligible = batch.files.stream()
+        .filter(entry -> isEligible(new Path(entry.path).getName()))
+        .collect(Collectors.toList());
+    return eligible.isEmpty()
+        ? Pair.of(Option.empty(), batch.checkpoint)
+        : Pair.of(Option.of(fromFiles(eligible)), batch.checkpoint);
   }
 
-  private Dataset<Row> fromFiles(String pathStr) {
-    List<String> paths = Arrays.stream(pathStr.split(","))
-        .filter(p -> isEligible(new Path(p).getName()))
-        .collect(Collectors.toList());
-    int parallelism = Math.max(1, Math.min(paths.size(), listingParallelism));
+  private Dataset<Row> fromFiles(List<UnstructuredFilePathSelector.FileEntry> entries) {
+    int parallelism = Math.max(1, Math.min(entries.size(), listingParallelism));
     HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(sparkContext.hadoopConfiguration());
     UnstructuredFileRecordBuilder builder = this.recordBuilder;
     // one file -> one row, lazily: inline bytes and extracted text of a partition must
     // never be resident all at once, or partition memory scales with total corpus size
-    JavaRDD<Row> rows = sparkContext.parallelize(paths, parallelism).mapPartitions(pathIterator ->
-        new LazyIterableIterator<String, Row>(pathIterator) {
+    JavaRDD<Row> rows = sparkContext.parallelize(entries, parallelism).mapPartitions(entryIterator ->
+        new LazyIterableIterator<UnstructuredFilePathSelector.FileEntry, Row>(entryIterator) {
           private FileSystem fs;
 
           @Override
           protected Row computeNext() {
-            String path = inputItr.next();
+            UnstructuredFilePathSelector.FileEntry entry = inputItr.next();
             try {
               if (fs == null) {
-                fs = HadoopFSUtils.getFs(new Path(path), storageConf);
+                fs = HadoopFSUtils.getFs(new Path(entry.path), storageConf);
               }
-              return builder.buildRow(fs, path);
+              return builder.buildRow(fs, entry);
             } catch (IOException e) {
-              throw new UncheckedIOException("Failed to build record for " + path, e);
+              throw new UncheckedIOException("Failed to build record for " + entry.path, e);
             }
           }
         });

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/DocumentParser.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/DocumentParser.java
@@ -26,14 +26,19 @@ import java.io.Serializable;
 
 /**
  * Extracts text and metadata from a single file's content stream. Implementations run
- * inside Spark executors, must be embedded JVM libraries (no external service calls),
- * and must NEVER throw from {@link #parse}: any failure is reported via
- * {@link ParseResult#failed}.
+ * inside Spark executors and must be embedded JVM libraries (no external service calls).
+ *
+ * <p>{@link #parse} must not throw an {@link Exception}: a file it cannot handle is
+ * reported via {@link ParseResult#failed} so one bad file never fails the ingestion job.
+ * An {@link Error} is a different matter and must be allowed to propagate, so the task
+ * fails and Spark retries it rather than continuing on an undefined JVM state.
  */
 public interface DocumentParser extends Serializable {
 
   /**
-   * Called once per executor instance before the first {@link #parse}.
+   * Called once per Spark task, on the instance that task will use, before its first
+   * {@link #parse}. Implementations are deserialized per task, not per executor, so
+   * anything expensive set up here is paid once per partition.
    */
   default void init(TypedProperties props) {
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/TextChunker.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/TextChunker.java
@@ -96,10 +96,15 @@ public class TextChunker implements Serializable {
   private int findBreak(String text, int start, int windowEnd) {
     int minBreak = start + Math.max(overlapChars + 1, chunkSizeChars / 2);
     for (String boundary : BOUNDARIES) {
-      int idx = text.lastIndexOf(boundary, windowEnd - boundary.length());
-      int breakEnd = idx + boundary.length();
-      if (idx >= 0 && breakEnd > minBreak && breakEnd <= windowEnd) {
-        return breakEnd;
+      int length = boundary.length();
+      // Only a break landing in (minBreak, windowEnd] is acceptable, so scan just that
+      // window. lastIndexOf would instead run back to index 0 whenever the boundary is
+      // absent, making chunking quadratic in document length.
+      int lowestIdx = Math.max(0, minBreak - length + 1);
+      for (int idx = windowEnd - length; idx >= lowestIdx; idx--) {
+        if (text.startsWith(boundary, idx)) {
+          return idx + length;
+        }
       }
     }
     return windowEnd;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/TikaDocumentParser.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/TikaDocumentParser.java
@@ -60,9 +60,11 @@ public class TikaDocumentParser implements DocumentParser {
         truncated = true;
       }
       return ParseResult.success(handler.toString().trim(), toMap(tikaMetadata), truncated);
-    } catch (Throwable t) {
-      // Never propagate: a corrupt file must not fail the ingestion job.
-      return ParseResult.failed(t.getClass().getSimpleName() + ": " + String.valueOf(t.getMessage()));
+    } catch (Exception e) {
+      // A corrupt file must not fail the ingestion job. Error is deliberately not caught:
+      // swallowing OutOfMemoryError would carry on with an undefined JVM state instead of
+      // failing the task and letting Spark retry it elsewhere.
+      return ParseResult.failed(e.getClass().getSimpleName() + ": " + String.valueOf(e.getMessage()));
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/TikaDocumentParser.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/TikaDocumentParser.java
@@ -36,7 +36,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hudi.utilities.config.UnstructuredFileSourceConfig.PARSE_ENABLED;
 
@@ -52,27 +51,44 @@ public class TikaDocumentParser implements DocumentParser {
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LoggerFactory.getLogger(TikaDocumentParser.class);
 
-  // one probe per JVM, not per task
-  private static final AtomicBoolean PROBED = new AtomicBoolean();
   private static final String PROBE_TEXT = "hudi unstructured ingest parser probe.\n";
+
+  // Probe outcome, memoized per JVM. init() runs once per task, so latching on "have we
+  // probed" would let only the first task on an executor fail and every later one - including
+  // Spark's retry of that task - carry on with a parser that cannot extract anything.
+  @VisibleForTesting
+  static volatile Boolean parserModulesPresent;
 
   private transient AutoDetectParser parser;
 
   @Override
   public void init(org.apache.hudi.common.config.TypedProperties props) {
-    // init() only runs when parsing is enabled, so reaching here means the user asked for text
-    // extraction. A deployment that cannot extract any text at all is a misconfiguration, and
-    // failing here is the difference between a clear error and a table that is silently empty:
-    // every row would get parse_status=EMPTY, no extracted_text, no chunks, and a null vector,
-    // with the job exiting successfully. EMPTY is also the normal result for an image, so
-    // nothing downstream can tell the two apart.
-    if (PROBED.compareAndSet(false, true) && !canExtractPlainText()) {
+    // Failing loudly beats the alternative: with no parser modules every row gets
+    // parse_status=EMPTY, no extracted_text, no chunks and a null vector, while the job still
+    // exits successfully. EMPTY is also the normal result for an image, so nothing downstream
+    // can tell an unparseable deployment from a corpus of pictures.
+    if (!hasParserModules()) {
       throw new HoodieException("Apache Tika extracted no text from a plain-text probe, so no Tika "
-          + "parser modules are on the classpath and no file will yield any text. The parsers ship "
-          + "in hudi-utilities-bundle; if you are running the slim bundle or a custom assembly, add "
-          + "org.apache.tika:tika-parsers-standard-package. To ingest blobs without text extraction, "
-          + "set " + PARSE_ENABLED.key() + "=false.");
+          + "parser modules are on the classpath and no file will yield any text. The parser modules "
+          + "ship in hudi-tika-bundle; pass it alongside hudi-utilities-bundle, or add "
+          + "org.apache.tika:tika-parsers-standard-package to a custom assembly. To ingest blobs "
+          + "without text extraction, set " + PARSE_ENABLED.key() + "=false.");
     }
+  }
+
+  /** Probes at most once per JVM, then reuses the outcome for every subsequent task. */
+  private static boolean hasParserModules() {
+    Boolean present = parserModulesPresent;
+    if (present == null) {
+      synchronized (TikaDocumentParser.class) {
+        present = parserModulesPresent;
+        if (present == null) {
+          present = canExtractPlainText();
+          parserModulesPresent = present;
+        }
+      }
+    }
+    return present;
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/TikaDocumentParser.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/TikaDocumentParser.java
@@ -19,16 +19,26 @@
 
 package org.apache.hudi.utilities.sources.helpers.unstructured;
 
+import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.exception.HoodieException;
+
 import org.apache.tika.exception.WriteLimitReachedException;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.BodyContentHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.hudi.utilities.config.UnstructuredFileSourceConfig.PARSE_ENABLED;
 
 /**
  * Default {@link DocumentParser} backed by Apache Tika's {@link AutoDetectParser}:
@@ -40,8 +50,49 @@ import java.util.Map;
 public class TikaDocumentParser implements DocumentParser {
 
   private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(TikaDocumentParser.class);
+
+  // one probe per JVM, not per task
+  private static final AtomicBoolean PROBED = new AtomicBoolean();
+  private static final String PROBE_TEXT = "hudi unstructured ingest parser probe.\n";
 
   private transient AutoDetectParser parser;
+
+  @Override
+  public void init(org.apache.hudi.common.config.TypedProperties props) {
+    // init() only runs when parsing is enabled, so reaching here means the user asked for text
+    // extraction. A deployment that cannot extract any text at all is a misconfiguration, and
+    // failing here is the difference between a clear error and a table that is silently empty:
+    // every row would get parse_status=EMPTY, no extracted_text, no chunks, and a null vector,
+    // with the job exiting successfully. EMPTY is also the normal result for an image, so
+    // nothing downstream can tell the two apart.
+    if (PROBED.compareAndSet(false, true) && !canExtractPlainText()) {
+      throw new HoodieException("Apache Tika extracted no text from a plain-text probe, so no Tika "
+          + "parser modules are on the classpath and no file will yield any text. The parsers ship "
+          + "in hudi-utilities-bundle; if you are running the slim bundle or a custom assembly, add "
+          + "org.apache.tika:tika-parsers-standard-package. To ingest blobs without text extraction, "
+          + "set " + PARSE_ENABLED.key() + "=false.");
+    }
+  }
+
+  /**
+   * Parses a tiny in-memory plain-text document to find out whether any real parser is
+   * registered. A functional probe rather than an inspection of Tika's registry: what
+   * matters to the caller is whether text comes back, not which modules resolved.
+   */
+  @VisibleForTesting
+  static boolean canExtractPlainText() {
+    try {
+      BodyContentHandler handler = new BodyContentHandler(1024);
+      new AutoDetectParser().parse(
+          new ByteArrayInputStream(PROBE_TEXT.getBytes(StandardCharsets.UTF_8)),
+          handler, new Metadata(), new ParseContext());
+      return handler.toString().contains("probe");
+    } catch (Exception e) {
+      LOG.warn("Tika plain-text probe failed", e);
+      return false;
+    }
+  }
 
   @Override
   public ParseResult parse(InputStream in, String fileName, int maxTextChars) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFilePathSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFilePathSelector.java
@@ -22,6 +22,7 @@ package org.apache.hudi.utilities.sources.helpers.unstructured;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
@@ -79,6 +80,10 @@ public class UnstructuredFilePathSelector implements Serializable {
   public UnstructuredFilePathSelector(TypedProperties props, Configuration hadoopConf) {
     this.rootPath = getStringWithAltKeys(props, DFSPathSelectorConfig.ROOT_INPUT_PATH);
     this.maxFilesPerBatch = getIntWithAltKeys(props, MAX_FILES_PER_BATCH);
+    // a non-positive cap would select nothing, leave the checkpoint untouched, and stall every
+    // subsequent sync without ever failing
+    ValidationUtils.checkArgument(maxFilesPerBatch > 0,
+        MAX_FILES_PER_BATCH.key() + " must be positive, got " + maxFilesPerBatch);
     this.hadoopConf = hadoopConf;
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFilePathSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFilePathSelector.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers.unstructured;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.table.checkpoint.Checkpoint;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.utilities.config.DFSPathSelectorConfig;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.apache.hudi.common.table.checkpoint.CheckpointUtils.createCheckpoint;
+import static org.apache.hudi.common.util.ConfigUtils.getIntWithAltKeys;
+import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
+import static org.apache.hudi.utilities.config.UnstructuredFileSourceConfig.MAX_FILES_PER_BATCH;
+
+/**
+ * Selects the next batch of files for {@code UnstructuredFileDFSSource}.
+ *
+ * <p>Differs from {@link org.apache.hudi.utilities.sources.helpers.DFSPathSelector} in three ways
+ * that matter at scale:
+ *
+ * <ul>
+ *   <li>The batch is bounded by file <em>count</em> as well as bytes. A byte budget alone never
+ *       bounds the number of files, and file count is what drives driver memory and task count.</li>
+ *   <li>The checkpoint carries {@code (modificationTime, lastPath)} rather than a bare timestamp,
+ *       so a group of files sharing one modification time can be split across syncs without the
+ *       unread remainder being stranded by a {@code mtime > checkpoint} filter. Files arriving in
+ *       one bulk upload routinely share a timestamp, and object stores report modification times
+ *       at second granularity.</li>
+ *   <li>Selected files are returned as a list of {@code (path, size, modificationTime)} rather
+ *       than one comma-joined string. Paths legitimately contain commas, and re-splitting on one
+ *       corrupts them.</li>
+ * </ul>
+ */
+public class UnstructuredFilePathSelector implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final List<String> IGNORE_FILE_PREFIXES = Arrays.asList(".", "_");
+
+  private final String rootPath;
+  private final int maxFilesPerBatch;
+  private final transient Configuration hadoopConf;
+
+  public UnstructuredFilePathSelector(TypedProperties props, Configuration hadoopConf) {
+    this.rootPath = getStringWithAltKeys(props, DFSPathSelectorConfig.ROOT_INPUT_PATH);
+    this.maxFilesPerBatch = getIntWithAltKeys(props, MAX_FILES_PER_BATCH);
+    this.hadoopConf = hadoopConf;
+  }
+
+  /**
+   * One selected file, carrying what the driver already learned from listing so executors do not
+   * have to stat it a second time.
+   */
+  public static class FileEntry implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public final String path;
+    public final long size;
+    public final long modificationTime;
+
+    public FileEntry(String path, long size, long modificationTime) {
+      this.path = path;
+      this.size = size;
+      this.modificationTime = modificationTime;
+    }
+  }
+
+  /**
+   * The files chosen for one sync and the checkpoint to record if it commits.
+   */
+  public static class Batch {
+    public final List<FileEntry> files;
+    public final Checkpoint checkpoint;
+
+    Batch(List<FileEntry> files, Checkpoint checkpoint) {
+      this.files = files;
+      this.checkpoint = checkpoint;
+    }
+  }
+
+  /**
+   * Position in the source folder: everything at an earlier modification time, plus everything at
+   * this modification time whose path sorts at or before {@code lastPath}, has been ingested.
+   */
+  @VisibleForTesting
+  static class Position {
+    final long modificationTime;
+    final String lastPath;
+
+    Position(long modificationTime, String lastPath) {
+      this.modificationTime = modificationTime;
+      this.lastPath = lastPath;
+    }
+
+    /** True when this file still needs ingesting. */
+    boolean isAfter(FileStatus file) {
+      if (file.getModificationTime() != modificationTime) {
+        return file.getModificationTime() > modificationTime;
+      }
+      // same timestamp: only the tail of the group beyond lastPath remains. A checkpoint written
+      // by the old timestamp-only format has no lastPath, and treating the whole group as done
+      // preserves the previous behaviour rather than re-ingesting it on upgrade.
+      return lastPath != null && file.getPath().toString().compareTo(lastPath) > 0;
+    }
+  }
+
+  @VisibleForTesting
+  static Position decode(Option<Checkpoint> checkpoint) {
+    if (!checkpoint.isPresent() || checkpoint.get().getCheckpointKey() == null
+        || checkpoint.get().getCheckpointKey().isEmpty()) {
+      return new Position(Long.MIN_VALUE, null);
+    }
+    String key = checkpoint.get().getCheckpointKey();
+    if (key.startsWith("{")) {
+      try {
+        JsonNode node = MAPPER.readTree(key);
+        JsonNode path = node.get("lastPath");
+        return new Position(node.get("mtime").asLong(),
+            path == null || path.isNull() ? null : path.asText());
+      } catch (IOException e) {
+        throw new HoodieIOException("Unreadable checkpoint: " + key, e);
+      }
+    }
+    // legacy timestamp-only checkpoint written by DFSPathSelector
+    return new Position(Long.parseLong(key.trim()), null);
+  }
+
+  @VisibleForTesting
+  static String encode(Position position) {
+    ObjectNode node = MAPPER.createObjectNode();
+    node.put("mtime", position.modificationTime);
+    if (position.lastPath == null) {
+      node.putNull("lastPath");
+    } else {
+      node.put("lastPath", position.lastPath);
+    }
+    return node.toString();
+  }
+
+  public Batch selectNextBatch(Option<Checkpoint> lastCheckpoint, long sourceLimit) {
+    Position from = decode(lastCheckpoint);
+    List<FileStatus> eligible = new ArrayList<>();
+    try {
+      FileSystem fs = HadoopFSUtils.getFs(rootPath, hadoopConf);
+      collectEligible(fs, new Path(rootPath), from, eligible);
+    } catch (IOException e) {
+      throw new HoodieIOException("Unable to list source root " + rootPath, e);
+    }
+
+    // ordering the whole batch by (mtime, path) is what makes a partial group resumable
+    eligible.sort(Comparator.comparingLong(FileStatus::getModificationTime)
+        .thenComparing(f -> f.getPath().toString()));
+
+    List<FileEntry> selected = new ArrayList<>();
+    long bytes = 0;
+    Position to = from;
+    for (FileStatus file : eligible) {
+      if (selected.size() >= maxFilesPerBatch) {
+        break;
+      }
+      if (!selected.isEmpty() && bytes + file.getLen() >= sourceLimit) {
+        break;
+      }
+      String path = file.getPath().toString();
+      selected.add(new FileEntry(path, file.getLen(), file.getModificationTime()));
+      bytes += file.getLen();
+      to = new Position(file.getModificationTime(), path);
+    }
+
+    return new Batch(selected, createCheckpoint(encode(to)));
+  }
+
+  private void collectEligible(FileSystem fs, Path path, Position from, List<FileStatus> out)
+      throws IOException {
+    FileStatus[] statuses = fs.listStatus(path, candidate ->
+        IGNORE_FILE_PREFIXES.stream().noneMatch(prefix -> candidate.getName().startsWith(prefix)));
+    for (FileStatus status : statuses) {
+      if (status.isDirectory()) {
+        if (!status.isSymlink()) {
+          collectEligible(fs, status.getPath(), from, out);
+        }
+      } else if (status.getLen() > 0 && from.isAfter(status)) {
+        out.add(status);
+      }
+    }
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFileRecordBuilder.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFileRecordBuilder.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 
 import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.Row;
@@ -84,10 +83,12 @@ public class UnstructuredFileRecordBuilder implements Serializable {
         getIntWithAltKeys(props, CHUNK_OVERLAP_CHARS));
   }
 
-  public Row buildRow(FileSystem fs, String pathStr) throws IOException {
+  public Row buildRow(FileSystem fs, UnstructuredFilePathSelector.FileEntry entry) throws IOException {
+    String pathStr = entry.path;
     Path path = new Path(pathStr);
-    FileStatus status = fs.getFileStatus(path);
-    long size = status.getLen();
+    // size and modification time come from the driver's listing; re-statting here would be a
+    // second full round of metadata requests against the object store
+    long size = entry.size;
     String fileName = path.getName();
 
     byte[] inlineBytes = null;
@@ -110,7 +111,7 @@ public class UnstructuredFileRecordBuilder implements Serializable {
         fileName,
         extensionOf(fileName),
         size,
-        status.getModificationTime(),
+        entry.modificationTime,
         blob,
         parseResult.getText(),
         // Spark's Row encoder requires a scala Map as the external type for MapType

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFileRecordBuilder.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFileRecordBuilder.java
@@ -97,7 +97,13 @@ public class UnstructuredFileRecordBuilder implements Serializable {
       inlineBytes = readFully(fs, path, (int) size);
       blob = RowFactory.create(HoodieSchema.Blob.INLINE, inlineBytes, null);
     } else {
-      Row reference = RowFactory.create(pathStr, null, null, false);
+      // length records what was ingested, so a reference that no longer matches the file can be
+      // detected from metadata alone. A replaced file is normally re-ingested because its
+      // modification time moves, but a copy that preserves mtime would otherwise diverge silently,
+      // and a historical row's reference always resolves to the file's current bytes.
+      // Valid as an integrity signal only because the blob is the whole file; a future sub-range
+      // reference (offset + length) would need the check to account for that.
+      Row reference = RowFactory.create(pathStr, null, size, false);
       blob = RowFactory.create(HoodieSchema.Blob.OUT_OF_LINE, null, reference);
     }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFileRecordBuilder.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFileRecordBuilder.java
@@ -22,6 +22,7 @@ package org.apache.hudi.utilities.sources.helpers.unstructured;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.ValidationUtils;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -70,6 +71,11 @@ public class UnstructuredFileRecordBuilder implements Serializable {
   public UnstructuredFileRecordBuilder(TypedProperties props) {
     this.props = props;
     this.inlineMaxBytes = getLongWithAltKeys(props, BLOB_INLINE_MAX_BYTES);
+    // readFully narrows the size to int, so a threshold past Integer.MAX_VALUE would
+    // surface as a NegativeArraySizeException on the first oversized file instead
+    ValidationUtils.checkArgument(inlineMaxBytes >= 0 && inlineMaxBytes <= Integer.MAX_VALUE,
+        BLOB_INLINE_MAX_BYTES.key() + " must be between 0 and " + Integer.MAX_VALUE
+            + ", got " + inlineMaxBytes);
     this.parseEnabled = getBooleanWithAltKeys(props, PARSE_ENABLED);
     this.parseMaxBytes = getLongWithAltKeys(props, PARSE_MAX_BYTES);
     this.parseMaxTextChars = getIntWithAltKeys(props, PARSE_MAX_TEXT_CHARS);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/embedding/EmbeddingTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/embedding/EmbeddingTransformer.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.util.collection.LazyIterableIterator;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.transform.Transformer;
 
+import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -39,6 +40,7 @@ import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.TaskCompletionListener;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -194,9 +196,7 @@ public class EmbeddingTransformer implements Transformer {
 
     @Override
     protected void end() {
-      if (executor != null) {
-        executor.shutdownNow();
-      }
+      shutdownExecutor();
     }
 
     /**
@@ -262,12 +262,27 @@ public class EmbeddingTransformer implements Transformer {
       }
     }
 
-    private ExecutorService executor() {
+    private synchronized ExecutorService executor() {
       if (executor == null) {
         executor = Executors.newFixedThreadPool(maxInflight,
             new CustomizedThreadFactory("embedding-transformer", true));
+        // end() runs only once the input drains normally. A task killed by an embeddings
+        // failure would otherwise strand maxInflight threads on an executor JVM that Spark
+        // goes on reusing, so release them on task completion however the task ends.
+        TaskContext taskContext = TaskContext.get();
+        if (taskContext != null) {
+          taskContext.addTaskCompletionListener(
+              (TaskCompletionListener) context -> shutdownExecutor());
+        }
       }
       return executor;
+    }
+
+    private synchronized void shutdownExecutor() {
+      if (executor != null) {
+        executor.shutdownNow();
+        executor = null;
+      }
     }
 
     private List<float[]> embed(List<String> texts) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/embedding/OpenAICompatibleEmbeddingProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/embedding/OpenAICompatibleEmbeddingProvider.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.utilities.transform.embedding;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.exception.HoodieException;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -35,6 +36,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.hudi.common.util.ConfigUtils.getLongWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
@@ -55,12 +57,16 @@ public class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
   private static final int MAX_ATTEMPTS = 5;
   private static final long BASE_BACKOFF_MS = 1_000L;
 
+  // One client per JVM per connect timeout, shared by every partition on the executor.
+  // java.net.http.HttpClient is not Closeable before Java 21 and owns a selector thread
+  // plus a connection pool, so an instance-level client would accumulate one of each per
+  // Spark task with no way to release them.
+  private static final ConcurrentHashMap<Long, HttpClient> CLIENTS = new ConcurrentHashMap<>();
+
   private String endpointUrl;
   private String model;
   private String apiKeyEnv;
   private long timeoutMs;
-
-  private transient HttpClient client;
 
   @Override
   public void init(TypedProperties props) {
@@ -98,13 +104,12 @@ public class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
     }
   }
 
-  // one client per provider instance, shared by concurrent batch requests: HttpClient is
-  // thread-safe and keep-alives/pools connections internally, so requests reuse sockets
-  private synchronized HttpClient client() {
-    if (client == null) {
-      client = HttpClient.newBuilder().connectTimeout(Duration.ofMillis(timeoutMs)).build();
-    }
-    return client;
+  // HttpClient is thread-safe and keep-alives/pools connections internally, so sharing
+  // one across concurrent batch requests reuses sockets rather than contending
+  @VisibleForTesting
+  HttpClient client() {
+    return CLIENTS.computeIfAbsent(timeoutMs,
+        timeout -> HttpClient.newBuilder().connectTimeout(Duration.ofMillis(timeout)).build());
   }
 
   private HttpRequest buildRequest(List<String> texts) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestUnstructuredFileDFSSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestUnstructuredFileDFSSource.java
@@ -106,6 +106,10 @@ public class TestUnstructuredFileDFSSource extends UtilitiesTestBase {
     Row reference = bigBlob.getStruct(2);
     assertTrue(reference.getString(0).endsWith("big.txt"));
     assertFalse(reference.getBoolean(3)); // managed=false: points at the original file in place
+    assertNull(reference.get(1), "offset is unset, meaning the blob starts at byte 0");
+    // the ingested size, so a reference that stops matching the file is detectable without
+    // reading the blob - the only signal when a replacement preserves the modification time
+    assertEquals(bigRow.getLong(df.schema().fieldIndex("size")), reference.getLong(2));
     // out-of-line files are still parsed (streamed from the source file)
     assertEquals("SUCCESS", bigRow.getString(df.schema().fieldIndex("parse_status")));
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredFilePathSelector.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredFilePathSelector.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.table.checkpoint.CheckpointUtils.createCheckpoint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -160,6 +161,18 @@ public class TestUnstructuredFilePathSelector {
 
     assertEquals(1, files.size());
     assertTrue(files.get(0).path.endsWith("new.txt"));
+  }
+
+  /**
+   * A non-positive cap selects nothing and leaves the checkpoint untouched, so every later sync
+   * would stall silently rather than fail. Reject it where the message can still name the config.
+   */
+  @Test
+  void testNonPositiveFileCapIsRejected() {
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> selector(0));
+    assertTrue(thrown.getMessage().contains(UnstructuredFileSourceConfig.MAX_FILES_PER_BATCH.key()),
+        "the error must name the offending config key, got: " + thrown.getMessage());
   }
 
   /** The byte budget still applies, but a single oversized file must not stall the sync forever. */

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredFilePathSelector.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredFilePathSelector.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers.unstructured;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.table.checkpoint.Checkpoint;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.config.UnstructuredFileSourceConfig;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.table.checkpoint.CheckpointUtils.createCheckpoint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Batch selection for the unstructured source: paths survive intact, batches are bounded by file
+ * count, and a group of files sharing one modification time can be split and resumed.
+ */
+public class TestUnstructuredFilePathSelector {
+
+  @TempDir
+  Path root;
+
+  private TypedProperties props(int maxFiles) {
+    TypedProperties props = new TypedProperties();
+    props.setProperty("hoodie.streamer.source.dfs.root", root.toString());
+    props.setProperty(UnstructuredFileSourceConfig.MAX_FILES_PER_BATCH.key(), String.valueOf(maxFiles));
+    return props;
+  }
+
+  private UnstructuredFilePathSelector selector(int maxFiles) {
+    return new UnstructuredFilePathSelector(props(maxFiles), new Configuration());
+  }
+
+  private void write(String name, long modificationTime) throws IOException {
+    Path file = root.resolve(name);
+    Files.createDirectories(file.getParent());
+    Files.write(file, ("content of " + name).getBytes(StandardCharsets.UTF_8));
+    assertTrue(file.toFile().setLastModified(modificationTime), "could not set mtime on " + name);
+  }
+
+  /**
+   * Paths were previously joined into one comma-delimited string and split back apart, so a single
+   * file whose name contains a comma was torn into fragments and failed the whole batch. Commas in
+   * filenames are ordinary in real document corpora.
+   */
+  @Test
+  void testPathsContainingCommasSurviveSelection() throws IOException {
+    write("Q3,2024 report.txt", 1_000L);
+    write("Smith, John - resume.txt", 2_000L);
+    write("ordinary.txt", 3_000L);
+
+    List<UnstructuredFilePathSelector.FileEntry> files =
+        selector(100).selectNextBatch(Option.empty(), Long.MAX_VALUE).files;
+
+    assertEquals(3, files.size(), "one entry per file, regardless of commas in the name");
+    Set<String> names = files.stream().map(f -> new java.io.File(f.path).getName())
+        .collect(Collectors.toSet());
+    assertTrue(names.contains("Q3,2024 report.txt"), "got: " + names);
+    assertTrue(names.contains("Smith, John - resume.txt"), "got: " + names);
+  }
+
+  /** Each entry carries what the driver already learned, so executors need not stat again. */
+  @Test
+  void testEntriesCarrySizeAndModificationTime() throws IOException {
+    write("doc.txt", 5_000L);
+
+    UnstructuredFilePathSelector.FileEntry entry =
+        selector(100).selectNextBatch(Option.empty(), Long.MAX_VALUE).files.get(0);
+
+    assertEquals(Files.size(root.resolve("doc.txt")), entry.size);
+    assertEquals(5_000L, entry.modificationTime);
+  }
+
+  /**
+   * A byte budget alone never bounds file count, which is what drives driver memory and task
+   * count. A folder of small files could therefore pull an entire corpus into one batch.
+   */
+  @Test
+  void testBatchIsBoundedByFileCount() throws IOException {
+    for (int i = 0; i < 50; i++) {
+      write(String.format("doc-%03d.txt", i), 1_000L + i);
+    }
+
+    assertEquals(10, selector(10).selectNextBatch(Option.empty(), Long.MAX_VALUE).files.size());
+  }
+
+  /**
+   * The core fix. Every file shares one modification time, which is what a bulk upload produces
+   * and what object stores report at second granularity. Previously the batch could not be split,
+   * because the next sync's {@code mtime > checkpoint} filter would strand the remainder - so the
+   * limit was ignored and the whole group was ingested at once. With the path recorded alongside
+   * the timestamp the group splits safely and resumes.
+   */
+  @Test
+  void testSameModificationTimeGroupSplitsAndResumes() throws IOException {
+    for (int i = 0; i < 50; i++) {
+      write(String.format("doc-%03d.txt", i), 7_777L);
+    }
+
+    UnstructuredFilePathSelector selector = selector(10);
+    List<String> ingested = new ArrayList<>();
+    Option<Checkpoint> checkpoint = Option.empty();
+
+    for (int sync = 0; sync < 5; sync++) {
+      UnstructuredFilePathSelector.Batch batch = selector.selectNextBatch(checkpoint, Long.MAX_VALUE);
+      assertEquals(10, batch.files.size(), "sync " + sync + " must honour the file cap");
+      batch.files.forEach(f -> ingested.add(f.path));
+      checkpoint = Option.of(batch.checkpoint);
+    }
+
+    assertEquals(50, ingested.size());
+    assertEquals(50, new HashSet<>(ingested).size(), "no file may be ingested twice");
+    assertTrue(selector.selectNextBatch(checkpoint, Long.MAX_VALUE).files.isEmpty(),
+        "the group must be exhausted, not left stranded");
+  }
+
+  /**
+   * A table written before this selector carries a bare timestamp. Upgrading must not re-ingest
+   * everything at that timestamp, so a legacy checkpoint keeps the old "strictly newer" meaning.
+   */
+  @Test
+  void testLegacyTimestampCheckpointIsHonoured() throws IOException {
+    write("old.txt", 1_000L);
+    write("new.txt", 9_000L);
+
+    List<UnstructuredFilePathSelector.FileEntry> files = selector(100)
+        .selectNextBatch(Option.of(createCheckpoint("1000")), Long.MAX_VALUE).files;
+
+    assertEquals(1, files.size());
+    assertTrue(files.get(0).path.endsWith("new.txt"));
+  }
+
+  /** The byte budget still applies, but a single oversized file must not stall the sync forever. */
+  @Test
+  void testByteLimitStillAppliesAndNeverStalls() throws IOException {
+    write("a.txt", 1_000L);
+    write("b.txt", 2_000L);
+    write("c.txt", 3_000L);
+
+    assertEquals(1, selector(100).selectNextBatch(Option.empty(), 1L).files.size(),
+        "a limit smaller than the first file must still make progress");
+
+    UnstructuredFilePathSelector.Batch batch =
+        selector(100).selectNextBatch(Option.empty(), Long.MAX_VALUE);
+    assertEquals(3, batch.files.size());
+    assertFalse(batch.files.isEmpty());
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredIngestHardening.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredIngestHardening.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers.unstructured;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for the hardening fixes on the unstructured ingest path: the bounded
+ * chunk-boundary search preserves output. The cost half of the fix is a measurement, so
+ * it lives in the scale harness rather than here.
+ */
+public class TestUnstructuredIngestHardening {
+
+  /**
+   * The bounded break search must pick the same break points the unbounded one did, so
+   * chunk text, ordering, overlap and char_start offsets are unchanged by the fix.
+   */
+  @Test
+  void testBoundedBreakSearchPreservesChunking() {
+    int chunkSize = 64;
+    int overlap = 8;
+    TextChunker chunker = new TextChunker(chunkSize, overlap);
+    String text = "First para line one.\nStill first para.\n\nSecond para here! And more? Yes.\n\n"
+        + "Third paragraph with a long unbroken runxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx end.";
+
+    List<TextChunker.Chunk> chunks = chunker.chunk(text);
+
+    assertTrue(chunks.size() > 1, "expected the text to split into several chunks");
+    for (int i = 0; i < chunks.size(); i++) {
+      TextChunker.Chunk chunk = chunks.get(i);
+      assertEquals(i, chunk.chunkId);
+      assertTrue(chunk.text.length() <= chunkSize, "chunk " + i + " exceeded the window");
+      // chunks are verbatim substrings, so char_start must index back into the original
+      assertEquals(chunk.text,
+          text.substring(chunk.charStart, chunk.charStart + chunk.text.length()));
+      if (i > 0) {
+        TextChunker.Chunk previous = chunks.get(i - 1);
+        assertEquals(previous.charStart + previous.text.length() - overlap, chunk.charStart,
+            "chunk " + i + " must start one overlap back from the previous chunk's end");
+      }
+    }
+    TextChunker.Chunk last = chunks.get(chunks.size() - 1);
+    assertEquals(text.length(), last.charStart + last.text.length(),
+        "the chunks must cover the whole text");
+  }
+
+  /**
+   * Text whose only usable boundary is the space character exercises the miss path for
+   * five of the six boundaries on every chunk, which is where the unbounded search used to
+   * walk back to index 0. Behaviour must be identical to the general case.
+   */
+  @Test
+  void testChunkingTextWithoutParagraphOrSentenceBoundaries() {
+    TextChunker chunker = new TextChunker(100, 10);
+    StringBuilder builder = new StringBuilder();
+    while (builder.length() < 5000) {
+      builder.append("alpha bravo charlie delta echo foxtrot golf hotel india juliet ");
+    }
+    String text = builder.toString();
+
+    List<TextChunker.Chunk> chunks = chunker.chunk(text);
+
+    assertTrue(chunks.size() > 40, "expected many chunks, got " + chunks.size());
+    for (TextChunker.Chunk chunk : chunks) {
+      assertEquals(chunk.text,
+          text.substring(chunk.charStart, chunk.charStart + chunk.text.length()));
+      assertTrue(chunk.text.length() <= 100);
+    }
+    TextChunker.Chunk last = chunks.get(chunks.size() - 1);
+    assertEquals(text.length(), last.charStart + last.text.length());
+  }
+
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredIngestHardening.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredIngestHardening.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.utilities.sources.helpers.unstructured;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.config.UnstructuredFileSourceConfig;
 
 import org.junit.jupiter.api.Test;
@@ -138,9 +139,10 @@ public class TestUnstructuredIngestHardening {
   }
 
   /**
-   * The probe is what tells a user their table will have no text at all. hudi-utilities has
+   * The probe is what tells a user their table would have no text at all. hudi-utilities has
    * the Tika parser modules on its test classpath, so here it must report that plain text
-   * extracts; a deployment running the shipped bundle alone gets false and the warning.
+   * extracts; a deployment running hudi-utilities-bundle without hudi-tika-bundle gets false
+   * and the failure raised by {@link TikaDocumentParser#init}.
    */
   @Test
   void testPlainTextProbeDetectsAvailableParserModules() {
@@ -152,6 +154,30 @@ public class TestUnstructuredIngestHardening {
         "probe.txt", 1000);
     assertEquals(ParseResult.ParseStatus.SUCCESS, parsed.getStatus());
     assertTrue(parsed.getText().contains("lakehouse"));
+  }
+
+  /**
+   * init() runs once per Spark task, so a JVM without parser modules has to fail every task.
+   * Memoizing "we already probed" instead of the probe's answer made only the first task fail;
+   * Spark's retry of it then short-circuited, succeeded, and left every row parse_status=EMPTY.
+   */
+  @Test
+  void testMissingParserModulesFailEveryTaskNotOnlyTheFirst() {
+    Boolean actual = TikaDocumentParser.parserModulesPresent;
+    try {
+      TikaDocumentParser.parserModulesPresent = Boolean.FALSE;
+      TikaDocumentParser parser = new TikaDocumentParser();
+
+      for (int task = 1; task <= 3; task++) {
+        HoodieException thrown =
+            assertThrows(HoodieException.class, () -> parser.init(new TypedProperties()),
+                "task " + task + " must fail too, not just the first one");
+        assertTrue(thrown.getMessage().contains("hudi-tika-bundle"),
+            "the error must name the bundle carrying the parser modules, got: " + thrown.getMessage());
+      }
+    } finally {
+      TikaDocumentParser.parserModulesPresent = actual;
+    }
   }
 
   private static InputStream streamThrowing(Throwable failure) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredIngestHardening.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredIngestHardening.java
@@ -19,6 +19,9 @@
 
 package org.apache.hudi.utilities.sources.helpers.unstructured;
 
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.utilities.config.UnstructuredFileSourceConfig;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
@@ -30,8 +33,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Regression coverage for the hardening fixes on the unstructured ingest path: the bounded
- * chunk-boundary search preserves output, and an Error escapes the Tika parser. The cost
- * half of the chunker fix is a measurement, so it lives in the scale harness rather than here.
+ * chunk-boundary search preserves output, an Error escapes the Tika parser, and the inline
+ * blob threshold is validated. The cost half of the chunker fix is a measurement, so it
+ * lives in the scale harness rather than here.
  */
 public class TestUnstructuredIngestHardening {
 
@@ -112,6 +116,23 @@ public class TestUnstructuredIngestHardening {
     assertEquals(ParseResult.ParseStatus.FAILED, result.getStatus());
     assertTrue(result.getError().contains("synthetic failure"),
         "the parse error must be recorded on the row, got: " + result.getError());
+  }
+
+  /**
+   * readFully narrows the file size to an int, so a threshold above Integer.MAX_VALUE has
+   * to be rejected at construction. Before the fix it surfaced as a
+   * NegativeArraySizeException on the first oversized file, deep inside an executor.
+   */
+  @Test
+  void testInlineThresholdAboveIntMaxIsRejected() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(UnstructuredFileSourceConfig.BLOB_INLINE_MAX_BYTES.key(),
+        String.valueOf(Integer.MAX_VALUE + 1L));
+
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> new UnstructuredFileRecordBuilder(props));
+    assertTrue(thrown.getMessage().contains(UnstructuredFileSourceConfig.BLOB_INLINE_MAX_BYTES.key()),
+        "the error must name the offending config key, got: " + thrown.getMessage());
   }
 
   private static InputStream streamThrowing(Throwable failure) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredIngestHardening.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredIngestHardening.java
@@ -24,7 +24,9 @@ import org.apache.hudi.utilities.config.UnstructuredFileSourceConfig;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -133,6 +135,23 @@ public class TestUnstructuredIngestHardening {
         assertThrows(IllegalArgumentException.class, () -> new UnstructuredFileRecordBuilder(props));
     assertTrue(thrown.getMessage().contains(UnstructuredFileSourceConfig.BLOB_INLINE_MAX_BYTES.key()),
         "the error must name the offending config key, got: " + thrown.getMessage());
+  }
+
+  /**
+   * The probe is what tells a user their table will have no text at all. hudi-utilities has
+   * the Tika parser modules on its test classpath, so here it must report that plain text
+   * extracts; a deployment running the shipped bundle alone gets false and the warning.
+   */
+  @Test
+  void testPlainTextProbeDetectsAvailableParserModules() {
+    assertTrue(TikaDocumentParser.canExtractPlainText(),
+        "tika-parsers-standard-package is on the test classpath, so the probe must find text");
+
+    ParseResult parsed = new TikaDocumentParser().parse(
+        new ByteArrayInputStream("hudi lakehouse probe text".getBytes(StandardCharsets.UTF_8)),
+        "probe.txt", 1000);
+    assertEquals(ParseResult.ParseStatus.SUCCESS, parsed.getStatus());
+    assertTrue(parsed.getText().contains("lakehouse"));
   }
 
   private static InputStream streamThrowing(Throwable failure) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredIngestHardening.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TestUnstructuredIngestHardening.java
@@ -21,15 +21,17 @@ package org.apache.hudi.utilities.sources.helpers.unstructured;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.InputStream;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Regression coverage for the hardening fixes on the unstructured ingest path: the bounded
- * chunk-boundary search preserves output. The cost half of the fix is a measurement, so
- * it lives in the scale harness rather than here.
+ * chunk-boundary search preserves output, and an Error escapes the Tika parser. The cost
+ * half of the chunker fix is a measurement, so it lives in the scale harness rather than here.
  */
 public class TestUnstructuredIngestHardening {
 
@@ -92,4 +94,35 @@ public class TestUnstructuredIngestHardening {
     assertEquals(text.length(), last.charStart + last.text.length());
   }
 
+  /**
+   * A corrupt file must not fail the job, but an Error must not be swallowed: catching it
+   * would carry on with an undefined JVM state instead of failing the task so Spark can
+   * retry it elsewhere. Before the fix the parser caught Throwable and turned an
+   * OutOfMemoryError into an ordinary FAILED row.
+   */
+  @Test
+  void testParserPropagatesErrorButRecordsException() {
+    TikaDocumentParser parser = new TikaDocumentParser();
+
+    assertThrows(OutOfMemoryError.class,
+        () -> parser.parse(streamThrowing(new OutOfMemoryError("synthetic oom")), "doc.txt", 1000));
+
+    ParseResult result =
+        parser.parse(streamThrowing(new IllegalStateException("synthetic failure")), "doc.txt", 1000);
+    assertEquals(ParseResult.ParseStatus.FAILED, result.getStatus());
+    assertTrue(result.getError().contains("synthetic failure"),
+        "the parse error must be recorded on the row, got: " + result.getError());
+  }
+
+  private static InputStream streamThrowing(Throwable failure) {
+    return new InputStream() {
+      @Override
+      public int read() {
+        if (failure instanceof Error) {
+          throw (Error) failure;
+        }
+        throw (RuntimeException) failure;
+      }
+    };
+  }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TextChunkerBenchmark.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/unstructured/TextChunkerBenchmark.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers.unstructured;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Manual benchmark for the bounded chunk-boundary search. Not a test: named *Benchmark so
+ * surefire leaves it alone. Run with
+ * {@code mvn -pl hudi-utilities exec:java -Dexec.classpathScope=test
+ * -Dexec.mainClass=org.apache.hudi.utilities.sources.helpers.unstructured.TextChunkerBenchmark}.
+ *
+ * <p>Reimplements the pre-fix findBreak so the two can be compared in one process, and
+ * asserts they produce identical chunk boundaries before reporting any timing - a speedup
+ * that changed the output would not be a speedup.
+ */
+public class TextChunkerBenchmark {
+
+  private static final String[] BOUNDARIES = {"\n\n", "\n", ". ", "! ", "? ", " "};
+
+  public static void main(String[] args) {
+    int chunkSize = 2000;
+    int overlap = 200;
+    System.out.printf("%-12s %12s %14s %14s %9s%n",
+        "chars", "chunks", "unbounded(ms)", "bounded(ms)", "speedup");
+    for (int chars : new int[] {50_000, 100_000, 250_000, 500_000, 1_000_000}) {
+      String text = unbrokenText(chars);
+      TextChunker chunker = new TextChunker(chunkSize, overlap);
+
+      List<int[]> boundedBreaks = run(() -> boundaries(chunker.chunk(text)));
+      List<int[]> unboundedBreaks = run(() -> chunkUnbounded(text, chunkSize, overlap));
+      if (!sameBreaks(boundedBreaks.get(0), unboundedBreaks.get(0))) {
+        throw new IllegalStateException("bounded search changed chunk boundaries at " + chars);
+      }
+
+      long unbounded = time(() -> chunkUnbounded(text, chunkSize, overlap));
+      long bounded = time(() -> chunker.chunk(text));
+      System.out.printf("%-12d %12d %14.1f %14.1f %8.1fx%n",
+          chars, boundedBreaks.get(0).length, unbounded / 1e6, bounded / 1e6,
+          (double) unbounded / Math.max(bounded, 1));
+    }
+  }
+
+  /** Text with no paragraph break, no newline and no sentence punctuation: only " " matches. */
+  private static String unbrokenText(int chars) {
+    Random random = new Random(7);
+    StringBuilder builder = new StringBuilder(chars + 32);
+    while (builder.length() < chars) {
+      int wordLength = 2 + random.nextInt(10);
+      for (int i = 0; i < wordLength; i++) {
+        builder.append((char) ('a' + random.nextInt(26)));
+      }
+      builder.append(' ');
+    }
+    return builder.substring(0, chars);
+  }
+
+  private static int[] boundaries(List<TextChunker.Chunk> chunks) {
+    int[] starts = new int[chunks.size()];
+    for (int i = 0; i < chunks.size(); i++) {
+      starts[i] = chunks.get(i).charStart;
+    }
+    return starts;
+  }
+
+  private static boolean sameBreaks(int[] a, int[] b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** The pre-fix implementation: lastIndexOf with no lower bound. */
+  private static int[] chunkUnbounded(String text, int chunkSizeChars, int overlapChars) {
+    List<Integer> starts = new ArrayList<>();
+    int start = 0;
+    while (start < text.length()) {
+      int windowEnd = Math.min(start + chunkSizeChars, text.length());
+      int end = windowEnd;
+      if (windowEnd != text.length()) {
+        int minBreak = start + Math.max(overlapChars + 1, chunkSizeChars / 2);
+        end = windowEnd;
+        for (String boundary : BOUNDARIES) {
+          int idx = text.lastIndexOf(boundary, windowEnd - boundary.length());
+          int breakEnd = idx + boundary.length();
+          if (idx >= 0 && breakEnd > minBreak && breakEnd <= windowEnd) {
+            end = breakEnd;
+            break;
+          }
+        }
+      }
+      starts.add(start);
+      if (end == text.length()) {
+        break;
+      }
+      start = end - overlapChars;
+    }
+    int[] result = new int[starts.size()];
+    for (int i = 0; i < result.length; i++) {
+      result[i] = starts.get(i);
+    }
+    return result;
+  }
+
+  private static <T> List<T> run(java.util.function.Supplier<T> body) {
+    List<T> out = new ArrayList<>();
+    out.add(body.get());
+    return out;
+  }
+
+  private static long time(Runnable body) {
+    for (int i = 0; i < 3; i++) {
+      body.run();
+    }
+    long start = System.nanoTime();
+    for (int i = 0; i < 5; i++) {
+      body.run();
+    }
+    return (System.nanoTime() - start) / 5;
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/embedding/TestEmbeddingResourceLifecycle.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/embedding/TestEmbeddingResourceLifecycle.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.transform.embedding;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.utilities.config.EmbeddingTransformerConfig;
+import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
+
+import com.sun.net.httpserver.HttpServer;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Resource lifecycle on the embedding path: the worker pool is released however a task
+ * ends. The leak is invisible in a successful run and only shows up as unbounded growth
+ * on a long-lived executor, so it is asserted directly.
+ */
+public class TestEmbeddingResourceLifecycle extends UtilitiesTestBase {
+
+  private static final String POOL_THREAD_PREFIX = "embedding-transformer";
+
+  private static HttpServer alwaysFailingServer;
+
+  @BeforeAll
+  public static void setupAll() throws Exception {
+    initTestServices();
+    alwaysFailingServer = HttpServer.create(new InetSocketAddress(0), 0);
+    alwaysFailingServer.createContext("/v1/embeddings", exchange -> {
+      // 400 is not retriable, so the batch fails immediately and kills the task
+      exchange.sendResponseHeaders(400, -1);
+      exchange.close();
+    });
+    alwaysFailingServer.start();
+  }
+
+  @AfterAll
+  public static void teardownAll() {
+    if (alwaysFailingServer != null) {
+      alwaysFailingServer.stop(0);
+    }
+  }
+
+  /**
+   * LazyIterableIterator only invokes end() when the input drains normally, so a task
+   * killed by an embeddings failure used to leave its fixed thread pool behind on an
+   * executor JVM that Spark keeps reusing. Releasing on task completion covers both paths.
+   */
+  @Test
+  void testWorkerPoolIsReleasedWhenTheTaskFails() throws Exception {
+    int before = livePoolThreads();
+
+    Dataset<Row> failing = new EmbeddingTransformer()
+        .apply(jsc, sparkSession, sourceDataset("doomed text").coalesce(1), failingProps());
+    assertThrows(Exception.class, failing::collectAsList);
+
+    assertTrue(awaitPoolThreadsBackTo(before),
+        "embedding worker threads leaked after the task failed: " + before
+            + " before, " + livePoolThreads() + " still live after");
+  }
+
+  private TypedProperties failingProps() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(EmbeddingTransformerConfig.ENDPOINT_URL.key(),
+        "http://localhost:" + alwaysFailingServer.getAddress().getPort() + "/v1/embeddings");
+    props.setProperty(EmbeddingTransformerConfig.MODEL.key(), "stub-model");
+    props.setProperty(EmbeddingTransformerConfig.DIMENSION.key(), "2");
+    props.setProperty(EmbeddingTransformerConfig.MAX_INFLIGHT_REQUESTS.key(), "3");
+    return props;
+  }
+
+  private Dataset<Row> sourceDataset(String... texts) {
+    StructType schema = new StructType(new StructField[] {
+        DataTypes.createStructField("path", DataTypes.StringType, false),
+        DataTypes.createStructField("extracted_text", DataTypes.StringType, true)});
+    List<Row> rows = new ArrayList<>();
+    for (int i = 0; i < texts.length; i++) {
+      rows.add(RowFactory.create("file-" + i, texts[i]));
+    }
+    return sparkSession.createDataFrame(rows, schema);
+  }
+
+  private static int livePoolThreads() {
+    int count = 0;
+    for (Thread thread : Thread.getAllStackTraces().keySet()) {
+      if (thread.isAlive() && thread.getName().startsWith(POOL_THREAD_PREFIX)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** shutdownNow interrupts rather than joins, so give the pool threads a moment to die. */
+  private static boolean awaitPoolThreadsBackTo(int expected) throws InterruptedException {
+    for (int attempt = 0; attempt < 100; attempt++) {
+      if (livePoolThreads() <= expected) {
+        return true;
+      }
+      Thread.sleep(100);
+    }
+    return false;
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/embedding/TestEmbeddingResourceLifecycle.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/embedding/TestEmbeddingResourceLifecycle.java
@@ -35,16 +35,20 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Resource lifecycle on the embedding path: the worker pool is released however a task
- * ends. The leak is invisible in a successful run and only shows up as unbounded growth
- * on a long-lived executor, so it is asserted directly.
+ * ends, and HTTP clients are shared per JVM rather than created per Spark partition.
+ * Both leaks are invisible in a successful run and only show up as unbounded growth on a
+ * long-lived executor, so they are asserted directly.
  */
 public class TestEmbeddingResourceLifecycle extends UtilitiesTestBase {
 
@@ -87,6 +91,32 @@ public class TestEmbeddingResourceLifecycle extends UtilitiesTestBase {
     assertTrue(awaitPoolThreadsBackTo(before),
         "embedding worker threads leaked after the task failed: " + before
             + " before, " + livePoolThreads() + " still live after");
+  }
+
+  /**
+   * java.net.http.HttpClient is not Closeable before Java 21 and owns a selector thread
+   * plus a connection pool, so one per partition would accumulate on the executor with no
+   * release path. Providers sharing a connect timeout must share a client.
+   */
+  @Test
+  void testHttpClientsAreSharedAcrossProviderInstances() {
+    TypedProperties props = failingProps();
+
+    OpenAICompatibleEmbeddingProvider first = new OpenAICompatibleEmbeddingProvider();
+    first.init(props);
+    OpenAICompatibleEmbeddingProvider second = new OpenAICompatibleEmbeddingProvider();
+    second.init(props);
+
+    HttpClient firstClient = first.client();
+    assertSame(firstClient, first.client(), "repeated calls must reuse one client");
+    assertSame(firstClient, second.client(),
+        "a second provider with the same timeout must reuse the same client");
+
+    TypedProperties otherTimeout = failingProps();
+    otherTimeout.setProperty(EmbeddingTransformerConfig.TIMEOUT_MS.key(), "31000");
+    OpenAICompatibleEmbeddingProvider third = new OpenAICompatibleEmbeddingProvider();
+    third.init(otherTimeout);
+    assertNotSame(firstClient, third.client(), "a different connect timeout needs its own client");
   }
 
   private TypedProperties failingProps() {

--- a/packaging/hudi-tika-bundle/pom.xml
+++ b/packaging/hudi-tika-bundle/pom.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>hudi</artifactId>
+        <groupId>org.apache.hudi</groupId>
+        <version>1.3.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>hudi-tika-bundle</artifactId>
+    <packaging>jar</packaging>
+
+    <!--
+      Apache Tika's format parser modules, for unstructured file ingestion.
+
+      Kept out of hudi-utilities-bundle deliberately. tika-core ships there because
+      hudi-utilities compiles against it; the parser modules do not, and bundling them
+      would add ~50MB, roughly thirty third-party licenses, and a bundle-wide
+      commons-compress relocation to every hudi-utilities-bundle user for a feature
+      most do not use.
+
+      Pass it alongside the utilities bundle, via spark-submit's "jars" option, only when
+      ingesting unstructured files with text extraction enabled.
+
+      Supplying tika-parsers-standard-package through spark-submit's "packages" option
+      instead does not work: Spark ships commons-compress 1.23, POI needs 1.24 or newer,
+      and user jars do not outrank Spark's own on the classpath. The relocation below is
+      what makes this bundle self-sufficient.
+    -->
+
+    <properties>
+        <checkstyle.skip>true</checkstyle.skip>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+        <skipTests>true</skipTests>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createSourcesJar>${shadeSources}</createSourcesJar>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                    <addHeader>true</addHeader>
+                                </transformer>
+                                <!-- Tika discovers parsers through META-INF/services/org.apache.tika.parser.Parser,
+                                     which every parser module ships its own copy of. Without merging them only one
+                                     module's parsers would register. -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>org.apache.tika:*</include>
+                                    <include>com.adobe.xmp:*</include>
+                                    <include>com.drewnoakes:*</include>
+                                    <include>com.epam:*</include>
+                                    <include>com.github.albfernandez:*</include>
+                                    <include>com.github.jai-imageio:*</include>
+                                    <include>com.github.junrar:*</include>
+                                    <include>com.github.virtuald:*</include>
+                                    <include>com.googlecode.plist:*</include>
+                                    <include>com.healthmarketscience.jackcess:*</include>
+                                    <include>com.pff:*</include>
+                                    <include>com.rometools:*</include>
+                                    <include>com.sun.istack:*</include>
+                                    <include>com.zaxxer:*</include>
+                                    <include>info.picocli:*</include>
+                                    <include>jakarta.activation:*</include>
+                                    <include>jakarta.xml.bind:*</include>
+                                    <include>org.apache.james:*</include>
+                                    <include>org.apache.pdfbox:*</include>
+                                    <include>org.apache.poi:*</include>
+                                    <include>org.apache.xmlbeans:*</include>
+                                    <include>org.bouncycastle:*</include>
+                                    <include>org.brotli:*</include>
+                                    <include>org.codelibs:*</include>
+                                    <include>org.eclipse.angus:*</include>
+                                    <include>org.gagravarr:*</include>
+                                    <include>org.glassfish.jaxb:*</include>
+                                    <include>org.jdom:*</include>
+                                    <include>org.jsoup:*</include>
+                                    <include>org.netpreserve:*</include>
+                                    <include>org.ow2.asm:*</include>
+                                    <include>org.tallison:*</include>
+                                    <include>org.tukaani:*</include>
+                                    <include>org.apache.commons:commons-compress</include>
+                                    <include>org.apache.commons:commons-collections4</include>
+                                    <include>org.apache.commons:commons-csv</include>
+                                    <include>org.apache.commons:commons-exec</include>
+                                    <include>org.apache.commons:commons-math3</include>
+                                </includes>
+                                <excludes>
+                                    <!-- hudi-utilities compiles against tika-core, so it ships in
+                                         hudi-utilities-bundle. Shading it here too would put two copies
+                                         on the classpath when both bundles are passed. -->
+                                    <exclude>org.apache.tika:tika-core</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <relocations combine.children="append">
+                                <relocation>
+                                    <!-- POI needs commons-compress 1.24+, but Spark ships an older copy that
+                                         wins on the classpath. Relocating rewrites the parser modules' own
+                                         references to the copy shaded in here, so the version they get no
+                                         longer depends on the runtime's. Confined to this bundle: tika-core
+                                         does not reference commons-compress, so nothing outside is rewritten. -->
+                                    <pattern>org.apache.commons.compress.</pattern>
+                                    <shadedPattern>org.apache.hudi.org.apache.commons.compress.</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <filters>
+                                <filter>
+                                    <!-- bouncycastle ships multi-release classes built for newer JDKs than the
+                                         shade plugin can parse; the base classes are the ones we run on anyway -->
+                                    <artifact>org.bouncycastle:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/versions/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/services/javax.*</exclude>
+                                        <exclude>**/*.proto</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <finalName>${project.artifactId}-${project.version}</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- Only for Main, which exists so the javadoc/sources plugins have a source file. -->
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers-standard-package</artifactId>
+            <version>${tika.version}</version>
+        </dependency>
+        <!-- Pinned ahead of the older copy that wins transitively: Tika's zip container
+             detection calls ArchiveStreamFactory.detect(InputStream), added in 1.14. This is
+             the copy that gets relocated into the bundle, so it must be the version Tika
+             expects rather than whatever the dependency tree resolves. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.27.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/packaging/hudi-tika-bundle/src/main/java/org/apache/hudi/tika/bundle/Main.java
+++ b/packaging/hudi-tika-bundle/src/main/java/org/apache/hudi/tika/bundle/Main.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.tika.bundle;
+
+import org.apache.hudi.common.util.ReflectionUtils;
+
+/**
+ * A simple main class to dump all classes loaded in current classpath.
+ *
+ * This is a workaround for generating sources and javadoc jars for packaging modules. The maven plugins for generating
+ * javadoc and sources plugins do not generate corresponding jars if there are no source files.
+ *
+ * This class does not have anything to do with Hudi but is there to keep mvn javadocs/source plugin happy.
+ */
+public class Main {
+
+  public static void main(String[] args) {
+    ReflectionUtils.getTopLevelClassesInClasspath(Main.class).forEach(System.out::println);
+  }
+}

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -97,6 +97,45 @@
                   <include>org.apache.hudi:hudi-spark-client</include>
                   <include>org.apache.hudi:hudi-utilities_${scala.binary.version}</include>
                   <include>org.apache.tika:tika-core</include>
+                  <!-- Apache Tika document parsers, for UnstructuredFileDFSSource -->
+                  <include>com.adobe.xmp:*</include>
+                  <include>com.drewnoakes:*</include>
+                  <include>com.epam:*</include>
+                  <include>com.github.albfernandez:*</include>
+                  <include>com.github.jai-imageio:*</include>
+                  <include>com.github.junrar:*</include>
+                  <include>com.github.virtuald:*</include>
+                  <include>com.googlecode.plist:*</include>
+                  <include>com.healthmarketscience.jackcess:*</include>
+                  <include>com.pff:*</include>
+                  <include>com.rometools:*</include>
+                  <include>com.sun.istack:*</include>
+                  <include>com.zaxxer:*</include>
+                  <include>info.picocli:*</include>
+                  <include>jakarta.activation:*</include>
+                  <include>jakarta.xml.bind:*</include>
+                  <include>org.apache.james:*</include>
+                  <include>org.apache.pdfbox:*</include>
+                  <include>org.apache.poi:*</include>
+                  <include>org.apache.tika:*</include>
+                  <include>org.apache.xmlbeans:*</include>
+                  <include>org.bouncycastle:*</include>
+                  <include>org.brotli:*</include>
+                  <include>org.codelibs:*</include>
+                  <include>org.eclipse.angus:*</include>
+                  <include>org.gagravarr:*</include>
+                  <include>org.glassfish.jaxb:*</include>
+                  <include>org.jdom:*</include>
+                  <include>org.jsoup:*</include>
+                  <include>org.netpreserve:*</include>
+                  <include>org.ow2.asm:*</include>
+                  <include>org.tallison:*</include>
+                  <include>org.tukaani:*</include>
+                  <include>org.apache.commons:commons-compress</include>
+                  <include>org.apache.commons:commons-collections4</include>
+                  <include>org.apache.commons:commons-csv</include>
+                  <include>org.apache.commons:commons-exec</include>
+                  <include>org.apache.commons:commons-math3</include>
                   <include>org.apache.hudi:hudi-spark-common_${scala.binary.version}</include>
                   <include>org.apache.hudi:hudi-spark_${scala.binary.version}</include>
                   <include>org.apache.hudi:${hudi.spark.module}_${scala.binary.version}</include>
@@ -188,6 +227,13 @@
                   <shadedPattern>${utilities.bundle.hive.shade.prefix}org.apache.hive.jdbc.</shadedPattern>
                 </relocation>
                 <relocation>
+                  <!-- Tika's POI needs commons-compress 1.24+, but Spark ships an older copy that
+                       would win on the classpath. Relocating rewrites Tika's own references here,
+                       so the version it gets no longer depends on the runtime's. -->
+                  <pattern>org.apache.commons.compress.</pattern>
+                  <shadedPattern>org.apache.hudi.org.apache.commons.compress.</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.apache.commons.io.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.commons.io.</shadedPattern>
                 </relocation>
@@ -242,6 +288,14 @@
               </relocations>
               <filters>
                 <filter>
+                  <!-- bouncycastle ships multi-release classes built for newer JDKs than the
+                       shade plugin can parse; the base classes are the ones we run on anyway -->
+                  <artifact>org.bouncycastle:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/versions/**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>META-INF/*.SF</exclude>
@@ -266,6 +320,14 @@
   </build>
 
   <dependencies>
+    <!-- Pinned ahead of the 1.9 that wins transitively: Tika's zip container detection calls
+         ArchiveStreamFactory.detect(InputStream), added in 1.14. This is the copy that gets
+         relocated into the bundle, so it must be the version Tika expects. -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.27.1</version>
+    </dependency>
     <!-- Hoodie - Spark -->
 
     <dependency>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -97,45 +97,6 @@
                   <include>org.apache.hudi:hudi-spark-client</include>
                   <include>org.apache.hudi:hudi-utilities_${scala.binary.version}</include>
                   <include>org.apache.tika:tika-core</include>
-                  <!-- Apache Tika document parsers, for UnstructuredFileDFSSource -->
-                  <include>com.adobe.xmp:*</include>
-                  <include>com.drewnoakes:*</include>
-                  <include>com.epam:*</include>
-                  <include>com.github.albfernandez:*</include>
-                  <include>com.github.jai-imageio:*</include>
-                  <include>com.github.junrar:*</include>
-                  <include>com.github.virtuald:*</include>
-                  <include>com.googlecode.plist:*</include>
-                  <include>com.healthmarketscience.jackcess:*</include>
-                  <include>com.pff:*</include>
-                  <include>com.rometools:*</include>
-                  <include>com.sun.istack:*</include>
-                  <include>com.zaxxer:*</include>
-                  <include>info.picocli:*</include>
-                  <include>jakarta.activation:*</include>
-                  <include>jakarta.xml.bind:*</include>
-                  <include>org.apache.james:*</include>
-                  <include>org.apache.pdfbox:*</include>
-                  <include>org.apache.poi:*</include>
-                  <include>org.apache.tika:*</include>
-                  <include>org.apache.xmlbeans:*</include>
-                  <include>org.bouncycastle:*</include>
-                  <include>org.brotli:*</include>
-                  <include>org.codelibs:*</include>
-                  <include>org.eclipse.angus:*</include>
-                  <include>org.gagravarr:*</include>
-                  <include>org.glassfish.jaxb:*</include>
-                  <include>org.jdom:*</include>
-                  <include>org.jsoup:*</include>
-                  <include>org.netpreserve:*</include>
-                  <include>org.ow2.asm:*</include>
-                  <include>org.tallison:*</include>
-                  <include>org.tukaani:*</include>
-                  <include>org.apache.commons:commons-compress</include>
-                  <include>org.apache.commons:commons-collections4</include>
-                  <include>org.apache.commons:commons-csv</include>
-                  <include>org.apache.commons:commons-exec</include>
-                  <include>org.apache.commons:commons-math3</include>
                   <include>org.apache.hudi:hudi-spark-common_${scala.binary.version}</include>
                   <include>org.apache.hudi:hudi-spark_${scala.binary.version}</include>
                   <include>org.apache.hudi:${hudi.spark.module}_${scala.binary.version}</include>
@@ -227,13 +188,6 @@
                   <shadedPattern>${utilities.bundle.hive.shade.prefix}org.apache.hive.jdbc.</shadedPattern>
                 </relocation>
                 <relocation>
-                  <!-- Tika's POI needs commons-compress 1.24+, but Spark ships an older copy that
-                       would win on the classpath. Relocating rewrites Tika's own references here,
-                       so the version it gets no longer depends on the runtime's. -->
-                  <pattern>org.apache.commons.compress.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.commons.compress.</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.apache.commons.io.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.commons.io.</shadedPattern>
                 </relocation>
@@ -288,14 +242,6 @@
               </relocations>
               <filters>
                 <filter>
-                  <!-- bouncycastle ships multi-release classes built for newer JDKs than the
-                       shade plugin can parse; the base classes are the ones we run on anyway -->
-                  <artifact>org.bouncycastle:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/versions/**</exclude>
-                  </excludes>
-                </filter>
-                <filter>
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>META-INF/*.SF</exclude>
@@ -320,14 +266,6 @@
   </build>
 
   <dependencies>
-    <!-- Pinned ahead of the 1.9 that wins transitively: Tika's zip container detection calls
-         ArchiveStreamFactory.detect(InputStream), added in 1.14. This is the copy that gets
-         relocated into the bundle, so it must be the version Tika expects. -->
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>1.27.1</version>
-    </dependency>
     <!-- Hoodie - Spark -->
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <module>packaging/hudi-presto-bundle</module>
     <module>packaging/hudi-utilities-bundle</module>
     <module>packaging/hudi-utilities-slim-bundle</module>
+    <module>packaging/hudi-tika-bundle</module>
     <module>packaging/hudi-timeline-server-bundle</module>
     <module>hudi-examples</module>
     <module>hudi-flink-datasource</module>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19676

Stacked on #19677, review that one first. Until it merges this PR's diff includes its commits.

### Summary and Changelog

`tika-parsers-standard-package` now ships in `hudi-utilities-bundle`, so unstructured ingestion extracts text with no runtime flags. Previously only `tika-core` shipped, and `tika-core` registers no parser at all, so every file produced `parse_status=EMPTY`, empty text, no chunks and a null vector while the job exited successfully.

commons-compress is relocated, which makes Tika's references follow the bundled copy rather than resolving whatever the runtime provides. It is pinned to 1.27.1 because a transitive 1.9 otherwise wins and predates the `ArchiveStreamFactory.detect(InputStream)` that Tika's zip container detection calls. Bouncycastle's multi-release classes are filtered out, being built for JDKs newer than the shade plugin can parse while the base classes are what runs.

`TikaDocumentParser` now parses a small in-memory plain-text document on `init` and fails when no text comes back. `init` runs only when parsing is enabled, so reaching it means text extraction was asked for, and a deployment that can extract none is a misconfiguration rather than a per-file problem. Blob-only ingestion remains available through `parse.enabled=false`.

The slim bundle is deliberately left alone. Its users get the new error naming the dependency to add.

### Impact

`hudi-utilities-bundle` grows from 90 MB to 141 MB. Users of that bundle who enable parsing get working text extraction where they previously got silently empty results; users who want blobs only should set `hoodie.streamer.source.unstructured.parse.enabled=false`, which also skips the probe.

### Risk Level

medium

The bundle gains around 85 artifacts, so the risk is dependency collision rather than logic. Mitigated by keeping jackson, slf4j and commons-io out of the added set and letting the runtime provide them, and by relocating commons-compress so the one known conflict cannot recur. Verified by ingesting a 15,774-file corpus through HoodieStreamer with the bundle alone, no `--packages`, no `--jars` and no `extraClassPath`: SUCCESS 4988, EMPTY 5011 matching exactly the binary files, FAILED 1, and no `NoSuchMethodError`.

### Documentation Update

The website should state that document parsing works out of the box with the utilities bundle, and that the slim bundle needs `org.apache.tika:tika-parsers-standard-package` supplied separately. Happy to follow up with that change once the approach here is settled.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
