### PR TITLE
fix(spark): make partition DDL commands honor slash separated date partitioning

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.timeline.{HoodieInstantTimeGenerator, Hoodie
 import org.apache.hudi.common.table.timeline.TimelineUtils.parseDateFromInstantTime
 import org.apache.hudi.common.util.PartitionPathEncodeUtils
 import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.keygen.KeyGenUtils
 import org.apache.hudi.storage.{HoodieStorage, StoragePath, StoragePathInfo}
 import org.apache.hudi.util.SparkConfigUtils
 
@@ -437,13 +438,13 @@ object HoodieSqlCommonUtils extends SparkAdapterSupport {
    * requested by `hoodie.datasource.write.slash.separated.date.partitioning`, mirroring the
    * substitution the write path performs in `KeyGenUtils#getRecordPartitionPath`.
    *
-   * A value with a leading dash is returned as-is: substituting would make the partition path start
-   * with "/", and an absolute relative-partition-path is resolved inconsistently -- the writer and
-   * the file-system view disagree on where such a partition lives. Such a value is not a date to
-   * begin with, so nothing is lost by not slashing it.
+   * The path-breaking values the writer refuses to slash are refused here for the same reasons, by
+   * asking [[KeyGenUtils#hasPathBreakingDash]] rather than restating the rule: these commands have
+   * to name the directory the writer created, so the two have to agree on every value, not just on
+   * the dates. See that method for what each excluded case does to the path.
    */
   private def toSlashSeparatedDate(partitionValue: String): String = {
-    if (partitionValue.startsWith("-")) partitionValue else partitionValue.replace('-', '/')
+    if (KeyGenUtils.hasPathBreakingDash(partitionValue)) partitionValue else partitionValue.replace('-', '/')
   }
 
   def makePartitionPath(hoodieCatalogTable: HoodieCatalogTable,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
@@ -406,15 +406,44 @@ object HoodieSqlCommonUtils extends SparkAdapterSupport {
   private def makePartitionPath(partitionFields: Seq[String],
                                 normalizedSpecs: Map[String, String],
                                 enableEncodeUrl: Boolean,
-                                enableHiveStylePartitioning: Boolean): String = {
+                                enableHiveStylePartitioning: Boolean,
+                                slashSeparatedDatePartitioning: Boolean): String = {
+    // NOTE: Slash-separated date partitioning only kicks in for a table partitioned by a single
+    //       (date) column, mirroring the guard in [[KeyGenUtils#getRecordPartitionPath]] that drives
+    //       the write path -- these commands have to name the very same directory the writer created.
+    //       Hive-style partitioning is excluded because the config documents the two as mutually
+    //       exclusive, and the write paths do not agree on what the combination should produce
+    //       (tracked in HUDI issue #19669), so there is no single directory to name here
+    val useSlashSeparatedDates =
+      slashSeparatedDatePartitioning && !enableHiveStylePartitioning && partitionFields.length == 1
     partitionFields.map { partitionColumn =>
       val encodedPartitionValue = if (enableEncodeUrl) {
         PartitionPathEncodeUtils.escapePathName(normalizedSpecs(partitionColumn))
       } else {
         normalizedSpecs(partitionColumn)
       }
-      if (enableHiveStylePartitioning) s"$partitionColumn=$encodedPartitionValue" else encodedPartitionValue
+      if (enableHiveStylePartitioning) {
+        s"$partitionColumn=$encodedPartitionValue"
+      } else if (useSlashSeparatedDates) {
+        toSlashSeparatedDate(encodedPartitionValue)
+      } else {
+        encodedPartitionValue
+      }
     }.mkString("/")
+  }
+
+  /**
+   * Turns a `yyyy-MM-dd` formatted partition value into the `yyyy/MM/dd` directory structure
+   * requested by `hoodie.datasource.write.slash.separated.date.partitioning`, mirroring the
+   * substitution the write path performs in `KeyGenUtils#getRecordPartitionPath`.
+   *
+   * A value with a leading dash is returned as-is: substituting would make the partition path start
+   * with "/", and an absolute relative-partition-path is resolved inconsistently -- the writer and
+   * the file-system view disagree on where such a partition lives. Such a value is not a date to
+   * begin with, so nothing is lost by not slashing it.
+   */
+  private def toSlashSeparatedDate(partitionValue: String): String = {
+    if (partitionValue.startsWith("-")) partitionValue else partitionValue.replace('-', '/')
   }
 
   def makePartitionPath(hoodieCatalogTable: HoodieCatalogTable,
@@ -422,8 +451,10 @@ object HoodieSqlCommonUtils extends SparkAdapterSupport {
     val tableConfig = hoodieCatalogTable.tableConfig
     val enableHiveStylePartitioning =  java.lang.Boolean.parseBoolean(tableConfig.getHiveStylePartitioningEnable)
     val enableEncodeUrl = java.lang.Boolean.parseBoolean(tableConfig.getUrlEncodePartitioning)
+    val slashSeparatedDatePartitioning = tableConfig.getSlashSeparatedDatePartitioning
 
-    makePartitionPath(hoodieCatalogTable.partitionFields, normalizedSpecs, enableEncodeUrl, enableHiveStylePartitioning)
+    makePartitionPath(hoodieCatalogTable.partitionFields, normalizedSpecs, enableEncodeUrl,
+      enableHiveStylePartitioning, slashSeparatedDatePartitioning)
   }
 
   private def validateInstant(queryInstant: String): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableAddPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableAddPartition.scala
@@ -271,4 +271,57 @@ class TestAlterTableAddPartition extends HoodieSparkSqlTestBase {
         "Partition metadata already exists for path")
     }
   }
+
+  test("Add partition leaves path breaking values alone under slash separated date partitioning") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |  id bigint,
+           |  name string,
+           |  ts string,
+           |  dt string
+           | )
+           | using hudi
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  orderingFields = 'ts',
+           |  hoodie.datasource.write.slash.separated.date.partitioning = 'true'
+           | )
+           | partitioned by (dt)
+           | location '$tablePath'
+           |""".stripMargin)
+
+      // NOTE: The writer refuses to slash these values -- see [[KeyGenUtils#hasPathBreakingDash]]
+      //       for what each one does to the path -- so the DDL command has to refuse them too, or
+      //       it creates a directory the writer would never have named
+      spark.sql(s"alter table $tableName add partition (dt='..-a')")
+      assertTrue(new File(tablePath, "..-a").exists(),
+        "ADD PARTITION should create the literal directory, not a dot segment")
+      // "../a" would resolve to a sibling of the table directory
+      assertFalse(new File(tmp.getCanonicalPath, "a").exists(),
+        "ADD PARTITION must not create a directory outside the table base path")
+
+      // "2026/" is normalized back to "2026" by StoragePath#normalize
+      spark.sql(s"alter table $tableName add partition (dt='2026-')")
+      assertTrue(new File(tablePath, "2026-").exists(),
+        "ADD PARTITION should keep a trailing dash")
+      assertFalse(new File(tablePath, "2026").exists(),
+        "ADD PARTITION should not drop a trailing dash by way of a trailing slash")
+
+      // "a//b" is collapsed to "a/b" by URI#normalize
+      spark.sql(s"alter table $tableName add partition (dt='a--b')")
+      assertTrue(new File(tablePath, "a--b").exists(),
+        "ADD PARTITION should keep a doubled dash")
+      assertFalse(new File(tablePath, "a").exists(),
+        "ADD PARTITION should not split a doubled dash into nested directories")
+
+      // a single interior dash is still a separator
+      spark.sql(s"alter table $tableName add partition (dt='2026-02-06')")
+      assertTrue(new File(tablePath, "2026/02/06").exists(),
+        "ADD PARTITION should still slash a well formed date")
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableAddPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableAddPartition.scala
@@ -18,6 +18,9 @@
 package org.apache.spark.sql.hudi.ddl
 
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.junit.jupiter.api.Assertions.{assertFalse, assertTrue}
+
+import java.io.File
 
 class TestAlterTableAddPartition extends HoodieSparkSqlTestBase {
 
@@ -225,6 +228,47 @@ class TestAlterTableAddPartition extends HoodieSparkSqlTestBase {
           if (urlEncode) Seq("p_a=url%25a/p_b=key%3Dval") else Seq("p_a=url%a/p_b=key=val")
         )
       }
+    }
+  }
+
+  test("Add partition for a slash separated date partitioned table") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+      // create table
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |  id bigint,
+           |  name string,
+           |  ts string,
+           |  dt string
+           | )
+           | using hudi
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  orderingFields = 'ts',
+           |  hoodie.datasource.write.slash.separated.date.partitioning = 'true'
+           | )
+           | partitioned by (dt)
+           | location '$tablePath'
+           |""".stripMargin)
+
+      // The writer lays a partition value out as yyyy/MM/dd, so the DDL command has to name that
+      // very directory rather than the dashed value
+      spark.sql(s"""insert into $tableName values (1, "a1", "v1", "2026-01-05")""")
+
+      spark.sql(s"alter table $tableName add partition (dt='2026-02-06')")
+
+      assertTrue(new File(tablePath, "2026/02/06").exists(),
+        "ADD PARTITION should create the slash separated directory")
+      assertFalse(new File(tablePath, "2026-02-06").exists(),
+        "ADD PARTITION should not leave a dashed directory behind")
+
+      // naming the right directory also lets the existence check see the partition the writer created
+      spark.sql(s"alter table $tableName add if not exists partition (dt='2026-01-05')")
+      checkExceptionContain(s"alter table $tableName add partition (dt='2026-01-05')")(
+        "Partition metadata already exists for path")
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala
@@ -692,4 +692,45 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
       }
     }
   }
