### PR TITLE
feat(utilities): ingest unstructured files announced by S3 event notifications

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -131,7 +131,9 @@ public class CloudSourceConfig extends HoodieConfig {
       .noDefaultValue()
       .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.select.file.extension")
       .markAdvanced()
-      .withDocumentation("Only match files with this extension. By default, this is the same as hoodie.streamer.source.hoodieincr.file.format");
+      .withDocumentation("Only match files with this extension. Accepts a comma separated list, "
+          + "in which case a file matching any one of the extensions is selected, e.g. \"json,jsonl\". "
+          + "By default, this is the same as hoodie.streamer.source.hoodieincr.file.format");
 
   public static final ConfigProperty<String> DATAFILE_FORMAT = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.datafile.format")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/UnstructuredFileSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/UnstructuredFileSourceConfig.java
@@ -122,6 +122,17 @@ public class UnstructuredFileSourceConfig extends HoodieConfig {
       .sinceVersion("1.2.0")
       .withDocumentation("Number of characters consecutive chunks overlap by.");
 
+  public static final ConfigProperty<Long> WORK_BYTES_PER_PARTITION = ConfigProperty
+      .key(PREFIX + "work.bytes.per.partition")
+      .defaultValue(16L * 1024 * 1024)
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("Target bytes of parseable content per Spark partition when files arrive "
+          + "through cloud notifications. Only files small enough to be parsed count toward it, "
+          + "since a file above " + PARSE_MAX_BYTES.key() + " is referenced without being read. "
+          + "Far below a columnar target on purpose: text extraction runs orders of magnitude "
+          + "slower per byte than a columnar scan.");
+
   public static final ConfigProperty<Integer> LISTING_PARALLELISM = ConfigProperty
       .key(PREFIX + "listing.parallelism")
       .defaultValue(0)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/UnstructuredFileDFSSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/UnstructuredFileDFSSource.java
@@ -19,37 +19,24 @@
 package org.apache.hudi.utilities.sources;
 
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.collection.LazyIterableIterator;
 import org.apache.hudi.common.util.collection.Pair;
-import org.apache.hudi.hadoop.fs.HadoopFSUtils;
-import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.sources.helpers.CloudObjectMetadata;
 import org.apache.hudi.utilities.sources.helpers.DFSPathSelector;
 import org.apache.hudi.utilities.sources.helpers.unstructured.UnstructuredFileRecordBuilder;
+import org.apache.hudi.utilities.sources.helpers.unstructured.UnstructuredFileRows;
 
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.MetadataBuilder;
-import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -78,39 +65,8 @@ import static org.apache.hudi.utilities.config.UnstructuredFileSourceConfig.LIST
  */
 public class UnstructuredFileDFSSource extends RowSource {
 
-  private static final Metadata BLOB_METADATA = new MetadataBuilder()
-      .putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
-      .build();
-
-  private static final StructType BLOB_REFERENCE_TYPE = DataTypes.createStructType(new StructField[] {
-      DataTypes.createStructField(HoodieSchema.Blob.EXTERNAL_REFERENCE_PATH, DataTypes.StringType, true),
-      DataTypes.createStructField(HoodieSchema.Blob.EXTERNAL_REFERENCE_OFFSET, DataTypes.LongType, true),
-      DataTypes.createStructField(HoodieSchema.Blob.EXTERNAL_REFERENCE_LENGTH, DataTypes.LongType, true),
-      DataTypes.createStructField(HoodieSchema.Blob.EXTERNAL_REFERENCE_IS_MANAGED, DataTypes.BooleanType, true)});
-
-  private static final StructType BLOB_TYPE = DataTypes.createStructType(new StructField[] {
-      DataTypes.createStructField(HoodieSchema.Blob.TYPE, DataTypes.StringType, false),
-      DataTypes.createStructField(HoodieSchema.Blob.INLINE_DATA_FIELD, DataTypes.BinaryType, true),
-      DataTypes.createStructField(HoodieSchema.Blob.EXTERNAL_REFERENCE, BLOB_REFERENCE_TYPE, true)});
-
-  private static final StructType CHUNK_TYPE = DataTypes.createStructType(new StructField[] {
-      DataTypes.createStructField("chunk_id", DataTypes.IntegerType, false),
-      DataTypes.createStructField("text", DataTypes.StringType, false),
-      DataTypes.createStructField("char_start", DataTypes.IntegerType, false)});
-
-  public static final StructType SOURCE_SCHEMA = new StructType(new StructField[] {
-      DataTypes.createStructField("path", DataTypes.StringType, false),
-      DataTypes.createStructField("file_name", DataTypes.StringType, false),
-      DataTypes.createStructField("extension", DataTypes.StringType, false),
-      DataTypes.createStructField("size", DataTypes.LongType, false),
-      DataTypes.createStructField("modification_time", DataTypes.LongType, false),
-      new StructField("content", BLOB_TYPE, false, BLOB_METADATA),
-      DataTypes.createStructField("extracted_text", DataTypes.StringType, true),
-      DataTypes.createStructField("doc_metadata",
-          DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType, true), true),
-      DataTypes.createStructField("chunks", DataTypes.createArrayType(CHUNK_TYPE, false), true),
-      DataTypes.createStructField("parse_status", DataTypes.StringType, false),
-      DataTypes.createStructField("parse_error", DataTypes.StringType, true)});
+  /** Retained for callers that referenced the schema on this class. */
+  public static final StructType SOURCE_SCHEMA = UnstructuredFileRows.SOURCE_SCHEMA;
 
   private final DFSPathSelector pathSelector;
   private final UnstructuredFileRecordBuilder recordBuilder;
@@ -123,25 +79,11 @@ public class UnstructuredFileDFSSource extends RowSource {
     super(props, sparkContext, sparkSession, schemaProvider);
     this.pathSelector = DFSPathSelector.createSourceSelector(props, sparkContext.hadoopConfiguration());
     this.recordBuilder = new UnstructuredFileRecordBuilder(props);
-    this.allowedExtensions = parseExtensions(getStringWithAltKeys(props, FILE_EXTENSIONS, true));
-    this.ignoredExtensions = parseExtensions(getStringWithAltKeys(props, FILE_EXTENSIONS_IGNORE, true));
+    this.allowedExtensions = UnstructuredFileRows.parseExtensions(getStringWithAltKeys(props, FILE_EXTENSIONS, true));
+    this.ignoredExtensions = UnstructuredFileRows.parseExtensions(getStringWithAltKeys(props, FILE_EXTENSIONS_IGNORE, true));
     int configuredParallelism = getIntWithAltKeys(props, LISTING_PARALLELISM);
     this.listingParallelism = configuredParallelism > 0
         ? configuredParallelism : sparkContext.defaultParallelism();
-  }
-
-  private static Set<String> parseExtensions(String csv) {
-    return csv == null || csv.trim().isEmpty()
-        ? new HashSet<>()
-        : Arrays.stream(csv.toLowerCase(Locale.ROOT).split(","))
-            .map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toSet());
-  }
-
-  private boolean isEligible(String fileName) {
-    String extension = UnstructuredFileRecordBuilder.extensionOf(fileName);
-    // an explicit allowlist decides alone; otherwise everything except the denylist
-    return allowedExtensions.isEmpty()
-        ? !ignoredExtensions.contains(extension) : allowedExtensions.contains(extension);
   }
 
   @Override
@@ -154,31 +96,11 @@ public class UnstructuredFileDFSSource extends RowSource {
   }
 
   private Dataset<Row> fromFiles(String pathStr) {
-    List<String> paths = Arrays.stream(pathStr.split(","))
-        .filter(p -> isEligible(new Path(p).getName()))
+    List<CloudObjectMetadata> objects = Arrays.stream(pathStr.split(","))
+        .filter(p -> UnstructuredFileRows.isEligible(new Path(p).getName(), allowedExtensions, ignoredExtensions))
+        // listing gives no usable size here, so the row builder interrogates each file as before
+        .map(p -> new CloudObjectMetadata(p, 0L))
         .collect(Collectors.toList());
-    int parallelism = Math.max(1, Math.min(paths.size(), listingParallelism));
-    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(sparkContext.hadoopConfiguration());
-    UnstructuredFileRecordBuilder builder = this.recordBuilder;
-    // one file -> one row, lazily: inline bytes and extracted text of a partition must
-    // never be resident all at once, or partition memory scales with total corpus size
-    JavaRDD<Row> rows = sparkContext.parallelize(paths, parallelism).mapPartitions(pathIterator ->
-        new LazyIterableIterator<String, Row>(pathIterator) {
-          private FileSystem fs;
-
-          @Override
-          protected Row computeNext() {
-            String path = inputItr.next();
-            try {
-              if (fs == null) {
-                fs = HadoopFSUtils.getFs(new Path(path), storageConf);
-              }
-              return builder.buildRow(fs, path);
-            } catch (IOException e) {
-              throw new UncheckedIOException("Failed to build record for " + path, e);
-            }
-          }
-        });
-    return sparkSession.createDataFrame(rows, SOURCE_SCHEMA);
+    return UnstructuredFileRows.toDataset(sparkSession, sparkContext, objects, recordBuilder, listingParallelism);
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/UnstructuredFileS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/UnstructuredFileS3EventsHoodieIncrSource.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.sources.helpers.CloudDataFetcher;
+import org.apache.hudi.utilities.sources.helpers.CloudObjectsSelectorCommon;
+import org.apache.hudi.utilities.sources.helpers.QueryRunner;
+import org.apache.hudi.utilities.sources.helpers.UnstructuredFileMaterializer;
+import org.apache.hudi.utilities.streamer.DefaultStreamContext;
+import org.apache.hudi.utilities.streamer.StreamContext;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Ingests unstructured files whose arrival is announced by S3 event notifications, rather than
+ * discovered by listing a prefix. Discovery, batching and checkpointing are inherited unchanged
+ * from {@link S3EventsHoodieIncrSource}; only the step that turns the selected objects into rows
+ * differs, and that is supplied by {@link UnstructuredFileMaterializer}.
+ *
+ * <p>Prefer this over {@code UnstructuredFileDFSSource} for a corpus that keeps growing: listing
+ * costs a full walk of the prefix on every sync whether or not anything arrived, while the events
+ * cost only what is new.
+ */
+public class UnstructuredFileS3EventsHoodieIncrSource extends S3EventsHoodieIncrSource {
+
+  public UnstructuredFileS3EventsHoodieIncrSource(
+      TypedProperties props,
+      JavaSparkContext sparkContext,
+      SparkSession sparkSession,
+      SchemaProvider schemaProvider,
+      HoodieIngestionMetrics metrics) {
+    this(props, sparkContext, sparkSession, metrics, new DefaultStreamContext(schemaProvider, Option.empty()));
+  }
+
+  public UnstructuredFileS3EventsHoodieIncrSource(
+      TypedProperties props,
+      JavaSparkContext sparkContext,
+      SparkSession sparkSession,
+      HoodieIngestionMetrics metrics,
+      StreamContext streamContext) {
+    super(props, sparkContext, sparkSession, new QueryRunner(sparkSession, props),
+        new CloudDataFetcher(props, sparkContext, sparkSession, metrics,
+            new CloudObjectsSelectorCommon(props),
+            new UnstructuredFileMaterializer(props, sparkContext)),
+        streamContext);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudDataFetcher.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudDataFetcher.java
@@ -60,6 +60,7 @@ public class CloudDataFetcher implements Serializable {
   private transient JavaSparkContext sparkContext;
   private transient SparkSession sparkSession;
   private transient CloudObjectsSelectorCommon cloudObjectsSelectorCommon;
+  private final CloudObjectMaterializer materializer;
 
   private static final long serialVersionUID = 1L;
 
@@ -70,11 +71,18 @@ public class CloudDataFetcher implements Serializable {
   }
 
   public CloudDataFetcher(TypedProperties props, JavaSparkContext jsc, SparkSession sparkSession, HoodieIngestionMetrics metrics, CloudObjectsSelectorCommon cloudObjectsSelectorCommon) {
+    this(props, jsc, sparkSession, metrics, cloudObjectsSelectorCommon,
+        new ColumnarFileMaterializer(props, cloudObjectsSelectorCommon));
+  }
+
+  public CloudDataFetcher(TypedProperties props, JavaSparkContext jsc, SparkSession sparkSession, HoodieIngestionMetrics metrics,
+                          CloudObjectsSelectorCommon cloudObjectsSelectorCommon, CloudObjectMaterializer materializer) {
     this.props = props;
     this.sparkContext = jsc;
     this.sparkSession = sparkSession;
     this.metrics = metrics;
     this.cloudObjectsSelectorCommon = cloudObjectsSelectorCommon;
+    this.materializer = materializer;
   }
 
   public static String getFileFormat(TypedProperties props) {
@@ -99,7 +107,7 @@ public class CloudDataFetcher implements Serializable {
     }
 
     QueryInfo queryInfo = queryInfoDatasetPair.getLeft();
-    String filter = CloudObjectsSelectorCommon.generateFilter(cloudType, props);
+    String filter = CloudObjectsSelectorCommon.generateFilter(cloudType, props, materializer);
     log.info("Adding filter string to Dataset: {}", filter);
     Dataset<Row> filteredSourceData = queryInfoDatasetPair.getRight().filter(filter);
 
@@ -144,15 +152,9 @@ public class CloudDataFetcher implements Serializable {
     for (CloudObjectMetadata o : cloudObjectMetadata) {
       totalSize += o.getSize();
     }
-    // inflate 10% for potential hoodie meta fields
-    double totalSizeWithHoodieMetaFields = totalSize * 1.1;
     metrics.updateStreamerSourceBytesToBeIngestedInSyncRound(totalSize);
-    int numPartitions = (int) Math.max(Math.ceil(totalSizeWithHoodieMetaFields / bytesPerPartition), 1);
-    // If the number of source partitions is configured to be greater, then use it instead.
-    if (numPartitions < numSourcePartitions) {
-      numPartitions = numSourcePartitions;
-    }
+    int numPartitions = materializer.partitionCount(cloudObjectMetadata, bytesPerPartition, numSourcePartitions);
     metrics.updateStreamerSourceParallelism(numPartitions);
-    return cloudObjectsSelectorCommon.loadAsDataset(sparkSession, cloudObjectMetadata, getFileFormat(props), schemaProviderOption, numPartitions);
+    return materializer.materialize(sparkSession, cloudObjectMetadata, schemaProviderOption, numPartitions);
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectMaterializer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectMaterializer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Turns the cloud objects an incremental source has selected into rows. Selecting which objects
+ * to read is common to every payload, so it stays in {@link CloudDataFetcher}; how those objects
+ * become rows is not, which is what implementations supply.
+ *
+ * <p>Three concerns move together and so belong on one type: the predicate that decides which
+ * object keys are eligible, how many Spark partitions the batch is spread over, and the read
+ * itself. A columnar reader selects by data-file format, sizes partitions by bytes scanned and
+ * defers to a Spark datasource; a reader that parses documents selects by document extension,
+ * sizes partitions by the bytes it will actually parse, and builds rows itself.
+ */
+public interface CloudObjectMaterializer extends Serializable {
+
+  /**
+   * Predicate restricting which object keys are eligible, appended to the filter that
+   * {@link CloudObjectsSelectorCommon#generateFilter} builds from the size and path configs.
+   * Returns an empty string to add no restriction.
+   *
+   * @param objectKey column holding the object key, which differs per cloud store
+   * @param props     streamer configs
+   */
+  String objectKeyPredicate(String objectKey, TypedProperties props);
+
+  /**
+   * Number of Spark partitions to spread this batch over. The default sizes by the bytes
+   * referenced, which suits a columnar scan; override where the cost of a batch is not
+   * proportional to the bytes it references.
+   *
+   * @param objects          objects selected for this batch
+   * @param bytesPerPartition configured target bytes per partition
+   * @param minPartitions    lower bound from the source profile, ignored when smaller
+   */
+  int partitionCount(List<CloudObjectMetadata> objects, long bytesPerPartition, int minPartitions);
+
+  /**
+   * Reads the selected objects into rows. Returns empty when there is nothing to read.
+   */
+  Option<Dataset<Row>> materialize(SparkSession spark,
+                                   List<CloudObjectMetadata> objects,
+                                   Option<SchemaProvider> schemaProvider,
+                                   int numPartitions);
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectMetadata.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectMetadata.java
@@ -19,15 +19,31 @@
 
 package org.apache.hudi.utilities.sources.helpers;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.io.Serializable;
 
-@AllArgsConstructor
 @Getter
 public class CloudObjectMetadata implements Serializable {
 
+  public static final long UNKNOWN_MODIFICATION_TIME = 0L;
+
   private final String path;
   private final long size;
+  /**
+   * Epoch millis at which the notification reported the object was written, or
+   * {@link #UNKNOWN_MODIFICATION_TIME} when the events carry no usable timestamp. Readers that
+   * need a timestamp must fall back to interrogating the object when this is unknown.
+   */
+  private final long modificationTime;
+
+  public CloudObjectMetadata(String path, long size) {
+    this(path, size, UNKNOWN_MODIFICATION_TIME);
+  }
+
+  public CloudObjectMetadata(String path, long size, long modificationTime) {
+    this.path = path;
+    this.size = size;
+    this.modificationTime = modificationTime;
+  }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -431,12 +431,14 @@ public class CloudObjectsSelectorCommon {
       return events.select(bucketCol, keyCol, sizeCol).distinct();
     }
     String rank = "_hoodie_event_rank";
-    return events.select(bucketCol, keyCol, sizeCol, timeCol)
+    // rank before projecting: the columns are nested, so selecting them first renames them to
+    // their leaf names and the window would no longer resolve bucketCol or keyCol
+    return events
         .withColumn(rank, functions.row_number().over(
             Window.partitionBy(functions.col(bucketCol), functions.col(keyCol))
                 .orderBy(functions.col(timeCol).desc_nulls_last())))
         .filter(functions.col(rank).equalTo(1))
-        .drop(rank);
+        .select(bucketCol, keyCol, sizeCol, timeCol);
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -51,6 +51,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.expressions.Window;
 import org.apache.spark.sql.functions;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Metadata;
@@ -60,6 +61,8 @@ import org.apache.spark.sql.types.StructType;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -79,7 +82,6 @@ import static org.apache.hudi.common.util.ConfigUtils.containsConfigProperty;
 import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getIntWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
-import static org.apache.hudi.utilities.config.CloudSourceConfig.CLOUD_DATAFILE_EXTENSION;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.CLOUD_INCREMENTAL_MERGE_SCHEMA;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.EXISTS_CHECK_PARALLELISM;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.EXISTS_CHECK_PARTITIONS;
@@ -111,6 +113,8 @@ public class CloudObjectsSelectorCommon {
   public static final String S3_BUCKET_NAME = "s3.bucket.name";
   public static final String GCS_OBJECT_KEY = "name";
   public static final String GCS_OBJECT_SIZE = "size";
+  public static final String S3_EVENT_TIME = "eventTime";
+  public static final String GCS_OBJECT_UPDATED = "updated";
   public static final String CLOUD_SOURCE_PATH_COLUMN = "_hoodie_cloud_source_path";
   private static final String SPACE_DELIMTER = " ";
   private static final String GCS_PREFIX = "gs://";
@@ -212,7 +216,26 @@ public class CloudObjectsSelectorCommon {
     } else {
       throw new HoodieIOException("unexpected object size's type in Cloud storage events: " + obj.getClass());
     }
-    return Option.of(new CloudObjectMetadata(url, size));
+    long modificationTime = row.size() > 3
+        ? epochMillis(row.get(3)) : CloudObjectMetadata.UNKNOWN_MODIFICATION_TIME;
+    return Option.of(new CloudObjectMetadata(url, size, modificationTime));
+  }
+
+  /**
+   * Epoch millis for a notification timestamp, which both S3 and GCS report as an ISO-8601 string.
+   * Anything unparseable yields {@link CloudObjectMetadata#UNKNOWN_MODIFICATION_TIME} rather than
+   * failing the batch, since the value only orders writes to the same object.
+   */
+  private static long epochMillis(Object rawValue) {
+    if (rawValue == null) {
+      return CloudObjectMetadata.UNKNOWN_MODIFICATION_TIME;
+    }
+    try {
+      return Instant.parse(rawValue.toString()).toEpochMilli();
+    } catch (DateTimeParseException e) {
+      log.warn("Ignoring unparseable cloud notification timestamp {}", rawValue);
+      return CloudObjectMetadata.UNKNOWN_MODIFICATION_TIME;
+    }
   }
 
   /**
@@ -260,11 +283,21 @@ public class CloudObjectsSelectorCommon {
 
   public static String generateFilter(Type type,
                                       TypedProperties props) {
-    String fileFormat = CloudDataFetcher.getFileFormat(props);
-    Option<String> selectRelativePathPrefix = getPropVal(props, SELECT_RELATIVE_PATH_PREFIX);
-    Option<String> ignoreRelativePathPrefix = getPropVal(props, IGNORE_RELATIVE_PATH_PREFIX);
-    Option<String> ignoreRelativePathSubStr = getPropVal(props, IGNORE_RELATIVE_PATH_SUBSTR);
-    Option<String> selectRelativePathRegex = getPropVal(props, SELECT_RELATIVE_PATH_REGEX);
+    return generateFilter(type, props, new ColumnarFileMaterializer(props));
+  }
+
+  /**
+   * Builds the filter restricting which cloud objects a batch selects. The size and relative-path
+   * restrictions are common to every payload; which object keys are eligible is not, and so comes
+   * from {@code materializer}.
+   */
+  public static String generateFilter(Type type,
+                                      TypedProperties props,
+                                      CloudObjectMaterializer materializer) {
+    Option<String> selectRelativePathPrefix = configuredValue(props, SELECT_RELATIVE_PATH_PREFIX);
+    Option<String> ignoreRelativePathPrefix = configuredValue(props, IGNORE_RELATIVE_PATH_PREFIX);
+    Option<String> ignoreRelativePathSubStr = configuredValue(props, IGNORE_RELATIVE_PATH_SUBSTR);
+    Option<String> selectRelativePathRegex = configuredValue(props, SELECT_RELATIVE_PATH_REGEX);
 
     String objectKey;
     String objectSizeKey;
@@ -272,9 +305,9 @@ public class CloudObjectsSelectorCommon {
     if (type.equals(Type.S3)) {
       objectKey = S3_OBJECT_KEY;
       objectSizeKey = S3_OBJECT_SIZE;
-      selectRelativePathPrefix = selectRelativePathPrefix.or(() -> getPropVal(props, S3_KEY_PREFIX));
-      ignoreRelativePathPrefix = ignoreRelativePathPrefix.or(() -> getPropVal(props, S3_IGNORE_KEY_PREFIX));
-      ignoreRelativePathSubStr = ignoreRelativePathSubStr.or(() -> getPropVal(props, S3_IGNORE_KEY_SUBSTRING));
+      selectRelativePathPrefix = selectRelativePathPrefix.or(() -> configuredValue(props, S3_KEY_PREFIX));
+      ignoreRelativePathPrefix = ignoreRelativePathPrefix.or(() -> configuredValue(props, S3_IGNORE_KEY_PREFIX));
+      ignoreRelativePathSubStr = ignoreRelativePathSubStr.or(() -> configuredValue(props, S3_IGNORE_KEY_SUBSTRING));
     } else {
       objectKey = GCS_OBJECT_KEY;
       objectSizeKey = GCS_OBJECT_SIZE;
@@ -302,9 +335,7 @@ public class CloudObjectsSelectorCommon {
       filter.append(SPACE_DELIMTER).append(String.format("and %s not like '%%%s%%'", objectKey, ignoreRelativePathSubStr.get()));
     }
 
-    // Match files with any of the given extensions, or use the fileFormat as the default.
-    getPropVal(props, CLOUD_DATAFILE_EXTENSION).or(() -> Option.of(fileFormat))
-        .map(extensions -> filter.append(extensionClause(objectKey, extensions)));
+    filter.append(materializer.objectKeyPredicate(objectKey, props));
 
     return filter.toString();
   }
@@ -315,7 +346,7 @@ public class CloudObjectsSelectorCommon {
    * a single value renders exactly the predicate it always did. Empty when no usable extension
    * is configured, which leaves the filter unchanged.
    */
-  private static String extensionClause(String objectKey, String extensions) {
+  static String extensionPredicate(String objectKey, String extensions) {
     List<String> predicates = Arrays.stream(extensions.split(","))
         .map(String::trim)
         .filter(extension -> !extension.isEmpty())
@@ -351,22 +382,25 @@ public class CloudObjectsSelectorCommon {
     String bucketCol;
     String keyCol;
     String sizeCol;
+    String timeCol;
     if (type == Type.GCS) {
       prefix = GCS_PREFIX;
       bucketCol = "bucket";
       keyCol = GCS_OBJECT_KEY;
       sizeCol = GCS_OBJECT_SIZE;
+      timeCol = GCS_OBJECT_UPDATED;
     } else if (type == Type.S3) {
       String s3FS = getStringWithAltKeys(props, S3_FS_PREFIX, true).toLowerCase();
       prefix = s3FS + "://";
       bucketCol = S3_BUCKET_NAME;
       keyCol = S3_OBJECT_KEY;
       sizeCol = S3_OBJECT_SIZE;
+      timeCol = S3_EVENT_TIME;
     } else {
       throw new UnsupportedOperationException("Invalid cloud type " + type);
     }
 
-    Dataset<Row> distinctObjects = cloudObjectMetadataDF.select(bucketCol, keyCol, sizeCol).distinct();
+    Dataset<Row> distinctObjects = selectDistinctObjects(cloudObjectMetadataDF, bucketCol, keyCol, sizeCol, timeCol);
     if (checkIfExists) {
       // The upstream Window.orderBy() in IncrSourceHelper collapses the dataset to one partition and AQE keeps the
       // distinct() output there, which would serialize every existence check on one task. Spread the checks over
@@ -380,6 +414,29 @@ public class CloudObjectsSelectorCommon {
             getCloudObjectMetadataPerPartition(prefix, storageConf, checkIfExists, existsCheckParallelism),
             Encoders.kryo(CloudObjectMetadata.class))
         .collectAsList();
+  }
+
+  /**
+   * One row per cloud object, carrying the notification timestamp when the events have one.
+   *
+   * <p>An object written more than once inside a single batch produces one event per write. Keying
+   * only on bucket and object key, and keeping the newest event, reads such an object once instead
+   * of once per write. Where the metadata table predates the timestamp column the events cannot be
+   * ordered, so this falls back to the previous behaviour of de-duplicating on size as well.
+   */
+  private static Dataset<Row> selectDistinctObjects(Dataset<Row> events, String bucketCol, String keyCol,
+                                                    String sizeCol, String timeCol) {
+    if (!Arrays.asList(events.schema().fieldNames()).contains(timeCol)) {
+      log.warn("Cloud events carry no {} column; objects rewritten within a batch will be read once per write", timeCol);
+      return events.select(bucketCol, keyCol, sizeCol).distinct();
+    }
+    String rank = "_hoodie_event_rank";
+    return events.select(bucketCol, keyCol, sizeCol, timeCol)
+        .withColumn(rank, functions.row_number().over(
+            Window.partitionBy(functions.col(bucketCol), functions.col(keyCol))
+                .orderBy(functions.col(timeCol).desc_nulls_last())))
+        .filter(functions.col(rank).equalTo(1))
+        .drop(rank);
   }
 
   /**
@@ -671,7 +728,7 @@ public class CloudObjectsSelectorCommon {
     return !modifiedNestedSchema.equals(rowField.dataType()) || !field.aliases().isEmpty();
   }
 
-  private static Option<String> getPropVal(TypedProperties props, ConfigProperty<String> configProperty) {
+  static Option<String> configuredValue(TypedProperties props, ConfigProperty<String> configProperty) {
     String value = getStringWithAltKeys(props, configProperty, true);
     if (!StringUtils.isNullOrEmpty(value)) {
       return Option.of(value);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -302,11 +302,31 @@ public class CloudObjectsSelectorCommon {
       filter.append(SPACE_DELIMTER).append(String.format("and %s not like '%%%s%%'", objectKey, ignoreRelativePathSubStr.get()));
     }
 
-    // Match files with a given extension, or use the fileFormat as the default.
+    // Match files with any of the given extensions, or use the fileFormat as the default.
     getPropVal(props, CLOUD_DATAFILE_EXTENSION).or(() -> Option.of(fileFormat))
-        .map(val -> filter.append(SPACE_DELIMTER).append(String.format("and %s like '%%%s'", objectKey, val)));
+        .map(extensions -> filter.append(extensionClause(objectKey, extensions)));
 
     return filter.toString();
+  }
+
+  /**
+   * Renders the file extension predicate. A comma separated value matches any one of the
+   * extensions, so a prefix holding more than one file type can be selected in a single sync;
+   * a single value renders exactly the predicate it always did. Empty when no usable extension
+   * is configured, which leaves the filter unchanged.
+   */
+  private static String extensionClause(String objectKey, String extensions) {
+    List<String> predicates = Arrays.stream(extensions.split(","))
+        .map(String::trim)
+        .filter(extension -> !extension.isEmpty())
+        .map(extension -> String.format("%s like '%%%s'", objectKey, extension))
+        .collect(Collectors.toList());
+    if (predicates.isEmpty()) {
+      return "";
+    }
+    return predicates.size() == 1
+        ? SPACE_DELIMTER + "and " + predicates.get(0)
+        : SPACE_DELIMTER + "and (" + String.join(" or ", predicates) + ")";
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -432,11 +432,13 @@ public class CloudObjectsSelectorCommon {
     }
     String rank = "_hoodie_event_rank";
     // rank before projecting: the columns are nested, so selecting them first renames them to
-    // their leaf names and the window would no longer resolve bucketCol or keyCol
+    // their leaf names and the window would no longer resolve bucketCol or keyCol.
+    // Order on the parsed instant, not the raw string: '.' sorts before 'Z', so a lexicographic
+    // desc puts 10:00:00Z ahead of the later 10:00:00.500Z whenever precision varies in a second.
     return events
         .withColumn(rank, functions.row_number().over(
             Window.partitionBy(functions.col(bucketCol), functions.col(keyCol))
-                .orderBy(functions.col(timeCol).desc_nulls_last())))
+                .orderBy(functions.to_timestamp(functions.col(timeCol)).desc_nulls_last())))
         .filter(functions.col(rank).equalTo(1))
         .select(bucketCol, keyCol, sizeCol, timeCol);
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/ColumnarFileMaterializer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/ColumnarFileMaterializer.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import java.util.List;
+
+import static org.apache.hudi.utilities.config.CloudSourceConfig.CLOUD_DATAFILE_EXTENSION;
+
+/**
+ * Reads cloud objects as data files through a Spark datasource, which is what every cloud
+ * incremental source did before materializers existed. Selects by the configured data file
+ * extension, defaulting to the data file format, and sizes partitions by the bytes referenced.
+ * This is the default materializer, so leaving it unset preserves existing behaviour.
+ */
+public class ColumnarFileMaterializer implements CloudObjectMaterializer {
+
+  private static final long serialVersionUID = 1L;
+
+  private final transient CloudObjectsSelectorCommon selectorCommon;
+  private final String fileFormat;
+
+  public ColumnarFileMaterializer(TypedProperties props) {
+    this(props, new CloudObjectsSelectorCommon(props));
+  }
+
+  public ColumnarFileMaterializer(TypedProperties props, CloudObjectsSelectorCommon selectorCommon) {
+    this.selectorCommon = selectorCommon;
+    this.fileFormat = CloudDataFetcher.getFileFormat(props);
+  }
+
+  @Override
+  public String objectKeyPredicate(String objectKey, TypedProperties props) {
+    return CloudObjectsSelectorCommon.extensionPredicate(
+        objectKey, CloudObjectsSelectorCommon.configuredValue(props, CLOUD_DATAFILE_EXTENSION)
+            .orElse(fileFormat));
+  }
+
+  @Override
+  public int partitionCount(List<CloudObjectMetadata> objects, long bytesPerPartition, int minPartitions) {
+    long totalSize = 0;
+    for (CloudObjectMetadata o : objects) {
+      totalSize += o.getSize();
+    }
+    // inflate 10% for potential hoodie meta fields
+    double totalSizeWithHoodieMetaFields = totalSize * 1.1;
+    int numPartitions = (int) Math.max(Math.ceil(totalSizeWithHoodieMetaFields / bytesPerPartition), 1);
+    return Math.max(numPartitions, minPartitions);
+  }
+
+  @Override
+  public Option<Dataset<Row>> materialize(SparkSession spark,
+                                          List<CloudObjectMetadata> objects,
+                                          Option<SchemaProvider> schemaProvider,
+                                          int numPartitions) {
+    return selectorCommon.loadAsDataset(spark, objects, fileFormat, schemaProvider, numPartitions);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/UnstructuredFileMaterializer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/UnstructuredFileMaterializer.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.sources.helpers.unstructured.UnstructuredFileRecordBuilder;
+import org.apache.hudi.utilities.sources.helpers.unstructured.UnstructuredFileRows;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.hudi.common.util.ConfigUtils.getIntWithAltKeys;
+import static org.apache.hudi.common.util.ConfigUtils.getLongWithAltKeys;
+import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
+import static org.apache.hudi.utilities.config.UnstructuredFileSourceConfig.FILE_EXTENSIONS;
+import static org.apache.hudi.utilities.config.UnstructuredFileSourceConfig.FILE_EXTENSIONS_IGNORE;
+import static org.apache.hudi.utilities.config.UnstructuredFileSourceConfig.LISTING_PARALLELISM;
+import static org.apache.hudi.utilities.config.UnstructuredFileSourceConfig.PARSE_MAX_BYTES;
+import static org.apache.hudi.utilities.config.UnstructuredFileSourceConfig.WORK_BYTES_PER_PARTITION;
+
+/**
+ * Reads cloud objects as unstructured files: each object becomes one row carrying a BLOB column
+ * plus extracted text, metadata and chunks, the same shape the directory-listing source produces.
+ *
+ * <p>Differs from a columnar read in all three of its responsibilities. Objects are selected by
+ * document extension rather than by data-file format. Partitions are sized by the bytes that will
+ * actually be parsed, because an object above {@code parse.max.bytes} is referenced without being
+ * read and so costs almost nothing. And rows are built directly rather than through a Spark
+ * datasource.
+ */
+public class UnstructuredFileMaterializer implements CloudObjectMaterializer {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Set<String> allowedExtensions;
+  private final Set<String> ignoredExtensions;
+  private final long parseMaxBytes;
+  private final long workBytesPerPartition;
+  private final int configuredParallelism;
+  private final int defaultParallelism;
+  private final UnstructuredFileRecordBuilder recordBuilder;
+
+  public UnstructuredFileMaterializer(TypedProperties props, JavaSparkContext jsc) {
+    this.allowedExtensions = UnstructuredFileRows.parseExtensions(getStringWithAltKeys(props, FILE_EXTENSIONS, true));
+    this.ignoredExtensions = UnstructuredFileRows.parseExtensions(getStringWithAltKeys(props, FILE_EXTENSIONS_IGNORE, true));
+    this.parseMaxBytes = getLongWithAltKeys(props, PARSE_MAX_BYTES);
+    this.workBytesPerPartition = getLongWithAltKeys(props, WORK_BYTES_PER_PARTITION);
+    this.configuredParallelism = getIntWithAltKeys(props, LISTING_PARALLELISM);
+    this.defaultParallelism = jsc.defaultParallelism();
+    this.recordBuilder = new UnstructuredFileRecordBuilder(props);
+  }
+
+  @Override
+  public String objectKeyPredicate(String objectKey, TypedProperties props) {
+    if (!allowedExtensions.isEmpty()) {
+      return CloudObjectsSelectorCommon.extensionPredicate(objectKey, String.join(",", allowedExtensions));
+    }
+    if (ignoredExtensions.isEmpty()) {
+      return "";
+    }
+    // no allowlist, so select everything except the denied extensions
+    List<String> denials = new ArrayList<>();
+    for (String extension : ignoredExtensions) {
+      denials.add(String.format("%s not like '%%%s'", objectKey, extension));
+    }
+    return " and " + String.join(" and ", denials);
+  }
+
+  @Override
+  public int partitionCount(List<CloudObjectMetadata> objects, long bytesPerPartition, int minPartitions) {
+    long parseableBytes = 0;
+    for (CloudObjectMetadata object : objects) {
+      if (object.getSize() <= parseMaxBytes) {
+        parseableBytes += object.getSize();
+      }
+    }
+    int byWork = (int) Math.max(1, Math.ceil((double) parseableBytes / workBytesPerPartition));
+    // a batch of nothing but unparseable objects still has per-object work, so keep the cluster busy
+    int floor = configuredParallelism > 0 ? configuredParallelism : defaultParallelism;
+    int partitions = Math.max(byWork, Math.min(floor, Math.max(objects.size(), 1)));
+    return Math.max(partitions, minPartitions);
+  }
+
+  @Override
+  public Option<Dataset<Row>> materialize(SparkSession spark,
+                                          List<CloudObjectMetadata> objects,
+                                          Option<SchemaProvider> schemaProvider,
+                                          int numPartitions) {
+    List<CloudObjectMetadata> selected = new ArrayList<>();
+    for (CloudObjectMetadata object : objects) {
+      if (UnstructuredFileRows.isEligible(fileNameOf(object.getPath()), allowedExtensions, ignoredExtensions)) {
+        selected.add(object);
+      }
+    }
+    if (selected.isEmpty()) {
+      return Option.empty();
+    }
+    JavaSparkContext jsc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    return Option.of(UnstructuredFileRows.toDataset(spark, jsc, selected, recordBuilder, numPartitions));
+  }
+
+  private static String fileNameOf(String path) {
+    int slash = path.lastIndexOf('/');
+    return slash < 0 ? path : path.substring(slash + 1);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFileRecordBuilder.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFileRecordBuilder.java
@@ -22,6 +22,7 @@ package org.apache.hudi.utilities.sources.helpers.unstructured;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.utilities.sources.helpers.CloudObjectMetadata;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -81,7 +82,23 @@ public class UnstructuredFileRecordBuilder implements Serializable {
   public Row buildRow(FileSystem fs, String pathStr) throws IOException {
     Path path = new Path(pathStr);
     FileStatus status = fs.getFileStatus(path);
-    long size = status.getLen();
+    return buildRow(fs, pathStr, status.getLen(), status.getModificationTime());
+  }
+
+  /**
+   * Builds the row for an object whose size and modification time are already known, which cloud
+   * notifications carry. Avoids a metadata request per object; falls back to interrogating the
+   * object when the events had no usable timestamp.
+   */
+  public Row buildRow(FileSystem fs, CloudObjectMetadata object) throws IOException {
+    if (object.getModificationTime() == CloudObjectMetadata.UNKNOWN_MODIFICATION_TIME) {
+      return buildRow(fs, object.getPath());
+    }
+    return buildRow(fs, object.getPath(), object.getSize(), object.getModificationTime());
+  }
+
+  private Row buildRow(FileSystem fs, String pathStr, long size, long modificationTime) throws IOException {
+    Path path = new Path(pathStr);
     String fileName = path.getName();
 
     byte[] inlineBytes = null;
@@ -104,7 +121,7 @@ public class UnstructuredFileRecordBuilder implements Serializable {
         fileName,
         extensionOf(fileName),
         size,
-        status.getModificationTime(),
+        modificationTime,
         blob,
         parseResult.getText(),
         // Spark's Row encoder requires a scala Map as the external type for MapType

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFileRows.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/UnstructuredFileRows.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers.unstructured;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.util.collection.LazyIterableIterator;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
+import org.apache.hudi.utilities.sources.helpers.CloudObjectMetadata;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The row shape unstructured file ingestion produces, and the conversion from a list of files to
+ * that shape. Shared so that discovery by directory listing and discovery by cloud notification
+ * emit identical tables: the blob placement and parse handling exist once, not once per source.
+ */
+public final class UnstructuredFileRows {
+
+  private static final Metadata BLOB_METADATA = new MetadataBuilder()
+      .putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
+      .build();
+
+  private static final StructType BLOB_REFERENCE_TYPE = DataTypes.createStructType(new StructField[] {
+      DataTypes.createStructField(HoodieSchema.Blob.EXTERNAL_REFERENCE_PATH, DataTypes.StringType, true),
+      DataTypes.createStructField(HoodieSchema.Blob.EXTERNAL_REFERENCE_OFFSET, DataTypes.LongType, true),
+      DataTypes.createStructField(HoodieSchema.Blob.EXTERNAL_REFERENCE_LENGTH, DataTypes.LongType, true),
+      DataTypes.createStructField(HoodieSchema.Blob.EXTERNAL_REFERENCE_IS_MANAGED, DataTypes.BooleanType, true)});
+
+  private static final StructType BLOB_TYPE = DataTypes.createStructType(new StructField[] {
+      DataTypes.createStructField(HoodieSchema.Blob.TYPE, DataTypes.StringType, false),
+      DataTypes.createStructField(HoodieSchema.Blob.INLINE_DATA_FIELD, DataTypes.BinaryType, true),
+      DataTypes.createStructField(HoodieSchema.Blob.EXTERNAL_REFERENCE, BLOB_REFERENCE_TYPE, true)});
+
+  private static final StructType CHUNK_TYPE = DataTypes.createStructType(new StructField[] {
+      DataTypes.createStructField("chunk_id", DataTypes.IntegerType, false),
+      DataTypes.createStructField("text", DataTypes.StringType, false),
+      DataTypes.createStructField("char_start", DataTypes.IntegerType, false)});
+
+  public static final StructType SOURCE_SCHEMA = new StructType(new StructField[] {
+      DataTypes.createStructField("path", DataTypes.StringType, false),
+      DataTypes.createStructField("file_name", DataTypes.StringType, false),
+      DataTypes.createStructField("extension", DataTypes.StringType, false),
+      DataTypes.createStructField("size", DataTypes.LongType, false),
+      DataTypes.createStructField("modification_time", DataTypes.LongType, false),
+      new StructField("content", BLOB_TYPE, false, BLOB_METADATA),
+      DataTypes.createStructField("extracted_text", DataTypes.StringType, true),
+      DataTypes.createStructField("doc_metadata",
+          DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType, true), true),
+      DataTypes.createStructField("chunks", DataTypes.createArrayType(CHUNK_TYPE, false), true),
+      DataTypes.createStructField("parse_status", DataTypes.StringType, false),
+      DataTypes.createStructField("parse_error", DataTypes.StringType, true)});
+
+  private UnstructuredFileRows() {
+  }
+
+  /**
+   * Parses a comma separated extension list into a lowercase set, empty when nothing is configured.
+   */
+  public static Set<String> parseExtensions(String csv) {
+    return csv == null || csv.trim().isEmpty()
+        ? Collections.emptySet()
+        : Arrays.stream(csv.toLowerCase(Locale.ROOT).split(","))
+            .map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toCollection(HashSet::new));
+  }
+
+  /**
+   * Whether a file is selected: an explicit allowlist decides alone, otherwise everything except
+   * the denylist.
+   */
+  public static boolean isEligible(String fileName, Set<String> allowed, Set<String> ignored) {
+    String extension = UnstructuredFileRecordBuilder.extensionOf(fileName);
+    return allowed.isEmpty() ? !ignored.contains(extension) : allowed.contains(extension);
+  }
+
+  /**
+   * One file to one row, over {@code parallelism} Spark partitions. Rows are produced lazily so
+   * the inline bytes and extracted text of a partition are never all resident at once, which keeps
+   * task memory independent of the size of the batch.
+   */
+  public static Dataset<Row> toDataset(SparkSession spark, JavaSparkContext jsc, List<CloudObjectMetadata> objects,
+                                       UnstructuredFileRecordBuilder builder, int parallelism) {
+    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(jsc.hadoopConfiguration());
+    int partitions = Math.max(1, Math.min(objects.size(), parallelism));
+    JavaRDD<Row> rows = jsc.parallelize(objects, partitions).mapPartitions(objectIterator ->
+        new LazyIterableIterator<CloudObjectMetadata, Row>(objectIterator) {
+          private FileSystem fs;
+
+          @Override
+          protected Row computeNext() {
+            CloudObjectMetadata object = inputItr.next();
+            try {
+              if (fs == null) {
+                fs = HadoopFSUtils.getFs(new Path(object.getPath()), storageConf);
+              }
+              return builder.buildRow(fs, object);
+            } catch (IOException e) {
+              throw new UncheckedIOException("Failed to build record for " + object.getPath(), e);
+            }
+          }
+        });
+    return spark.createDataFrame(rows, SOURCE_SCHEMA);
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -293,6 +294,57 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
     assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("avro"));
     assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(""));
     assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(null));
+  }
+
+  @Test
+  void extensionFilterKeepsASinglePredicateForOneExtension() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), "json");
+    assertEquals("s3.object.size > 0 and s3.object.key like '%json'",
+        CloudObjectsSelectorCommon.generateFilter(CloudObjectsSelectorCommon.Type.S3, props));
+  }
+
+  @Test
+  void extensionFilterMatchesAnyOneOfSeveralExtensions() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), "pdf,docx,html");
+    assertEquals("s3.object.size > 0 and (s3.object.key like '%pdf' or s3.object.key like '%docx'"
+            + " or s3.object.key like '%html')",
+        CloudObjectsSelectorCommon.generateFilter(CloudObjectsSelectorCommon.Type.S3, props));
+  }
+
+  @Test
+  void extensionFilterTrimsBlanksAndDropsEmptyEntries() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), " pdf , ,docx, ");
+    assertEquals("s3.object.size > 0 and (s3.object.key like '%pdf' or s3.object.key like '%docx')",
+        CloudObjectsSelectorCommon.generateFilter(CloudObjectsSelectorCommon.Type.S3, props));
+  }
+
+  @Test
+  void extensionFilterFallsBackToTheDataFileFormat() {
+    // pins long-standing behaviour: with nothing configured the filter selects parquet only
+    assertEquals("s3.object.size > 0 and s3.object.key like '%parquet'",
+        CloudObjectsSelectorCommon.generateFilter(
+            CloudObjectsSelectorCommon.Type.S3, new TypedProperties()));
+  }
+
+  @Test
+  void extensionFilterUsesTheGcsObjectKeyAndSizeColumns() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), "pdf,png");
+    assertEquals("size > 0 and (name like '%pdf' or name like '%png')",
+        CloudObjectsSelectorCommon.generateFilter(CloudObjectsSelectorCommon.Type.GCS, props));
+  }
+
+  @Test
+  void extensionFilterComposesWithThePathPrefixFilter() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.SELECT_RELATIVE_PATH_PREFIX.key(), "docs/");
+    props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), "pdf,docx");
+    assertEquals("s3.object.size > 0 and s3.object.key like 'docs/%'"
+            + " and (s3.object.key like '%pdf' or s3.object.key like '%docx')",
+        CloudObjectsSelectorCommon.generateFilter(CloudObjectsSelectorCommon.Type.S3, props));
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -56,6 +56,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -294,6 +295,50 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
     assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("avro"));
     assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(""));
     assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(null));
