### PR TITLE
[MINOR] Reword the hive.libthrift.version comment in the root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,9 +130,9 @@
     <hive.version>2.3.10</hive.version>
     <!-- The thrift artifacts the Hive client jars above are compiled against (Hive 2.3.10
          bumped libthrift for CVE-2020-13949); keep in lockstep with hive.version. The spark4
-         profiles override hive.libthrift.version to the libthrift Spark 4.x itself ships with
-         the same Hive 2.3.10 client, so the pin never downgrades the Spark-selected version.
-         See #19680. -->
+         profiles override this to the libthrift version Spark 4.x ships (0.16.0), which pairs
+         with the same Hive 2.3.10 client, so the pin never downgrades the Spark-selected
+         version. See #19680. -->
     <hive.libthrift.version>0.14.1</hive.libthrift.version>
     <hive.libfb303.version>0.9.3</hive.libfb303.version>
     <hive.parquet.version>1.10.1</hive.parquet.version>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Follow-up to a review comment on #19682: the `hive.libthrift.version` comment in the root pom has a sentence that reads as broken -- "override hive.libthrift.version to the libthrift Spark 4.x itself ships with the same Hive 2.3.10 client".

### Summary and Changelog

Reword that sentence and name the version the spark4 profiles actually set (0.16.0). Comment text only, no property or dependency changes.

### Impact

None.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
