### PR TITLE
test(writer): cover legacy populate.meta.fields persistence on table version 6

### DIFF
--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -423,28 +423,39 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
         "the mode must survive on a v6 table -- Uber-style deployments set it there via hudi-cli");
   }
 
+  private static Stream<Arguments> tableVersionsAndMetaFieldsModes() {
+    return Stream.of(HoodieTableVersion.SIX, HoodieTableVersion.NINE, HoodieTableVersion.TEN)
+        .flatMap(version -> Arrays.stream(MetaFieldsMode.values())
+            .map(mode -> arguments(version, mode)));
+  }
+
   /**
    * {@link HoodieTableConfig#create} must derive and persist the legacy populate boolean below
    * table version 10 on its own: callers such as the repair-overwrite-props procedure invoke it
    * directly with user-supplied properties, without going through the table builder that also
-   * derives the boolean.
+   * derives the boolean. From version 10 the mode alone is recorded.
    */
   @ParameterizedTest
-  @EnumSource(MetaFieldsMode.class)
-  void testCreateDerivesLegacyBooleanBelowTableVersionTen(MetaFieldsMode mode) throws IOException {
-    StoragePath v6MetaPath = new StoragePath(basePath,
-        "v6-" + mode.name() + "/" + HoodieTableMetaClient.METAFOLDER_NAME);
+  @MethodSource("tableVersionsAndMetaFieldsModes")
+  void testCreatePersistsLegacyBooleanPerTableVersion(HoodieTableVersion version, MetaFieldsMode mode)
+      throws IOException {
+    StoragePath versionedMetaPath = new StoragePath(basePath,
+        "v" + version.versionCode() + "-" + mode.name() + "/" + HoodieTableMetaClient.METAFOLDER_NAME);
     Properties props = new Properties();
     props.setProperty(HoodieTableConfig.NAME.key(), "test-table");
-    props.setProperty(HoodieTableConfig.VERSION.key(),
-        String.valueOf(HoodieTableVersion.SIX.versionCode()));
+    props.setProperty(HoodieTableConfig.VERSION.key(), String.valueOf(version.versionCode()));
     props.setProperty(HoodieTableConfig.META_FIELDS_MODE.key(), mode.name());
-    HoodieTableConfig.create(storage, v6MetaPath, props);
+    HoodieTableConfig.create(storage, versionedMetaPath, props);
 
-    assertEquals(Boolean.toString(mode.toLegacyPopulateMetaFields()),
-        new HoodieTableConfig(storage, v6MetaPath).getProps()
-            .getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
-        "create() must persist the derived boolean below v10 for unpatched readers, " + mode);
+    HoodieTableConfig persisted = new HoodieTableConfig(storage, versionedMetaPath);
+    if (version.lesserThan(HoodieTableVersion.TEN)) {
+      assertEquals(Boolean.toString(mode.toLegacyPopulateMetaFields()),
+          persisted.getProps().getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+          "create() must persist the derived boolean below v10 for unpatched readers, " + mode);
+    } else {
+      assertFalse(persisted.getProps().containsKey(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+          "create() must record the mode alone from v10, " + mode);
+    }
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -423,6 +423,30 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
         "the mode must survive on a v6 table -- Uber-style deployments set it there via hudi-cli");
   }
 
+  /**
+   * {@link HoodieTableConfig#create} must derive and persist the legacy populate boolean below
+   * table version 10 on its own: callers such as the repair-overwrite-props procedure invoke it
+   * directly with user-supplied properties, without going through the table builder that also
+   * derives the boolean.
+   */
+  @ParameterizedTest
+  @EnumSource(MetaFieldsMode.class)
+  void testCreateDerivesLegacyBooleanBelowTableVersionTen(MetaFieldsMode mode) throws IOException {
+    StoragePath v6MetaPath = new StoragePath(basePath,
+        "v6-" + mode.name() + "/" + HoodieTableMetaClient.METAFOLDER_NAME);
+    Properties props = new Properties();
+    props.setProperty(HoodieTableConfig.NAME.key(), "test-table");
+    props.setProperty(HoodieTableConfig.VERSION.key(),
+        String.valueOf(HoodieTableVersion.SIX.versionCode()));
+    props.setProperty(HoodieTableConfig.META_FIELDS_MODE.key(), mode.name());
+    HoodieTableConfig.create(storage, v6MetaPath, props);
+
+    assertEquals(Boolean.toString(mode.toLegacyPopulateMetaFields()),
+        new HoodieTableConfig(storage, v6MetaPath).getProps()
+            .getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+        "create() must persist the derived boolean below v10 for unpatched readers, " + mode);
+  }
+
   @Test
   void testDropInvalidConfigs() {
     // test invalid configs are dropped

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -229,21 +230,22 @@ class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
       assertFalse(newTable.getProps().containsKey(HoodieTableConfig.POPULATE_META_FIELDS.key()),
           "a table created at v10 records the mode alone for " + mode);
 
-      final String oldPath = tempDir.toAbsolutePath() + Path.SEPARATOR + "mfm-v6-" + mode.name();
-      HoodieTableConfig oldTable = HoodieTableMetaClient.newTableBuilder()
-          .setTableType(HoodieTableType.COPY_ON_WRITE.name())
-          .setTableName("mfm-v6-" + mode.name())
-          .setTableVersion(HoodieTableVersion.SIX.versionCode())
-          .setMetaFieldsMode(mode)
-          .initTable(this.metaClient.getStorageConf(), oldPath)
-          .getTableConfig();
-      assertEquals(mode, oldTable.getMetaFieldsMode());
-      // Assert the raw property, not populateMetaFields(): the accessor resolves through the mode,
-      // so it answers the same whether or not the boolean was persisted. An unpatched reader sees
-      // only the raw key.
-      assertEquals(Boolean.toString(mode.toLegacyPopulateMetaFields()),
-          oldTable.getProps().getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
-          "a table below v10 must persist the derived boolean for unpatched readers, " + mode);
+      for (HoodieTableVersion oldVersion : Arrays.asList(HoodieTableVersion.SIX, HoodieTableVersion.NINE)) {
+        final String oldPath = tempDir.toAbsolutePath() + Path.SEPARATOR
+            + "mfm-v" + oldVersion.versionCode() + "-" + mode.name();
+        HoodieTableConfig oldTable = HoodieTableMetaClient.newTableBuilder()
+            .setTableType(HoodieTableType.COPY_ON_WRITE.name())
+            .setTableName("mfm-v" + oldVersion.versionCode() + "-" + mode.name())
+            .setTableVersion(oldVersion.versionCode())
+            .setMetaFieldsMode(mode)
+            .initTable(this.metaClient.getStorageConf(), oldPath)
+            .getTableConfig();
+        assertEquals(mode, oldTable.getMetaFieldsMode());
+        assertEquals(Boolean.toString(mode.toLegacyPopulateMetaFields()),
+            oldTable.getProps().getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+            "a table at version " + oldVersion.versionCode()
+                + " must persist the derived boolean for unpatched readers, " + mode);
+      }
     }
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -238,8 +238,12 @@ class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
           .initTable(this.metaClient.getStorageConf(), oldPath)
           .getTableConfig();
       assertEquals(mode, oldTable.getMetaFieldsMode());
-      assertEquals(mode.toLegacyPopulateMetaFields(), oldTable.populateMetaFields(),
-          "a table below v10 must still carry the derived boolean for unpatched readers, " + mode);
+      // Assert the raw property, not populateMetaFields(): the accessor resolves through the mode,
+      // so it answers the same whether or not the boolean was persisted. An unpatched reader sees
+      // only the raw key.
+      assertEquals(Boolean.toString(mode.toLegacyPopulateMetaFields()),
+          oldTable.getProps().getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+          "a table below v10 must persist the derived boolean for unpatched readers, " + mode);
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestMetaFieldsModeE2E.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestMetaFieldsModeE2E.java
@@ -27,7 +27,9 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.MetaFieldsMode;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
 import org.apache.spark.api.java.function.VoidFunction2;
@@ -279,6 +281,33 @@ class TestMetaFieldsModeE2E extends SparkClientFunctionalTestHarness {
     assertEquals(MetaFieldsMode.ALL, tc.getMetaFieldsMode());
     assertTrue(tc.populateMetaFields(),
         "ALL must persist populate.meta.fields=true for pre-1.3.0 readers");
+  }
+
+  /**
+   * Writing a table at table version 6 must record the mode and the derived legacy boolean as raw
+   * properties, and populate the meta columns per the mode. The boolean is asserted on the raw
+   * persisted key rather than through {@code populateMetaFields()} (which resolves through the mode
+   * and answers the same either way) because an unpatched pre-1.3.0 reader sees only the raw key.
+   */
+  @ParameterizedTest
+  @EnumSource(MetaFieldsMode.class)
+  void tableVersionSixWritePersistsModeAndDerivedLegacyBoolean(MetaFieldsMode mode) {
+    Map<String, String> options = baseOptions();
+    options.put(HoodieWriteConfig.WRITE_TABLE_VERSION.key(),
+        String.valueOf(HoodieTableVersion.SIX.versionCode()));
+    options.put(HoodieTableConfig.META_FIELDS_MODE.key(), mode.name());
+    options.put(DataSourceWriteOptions.OPERATION().key(), DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+
+    HoodieTableConfig tc = writeSampleAndGetTableConfig(options, basePath());
+
+    assertEquals(HoodieTableVersion.SIX, tc.getTableVersion());
+    assertEquals(mode, tc.getMetaFieldsMode());
+    assertEquals(mode.name(), tc.getString(HoodieTableConfig.META_FIELDS_MODE),
+        "the mode must be persisted verbatim on a v6 table");
+    assertEquals(Boolean.toString(mode.toLegacyPopulateMetaFields()),
+        tc.getProps().getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+        "a table below v10 must persist the derived legacy boolean for unpatched readers");
+    assertMetaColumnPopulation(basePath(), mode);
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestMetaFieldsModeE2E.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestMetaFieldsModeE2E.java
@@ -44,7 +44,9 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -54,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -283,30 +286,41 @@ class TestMetaFieldsModeE2E extends SparkClientFunctionalTestHarness {
         "ALL must persist populate.meta.fields=true for pre-1.3.0 readers");
   }
 
+  private static Stream<Arguments> tableVersionsAndMetaFieldsModes() {
+    return Stream.of(HoodieTableVersion.SIX, HoodieTableVersion.NINE, HoodieTableVersion.TEN)
+        .flatMap(version -> Arrays.stream(MetaFieldsMode.values())
+            .map(mode -> Arguments.of(version, mode)));
+  }
+
   /**
-   * Writing a table at table version 6 must record the mode and the derived legacy boolean as raw
-   * properties, and populate the meta columns per the mode. The boolean is asserted on the raw
-   * persisted key rather than through {@code populateMetaFields()} (which resolves through the mode
-   * and answers the same either way) because an unpatched pre-1.3.0 reader sees only the raw key.
+   * A write at any supported table version must record the mode verbatim, and below version 10 also
+   * the derived legacy boolean as a raw property; from version 10 the mode alone is recorded. The
+   * boolean is asserted on the raw persisted key rather than through {@code populateMetaFields()}
+   * (which resolves through the mode and answers the same either way) because an unpatched
+   * pre-1.3.0 reader sees only the raw key. Meta-column population is verified for every case.
    */
   @ParameterizedTest
-  @EnumSource(MetaFieldsMode.class)
-  void tableVersionSixWritePersistsModeAndDerivedLegacyBoolean(MetaFieldsMode mode) {
+  @MethodSource("tableVersionsAndMetaFieldsModes")
+  void writePersistsModeAndLegacyBooleanPerTableVersion(HoodieTableVersion version, MetaFieldsMode mode) {
     Map<String, String> options = baseOptions();
-    options.put(HoodieWriteConfig.WRITE_TABLE_VERSION.key(),
-        String.valueOf(HoodieTableVersion.SIX.versionCode()));
+    options.put(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), String.valueOf(version.versionCode()));
     options.put(HoodieTableConfig.META_FIELDS_MODE.key(), mode.name());
     options.put(DataSourceWriteOptions.OPERATION().key(), DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
 
     HoodieTableConfig tc = writeSampleAndGetTableConfig(options, basePath());
 
-    assertEquals(HoodieTableVersion.SIX, tc.getTableVersion());
+    assertEquals(version, tc.getTableVersion());
     assertEquals(mode, tc.getMetaFieldsMode());
     assertEquals(mode.name(), tc.getString(HoodieTableConfig.META_FIELDS_MODE),
-        "the mode must be persisted verbatim on a v6 table");
-    assertEquals(Boolean.toString(mode.toLegacyPopulateMetaFields()),
-        tc.getProps().getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
-        "a table below v10 must persist the derived legacy boolean for unpatched readers");
+        "the mode must be persisted at table version " + version.versionCode());
+    if (version.lesserThan(HoodieTableVersion.TEN)) {
+      assertEquals(Boolean.toString(mode.toLegacyPopulateMetaFields()),
+          tc.getProps().getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+          "a table below v10 must persist the derived legacy boolean for unpatched readers");
+    } else {
+      assertFalse(tc.getProps().containsKey(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+          "a table at v10 must record the mode alone");
+    }
     assertMetaColumnPopulation(basePath(), mode);
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19694. Tables below version 10 must persist the deprecated `hoodie.populate.meta.fields` boolean derived from `hoodie.meta.fields.mode` (#19205) so pre-1.3.0 readers do not fall back to the `true` default and treat a selectively populated table as fully populated. The persistence is implemented, but the existing v6 assertion resolves through the mode property and cannot fail when the raw key is missing, and neither the `HoodieTableConfig.create` site nor an actual table version 6 write is covered.

### Summary and Changelog

Test-only change, no production code.

- `TestHoodieTableMetaClient`: the pre-v10 branch now asserts the raw persisted `hoodie.populate.meta.fields` value instead of `populateMetaFields()` (which resolves through the mode and passes either way), for table versions 6 and 9.
- `TestHoodieTableConfig`: new parameterized test (table versions 6, 9, 10 by every mode) pinning that `HoodieTableConfig.create` derives and persists the boolean below version 10 on its own, and records the mode alone at version 10; it is called directly with user-supplied properties by the repair overwrite props procedure, and a regression confined to it passes the builder-path tests.
- `TestMetaFieldsModeE2E`: new parameterized test writing a table via the Spark datasource at table versions 6, 9, and 10 for every `MetaFieldsMode`, asserting the persisted table version, the raw properties (boolean present and derived below version 10, absent at version 10), and the physical meta column population.

Verified red/green by mutation: disabling the builder persistence fails the strengthened metaclient assertion with `expected: <true> but was: <null>`, and disabling only the `create()` branch fails the new `TestHoodieTableConfig` test the same way while all previously existing tests stay green.

### Impact

None, tests only.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable

