### PR TITLE
fix(common): rejoin slash-separated partition values for non-time-typed columns

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/PartitionPathParser.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/PartitionPathParser.java
@@ -43,18 +43,37 @@ public class PartitionPathParser {
   public Object[] getPartitionFieldVals(Option<String[]> partitionFields,
                                         String partitionPath,
                                         HoodieSchema writerSchema) {
+    return getPartitionFieldVals(partitionFields, partitionPath, writerSchema, false);
+  }
+
+  /**
+   * @param slashSeparatedDatePartitioning whether the table was written with
+   *        {@code hoodie.datasource.write.slash.separated.date.partitioning}, in which case a
+   *        partition value spans several path segments rather than one.
+   */
+  public Object[] getPartitionFieldVals(Option<String[]> partitionFields,
+                                        String partitionPath,
+                                        HoodieSchema writerSchema,
+                                        boolean slashSeparatedDatePartitioning) {
     if (!partitionFields.isPresent()) {
       return new Object[0];
     }
-    return getPartitionValues(partitionFields.get(), partitionPath, writerSchema);
+    return getPartitionValues(partitionFields.get(), partitionPath, writerSchema, slashSeparatedDatePartitioning);
   }
 
   private static Object[] getPartitionValues(String[] partitionFields,
                                              String partitionPath,
-                                             HoodieSchema schema) {
+                                             HoodieSchema schema,
+                                             boolean slashSeparatedDatePartitioning) {
     String[] parts = partitionPath.split("/");
     int pathSegment = 0;
     boolean hasDateField = false;
+    // NOTE: The writer only slash-separates a table partitioned by a single column -- see the guard
+    //       in [[KeyGenUtils#getRecordPartitionPath]] -- so that is the only shape whose value is
+    //       known to span several segments here. Multi-field slash partitioning produces a layout
+    //       that cannot be lined up with the partition columns at all; that is tracked in HUDI
+    //       issue #19666 and deliberately left alone
+    boolean valueSpansSegments = slashSeparatedDatePartitioning && partitionFields.length == 1;
     Object[] partitionValues = new Object[partitionFields.length];
     for (int i = 0; i < partitionFields.length; i++) {
       String partitionField = partitionFields[i];
@@ -70,13 +89,33 @@ public class PartitionPathParser {
         partitionValues[i] = inferDateValue(partitionPath, parts, pathSegment, numDateDirs, fieldSchema);
         pathSegment += numDateDirs;
       } else {
-        String segment = parts[pathSegment];
+        // A slash-separated value occupies every segment this field is entitled to, mirroring the
+        // way [[#inferDateValue]] consumes them for a time-based column
+        int numDirs = valueSpansSegments ? parts.length - partitionFields.length + 1 : 1;
+        String segment = joinSegmentsWithDash(parts, pathSegment, numDirs);
         String[] segmentParts = segment.split(EQUALS_SIGN);
         partitionValues[i] = parseValue(segmentParts[segmentParts.length - 1], fieldSchema);
-        pathSegment++;
+        pathSegment += numDirs;
       }
     }
     return partitionValues;
+  }
+
+  /**
+   * Undoes the {@code -} -> {@code /} substitution the writer performs for
+   * {@code hoodie.datasource.write.slash.separated.date.partitioning}, rejoining the {@code numDirs}
+   * path segments starting at {@code pathSegment} back into the single value they were written from.
+   * For a value that was not slash-separated {@code numDirs} is 1 and the segment is returned as-is.
+   */
+  private static String joinSegmentsWithDash(String[] parts, int pathSegment, int numDirs) {
+    if (numDirs == 1) {
+      return parts[pathSegment];
+    }
+    StringBuilder value = new StringBuilder(parts[pathSegment]);
+    for (int i = 1; i < numDirs; i++) {
+      value.append(DASH).append(parts[pathSegment + i]);
+    }
+    return value.toString();
   }
 
   @VisibleForTesting

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -283,7 +283,7 @@ public final class HoodieFileGroupReader<T> implements HoodieRecordReader<T> {
       }
       PartitionPathParser partitionPathParser = new PartitionPathParser();
       Object[] partitionValues = partitionPathParser.getPartitionFieldVals(partitionPathFields, inputSplit.getPartitionPath(),
-          readerContext.getSchemaHandler().getTableSchema());
+          readerContext.getSchemaHandler().getTableSchema(), metaClient.getTableConfig().getSlashSeparatedDatePartitioning());
       // filter out the partition values that are not required by the data schema
       List<Pair<String, Object>> partitionPathFieldsAndValues = partitionPathFields.map(partitionFields -> {
         HoodieSchema dataSchema = dataFileIterator.get().getRight();

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestPartitionPathParser.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestPartitionPathParser.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.util.Option;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
@@ -56,14 +57,62 @@ class TestPartitionPathParser {
   @MethodSource("partitionPathCases")
   void testGetPartitionFieldVals(String partitionPath, String[] partitionFields, Object[] expectedValues) {
     PartitionPathParser parser = new PartitionPathParser();
-    HoodieSchema schema = HoodieSchema.parse("{\"type\":\"record\",\"name\":\"TestRecord\",\"fields\":[{\"name\":\"string_field\",\"type\":[\"null\", \"string\"]},"
-        + "{\"name\":\"date_field\",\"type\": {\"type\":\"int\",\"logicalType\": \"date\"}},{\"name\":\"timestamp_field\",\"type\": {\"type\":\"long\",\"logicalType\": \"timestamp-millis\"}}]}");
 
-    Object[] result = parser.getPartitionFieldVals(Option.ofNullable(partitionFields), partitionPath, schema);
+    Object[] result = parser.getPartitionFieldVals(Option.ofNullable(partitionFields), partitionPath, testSchema());
     assertEquals(expectedValues.length, result.length);
     for (int i = 0; i < expectedValues.length; i++) {
       assertEquals(expectedValues[i], result[i]);
     }
+  }
+
+  private static HoodieSchema testSchema() {
+    return HoodieSchema.parse("{\"type\":\"record\",\"name\":\"TestRecord\",\"fields\":[{\"name\":\"string_field\",\"type\":[\"null\", \"string\"]},"
+        + "{\"name\":\"date_field\",\"type\": {\"type\":\"int\",\"logicalType\": \"date\"}},{\"name\":\"timestamp_field\",\"type\": {\"type\":\"long\",\"logicalType\": \"timestamp-millis\"}}]}");
+  }
+
+  private static Stream<Arguments> slashSeparatedPartitionPathCases() {
+    return Stream.of(
+        // the writer turned every dash into a directory separator, so the segments are rejoined
+        // back into the single value they were written from
+        Arguments.of("2026/01/05", new String[] {"string_field"}, new Object[] {"2026-01-05"}),
+        Arguments.of("2026/01", new String[] {"string_field"}, new Object[] {"2026-01"}),
+        // a value that held no dash occupies one segment, as it does without the config
+        Arguments.of("2026", new String[] {"string_field"}, new Object[] {"2026"}),
+        Arguments.of("__HIVE_DEFAULT_PARTITION__", new String[] {"string_field"}, new Object[] {null}),
+        // a time-based column already handled the multi-directory layout and is left alone
+        Arguments.of("2026/01/05", new String[] {"date_field"}, new Object[] {Date.valueOf("2026-01-05")}),
+        // the writer only slash-separates a single-field table, so a multi-field path is read the
+        // same way whether or not the config is set (HUDI issue #19666)
+        Arguments.of("value1/2025/01/03", new String[] {"string_field", "date_field"},
+            new Object[] {"value1", Date.valueOf("2025-01-03")})
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("slashSeparatedPartitionPathCases")
+  void testGetPartitionFieldValsWithSlashSeparatedDatePartitioning(String partitionPath,
+                                                                   String[] partitionFields,
+                                                                   Object[] expectedValues) {
+    PartitionPathParser parser = new PartitionPathParser();
+
+    Object[] result = parser.getPartitionFieldVals(Option.ofNullable(partitionFields), partitionPath, testSchema(), true);
+    assertEquals(expectedValues.length, result.length);
+    for (int i = 0; i < expectedValues.length; i++) {
+      assertEquals(expectedValues[i], result[i]);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"2026/01/05", "2026/01"})
+  void testSlashSeparatedValueIsOnlyRejoinedWhenTheTableConfigSaysSo(String partitionPath) {
+    PartitionPathParser parser = new PartitionPathParser();
+
+    // without the config the segments are assumed to belong to different partition fields, so a
+    // single-field table only ever sees the first one
+    Object[] result = parser.getPartitionFieldVals(
+        Option.of(new String[] {"string_field"}), partitionPath, testSchema());
+    assertEquals(1, result.length);
+    assertEquals("2026", result[0]);
   }
 
   private static Stream<Arguments> fieldCases() {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19705.

`PartitionPathParser#getPartitionValues` splits the partition path on `/` and consumes exactly one
segment per partition field, unless the field is time-based. The multi-directory case is handled
only for `DATE`, `TIMESTAMP` and `TIME` (`isTimeBasedType`), so under
`hoodie.datasource.write.slash.separated.date.partitioning=true` a partition column declared
`STRING` — an ordinary way to hold a `yyyy-MM-dd` value, and what the feature's own test table uses
— produces the directory `2026/01/05`, and the parser reads the value back as `2026`. The remaining
segments are silently dropped.

This is not the Spark read path — `HoodieSparkUtils#doParsePartitionColumnValues` handles the slash
layout, which is why the datasource tests pass. `PartitionPathParser` is the engine-agnostic parser,
reached from `HoodieFileGroupReader` when a bootstrap table merges skeleton and data files, so the
truncated value is handed to `convertValueToEngineType` and materialized into the returned records.

Calling `getPartitionFieldVals` directly against a schema with two string fields and one date field:

| partition path | partition fields | before | after |
|---|---|---|---|
| `2026/01/05` | `[string_field]` | `[2026]` | `[2026-01-05]` |
| `2026/01` | `[string_field]` | `[2026]` | `[2026-01]` |
| `2026/01/05` | `[date_field]` | `[2026-01-05]` | `[2026-01-05]` |
| `2026-01-05` | `[string_field]` | `[2026-01-05]` | `[2026-01-05]` |

### Summary and Changelog

The parser now undoes the `-` -> `/` substitution the writer performed, when told the table uses it.

* `PartitionPathParser#getPartitionFieldVals` gains an overload taking a
  `slashSeparatedDatePartitioning` flag. The existing three-argument signature is kept and delegates
  with `false`, so nothing outside this PR changes behavior.
* The non-time-typed branch consumes `parts.length - partitionFields.length + 1` segments and
  rejoins them with `-`, mirroring the way `inferDateValue` already consumes them for a time-based
  column. For a value that was not slash-separated the count is 1 and the segment is used as-is.
* The rejoin is confined to a table partitioned by a **single** column, mirroring the guard in
  `KeyGenUtils#getRecordPartitionPath` that decides when the writer slash-separates at all.
  Multi-field slash partitioning produces a layout that cannot be lined up with the partition
  columns in the first place; that is tracked in #19666 and left alone here.
* `HoodieFileGroupReader` passes `metaClient.getTableConfig().getSlashSeparatedDatePartitioning()`
  at its call site. `metaClient` is already a field, so no constructor change was needed.

Tests in `TestPartitionPathParser`: a new parameterized case set covering the rejoin, a value with
no dash, `__HIVE_DEFAULT_PARTITION__`, a time-based column (unchanged), and a multi-field path
(unchanged); plus a case pinning the pre-existing behavior when the flag is not set, so the default
path stays covered. The existing inline schema was lifted into a `testSchema()` helper shared by
both tests.

The new cases fail on the unfixed code with `expected: <2026-01-05> but was: <2026>` and
`expected: <2026-01> but was: <2026>`.

### Impact

A bootstrap table using `hoodie.datasource.write.slash.separated.date.partitioning` with a
non-time-typed partition column returns the real partition value instead of the first path segment.

No behavior change otherwise: the new branch is reached only through the new overload, and the only
caller passes a table config that defaults to `false`. The three-argument
`getPartitionFieldVals` keeps its exact current behavior, so any out-of-tree caller is unaffected.

### Risk Level

low

One branch in one method, gated on a config that defaults to false, plus one call site. Verified
with `TestPartitionPathParser` (29 tests, all passing) and by re-running the new cases against the
unfixed code to confirm they fail there.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
