### PR TITLE
feat(utilities): add fail-fast continuous mode for HoodieMultiTableStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieMultiTableStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieMultiTableStreamer.java
@@ -23,6 +23,7 @@ import org.apache.hudi.SparkAdapterSupport$;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.util.CustomizedThreadFactory;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -51,10 +52,15 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 import static org.apache.hudi.utilities.config.HoodieSchemaProviderConfig.SCHEMA_REGISTRY_BASE_URL;
@@ -79,12 +85,16 @@ public class HoodieMultiTableStreamer {
   private transient JavaSparkContext jssc;
   private final Set<String> successTables;
   private final Set<String> failedTables;
+  @Getter(AccessLevel.NONE)
+  private final boolean failFastOnContinuousMode;
 
   public HoodieMultiTableStreamer(Config config, JavaSparkContext jssc) throws IOException {
     this.tableExecutionContexts = new ArrayList<>();
-    this.successTables = new HashSet<>();
-    this.failedTables = new HashSet<>();
+    // In continuous mode tables are synced concurrently, so use thread-safe sets.
+    this.successTables = ConcurrentHashMap.newKeySet();
+    this.failedTables = ConcurrentHashMap.newKeySet();
     this.jssc = jssc;
+    this.failFastOnContinuousMode = config.failFastOnContinuousMode;
     String commonPropsFile = config.propsFilePath;
     String configFolder = config.configFolder;
     ValidationUtils.checkArgument(!config.filterDupes || config.operation != WriteOperationType.UPSERT,
@@ -389,6 +399,12 @@ public class HoodieMultiTableStreamer {
         + " source-fetch -> Transform -> Hudi Write in loop")
     public Boolean continuousMode = false;
 
+    @Parameter(names = {"--fail-fast-on-continuous"},
+        description = "Only applies in continuous mode. When enabled, the failure of any single table sync fails the "
+            + "whole job: the remaining table syncs are shut down and the process exits with a non-zero status. When "
+            + "disabled (default), each table is synced independently and a single failure does not stop the others.")
+    public Boolean failFastOnContinuousMode = false;
+
     @Parameter(names = {"--min-sync-interval-seconds"},
         description = "the min sync interval of each sync in continuous mode")
     public Integer minSyncIntervalSeconds = 0;
@@ -461,8 +477,25 @@ public class HoodieMultiTableStreamer {
 
   /**
    * Creates actual HoodieDeltaStreamer objects for every table/topic and does incremental sync.
+   *
+   * <p>In continuous mode each table's sync blocks until it is shut down, so the tables are synced concurrently.
+   * Otherwise the tables are synced sequentially, one after another.
    */
   public void sync() {
+    boolean isContinuous = !tableExecutionContexts.isEmpty() && tableExecutionContexts.get(0).getConfig().continuousMode;
+    if (isContinuous) {
+      syncContinuously();
+    } else {
+      syncSequentially();
+    }
+
+    log.info("Ingestion was successful for topics: {}", successTables);
+    if (!failedTables.isEmpty()) {
+      log.info("Ingestion failed for topics: {}", failedTables);
+    }
+  }
+
+  private void syncSequentially() {
     for (TableExecutionContext context : tableExecutionContexts) {
       HoodieStreamer streamer = null;
       try {
@@ -479,11 +512,81 @@ public class HoodieMultiTableStreamer {
         }
       }
     }
+  }
 
-    log.info("Ingestion was successful for topics: {}", successTables);
-    if (!failedTables.isEmpty()) {
-      log.info("Ingestion failed for topics: {}", failedTables);
+  /**
+   * Syncs all tables concurrently, one thread per table. Used for continuous mode where each table's sync blocks
+   * indefinitely.
+   *
+   * <p>When {@code --fail-fast-on-continuous} is enabled, the first table failure fails the whole job: the sibling
+   * streamers are shut down and a {@link HoodieException} is thrown so the caller can exit with a non-zero status.
+   * Otherwise every table is synced independently and a single failure does not affect the others.
+   */
+  private void syncContinuously() {
+    // Streamer instances are registered from worker threads, so a thread-safe list is required.
+    final List<HoodieStreamer> streamerInstances = new CopyOnWriteArrayList<>();
+    final ExecutorService executor = Executors.newFixedThreadPool(tableExecutionContexts.size(),
+        new CustomizedThreadFactory("multi-table-streamer", true));
+    try {
+      final CompletableFuture<?>[] tableFutures = tableExecutionContexts.stream()
+          .map(context -> CompletableFuture.runAsync(() -> {
+            HoodieStreamer streamer = null;
+            try {
+              streamer = new HoodieStreamer(context.getConfig(), jssc, Option.ofNullable(context.getProperties()));
+              streamerInstances.add(streamer);
+              streamer.sync();
+              successTables.add(Helpers.getTableWithDatabase(context));
+            } catch (Exception e) {
+              log.error("error while running MultiTableDeltaStreamer for table: {}", context.getTableName(), e);
+              failedTables.add(Helpers.getTableWithDatabase(context));
+              if (failFastOnContinuousMode) {
+                throw new CompletionException(e);
+              }
+            } finally {
+              if (streamer != null) {
+                streamer.shutdownGracefully();
+              }
+            }
+          }, executor)).toArray(CompletableFuture[]::new);
+
+      // In fail-fast mode getConditionalFuture returns anyOf(...), which completes exceptionally as soon as the first
+      // table fails; otherwise it returns allOf(...) and only completes once every table sync has terminated.
+      Throwable failure = getConditionalFuture(tableFutures)
+          .handle((unused, throwable) -> throwable)
+          .join();
+      log.info("Successful tables: {}, Failed tables: {}", successTables, failedTables);
+      if (failure != null && failFastOnContinuousMode) {
+        log.error("MultiTableDeltaStreamer failed with an exception, shutting down remaining sources as fail fast is enabled!", failure);
+        shutdownStreamers(streamerInstances);
+        throw new HoodieException("Fail fast is enabled and a table sync failed in continuous mode.", failure);
+      }
+    } finally {
+      executor.shutdownNow();
     }
+  }
+
+  private void shutdownStreamers(List<HoodieStreamer> streamerInstances) {
+    for (HoodieStreamer streamer : streamerInstances) {
+      try {
+        if (!streamer.getIngestionService().isShutdown()) {
+          streamer.getIngestionService().shutdown(true);
+        }
+      } catch (Exception e) {
+        log.warn("Failed to shut down a streamer instance during fail-fast handling.", e);
+      }
+    }
+  }
+
+  /**
+   * Returns a future that completes when the first table sync fails (fail-fast) or when all table syncs
+   * complete (default).
+   */
+  private CompletableFuture<?> getConditionalFuture(final CompletableFuture<?>[] tableFutures) {
+    if (failFastOnContinuousMode) {
+      log.info("Fail fast enabled in continuous mode. The whole job fails on any single table failure.");
+      return CompletableFuture.anyOf(tableFutures);
+    }
+    return CompletableFuture.allOf(tableFutures);
   }
 
   public static class Constants {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
@@ -31,6 +31,7 @@ import org.apache.hudi.utilities.schema.SchemaRegistryProvider;
 import org.apache.hudi.utilities.sources.JsonKafkaSource;
 import org.apache.hudi.utilities.sources.ParquetDFSSource;
 import org.apache.hudi.utilities.sources.TestDataSource;
+import org.apache.hudi.utilities.streamer.NoNewDataTerminationStrategy;
 import org.apache.hudi.utilities.streamer.TableExecutionContext;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
@@ -44,6 +45,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -240,6 +242,75 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
       totalTable2Records += table2Records;
       // sync and verify
       syncAndVerify(streamer, targetBasePath1, targetBasePath2, totalTable1Records, totalTable2Records);
+    }
+  }
+
+  @Test
+  public void testFailFastOnContinuousDefaultsToFalse() {
+    HoodieMultiTableDeltaStreamer.Config cfg = new HoodieMultiTableDeltaStreamer.Config();
+    assertFalse(cfg.failFastOnContinuousMode);
+  }
+
+  @Test
+  public void testMultiTableContinuousModeSyncsAllTablesInParallel() throws IOException {
+    // ingest test data to 2 parquet source paths
+    String parquetSourceRoot1 = basePath + "/parquetContSrc1/";
+    prepareParquetDFSFiles(10, parquetSourceRoot1);
+    String parquetSourceRoot2 = basePath + "/parquetContSrc2/";
+    prepareParquetDFSFiles(5, parquetSourceRoot2);
+
+    String parquetPropsFile = populateCommonPropsAndWriteToFile();
+
+    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(parquetPropsFile, basePath + "/config", ParquetDFSSource.class.getName(), false, false,
+        false, "multi_table_parquet_continuous", null);
+    // Continuous mode blocks per table, so tables must be synced concurrently.
+    cfg.continuousMode = true;
+
+    HoodieMultiTableDeltaStreamer streamer = new HoodieMultiTableDeltaStreamer(cfg, jsc);
+    List<TableExecutionContext> executionContexts = streamer.getTableExecutionContexts();
+    ingestPerParquetSourceProps(executionContexts, Arrays.asList(new String[] {parquetSourceRoot1, parquetSourceRoot2}));
+    // A termination strategy ensures each table's streamer shuts down once there is no new data, so the test does not hang.
+    setTerminationStrategy(executionContexts);
+
+    String targetBasePath1 = executionContexts.get(0).getConfig().targetBasePath;
+    String targetBasePath2 = executionContexts.get(1).getConfig().targetBasePath;
+
+    streamer.sync();
+
+    assertEquals(2, streamer.getSuccessTables().size());
+    assertTrue(streamer.getFailedTables().isEmpty());
+    assertRecordCount(10, targetBasePath1, sqlContext);
+    assertRecordCount(5, targetBasePath2, sqlContext);
+  }
+
+  @Test
+  public void testFailFastOnContinuousThrowsWhenATableFails() throws IOException {
+    String parquetSourceRoot1 = basePath + "/parquetFailFastSrc1/";
+    prepareParquetDFSFiles(10, parquetSourceRoot1);
+    String parquetSourceRoot2 = basePath + "/parquetFailFastSrc2/";
+    prepareParquetDFSFiles(5, parquetSourceRoot2);
+
+    String parquetPropsFile = populateCommonPropsAndWriteToFile();
+
+    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(parquetPropsFile, basePath + "/config", ParquetDFSSource.class.getName(), false, false,
+        false, "multi_table_parquet_fail_fast", null);
+    cfg.continuousMode = true;
+    cfg.failFastOnContinuousMode = true;
+
+    HoodieMultiTableDeltaStreamer streamer = new HoodieMultiTableDeltaStreamer(cfg, jsc);
+    List<TableExecutionContext> executionContexts = streamer.getTableExecutionContexts();
+    ingestPerParquetSourceProps(executionContexts, Arrays.asList(new String[] {parquetSourceRoot1, parquetSourceRoot2}));
+    setTerminationStrategy(executionContexts);
+    // Break the second table's source so its sync fails.
+    executionContexts.get(1).getProperties().setProperty("hoodie.streamer.source.dfs.root", basePath + "/does_not_exist");
+
+    assertThrows(HoodieException.class, streamer::sync);
+    assertFalse(streamer.getFailedTables().isEmpty());
+  }
+
+  private void setTerminationStrategy(List<TableExecutionContext> executionContexts) {
+    for (TableExecutionContext context : executionContexts) {
+      context.getConfig().postWriteTerminationStrategyClass = NoNewDataTerminationStrategy.class.getName();
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

In continuous mode each table's sync() blocks until shutdown, so the existing sequential loop would only ever sync the first table. 

### Summary and Changelog

Sync the tables concurrently (one thread per table) when continuous mode is on, while keeping the sequential path for run-once mode.

**Add a `--fail-fast-on-continuous` flag:** when enabled, the first table failure shuts down the sibling streamers and throws a `HoodieException` so the job exits non-zero; when disabled (default), each table is synced independently and a single failure does not affect the others.

Use thread-safe collections for the success/failed table tracking now that syncs run in parallel.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update


1. Multi table streamer now supports continuous mode.
2.  `--fail-fast-on-continuous` flag added 

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