+  }
+
+  @Test
+  void objectMetadataDeduplicatesOnKeyAndCarriesTheEventTimestamp() {
+    // the object key and bucket are nested columns, so anything referencing them has to do so
+    // before the projection flattens them to their leaf names
+    Dataset<Row> events = sparkSession.read().json(jsc.parallelize(Arrays.asList(
+        "{\"eventTime\":\"2026-08-12T10:00:00.000Z\",\"s3\":{\"bucket\":{\"name\":\"b\"},"
+            + "\"object\":{\"key\":\"docs/a.txt\",\"size\":10}}}",
+        "{\"eventTime\":\"2026-08-12T11:00:00.000Z\",\"s3\":{\"bucket\":{\"name\":\"b\"},"
+            + "\"object\":{\"key\":\"docs/a.txt\",\"size\":20}}}",
+        "{\"eventTime\":\"2026-08-12T10:30:00.000Z\",\"s3\":{\"bucket\":{\"name\":\"b\"},"
+            + "\"object\":{\"key\":\"docs/c.txt\",\"size\":30}}}"), 1));
+
+    TypedProperties props = new TypedProperties();
+    props.setProperty(S3EventsHoodieIncrSourceConfig.S3_FS_PREFIX.key(), "s3a");
+    List<CloudObjectMetadata> objects = CloudObjectsSelectorCommon.getObjectMetadata(
+        CloudObjectsSelectorCommon.Type.S3, jsc, events, false, props);
+
+    Map<String, CloudObjectMetadata> byPath = objects.stream()
+        .collect(Collectors.toMap(CloudObjectMetadata::getPath, o -> o));
+    assertEquals(2, objects.size(), "an object written twice in one batch must be read once: " + byPath.keySet());
+
+    // the later of the two writes to a.txt wins, so its size and timestamp are the newer pair
+    CloudObjectMetadata rewritten = byPath.get("s3a://b/docs/a.txt");
+    assertEquals(20L, rewritten.getSize());
+    assertEquals(Instant.parse("2026-08-12T11:00:00.000Z").toEpochMilli(), rewritten.getModificationTime());
+
+    CloudObjectMetadata once = byPath.get("s3a://b/docs/c.txt");
+    assertEquals(30L, once.getSize());
+    assertEquals(Instant.parse("2026-08-12T10:30:00.000Z").toEpochMilli(), once.getModificationTime());
+  }
+
+  @Test
+  void objectMetadataFallsBackWhenEventsCarryNoTimestamp() {
+    // a metadata table written before the timestamp column existed must keep working
+    Dataset<Row> events = sparkSession.read().json(jsc.parallelize(Arrays.asList(
+        "{\"s3\":{\"bucket\":{\"name\":\"b\"},\"object\":{\"key\":\"docs/a.txt\",\"size\":10}}}"), 1));
+    TypedProperties props = new TypedProperties();
+    props.setProperty(S3EventsHoodieIncrSourceConfig.S3_FS_PREFIX.key(), "s3a");
+    List<CloudObjectMetadata> objects = CloudObjectsSelectorCommon.getObjectMetadata(
+        CloudObjectsSelectorCommon.Type.S3, jsc, events, false, props);
+    assertEquals(1, objects.size());
+    assertEquals(CloudObjectMetadata.UNKNOWN_MODIFICATION_TIME, objects.get(0).getModificationTime());
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -342,6 +342,29 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
   }
 
   @Test