+
+  test("Drop partition for a slash separated date partitioned table") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+      // create table
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |  id bigint,
+           |  name string,
+           |  ts string,
+           |  dt string
+           | )
+           | using hudi
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  orderingFields = 'ts',
+           |  hoodie.datasource.write.slash.separated.date.partitioning = 'true'
+           | )
+           | partitioned by (dt)
+           | location '$tablePath'
+           |""".stripMargin)
+      // insert data
+      spark.sql(s"""insert into $tableName values (1, "z3", "v1", "2026-01-05"), (2, "l4", "v1", "2026-01-06")""")
+
+      // the writer laid these out as 2026/01/05 and 2026/01/06, so DROP PARTITION has to name the
+      // same directory -- naming the dashed value drops nothing while still reporting success
+      spark.sql(s"alter table $tableName drop partition (dt='2026-01-05')")
+
+      // trigger clean so that partition deletion kicks in.
+      withSQLConf(HoodieCleanConfig.CLEANER_POLICY.key() -> HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS.name()) {
+        spark.sql(s"call run_clean(table => '$tableName', retain_commits => 1)")
+          .collect()
+      }
+
+      checkAnswer(s"select id, name, ts, dt from $tableName")(
+        Seq(2, "l4", "v1", "2026-01-06")
+      )
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestTruncateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestTruncateTable.scala
@@ -148,4 +148,39 @@ class TestTruncateTable extends HoodieSparkSqlTestBase {
       }
     }
   }
+
+  test("Test Truncate partition for a slash separated date partitioned table") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |  id bigint,
+           |  name string,
+           |  ts string,
+           |  dt string
+           | )
+           | using hudi
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  orderingFields = 'ts',
+           |  hoodie.datasource.write.slash.separated.date.partitioning = 'true'
+           | )
+           | partitioned by (dt)
+           | location '$tablePath'
+           |""".stripMargin)
+
+      spark.sql(s"""insert into $tableName values (1, "z3", "v1", "2026-01-05"), (2, "l4", "v1", "2026-01-06")""")
+
+      // the writer laid these out as 2026/01/05 and 2026/01/06, so TRUNCATE PARTITION has to name
+      // the same directory -- naming the dashed value truncates nothing
+      spark.sql(s"truncate table $tableName partition (dt='2026-01-05')")
+
+      checkAnswer(s"select id, name, ts, dt from $tableName")(
+        Seq(2, "l4", "v1", "2026-01-06")
+      )
+    }
+  }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19702.

