### PR TITLE
chore(api): declare the unstructured ingestion SPIs evolving

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/DocumentParser.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/unstructured/DocumentParser.java
@@ -19,6 +19,9 @@
 
 package org.apache.hudi.utilities.sources.helpers.unstructured;
 
+import org.apache.hudi.ApiMaturityLevel;
+import org.apache.hudi.PublicAPIClass;
+import org.apache.hudi.PublicAPIMethod;
 import org.apache.hudi.common.config.TypedProperties;
 
 import java.io.InputStream;
@@ -30,11 +33,13 @@ import java.io.Serializable;
  * and must NEVER throw from {@link #parse}: any failure is reported via
  * {@link ParseResult#failed}.
  */
+@PublicAPIClass(maturity = ApiMaturityLevel.EVOLVING)
 public interface DocumentParser extends Serializable {
 
   /**
    * Called once per executor instance before the first {@link #parse}.
    */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   default void init(TypedProperties props) {
   }
 
@@ -45,5 +50,6 @@ public interface DocumentParser extends Serializable {
    * @param fileName     name of the file (used for format detection hints)
    * @param maxTextChars cap on extracted text length; hitting it yields a TRUNCATED result
    */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   ParseResult parse(InputStream in, String fileName, int maxTextChars);
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/embedding/EmbeddingProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/embedding/EmbeddingProvider.java
@@ -19,6 +19,9 @@
 
 package org.apache.hudi.utilities.transform.embedding;
 
+import org.apache.hudi.ApiMaturityLevel;
+import org.apache.hudi.PublicAPIClass;
+import org.apache.hudi.PublicAPIMethod;
 import org.apache.hudi.common.config.TypedProperties;
 
 import java.io.Serializable;
@@ -29,11 +32,13 @@ import java.util.List;
  * executors and are called with record-level batches buffered within a partition; an
  * in-JVM (e.g. ONNX) implementation can slot in beside API-backed ones.
  */
+@PublicAPIClass(maturity = ApiMaturityLevel.EVOLVING)
 public interface EmbeddingProvider extends Serializable {
 
   /**
    * Called once per executor instance before the first {@link #embed}.
    */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   default void init(TypedProperties props) {
   }
 
@@ -42,5 +47,6 @@ public interface EmbeddingProvider extends Serializable {
    * Errors should be retried internally where transient; a thrown exception
    * fails the batch (and the sync) -- the caller never silently drops vectors.
    */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   List<float[]> embed(List<String> texts);
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

closes #19700

### Summary and Changelog

`DocumentParser` and `EmbeddingProvider` are the two extension points of unstructured file ingestion, and `hoodie.streamer.source.unstructured.parser.class` and `hoodie.streamer.transformer.embedding.provider.class` exist so that users can supply their own implementations. Neither declared a stability level, while `Source` and `Transformer` next to them are both `@PublicAPIClass(maturity = STABLE)`.

This marks both interfaces and their methods `@PublicAPIClass`/`@PublicAPIMethod` with `ApiMaturityLevel.EVOLVING`, matching how `Transformer` annotates itself. Annotations only, no behavior change.

### Impact

Records that these two SPIs are still expected to change, so the signature work they need (carrying an object's URI, size and content type into the parser, and accepting inputs other than text in the provider) does not read as breaking later.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