+  void objectMetadataOrdersEventsChronologicallyNotLexicographically() {
+    // Same second, differing fractional precision. '.' sorts before 'Z', so ranking on the raw
+    // string puts 10:00:00Z ahead of the later 10:00:00.500Z and the older write would win.
+    Dataset<Row> events = sparkSession.read().json(jsc.parallelize(Arrays.asList(
+        "{\"eventTime\":\"2026-08-12T10:00:00Z\",\"s3\":{\"bucket\":{\"name\":\"b\"},"
+            + "\"object\":{\"key\":\"docs/a.txt\",\"size\":10}}}",
+        "{\"eventTime\":\"2026-08-12T10:00:00.500Z\",\"s3\":{\"bucket\":{\"name\":\"b\"},"
+            + "\"object\":{\"key\":\"docs/a.txt\",\"size\":20}}}"), 1));
+
+    TypedProperties props = new TypedProperties();
+    props.setProperty(S3EventsHoodieIncrSourceConfig.S3_FS_PREFIX.key(), "s3a");
+    List<CloudObjectMetadata> objects = CloudObjectsSelectorCommon.getObjectMetadata(
+        CloudObjectsSelectorCommon.Type.S3, jsc, events, false, props);
+
+    assertEquals(1, objects.size());
+    CloudObjectMetadata rewritten = objects.get(0);
+    assertEquals(Instant.parse("2026-08-12T10:00:00.500Z").toEpochMilli(), rewritten.getModificationTime(),
+        "the chronologically later event must win, whatever its fractional precision");
+    // size travels with the winning event, and it decides inline vs out-of-line blob placement
+    assertEquals(20L, rewritten.getSize());
+  }
+
+  @Test
   void extensionFilterKeepsASinglePredicateForOneExtension() {
     TypedProperties props = new TypedProperties();
     props.setProperty(CloudSourceConfig.CLOUD_DATAFILE_EXTENSION.key(), "json");


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

issue: #19697

Stacked on #19672, which should be reviewed and merged first. Until it merges this PR shows both commits.

Unstructured file ingestion can only discover files by listing a prefix, so every sync walks the whole prefix whether or not anything arrived. Hudi already avoids that for data files by reading a Hudi table of S3 or GCS notifications, but the step that turns the selected objects into rows was hardwired to a Spark datasource read, so documents could not use it.

### Summary and Changelog

Introduces `CloudObjectMaterializer`, the step that turns the objects a batch has selected into rows. Three concerns move together and so live on one type: the predicate deciding which object keys are eligible, the partition count, and the read itself. `ColumnarFileMaterializer` holds the previous behaviour and is registered as the default, and `generateFilter` keeps its existing two-argument form and delegates through it, so nothing changes for current pipelines.

`UnstructuredFileMaterializer` selects by document extension, sizes partitions by the bytes that will actually be parsed rather than the bytes referenced, and builds rows directly. An object above `parse.max.bytes` is referenced without being read and costs almost nothing, which makes a byte count of the whole batch a poor proxy for its cost. `UnstructuredFileS3EventsHoodieIncrSource` wires the two together. Row construction is now shared by both discovery paths through `UnstructuredFileRows`, so blob placement and parse handling exist once rather than once per source.

`CloudObjectMetadata` carries the notification timestamp, which the table needs to order repeated writes to the same path, and objects are de-duplicated on bucket and key keeping the newest event rather than on size as well: an object written twice inside one batch was previously read once per write. Where a metadata table predates the timestamp column the events cannot be ordered, so that falls back to the previous behaviour with a warning rather than failing.

### Impact

Additive. `ColumnarFileMaterializer` is the default and reproduces the previous read exactly, and no existing test file is modified by this PR, which is the evidence for that. The de-duplication change does affect existing cloud sources: an object rewritten inside a single batch is now read once instead of once per write. New user-facing config: `hoodie.streamer.source.unstructured.work.bytes.per.partition`.

### Risk Level

low. The behaviour-preserving claim is checked by the existing suites rather than asserted: `TestS3EventsHoodieIncrSource` (16), `TestGcsEventsHoodieIncrSource` (11), `TestCloudObjectsSelectorCommon` (29), `TestUnstructuredFileDFSSource` (2) and `TestCloudObjectsSelector` (50) all pass unchanged, including the argument captor that pins the partition count and the tests that pin the generated filter string.

Validated end to end against real S3 on a 4,032 object corpus spread over 1,008 prefixes: the new source produces a table identical in content to the folder-based source, 4,044 rows with 4,044 successful parses after 12 further objects were added. A discovery-cost comparison on the same corpus measured 121.8s by listing against 12.3s by notification for a sync with nothing to ingest.

Two defects were found by that run rather than by the suite, and both are fixed here with tests that reproduce them: the de-duplication ranked over nested columns after projecting them, which renames them to their leaf names and fails the batch with `UNRESOLVED_COLUMN`; and the rendered object-key predicate was built from a hash set, so its order was arbitrary across runs.

### Documentation Update

New config documented on the config class, so the reference tables generate from it. The website page describing unstructured ingestion will need the new source class name and a note that `hoodie.streamer.source.s3incr.fs.prefix` must match the registered filesystem scheme, since `s3` is the default while `s3a` is what `hadoop-aws` registers.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