`HoodieSqlCommonUtils#makePartitionPath` derives the on-disk partition directory for the partition
DDL commands from the table config, but it only reads two of the three configs that decide the
layout — hive-style partitioning and URL encoding — and never
`HoodieTableConfig#getSlashSeparatedDatePartitioning`. On a table written with
`hoodie.datasource.write.slash.separated.date.partitioning=true` the writer lays a value out as
`2026/01/05` while the DDL commands compute `2026-01-05`, so the two disagree for every partition
value containing a dash.

Three commands are affected:

| command | consequence today |
|---|---|
| `ALTER TABLE ... ADD PARTITION` | creates a stray `<base>/2026-02-06/` with a partition metafile in it, and the `hasPartitionMetadata` existence check looks at the wrong path, so `IF NOT EXISTS` never sees the partition the writer created |
| `ALTER TABLE ... DROP PARTITION` | targets a directory that does not exist: reports success and drops nothing |
| `TRUNCATE TABLE ... PARTITION` | same, truncates nothing |

The silent no-ops are the dangerous half: the user is told the partition was dropped and the data
is still queryable.

### Summary and Changelog

`makePartitionPath` now reads `getSlashSeparatedDatePartitioning` alongside the two configs it
already honoured, and applies the same `-` -> `/` substitution the write path performs, so DDL
names the very directory the writer created.

