### PR TITLE
fix(flink): prevent reusing diverged buffers on memory exhaustion

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
@@ -154,12 +154,6 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
   private transient NormalizedKeyComputer recordKeyComputer;
   private transient RecordComparator recordKeyComparator;
 
-  private enum BufferWriteResult {
-    SUCCESS,
-    BUFFER_CREATION_FAILED,
-    BUFFER_DIVERGED
-  }
-
   /**
    * Constructs a StreamingSinkFunction.
    *
@@ -319,7 +313,7 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
    * <p>1. Data Bucket do not exist and there is no enough memory pages to create a new binary buffer.
    * <p>2. Data Bucket exists, but fails to request new memory pages from memory pool.
    */
-  private BufferWriteResult doBufferRecord(String bucketID, HoodieFlinkInternalRow record) throws IOException {
+  private boolean doBufferRecord(String bucketID, HoodieFlinkInternalRow record) throws IOException {
     RowDataBucket bucket = this.buckets.get(bucketID);
     if (bucket == null) {
       try {
@@ -331,13 +325,11 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
         this.buckets.put(bucketID, bucket);
       } catch (MemoryPagesExhaustedException e) {
         log.info("There are not enough free pages in the memory pool to create a buffer; flushing is required first.");
-        return BufferWriteResult.BUFFER_CREATION_FAILED;
+        return false;
       }
     }
 
-    return bucket.writeRow(record.getRowData())
-        ? BufferWriteResult.SUCCESS
-        : BufferWriteResult.BUFFER_DIVERGED;
+    return bucket.writeRow(record.getRowData());
   }
 
   /**
@@ -356,11 +348,11 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
     final String bucketID = getBucketID(record.getPartitionPath(), record.getFileId());
 
     // 1. try buffer the record into the memory pool
-    BufferWriteResult result = doBufferRecord(bucketID, record);
-    if (result != BufferWriteResult.SUCCESS) {
+    boolean success = doBufferRecord(bucketID, record);
+    if (!success) {
       // 2. reclaim pages. A buffer whose write returned false must never be reused because
       // BinaryInMemorySortBuffer may already have changed its variable-length storage state.
-      reclaimMemoryAfterFailedWrite(bucketID, result);
+      reclaimMemoryAfterFailedWrite(bucketID);
 
       // 2.1 retry once with a newly-created buffer
       retryBufferRecord(bucketID, record);
@@ -386,19 +378,21 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
     }
   }
 
-  private void reclaimMemoryAfterFailedWrite(String bucketID, BufferWriteResult result) {
-    if (result == BufferWriteResult.BUFFER_DIVERGED) {
-      RowDataBucket divergedBucket = this.buckets.get(bucketID);
+  private void reclaimMemoryAfterFailedWrite(String bucketID) {
+    // A creation failure leaves no bucket in the map, while a write failure leaves the
+    // diverged bucket in the map so that its committed records can be flushed and disposed.
+    RowDataBucket failedBucket = this.buckets.get(bucketID);
+    if (failedBucket != null) {
       ValidationUtils.checkState(
-          divergedBucket != null && divergedBucket.isDiverged(),
-          "The failed RowData bucket is missing or has not diverged");
-      flushAndDisposeBucket(divergedBucket);
+          failedBucket.isDiverged(), "The failed RowData bucket has not diverged");
+      RowDataBucket largestOtherBucket = this.buckets.values().stream()
+          .filter(bucket -> bucket != failedBucket && !bucket.isEmpty())
+          .max(Comparator.comparingLong(RowDataBucket::getBufferSize))
+          .orElse(null);
+      flushAndDisposeAfterWriteFailure(largestOtherBucket, failedBucket);
       return;
     }
 
-    ValidationUtils.checkState(
-        result == BufferWriteResult.BUFFER_CREATION_FAILED,
-        "Unexpected successful buffer write result during memory reclamation");
     RowDataBucket bucketToFlush = this.buckets.values().stream()
         .filter(bucket -> !bucket.isEmpty())
         .max(Comparator.comparingLong(RowDataBucket::getBufferSize))
@@ -409,21 +403,47 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
 
   private void retryBufferRecord(
       String bucketID, HoodieFlinkInternalRow record) throws IOException {
-    final BufferWriteResult result;
+    final boolean success;
     try {
-      result = doBufferRecord(bucketID, record);
+      success = doBufferRecord(bucketID, record);
     } catch (IOException | RuntimeException e) {
       disposeFailedRetryBucket(bucketID, e);
       throw e;
     }
 
-    if (result != BufferWriteResult.SUCCESS) {
+    if (!success) {
       HoodieException exception = new HoodieException(
-          result == BufferWriteResult.BUFFER_CREATION_FAILED
+          this.buckets.get(bucketID) == null
               ? "Not enough memory pages to create a RowData buffer after flushing"
               : "The write buffer is too small to hold a single record");
       disposeFailedRetryBucket(bucketID, exception);
       throw exception;
+    }
+  }
+
+  private void flushAndDisposeAfterWriteFailure(
+      RowDataBucket largestOtherBucket, RowDataBucket failedBucket) {
+    RuntimeException failure = null;
+    if (largestOtherBucket != null) {
+      try {
+        flushAndDisposeBucket(largestOtherBucket);
+      } catch (RuntimeException e) {
+        failure = e;
+      }
+    }
+
+    try {
+      flushAndDisposeBucket(failedBucket);
+    } catch (RuntimeException e) {
+      if (failure == null) {
+        failure = e;
+      } else {
+        failure.addSuppressed(e);
+      }
+    }
+
+    if (failure != null) {
+      throw failure;
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
@@ -76,7 +76,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import static org.apache.hudi.common.util.HoodieRecordUtils.getOrderingFieldNames;
 
@@ -154,6 +153,12 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
 
   private transient NormalizedKeyComputer recordKeyComputer;
   private transient RecordComparator recordKeyComparator;
+
+  private enum BufferWriteResult {
+    SUCCESS,
+    BUFFER_CREATION_FAILED,
+    BUFFER_DIVERGED
+  }
 
   /**
    * Constructs a StreamingSinkFunction.
@@ -314,20 +319,25 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
    * <p>1. Data Bucket do not exist and there is no enough memory pages to create a new binary buffer.
    * <p>2. Data Bucket exists, but fails to request new memory pages from memory pool.
    */
-  private boolean doBufferRecord(String bucketID, HoodieFlinkInternalRow record) throws IOException {
-    try {
-      RowDataBucket bucket = this.buckets.computeIfAbsent(bucketID,
-          k -> new RowDataBucket(
-              bucketID,
-              createDataBuffer(),
-              getBucketInfo(record),
-              this.config.get(FlinkOptions.WRITE_BATCH_SIZE)));
-
-      return bucket.writeRow(record.getRowData());
-    } catch (MemoryPagesExhaustedException e) {
-      log.info("There is no enough free pages in memory pool to create buffer, need flushing first.", e);
-      return false;
+  private BufferWriteResult doBufferRecord(String bucketID, HoodieFlinkInternalRow record) throws IOException {
+    RowDataBucket bucket = this.buckets.get(bucketID);
+    if (bucket == null) {
+      try {
+        bucket = new RowDataBucket(
+            bucketID,
+            createDataBuffer(),
+            getBucketInfo(record),
+            this.config.get(FlinkOptions.WRITE_BATCH_SIZE));
+        this.buckets.put(bucketID, bucket);
+      } catch (MemoryPagesExhaustedException e) {
+        log.info("There are not enough free pages in the memory pool to create a buffer; flushing is required first.");
+        return BufferWriteResult.BUFFER_CREATION_FAILED;
+      }
     }
+
+    return bucket.writeRow(record.getRowData())
+        ? BufferWriteResult.SUCCESS
+        : BufferWriteResult.BUFFER_DIVERGED;
   }
 
   /**
@@ -346,33 +356,20 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
     final String bucketID = getBucketID(record.getPartitionPath(), record.getFileId());
 
     // 1. try buffer the record into the memory pool
-    boolean success = doBufferRecord(bucketID, record);
-    if (!success) {
-      // 2. flushes the bucket if the memory pool is full
-      RowDataBucket bucketToFlush = this.buckets.values().stream()
-          .max(Comparator.comparingLong(RowDataBucket::getBufferSize))
-          .orElseThrow(NoSuchElementException::new);
-      if (flushBucket(bucketToFlush)) {
-        // 2.1 flushes the data bucket with maximum size
-        this.tracer.countDown(bucketToFlush.getBufferSize());
-        disposeBucket(bucketToFlush);
-      } else {
-        log.warn("The buffer size hits the threshold {}, but still flush the max size data bucket failed!", this.tracer.maxBufferSize);
-      }
-      // 2.2 try to write row again
-      success = doBufferRecord(bucketID, record);
-      if (!success) {
-        throw new RuntimeException("Buffer is too small to hold a single record.");
-      }
+    BufferWriteResult result = doBufferRecord(bucketID, record);
+    if (result != BufferWriteResult.SUCCESS) {
+      // 2. reclaim pages. A buffer whose write returned false must never be reused because
+      // BinaryInMemorySortBuffer may already have changed its variable-length storage state.
+      reclaimMemoryAfterFailedWrite(bucketID, result);
+
+      // 2.1 retry once with a newly-created buffer
+      retryBufferRecord(bucketID, record);
     }
     RowDataBucket bucket = this.buckets.get(bucketID);
     this.tracer.trace(bucket.getLastRecordSize());
     // 3. flushes the bucket if it is full
     if (bucket.isFull()) {
-      if (flushBucket(bucket)) {
-        this.tracer.countDown(bucket.getBufferSize());
-        disposeBucket(bucket);
-      }
+      flushAndDisposeBucket(bucket);
     }
     // update buffer metrics after tracing buffer size
     writeMetrics.setWriteBufferedSize(this.tracer.bufferSize);
@@ -382,8 +379,79 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
    * RowData data bucket can not be used after disposing.
    */
   private void disposeBucket(RowDataBucket rowDataBucket) {
-    rowDataBucket.dispose();
-    this.buckets.remove(rowDataBucket.getBucketId());
+    try {
+      rowDataBucket.dispose();
+    } finally {
+      this.buckets.remove(rowDataBucket.getBucketId());
+    }
+  }
+
+  private void reclaimMemoryAfterFailedWrite(String bucketID, BufferWriteResult result) {
+    if (result == BufferWriteResult.BUFFER_DIVERGED) {
+      RowDataBucket divergedBucket = this.buckets.get(bucketID);
+      ValidationUtils.checkState(
+          divergedBucket != null && divergedBucket.isDiverged(),
+          "The failed RowData bucket is missing or has not diverged");
+      flushAndDisposeBucket(divergedBucket);
+      return;
+    }
+
+    ValidationUtils.checkState(
+        result == BufferWriteResult.BUFFER_CREATION_FAILED,
+        "Unexpected successful buffer write result during memory reclamation");
+    RowDataBucket bucketToFlush = this.buckets.values().stream()
+        .filter(bucket -> !bucket.isEmpty())
+        .max(Comparator.comparingLong(RowDataBucket::getBufferSize))
+        .orElseThrow(() -> new HoodieException(
+            "Not enough memory pages to create a RowData buffer and no non-empty bucket can be flushed"));
+    flushAndDisposeBucket(bucketToFlush);
+  }
+
+  private void retryBufferRecord(
+      String bucketID, HoodieFlinkInternalRow record) throws IOException {
+    final BufferWriteResult result;
+    try {
+      result = doBufferRecord(bucketID, record);
+    } catch (IOException | RuntimeException e) {
+      disposeFailedRetryBucket(bucketID, e);
+      throw e;
+    }
+
+    if (result != BufferWriteResult.SUCCESS) {
+      HoodieException exception = new HoodieException(
+          result == BufferWriteResult.BUFFER_CREATION_FAILED
+              ? "Not enough memory pages to create a RowData buffer after flushing"
+              : "The write buffer is too small to hold a single record");
+      disposeFailedRetryBucket(bucketID, exception);
+      throw exception;
+    }
+  }
+
+  private void disposeFailedRetryBucket(String bucketID, Throwable failure) {
+    RowDataBucket bucket = this.buckets.get(bucketID);
+    if (bucket == null) {
+      return;
+    }
+    try {
+      disposeBucket(bucket);
+    } catch (RuntimeException cleanupFailure) {
+      failure.addSuppressed(cleanupFailure);
+    }
+  }
+
+  private void flushAndDisposeBucket(RowDataBucket bucket) {
+    long bufferSize = bucket.getBufferSize();
+    try {
+      if (!bucket.isEmpty()) {
+        flushBucket(bucket);
+      }
+    } finally {
+      try {
+        this.tracer.countDown(bufferSize);
+      } finally {
+        disposeBucket(bucket);
+      }
+    }
   }
 
   private static BucketInfo getBucketInfo(HoodieFlinkInternalRow internalRow) {
@@ -406,7 +474,7 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
         && this.buckets.values().stream().anyMatch(bucket -> !bucket.isEmpty());
   }
 
-  private boolean flushBucket(RowDataBucket bucket) {
+  private void flushBucket(RowDataBucket bucket) {
     String instant = instantToWrite(true);
 
     ValidationUtils.checkState(!bucket.isEmpty(), "Data bucket to flush has no buffering records");
@@ -422,7 +490,6 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
 
     this.eventGateway.sendEventToCoordinator(event);
     writeStatuses.addAll(writeStatus);
-    return true;
   }
 
   public void flushRemaining(boolean endInput) {
@@ -431,15 +498,14 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
     final List<WriteStatus> writeStatus;
     if (!buckets.isEmpty()) {
       writeStatus = new ArrayList<>();
-      this.buckets.values()
-          // The records are partitioned by the bucket ID and each batch sent to
-          // the writer belongs to one bucket.
-          .forEach(bucket -> {
-            if (!bucket.isEmpty()) {
-              writeStatus.addAll(writeRecords(currentInstant, bucket));
-              bucket.dispose();
-            }
-          });
+      // The records are partitioned by the bucket ID and each batch sent to
+      // the writer belongs to one bucket.
+      for (RowDataBucket bucket : new ArrayList<>(this.buckets.values())) {
+        if (!bucket.isEmpty()) {
+          writeStatus.addAll(writeRecords(currentInstant, bucket));
+        }
+        disposeBucket(bucket);
+      }
     } else {
       log.info("No data to write in subtask [{}] for instant [{}]", taskID, currentInstant);
       writeStatus = Collections.emptyList();
@@ -530,13 +596,40 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
 
   @Override
   public void close() throws Exception {
+    Exception closeFailure = null;
+    if (this.buckets != null) {
+      for (RowDataBucket bucket : new ArrayList<>(this.buckets.values())) {
+        try {
+          disposeBucket(bucket);
+        } catch (RuntimeException e) {
+          closeFailure = addCloseFailure(closeFailure, e);
+        }
+      }
+    }
+
     try {
       if (this.memorySegmentPool instanceof Closeable) {
         ((Closeable) this.memorySegmentPool).close();
       }
-    } finally {
-      super.close();
+    } catch (Exception e) {
+      closeFailure = addCloseFailure(closeFailure, e);
     }
+    try {
+      super.close();
+    } catch (Exception e) {
+      closeFailure = addCloseFailure(closeFailure, e);
+    }
+    if (closeFailure != null) {
+      throw closeFailure;
+    }
+  }
+
+  private static Exception addCloseFailure(Exception failure, Exception nextFailure) {
+    if (failure == null) {
+      return nextFailure;
+    }
+    failure.addSuppressed(nextFailure);
+    return failure;
   }
 
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteFunction.java
@@ -314,22 +314,19 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
    * <p>2. Data Bucket exists, but fails to request new memory pages from memory pool.
    */
   private boolean doBufferRecord(String bucketID, HoodieFlinkInternalRow record) throws IOException {
-    RowDataBucket bucket = this.buckets.get(bucketID);
-    if (bucket == null) {
-      try {
-        bucket = new RowDataBucket(
-            bucketID,
-            createDataBuffer(),
-            getBucketInfo(record),
-            this.config.get(FlinkOptions.WRITE_BATCH_SIZE));
-        this.buckets.put(bucketID, bucket);
-      } catch (MemoryPagesExhaustedException e) {
-        log.info("There are not enough free pages in the memory pool to create a buffer; flushing is required first.");
-        return false;
-      }
-    }
+    try {
+      RowDataBucket bucket = this.buckets.computeIfAbsent(bucketID,
+          k -> new RowDataBucket(
+              bucketID,
+              createDataBuffer(),
+              getBucketInfo(record),
+              this.config.get(FlinkOptions.WRITE_BATCH_SIZE)));
 
-    return bucket.writeRow(record.getRowData());
+      return bucket.writeRow(record.getRowData());
+    } catch (MemoryPagesExhaustedException e) {
+      log.info("There are not enough free pages in the memory pool to create a buffer; flushing is required first.");
+      return false;
+    }
   }
 
   /**
@@ -382,23 +379,45 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
     // A creation failure leaves no bucket in the map, while a write failure leaves the
     // diverged bucket in the map so that its committed records can be flushed and disposed.
     RowDataBucket failedBucket = this.buckets.get(bucketID);
-    if (failedBucket != null) {
-      ValidationUtils.checkState(
-          failedBucket.isDiverged(), "The failed RowData bucket has not diverged");
-      RowDataBucket largestOtherBucket = this.buckets.values().stream()
-          .filter(bucket -> bucket != failedBucket && !bucket.isEmpty())
-          .max(Comparator.comparingLong(RowDataBucket::getBufferSize))
-          .orElse(null);
-      flushAndDisposeAfterWriteFailure(largestOtherBucket, failedBucket);
+    RowDataBucket bucketToFlush = this.buckets.values().stream()
+        .filter(bucket -> !bucketID.equals(bucket.getBucketId()) && !bucket.isEmpty())
+        .max(Comparator.comparingLong(RowDataBucket::getBufferSize))
+        .orElse(null);
+
+    if (failedBucket == null) {
+      if (bucketToFlush == null) {
+        throw new HoodieException(
+            "Not enough memory pages to create a RowData buffer and no non-empty bucket can be flushed");
+      }
+      flushAndDisposeBucket(bucketToFlush);
       return;
     }
 
-    RowDataBucket bucketToFlush = this.buckets.values().stream()
-        .filter(bucket -> !bucket.isEmpty())
-        .max(Comparator.comparingLong(RowDataBucket::getBufferSize))
-        .orElseThrow(() -> new HoodieException(
-            "Not enough memory pages to create a RowData buffer and no non-empty bucket can be flushed"));
-    flushAndDisposeBucket(bucketToFlush);
+    ValidationUtils.checkState(
+        failedBucket.isDiverged(), "The failed RowData bucket has not diverged");
+
+    RuntimeException failure = null;
+    if (bucketToFlush != null) {
+      try {
+        flushAndDisposeBucket(bucketToFlush);
+      } catch (RuntimeException e) {
+        failure = e;
+      }
+    }
+
+    try {
+      flushAndDisposeBucket(failedBucket);
+    } catch (RuntimeException e) {
+      if (failure == null) {
+        failure = e;
+      } else {
+        failure.addSuppressed(e);
+      }
+    }
+
+    if (failure != null) {
+      throw failure;
+    }
   }
 
   private void retryBufferRecord(
@@ -418,32 +437,6 @@ public class StreamWriteFunction extends AbstractStreamWriteFunction<HoodieFlink
               : "The write buffer is too small to hold a single record");
       disposeFailedRetryBucket(bucketID, exception);
       throw exception;
-    }
-  }
-
-  private void flushAndDisposeAfterWriteFailure(
-      RowDataBucket largestOtherBucket, RowDataBucket failedBucket) {
-    RuntimeException failure = null;
-    if (largestOtherBucket != null) {
-      try {
-        flushAndDisposeBucket(largestOtherBucket);
-      } catch (RuntimeException e) {
-        failure = e;
-      }
-    }
-
-    try {
-      flushAndDisposeBucket(failedBucket);
-    } catch (RuntimeException e) {
-      if (failure == null) {
-        failure = e;
-      } else {
-        failure.addSuppressed(e);
-      }
-    }
-
-    if (failure != null) {
-      throw failure;
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/buffer/RowDataBucket.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/buffer/RowDataBucket.java
@@ -41,6 +41,7 @@ public class RowDataBucket {
   private final BufferSizeDetector detector;
   @Getter
   private final String bucketId;
+  @Getter
   private boolean diverged;
 
   public RowDataBucket(
@@ -75,10 +76,6 @@ public class RowDataBucket {
       diverged = true;
     }
     return success;
-  }
-
-  public boolean isDiverged() {
-    return diverged;
   }
 
   public long getBufferSize() {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/buffer/RowDataBucket.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/buffer/RowDataBucket.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.sink.buffer;
 
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.table.action.commit.BucketInfo;
 
 import lombok.Getter;
@@ -40,6 +41,7 @@ public class RowDataBucket {
   private final BufferSizeDetector detector;
   @Getter
   private final String bucketId;
+  private boolean diverged;
 
   public RowDataBucket(
       String bucketId,
@@ -61,11 +63,22 @@ public class RowDataBucket {
   }
 
   public boolean writeRow(RowData rowData) throws IOException {
+    ValidationUtils.checkState(
+        !diverged,
+        "RowData bucket " + bucketId + " diverged after a failed write and cannot be reused");
     boolean success = dataBuffer.write(rowData);
     if (success) {
       detector.detect(rowData);
+    } else {
+      // BinaryInMemorySortBuffer may have partially appended variable-length data before
+      // returning false. Its internal pointers can no longer be trusted for another write.
+      diverged = true;
     }
     return success;
+  }
+
+  public boolean isDiverged() {
+    return diverged;
   }
 
   public long getBufferSize() {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/TestBucketStreamWriteMemoryExhaustion.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/TestBucketStreamWriteMemoryExhaustion.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.bucket;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.sink.StreamWriteFunction;
+import org.apache.hudi.sink.buffer.RowDataBucket;
+import org.apache.hudi.sink.utils.BucketStreamWriteFunctionWrapper;
+import org.apache.hudi.utils.TestConfigurations;
+import org.apache.hudi.utils.TestData;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** End-to-end tests for bucket writes under a tight write memory pool. */
+class TestBucketStreamWriteMemoryExhaustion {
+
+  @TempDir
+  File tempFile;
+
+  @Test
+  void testRecoveryPreservesVariableLengthValuesAndReleasesPages() throws Exception {
+    DataType dataType = DataTypes.ROW(
+        DataTypes.FIELD("uuid", DataTypes.VARCHAR(20)),
+        DataTypes.FIELD("payload", DataTypes.VARCHAR(Integer.MAX_VALUE)),
+        DataTypes.FIELD("attributes", DataTypes.MAP(DataTypes.VARCHAR(64), DataTypes.VARCHAR(64))),
+        DataTypes.FIELD("ts", DataTypes.TIMESTAMP(3)),
+        DataTypes.FIELD("partition", DataTypes.VARCHAR(10)))
+        .notNull();
+    RowType rowType = (RowType) dataType.getLogicalType();
+
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath(), dataType);
+    conf.set(FlinkOptions.TABLE_TYPE, HoodieTableType.COPY_ON_WRITE.name());
+    conf.set(FlinkOptions.OPERATION, "upsert");
+    conf.set(FlinkOptions.INDEX_TYPE, "BUCKET");
+    conf.set(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS, 4);
+    // Leaves 1 MB for the shared RowData memory pool.
+    conf.set(FlinkOptions.WRITE_TASK_MAX_SIZE, 201.0);
+    conf.set(FlinkOptions.WRITE_MERGE_MAX_MEMORY, 100);
+
+    Map<String, String> expectedPayloads = new HashMap<>();
+    Map<String, String> expectedAttributes = new HashMap<>();
+    List<RowData> rows = createRows(rowType, expectedPayloads, expectedAttributes);
+
+    TrackingBucketWriteFunctionWrapper pipeline =
+        new TrackingBucketWriteFunctionWrapper(tempFile.getAbsolutePath(), conf);
+    pipeline.openFunction();
+    int initialFreePages = pipeline.freePages();
+    try {
+      for (RowData row : rows) {
+        pipeline.invoke(row);
+      }
+      int recoveryFlushCount = pipeline.writeBatchCount();
+      assertTrue(recoveryFlushCount > 0, "the tight pool should trigger at least one recovery flush");
+      pipeline.checkpointFunction(1);
+
+      assertEquals(
+          initialFreePages,
+          pipeline.freePages(),
+          "all pages should be returned after the checkpoint flush disposes every bucket");
+
+      handleWriteEvents(pipeline, recoveryFlushCount + 1);
+      pipeline.checkpointComplete(1);
+
+      List<GenericRecord> actualRecords = TestData.readAllData(tempFile, rowType, 1);
+      assertEquals(rows.size(), actualRecords.size(), "memory exhaustion recovery must not lose or duplicate records");
+      for (GenericRecord actualRecord : actualRecords) {
+        String id = actualRecord.get("uuid").toString();
+        assertTrue(
+            actualRecord.get("payload").toString().equals(expectedPayloads.get(id)),
+            "variable-length payload should remain intact for " + id);
+        Map<?, ?> actualAttributes = (Map<?, ?>) actualRecord.get("attributes");
+        assertEquals(1, actualAttributes.size());
+        Map.Entry<?, ?> attribute = actualAttributes.entrySet().iterator().next();
+        assertEquals(
+            expectedAttributes.get(id),
+            attribute.getKey().toString() + "=" + attribute.getValue().toString());
+      }
+    } finally {
+      pipeline.close();
+    }
+  }
+
+  private static List<RowData> createRows(
+      RowType rowType,
+      Map<String, String> expectedPayloads,
+      Map<String, String> expectedAttributes) {
+    List<RowData> rows = new ArrayList<>();
+    for (int i = 0; i < 40; i++) {
+      String id = "uuid-" + i;
+      String payload = "payload-" + i + "-" + repeat((char) ('a' + i % 26), 256 * 1024);
+      String attributeKey = "key-" + i;
+      String attributeValue = "value-" + i;
+      Map<Object, Object> attributes = new HashMap<>();
+      attributes.put(StringData.fromString(attributeKey), StringData.fromString(attributeValue));
+
+      rows.add(TestData.insertRow(
+          rowType,
+          StringData.fromString(id),
+          StringData.fromString(payload),
+          new GenericMapData(attributes),
+          TimestampData.fromEpochMillis(i),
+          StringData.fromString("par0")));
+      expectedPayloads.put(id, payload);
+      expectedAttributes.put(id, attributeKey + "=" + attributeValue);
+    }
+    return rows;
+  }
+
+  private static void handleWriteEvents(
+      TrackingBucketWriteFunctionWrapper pipeline, int eventCount) {
+    for (int i = 0; i < eventCount; i++) {
+      OperatorEvent event = pipeline.getNextEvent();
+      pipeline.getCoordinator().handleEventFromOperator(0, event);
+    }
+  }
+
+  private static String repeat(char value, int count) {
+    return String.valueOf(value).repeat(count);
+  }
+
+  private static class TrackingBucketWriteFunctionWrapper
+      extends BucketStreamWriteFunctionWrapper<RowData> {
+
+    TrackingBucketWriteFunctionWrapper(String basePath, Configuration conf) throws Exception {
+      super(basePath, conf);
+    }
+
+    @Override
+    protected StreamWriteFunction createWriteFunction() {
+      return new TrackingBucketStreamWriteFunction(conf, rowType);
+    }
+
+    int freePages() {
+      TrackingBucketStreamWriteFunction function =
+          (TrackingBucketStreamWriteFunction) writeFunction;
+      return function.freePages();
+    }
+
+    int writeBatchCount() {
+      TrackingBucketStreamWriteFunction function =
+          (TrackingBucketStreamWriteFunction) writeFunction;
+      return function.writeBatchCount();
+    }
+  }
+
+  private static class TrackingBucketStreamWriteFunction extends BucketStreamWriteFunction {
+
+    private int writeBatchCount;
+
+    TrackingBucketStreamWriteFunction(Configuration conf, RowType rowType) {
+      super(conf, rowType);
+    }
+
+    int freePages() {
+      return memorySegmentPool.freePages();
+    }
+
+    int writeBatchCount() {
+      return writeBatchCount;
+    }
+
+    @Override
+    protected List<WriteStatus> writeRecords(String instant, RowDataBucket rowDataBucket) {
+      List<WriteStatus> writeStatuses = super.writeRecords(instant, rowDataBucket);
+      writeBatchCount++;
+      return writeStatuses;
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/TestBucketStreamWriteMemoryExhaustion.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/TestBucketStreamWriteMemoryExhaustion.java
@@ -84,11 +84,27 @@ class TestBucketStreamWriteMemoryExhaustion {
     pipeline.openFunction();
     int initialFreePages = pipeline.freePages();
     try {
+      boolean reclaimedOtherBucketBeforeDivergedBucket = false;
       for (RowData row : rows) {
+        int flushCountBeforeInvoke = pipeline.writeBatchCount();
         pipeline.invoke(row);
+        List<FlushedBucket> invocationFlushes = pipeline.flushesFrom(flushCountBeforeInvoke);
+        for (int i = 1; i < invocationFlushes.size(); i++) {
+          FlushedBucket previous = invocationFlushes.get(i - 1);
+          FlushedBucket current = invocationFlushes.get(i);
+          if (current.diverged && !previous.diverged) {
+            assertTrue(
+                !current.bucketId.equals(previous.bucketId),
+                "memory reclamation should flush another bucket before the diverged bucket");
+            reclaimedOtherBucketBeforeDivergedBucket = true;
+          }
+        }
       }
       int recoveryFlushCount = pipeline.writeBatchCount();
       assertTrue(recoveryFlushCount > 0, "the tight pool should trigger at least one recovery flush");
+      assertTrue(
+          reclaimedOtherBucketBeforeDivergedBucket,
+          "a write failure should reclaim another bucket before disposing the diverged bucket");
       pipeline.checkpointFunction(1);
 
       assertEquals(
@@ -179,11 +195,17 @@ class TestBucketStreamWriteMemoryExhaustion {
           (TrackingBucketStreamWriteFunction) writeFunction;
       return function.writeBatchCount();
     }
+
+    List<FlushedBucket> flushesFrom(int startIndex) {
+      TrackingBucketStreamWriteFunction function =
+          (TrackingBucketStreamWriteFunction) writeFunction;
+      return function.flushesFrom(startIndex);
+    }
   }
 
   private static class TrackingBucketStreamWriteFunction extends BucketStreamWriteFunction {
 
-    private int writeBatchCount;
+    private final List<FlushedBucket> flushedBuckets = new ArrayList<>();
 
     TrackingBucketStreamWriteFunction(Configuration conf, RowType rowType) {
       super(conf, rowType);
@@ -194,14 +216,28 @@ class TestBucketStreamWriteMemoryExhaustion {
     }
 
     int writeBatchCount() {
-      return writeBatchCount;
+      return flushedBuckets.size();
+    }
+
+    List<FlushedBucket> flushesFrom(int startIndex) {
+      return new ArrayList<>(flushedBuckets.subList(startIndex, flushedBuckets.size()));
     }
 
     @Override
     protected List<WriteStatus> writeRecords(String instant, RowDataBucket rowDataBucket) {
       List<WriteStatus> writeStatuses = super.writeRecords(instant, rowDataBucket);
-      writeBatchCount++;
+      flushedBuckets.add(new FlushedBucket(rowDataBucket.getBucketId(), rowDataBucket.isDiverged()));
       return writeStatuses;
+    }
+  }
+
+  private static class FlushedBucket {
+    private final String bucketId;
+    private final boolean diverged;
+
+    private FlushedBucket(String bucketId, boolean diverged) {
+      this.bucketId = bucketId;
+      this.diverged = diverged;
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/buffer/TestRowDataBucket.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/buffer/TestRowDataBucket.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.buffer;
+
+import org.apache.hudi.sink.utils.BufferUtils;
+import org.apache.hudi.table.action.commit.BucketInfo;
+import org.apache.hudi.table.action.commit.BucketType;
+import org.apache.hudi.utils.TestData;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.MutableObjectIterator;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link RowDataBucket}. */
+class TestRowDataBucket {
+
+  @Test
+  void testDivergedBucketCannotBeReusedAndReleasesAllPages() throws Exception {
+    RowType rowType = (RowType) DataTypes.ROW(
+        DataTypes.FIELD("uuid", DataTypes.VARCHAR(20)),
+        DataTypes.FIELD("payload", DataTypes.VARCHAR(Integer.MAX_VALUE)))
+        .notNull()
+        .getLogicalType();
+    HeapMemorySegmentPool pool = new HeapMemorySegmentPool(32 * 1024, 256 * 1024);
+    int initialFreePages = pool.freePages();
+    RowDataBucket bucket = new RowDataBucket(
+        "bucket-0",
+        BufferUtils.createBuffer(rowType, pool),
+        new BucketInfo(BucketType.INSERT, "file-0", "partition-0"),
+        256.0);
+
+    List<String> expectedIds = new ArrayList<>();
+    String payload = repeat('x', 64 * 1024);
+    boolean writeFailed = false;
+    try {
+      for (int i = 0; i < 100; i++) {
+        String id = "uuid-" + i;
+        RowData row = TestData.insertRow(
+            rowType, StringData.fromString(id), StringData.fromString(payload));
+        if (!bucket.writeRow(row)) {
+          writeFailed = true;
+          break;
+        }
+        expectedIds.add(id);
+      }
+
+      assertTrue(writeFailed, "the tiny pool should cause BinaryInMemorySortBuffer.write to return false");
+      assertTrue(bucket.isDiverged());
+      assertFalse(bucket.isEmpty(), "successful rows written before exhaustion should remain readable");
+
+      MutableObjectIterator<BinaryRowData> iterator = bucket.getDataIterator();
+      BinaryRowData reuse = new BinaryRowData(rowType.getFieldCount());
+      List<String> actualIds = new ArrayList<>();
+      BinaryRowData row;
+      while ((row = iterator.next(reuse)) != null) {
+        actualIds.add(row.getString(0).toString());
+        assertTrue(payload.equals(row.getString(1).toString()), "variable-length payload should remain intact");
+      }
+      assertEquals(expectedIds, actualIds, "only successfully indexed rows should be readable");
+
+      RowData extraRow = TestData.insertRow(
+          rowType, StringData.fromString("uuid-extra"), StringData.fromString(payload));
+      assertThrows(IllegalStateException.class, () -> bucket.writeRow(extraRow));
+    } finally {
+      bucket.dispose();
+    }
+
+    assertEquals(initialFreePages, pool.freePages(), "disposing the diverged bucket should return every page");
+  }
+
+  private static String repeat(char value, int count) {
+    return String.valueOf(value).repeat(count);
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

  Part of #19664.

  When the shared Flink write-memory pool is exhausted, `BinaryInMemorySortBuffer.write(RowData)` may return `false` after its variable-length storage has already been partially mutated, even though no index entry was committed for the failed row.

  `StreamWriteFunction` previously handled this case in the same way as a failure to create a new buffer. It could flush another bucket and then retry the record against the same `RowDataBucket`. Reusing such a diverged buffer may resolve variable-length offsets against inconsistent memory segments, leading to corrupted buffered values or runtime exceptions.

  This is the correctness-focused PR1 proposed in #19664. Owner-aware shared memory-pool preemption remains outside the scope of this PR and can be introduced separately.

### Summary and Changelog

  This PR prevents a write buffer from being reused after `BinaryInMemorySortBuffer.write` returns `false`, and makes the corresponding memory-exhaustion recovery path exception-safe.

  Changes include:

  - Introduce explicit buffer-write outcomes to distinguish:
    - failure to create a new buffer because no memory pages are available;
    - failure while writing into an existing buffer, leaving that buffer potentially diverged.
  - Mark a `RowDataBucket` as terminally diverged when its underlying buffer returns `false`.
  - Reject all subsequent writes to a diverged bucket.
  - Recover a diverged non-empty bucket by flushing only the successfully indexed records and then disposing the bucket.
  - Skip flushing a diverged empty bucket and dispose it directly.
  - Preserve the existing largest-bucket reclamation strategy only for buffer creation failures.
  - Retry the failed record once using a newly created buffer.
  - Ensure pages are returned when recovery flushing or retrying fails.
  - Dispose remaining buckets during checkpoint flushing and operator shutdown, including empty buckets.
  - Preserve cleanup failures as suppressed exceptions during operator close.

  Tests added:

  - A focused `RowDataBucket` test verifying that:
    - memory exhaustion causes the bucket to become diverged;
    - a second write is rejected;
    - previously successful records and variable-length values remain readable;
    - disposing the bucket returns all allocated memory pages.
  - An end-to-end Flink bucket-write test using:
    - a 1 MB shared write-memory pool;
    - four buckets;
    - forty records with 256 KB variable-length payloads and map values.
  - The end-to-end test verifies that:
    - memory-exhaustion recovery flushing is triggered;
    - no records are lost or duplicated;
    - variable-length string and map values remain intact;
    - all memory pages are returned after checkpoint flushing.

  Verification result:

  ```text
  Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
  BUILD SUCCESS
```

  No code was copied from another project.

### Impact

  There are no public API, configuration, or storage-format changes.

  For normal writes where the memory pool is not exhausted, buffering behavior is unchanged.

  Under memory pressure, Hudi now discards a buffer that may have diverged instead of attempting to reuse it. This prevents data corruption and runtime failures. It may cause an additional eager flush only on the memory-exhaustion
 recovery path.

  The change also improves memory-page cleanup on exceptional flush, retry, checkpoint, and shutdown paths.

### Risk Level

  medium

  This changes the Flink write path used during memory exhaustion and therefore touches data-correctness-sensitive recovery behavior.

  The risk is mitigated by:

  - keeping the normal successful buffering path unchanged;
  - distinguishing buffer creation failures from existing-buffer write failures;
  - retrying only once on a fresh buffer;
  - flushing only successfully indexed records from a diverged buffer;
  - adding focused buffer-level coverage;
  - adding end-to-end multi-bucket coverage that validates record count, variable-length values, recovery flushing, and complete page restoration.

### Documentation Update

  none

  This is an internal correctness fix with no new configuration, public API, or user-facing workflow.

### Contributor's checklist

  - [x] Read through contributor's guide (https://hudi.apache.org/contribute/how-to-contribute)
  - [x] Enough context is provided in the sections above
  - [x] Adequate tests were added if applicable