### PR TITLE
fix(spark): align libthrift with the Hive 2.3.10 client jars

### DIFF
--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -332,6 +332,31 @@
     </dependency>
 
     <!-- Hive -->
+    <!-- Direct pin: the Hive 2.3.10 client jars are compiled against libthrift 0.14.1
+         (HiveAuthUtils.getSocketTransport uses TConfiguration), but dependency mediation
+         otherwise picks 0.12.0 from spark-hive, which lacks that class and turns every
+         hive-jdbc connect into a NoClassDefFoundError. See #19680. -->
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${hive.libthrift.version}</version>
+      <exclusions>
+        <!-- Servlet-side extras of libthrift; excluded so the only classpath change
+             against the mediated 0.12.0 is the libthrift version itself. -->
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>${hive.groupid}</groupId>
       <artifactId>hive-exec</artifactId>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -116,6 +116,11 @@
                   <include>org.apache.hive:hive-service-rpc</include>
                   <include>org.apache.hive:hive-metastore</include>
                   <include>org.apache.hive:hive-jdbc</include>
+                  <!-- Thrift runtime matching the Hive client jars above; only bundled under
+                       spark-bundle-shade-hive (compile scope), where the relocated Hive classes
+                       must not bind to the older Spark-provided libthrift. See #19680. -->
+                  <include>org.apache.thrift:libthrift</include>
+                  <include>org.apache.thrift:libfb303</include>
 
                   <include>org.apache.curator:curator-framework</include>
                   <include>org.apache.curator:curator-client</include>
@@ -173,6 +178,17 @@
                 <relocation>
                   <pattern>org.apache.hadoop.hive.service.</pattern>
                   <shadedPattern>${spark.bundle.hive.shade.prefix}org.apache.hadoop.hive.service.</shadedPattern>
+                </relocation>
+                <!-- Keep the relocated Hive classes on their matching thrift runtime instead of
+                     the older Spark-provided libthrift; fb303 rides along because the generated
+                     hive-metastore client extends its classes. No-op when the prefix is empty. -->
+                <relocation>
+                  <pattern>org.apache.thrift.</pattern>
+                  <shadedPattern>${spark.bundle.hive.shade.prefix}org.apache.thrift.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.facebook.fb303.</pattern>
+                  <shadedPattern>${spark.bundle.hive.shade.prefix}com.facebook.fb303.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.codahale.metrics.</pattern>
@@ -301,6 +317,23 @@
       <groupId>${hive.groupid}</groupId>
       <artifactId>hive-common</artifactId>
       <version>${hive.version}</version>
+      <scope>${spark.bundle.hive.scope}</scope>
+    </dependency>
+
+    <!-- Thrift runtime matching the Hive client jars above. Declared directly (rather than
+         relying on the transitive versions) so its scope tracks the Hive jars: provided by
+         default, bundled and relocated under spark-bundle-shade-hive. See #19680. -->
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${hive.libthrift.version}</version>
+      <scope>${spark.bundle.hive.scope}</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libfb303</artifactId>
+      <version>${hive.libfb303.version}</version>
       <scope>${spark.bundle.hive.scope}</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,9 +128,13 @@
     <hadoop.version>2.10.2</hadoop.version>
     <hive.groupid>org.apache.hive</hive.groupid>
     <hive.version>2.3.10</hive.version>
-    <!-- The libthrift the Hive client jars above are compiled against (Hive 2.3.10 bumped
-         it for CVE-2020-13949); keep in lockstep with hive.version. See #19680. -->
+    <!-- The thrift artifacts the Hive client jars above are compiled against (Hive 2.3.10
+         bumped libthrift for CVE-2020-13949); keep in lockstep with hive.version. The spark4
+         profiles override hive.libthrift.version to the libthrift Spark 4.x itself ships with
+         the same Hive 2.3.10 client, so the pin never downgrades the Spark-selected version.
+         See #19680. -->
     <hive.libthrift.version>0.14.1</hive.libthrift.version>
+    <hive.libfb303.version>0.9.3</hive.libfb303.version>
     <hive.parquet.version>1.10.1</hive.parquet.version>
     <hive.avro.version>1.11.4</hive.avro.version>
     <presto.version>0.273</presto.version>
@@ -2889,6 +2893,9 @@
         <hadoop.version>3.4.0</hadoop.version>
         <kafka.version>3.8.0</kafka.version>
         <hive.storage.version>2.8.1</hive.storage.version>
+        <!-- Spark 4.x ships libthrift 0.16.0 alongside the same Hive 2.3.10 client;
+             keep the Spark-selected version instead of the Spark 3 minimum. See #19680. -->
+        <hive.libthrift.version>0.16.0</hive.libthrift.version>
         <!-- Lance: Use Spark 4.0-specific artifact (Scala 2.13 only) -->
         <lance.spark.artifact>lance-spark-4.0_2.13</lance.spark.artifact>
         <lance.skip.tests>false</lance.skip.tests>