* `HoodieSqlCommonUtils#makePartitionPath` takes a `slashSeparatedDatePartitioning` flag and
  substitutes on the encoded value, after encoding, matching the ordering in
  `KeyGenUtils#getRecordPartitionPath` and `PartitionPathFormatterBase#combine`.
* The substitution is confined to a table partitioned by a **single** column, mirroring the guard
  in `KeyGenUtils#getRecordPartitionPath`. Multi-field slash partitioning is separately broken and
  tracked in #19666; this PR does not change its behavior.
* It is also skipped when hive-style partitioning is on. The config documents the two as mutually
  exclusive, and the write paths do not agree on what the combination produces (#19669), so there
  is no single directory for DDL to name. `HoodieCatalogTable#extraTableConfig` already forces
  `hive_style_partitioning=false` whenever the slash config is set through SQL, so this only guards
  tables created by `df.write`.
* Path-breaking values are left alone, by calling `KeyGenUtils#hasPathBreakingDash` rather than
  restating the rule. #19648 made that helper public and widened it to reject any dash-delimited
  token that is empty, `.` or `..` — a leading `/` is resolved inconsistently by
  `FSUtils#constructAbsolutePath(String, String)` versus the `StoragePath` overload used by
  `AbstractTableFileSystemView`, a trailing or doubled slash is normalized away, and `..-a` becomes
  `../a`, which resolves outside the table base path entirely. These commands have to name the
  directory the writer created, so they have to agree with it on every value, not just on the well
  formed dates; duplicating the rule here is what would let the two drift apart again.

Tests, one per affected command, all on a SQL-created slash table:

* `TestAlterTableAddPartition` — asserts `ADD PARTITION` creates `2026/02/06` and leaves no
  `2026-02-06` behind, and that `ADD PARTITION` for a partition the writer created is now correctly
  rejected as already existing.
* `TestAlterTableDropPartition` — asserts the dropped rows are actually gone after a clean.
* `TestTruncateTable` — asserts the truncated partition's rows are gone.
* `TestAlterTableAddPartition` also covers the three path-breaking token classes at the DDL level,
  where the stray directory is observable: `..-a` must not create a sibling of the table directory,
  `2026-` must not lose its trailing dash to a slash that gets normalized off, and `a--b` must not
  split into nested directories — while `2026-02-06` still slashes, so the guard does not
  over-trigger.

Each of the three fails on the unfixed code: `ADD PARTITION` with
`expected: <true> but was: <false>` on the slash directory, and `DROP`/`TRUNCATE` still returning
the row that should have been removed.

### Impact

Partition DDL on tables using `hoodie.datasource.write.slash.separated.date.partitioning` starts
naming the correct directory. `ADD PARTITION` stops creating stray directories, and
`DROP`/`TRUNCATE PARTITION` start actually removing data instead of silently succeeding.

No behavior change for any table that does not enable the config: the new branch is guarded on
`getSlashSeparatedDatePartitioning`, which defaults to `false`.

A table that has already accumulated stray dashed directories from `ADD PARTITION` is not cleaned
up by this change; those directories carry a partition metafile but no data.

### Risk Level

low

Confined to one method, guarded on a config that defaults to false, and the guarded branch mirrors
the substitution the write path already performs. Verified with the three new tests, plus
`TestAlterTableAddPartition`, `TestAlterTableDropPartition`, `TestTruncateTable`,
`TestShowPartitions` and `TestSlashSeparatedPartitionValue` — all passing — and with each new test
re-run against the unfixed code to confirm it fails there. Neutralizing the guard back to the old
leading-dash-only form fails the new test alone (on the `..-a` assertion), leaving the other 12 in
that suite green.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