@@ -2956,6 +2963,9 @@
         <hadoop.version>3.4.2</hadoop.version>
         <kafka.version>3.9.1</kafka.version>
         <hive.storage.version>2.8.1</hive.storage.version>
+        <!-- Spark 4.x ships libthrift 0.16.0 alongside the same Hive 2.3.10 client;
+             keep the Spark-selected version instead of the Spark 3 minimum. See #19680. -->
+        <hive.libthrift.version>0.16.0</hive.libthrift.version>
         <lance.spark.artifact>lance-spark-4.1_2.13</lance.spark.artifact>
         <lance.skip.tests>false</lance.skip.tests>
         <!-- Vortex: Use Spark 4.1 artifact (Scala 2.13 only) -->
@@ -3023,6 +3033,9 @@
         <hadoop.version>3.5.0</hadoop.version>
         <kafka.version>3.9.2</kafka.version>
         <hive.storage.version>2.8.1</hive.storage.version>
+        <!-- Spark 4.x ships libthrift 0.16.0 alongside the same Hive 2.3.10 client;
+             keep the Spark-selected version instead of the Spark 3 minimum. See #19680. -->
+        <hive.libthrift.version>0.16.0</hive.libthrift.version>
         <!-- TODO: Enable lance tests on Spark 4.2 -->
         <lance.spark.artifact>lance-spark-4.0_2.13</lance.spark.artifact>
         <lance.skip.tests>true</lance.skip.tests>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,9 @@
     <hadoop.version>2.10.2</hadoop.version>
     <hive.groupid>org.apache.hive</hive.groupid>
     <hive.version>2.3.10</hive.version>
+    <!-- The libthrift the Hive client jars above are compiled against (Hive 2.3.10 bumped
+         it for CVE-2020-13949); keep in lockstep with hive.version. See #19680. -->
+    <hive.libthrift.version>0.14.1</hive.libthrift.version>
     <hive.parquet.version>1.10.1</hive.parquet.version>
     <hive.avro.version>1.11.4</hive.avro.version>
     <presto.version>0.273</presto.version>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19680. The Hive 2.3.10 client jars are compiled against libthrift 0.14.1 (`HiveAuthUtils.getSocketTransport` uses `TConfiguration`), but in hudi-spark dependency mediation picks 0.12.0 from `spark-hive`, which lacks that class. Every `jdbc:hive2://` connect on this classpath dies with `NoClassDefFoundError: org/apache/thrift/TConfiguration` instead of connecting or failing with an SQLException, which breaks `sync_validate`'s record-count modes and surfaced through the test failure in #19679.

### Summary and Changelog

- Add a `hive.libthrift.version` property (0.14.1) next to `hive.version` in the root pom, to be kept in lockstep with it.
- Pin libthrift directly in hudi-spark so it outranks spark-hive's transitive 0.12.0, excluding libthrift's tomcat/annotation extras so the resolved classpath changes by exactly one thing: libthrift 0.12.0 -> 0.14.1 (verified with `dependency:build-classpath` before/after).
- Override `hive.libthrift.version` to 0.16.0 in the spark4.x profiles, the version those Spark releases pair with the same Hive 2.3.10 client, so the pin never downgrades the Spark-selected thrift; 0.14.1 stays the Spark 3 minimum.
- Under `-Pspark-bundle-shade-hive`, bundle and relocate libthrift and libfb303 next to the shaded Hive client jars, so the relocated classes cannot bind to Spark's provided libthrift 0.12.0. fb303 rides along because the generated hive-metastore client extends its classes.
- Verified against the resolved test classpath that `DriverManager.getConnection` now behaves as designed: portless URL fails fast with `SQLException: ... Invalid port -1`, a refused host:port fails with `SQLException <- TTransportException <- ConnectException`, and the hostless URL used by the test from #19681 still fails in URL parsing with `JdbcUriParseException`.

### Impact

Anyone consuming the hudi-spark artifact gets a working hive-jdbc path again. The default spark bundle is unaffected (the hive jars and the new thrift pins are provided-scope there, so nothing extra is bundled).

### Risk Level

low. libthrift 0.14.1 keeps the pre-0.14 client API surface (e.g. `TSocket(String, int, int)`) that spark-hive's 0.12.0-era callers use, and hudi-integ-test-bundle already pairs these hive jars with libthrift 0.23.0. Mitigation is a full hudi-spark test suite run, since thrift also serves the embedded HMS paths in tests.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

