### PR TITLE
fix(spark-sql): resolve a partition path without validating the record key

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoKeyGenerator.scala
@@ -39,7 +39,11 @@ import org.apache.spark.unsafe.types.UTF8String
 class MergeIntoKeyGenerator(props: TypedProperties) extends SqlKeyGenerator(props) {
 
   override def getRecordKey(record: GenericRecord): String = {
-    val recordKey = record.get(RECORD_KEY_META_FIELD_ORD)
+    val recordKey = if (carriesMetaField(record, RECORD_KEY_META_FIELD_ORD)) {
+      record.get(RECORD_KEY_META_FIELD_ORD)
+    } else {
+      null
+    }
     if (recordKey != null) {
       recordKey.toString
     } else {
@@ -66,7 +70,11 @@ class MergeIntoKeyGenerator(props: TypedProperties) extends SqlKeyGenerator(prop
   }
 
   override def getPartitionPath(record: GenericRecord): String = {
-    val partitionPath = record.get(PARTITION_PATH_META_FIELD_ORD)
+    val partitionPath = if (carriesMetaField(record, PARTITION_PATH_META_FIELD_ORD)) {
+      record.get(PARTITION_PATH_META_FIELD_ORD)
+    } else {
+      null
+    }
     if (partitionPath != null) {
       partitionPath.toString
     } else {
@@ -92,4 +100,20 @@ class MergeIntoKeyGenerator(props: TypedProperties) extends SqlKeyGenerator(prop
     }
   }
 
+  /**
+   * Whether the record is long enough for `ord` to address a meta field at all.
+   *
+   * The meta fields are only prepended once a record has been through the write path, so a record
+   * built against a projected schema can be shorter than the ordinal: a MOR partial update
+   * materialises the merged record against `WRITE_PARTIAL_UPDATE_SCHEMA`, which carries only the
+   * columns named in `UPDATE SET`. Reading the ordinal off such a record raises a bare
+   * `ArrayIndexOutOfBoundsException` out of the key generator, which does not name the statement
+   * that caused it. Falling back to the SQL key generator gives the same answer the unpopulated
+   * meta field would have routed to.
+   *
+   * This is a bounds check, not a proof that the field at `ord` is a meta field: a record of the
+   * right length whose schema is not meta-prefixed still reads data here, exactly as before.
+   */
+  private def carriesMetaField(record: GenericRecord, ord: Int): Boolean =
+    record.getSchema.getFields.size > ord
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/SqlKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/SqlKeyGenerator.scala
@@ -77,7 +77,13 @@ class SqlKeyGenerator(props: TypedProperties) extends BuiltinKeyGenerator(props)
 
   override def getRecordKey(record: GenericRecord): String =
     originalKeyGen.map {
-      _.getKey(record).getRecordKey
+      // Mirror of getPartitionPath below: resolve the record key alone where the generator exposes
+      // it, so neither accessor pays for the other half. Going through getKey would also compute the
+      // partition path and discard it, and would let a partition-side failure surface from a
+      // record-key lookup: TimestampBasedAvroKeyGenerator raises HoodieKeyGeneratorException
+      // independently of the key.
+      case baseKeyGen: BaseKeyGenerator => baseKeyGen.getRecordKey(record)
+      case keyGen => keyGen.getKey(record).getRecordKey
     } getOrElse {
       complexKeyGen.getRecordKey(record)
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/SqlKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/SqlKeyGenerator.scala
@@ -77,13 +77,7 @@ class SqlKeyGenerator(props: TypedProperties) extends BuiltinKeyGenerator(props)
 
   override def getRecordKey(record: GenericRecord): String =
     originalKeyGen.map {
-      // Mirror of getPartitionPath below: resolve the record key alone where the generator exposes
-      // it, so neither accessor pays for the other half. Going through getKey would also compute the
-      // partition path and discard it, and would let a partition-side failure surface from a
-      // record-key lookup: TimestampBasedAvroKeyGenerator raises HoodieKeyGeneratorException
-      // independently of the key.
-      case baseKeyGen: BaseKeyGenerator => baseKeyGen.getRecordKey(record)
-      case keyGen => keyGen.getKey(record).getRecordKey
+      _.getKey(record).getRecordKey
     } getOrElse {
       complexKeyGen.getRecordKey(record)
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/SqlKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/SqlKeyGenerator.scala
@@ -99,7 +99,15 @@ class SqlKeyGenerator(props: TypedProperties) extends BuiltinKeyGenerator(props)
 
   override def getPartitionPath(record: GenericRecord): String = {
     val partitionPath = originalKeyGen.map {
-      _.getKey(record).getPartitionPath
+      // Resolve the partition path on its own where the key generator exposes it. Going through
+      // BaseKeyGenerator#getKey would also compute and validate the record key, which a MOR partial
+      // update legitimately leaves unset: the merged record is materialised against
+      // WRITE_PARTIAL_UPDATE_SCHEMA and so carries only the columns named in UPDATE SET. Callers
+      // that want the record key validated still ask for it, via getKey or getRecordKey.
+      case baseKeyGen: BaseKeyGenerator => baseKeyGen.getPartitionPath(record)
+      // SparkKeyGeneratorInterface exposes no Avro-facing accessor beyond getKey, so a generator
+      // that is not a BaseKeyGenerator retains the previous behaviour.
+      case keyGen => keyGen.getKey(record).getPartitionPath
     } getOrElse {
       complexKeyGen.getPartitionPath(record)
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestMergeIntoKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestMergeIntoKeyGenerator.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command
+
+import org.apache.hudi.common.config.TypedProperties
+import org.apache.hudi.common.util.PartitionPathEncodeUtils
+import org.apache.hudi.exception.HoodieKeyException
+import org.apache.hudi.keygen.SimpleKeyGenerator
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericData
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests that [[MergeIntoKeyGenerator]] reads the meta-field ordinals only from records long enough
+ * to have them.
+ *
+ * It resolves both the record key and the partition path by ordinal (2 and 3) off the meta-field
+ * prefix, falling back to [[SqlKeyGenerator]] when the meta field is unpopulated. A MOR partial
+ * update materialises the merged record against `WRITE_PARTIAL_UPDATE_SCHEMA`, so the record can be
+ * shorter than the ordinal, and an unguarded read raises `ArrayIndexOutOfBoundsException` from
+ * inside the key generator, naming nothing about the statement that caused it.
+ */
+class TestMergeIntoKeyGenerator {
+
+  /** A record carrying only the columns an `UPDATE SET amount, ts` would assign. */
+  private val partialSchema = new Schema.Parser().parse(
+    """
+       |{
+       |  "type": "record",
+       |  "name": "partial_record",
+       |  "fields": [
+       |    {"name": "amount", "type": ["null", "double"], "default": null},
+       |    {"name": "ts", "type": ["null", "long"], "default": null}
+       |  ]
+       |}
+     """.stripMargin)
+
+  /** The shape the write path produces: the five meta fields, then the data columns. */
+  private val metaPrefixedSchema = new Schema.Parser().parse(
+    """
+       |{
+       |  "type": "record",
+       |  "name": "meta_prefixed_record",
+       |  "fields": [
+       |    {"name": "_hoodie_commit_time", "type": ["null", "string"], "default": null},
+       |    {"name": "_hoodie_commit_seqno", "type": ["null", "string"], "default": null},
+       |    {"name": "_hoodie_record_key", "type": ["null", "string"], "default": null},
+       |    {"name": "_hoodie_partition_path", "type": ["null", "string"], "default": null},
+       |    {"name": "_hoodie_file_name", "type": ["null", "string"], "default": null},
+       |    {"name": "id", "type": ["null", "long"], "default": null},
+       |    {"name": "amount", "type": ["null", "double"], "default": null},
+       |    {"name": "dt", "type": ["null", "string"], "default": null}
+       |  ]
+       |}
+     """.stripMargin)
+
+  private def keyGenerator: MergeIntoKeyGenerator = {
+    val props = new TypedProperties()
+    props.put(SqlKeyGenerator.ORIGINAL_KEYGEN_CLASS_NAME, classOf[SimpleKeyGenerator].getName)
+    props.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key, "id")
+    props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key, "dt")
+    props.put(SqlKeyGenerator.PARTITION_SCHEMA, "dt string")
+    new MergeIntoKeyGenerator(props)
+  }
+
+  private def partialRecord: GenericData.Record = {
+    val record = new GenericData.Record(partialSchema)
+    record.put("amount", 15.0d)
+    record.put("ts", 200L)
+    record
+  }
+
+  /**
+   * Two fields against partition-path ordinal 3. Before the guard this raised
+   * ArrayIndexOutOfBoundsException; it now falls through to the SQL key generator, which resolves
+   * the absent partition field to the default partition.
+   */
+  @Test
+  def testGetPartitionPathFallsBackOnARecordShorterThanTheOrdinal(): Unit = {
+    assertEquals(PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH,
+      keyGenerator.getPartitionPath(partialRecord))
+  }
+
+  /**
+   * Same record against record-key ordinal 2. The fallback reaches record-key validation, so the
+   * failure names the field rather than an array bound.
+   */
+  @Test
+  def testGetRecordKeyFallsBackOnARecordShorterThanTheOrdinal(): Unit = {
+    val thrown = assertThrows(classOf[HoodieKeyException], () => keyGenerator.getRecordKey(partialRecord))
+    assert(thrown.getMessage.contains("id"), s"expected the message to name the field, got: ${thrown.getMessage}")
+  }
+
+  /**
+   * Regression guard for the normal path: a meta-prefixed record is long enough, so both accessors
+   * still read the ordinal rather than falling back. Without this the guard could disable meta-field
+   * resolution outright and the tests above would still pass.
+   */
+  @Test
+  def testMetaPrefixedRecordStillResolvesFromTheMetaFields(): Unit = {
+    val record = new GenericData.Record(metaPrefixedSchema)
+    record.put("_hoodie_record_key", "id:1")
+    record.put("_hoodie_partition_path", "dt=2026-08-11")
+    record.put("id", 1L)
+    record.put("dt", "2026-08-12") // deliberately disagrees, to show the meta field is what is read
+    assertEquals("id:1", keyGenerator.getRecordKey(record))
+    assertEquals("dt=2026-08-11", keyGenerator.getPartitionPath(record))
+  }
+
+  /**
+   * A meta-prefixed record whose meta fields are unpopulated is still long enough, so the ordinal is
+   * read, found null, and the existing fallback runs. Pins that the guard did not change which of
+   * the two fallback reasons applies.
+   */
+  @Test
+  def testMetaPrefixedRecordWithNullMetaFieldsFallsBackToTheDataColumns(): Unit = {
+    val record = new GenericData.Record(metaPrefixedSchema)
+    record.put("id", 1L)
+    record.put("dt", "2026-08-11")
+    assertEquals("1", keyGenerator.getRecordKey(record))
+    assertEquals("2026-08-11", keyGenerator.getPartitionPath(record))
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestSqlKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestSqlKeyGenerator.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command
+
+import org.apache.hudi.common.config.TypedProperties
+import org.apache.hudi.exception.HoodieKeyException
+import org.apache.hudi.keygen.SimpleKeyGenerator
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericData
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests that [[SqlKeyGenerator]] resolves a partition path without also requiring the record key.
+ *
+ * MOR partial updates materialise the merged record against `WRITE_PARTIAL_UPDATE_SCHEMA`, which
+ * carries only the fields named in `UPDATE SET`. `HoodieIndexUtils#inferPartitionPath` then asks
+ * the key generator for that record's partition path, so a record key absent from the assignments
+ * is legitimately unset at that point and must not fail partition resolution.
+ */
+class TestSqlKeyGenerator {
+
+  private val schema = new Schema.Parser().parse(
+    s"""
+       |{
+       |  "type": "record",
+       |  "name": "test_record",
+       |  "fields": [
+       |    {"name": "id", "type": ["null", "long"], "default": null},
+       |    {"name": "amount", "type": ["null", "double"], "default": null},
+       |    {"name": "dt", "type": ["null", "string"], "default": null}
+       |  ]
+       |}
+     """.stripMargin)
+
+  private def keyGenerator: SqlKeyGenerator = {
+    val props = new TypedProperties()
+    props.put(SqlKeyGenerator.ORIGINAL_KEYGEN_CLASS_NAME, classOf[SimpleKeyGenerator].getName)
+    props.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key, "id")
+    props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key, "dt")
+    new SqlKeyGenerator(props)
+  }
+
+  /** The partition column is populated; only the record key is missing, as under a partial update. */
+  private def recordWithoutRecordKey: GenericData.Record = {
+    val record = new GenericData.Record(schema)
+    record.put("amount", 15.0d)
+    record.put("dt", "2026-08-11")
+    record
+  }
+
+  @Test
+  def testGetPartitionPathDoesNotRequireRecordKey(): Unit = {
+    // Before the fix this threw HoodieKeyException, because getPartitionPath delegated to
+    // BaseKeyGenerator#getKey, which builds the whole HoodieKey and so validates the record key.
+    assertEquals("2026-08-11", keyGenerator.getPartitionPath(recordWithoutRecordKey))
+  }
+
+  @Test
+  def testGetRecordKeyStillRejectsAMissingRecordKey(): Unit = {
+    // Scope guard: the fix must not weaken record-key validation, only stop getPartitionPath from
+    // triggering it. A record key that is genuinely required and absent is still an error.
+    assertThrows(classOf[HoodieKeyException], () => keyGenerator.getRecordKey(recordWithoutRecordKey))
+  }
+
+  @Test
+  def testGetPartitionPathAndRecordKeyOnACompleteRecord(): Unit = {
+    val record = recordWithoutRecordKey
+    record.put("id", 1L)
+    assertEquals("2026-08-11", keyGenerator.getPartitionPath(record))
+    assertEquals("1", keyGenerator.getRecordKey(record))
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestSqlKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestSqlKeyGenerator.scala
@@ -17,16 +17,20 @@
 
 package org.apache.spark.sql.hudi.command
 
+import org.apache.hudi.common.config.TimestampKeyGeneratorConfig
 import org.apache.hudi.common.config.TypedProperties
 import org.apache.hudi.common.util.PartitionPathEncodeUtils
 import org.apache.hudi.exception.HoodieKeyException
-import org.apache.hudi.keygen.SimpleKeyGenerator
+import org.apache.hudi.keygen.{SimpleKeyGenerator, TimestampBasedKeyGenerator}
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions
 
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
+import org.joda.time.DateTimeZone
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
 import org.junit.jupiter.api.Test
+
+import scala.collection.JavaConverters._
 
 /**
  * Tests that [[SqlKeyGenerator]] resolves a partition path without also requiring the record key.
@@ -39,7 +43,7 @@ import org.junit.jupiter.api.Test
 class TestSqlKeyGenerator {
 
   private val schema = new Schema.Parser().parse(
-    s"""
+    """
        |{
        |  "type": "record",
        |  "name": "test_record",
@@ -51,14 +55,38 @@ class TestSqlKeyGenerator {
        |}
      """.stripMargin)
 
-  private def keyGenerator(partitionSchema: Option[String] = None): SqlKeyGenerator = {
+  /** The same record shape with only the named fields, as a partial update produces. */
+  private def projected(fieldNames: String*): Schema = {
+    val fields = schema.getFields.asScala
+      .filter(f => fieldNames.contains(f.name))
+      .map(f => new Schema.Field(f.name, f.schema, null, f.defaultVal))
+    Schema.createRecord("test_record", null, null, false, fields.asJava)
+  }
+
+  private def keyGenerator(partitionSchema: Option[String] = None,
+                           withRecordKey: Boolean = true): SqlKeyGenerator = {
     val props = new TypedProperties()
     props.put(SqlKeyGenerator.ORIGINAL_KEYGEN_CLASS_NAME, classOf[SimpleKeyGenerator].getName)
+    if (withRecordKey) {
+      props.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key, "id")
+    }
+    props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key, "dt")
+    // Spark SQL always sets this (see MergeIntoHoodieTableCommand), and it is what drives
+    // convertPartitionPathToSqlType, so cover it rather than leaving it None.
+    partitionSchema.foreach(ps => props.put(SqlKeyGenerator.PARTITION_SCHEMA, ps))
+    new SqlKeyGenerator(props)
+  }
+
+  /** Delegates to a TimestampBasedKeyGenerator rather than a SimpleKeyGenerator. */
+  private def timestampKeyGenerator(partitionSchema: Option[String] = None): SqlKeyGenerator = {
+    val props = new TypedProperties()
+    props.put(SqlKeyGenerator.ORIGINAL_KEYGEN_CLASS_NAME, classOf[TimestampBasedKeyGenerator].getName)
     props.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key, "id")
     props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key, "dt")
-    // Spark SQL always sets this (see MergeIntoHoodieTableCommand), and it is what makes
-    // convertPartitionPathToSqlType do any work, so cover it rather than leaving it None.
-    partitionSchema.foreach(schema => props.put(SqlKeyGenerator.PARTITION_SCHEMA, schema))
+    props.put(TimestampKeyGeneratorConfig.TIMESTAMP_TYPE_FIELD.key, "DATE_STRING")
+    props.put(TimestampKeyGeneratorConfig.TIMESTAMP_INPUT_DATE_FORMAT.key, "yyyy-MM-dd")
+    props.put(TimestampKeyGeneratorConfig.TIMESTAMP_OUTPUT_DATE_FORMAT.key, "yyyy-MM-dd")
+    partitionSchema.foreach(ps => props.put(SqlKeyGenerator.PARTITION_SCHEMA, ps))
     new SqlKeyGenerator(props)
   }
 
@@ -92,11 +120,63 @@ class TestSqlKeyGenerator {
     assertEquals("1", keyGenerator().getRecordKey(record))
   }
 
+  /**
+   * Drives convertPartitionPathToSqlType's TimestampType arm, which is the only arm that does any
+   * work: a `dt string` partition schema takes the identity case, so it pins nothing. The value is
+   * microseconds because that is what the GenericRecord path assumes when
+   * hoodie.datasource.write.keygenerator.consistent.logical.timestamp.enabled is off. Timezone is
+   * pinned because the output is formatted in the default zone.
+   */
   @Test
-  def testGetPartitionPathResolvesThroughTheSqlPartitionSchema(): Unit = {
-    val record = recordWithoutRecordKey
-    record.put("id", 1L)
-    assertEquals("2026-08-11", keyGenerator(Some("dt string")).getPartitionPath(record))
+  def testGetPartitionPathConvertsATimestampPartitionValue(): Unit = {
+    val previousZone = DateTimeZone.getDefault
+    DateTimeZone.setDefault(DateTimeZone.UTC)
+    try {
+      val record = new GenericData.Record(schema)
+      record.put("id", 1L)
+      // 2026-08-11 00:00:00 UTC expressed in microseconds.
+      record.put("dt", String.valueOf(1786406400000000L))
+      assertEquals("2026-08-11 00%3A00%3A00", keyGenerator(Some("dt timestamp")).getPartitionPath(record))
+    } finally {
+      DateTimeZone.setDefault(previousZone)
+    }
+  }
+
+  /**
+   * A TimestampBasedKeyGenerator delegate does NOT substitute HUDI_DEFAULT_PARTITION_PATH for an
+   * absent partition field: it formats the epoch instead, so the HUDI-8315 guard in
+   * convertPartitionPathToSqlType never fires for it. Pinned because this change makes the case
+   * reachable, where previously the record-key exception pre-empted it.
+   */
+  @Test
+  def testTimestampDelegateResolvesAnAbsentPartitionFieldToTheEpoch(): Unit = {
+    val previousZone = DateTimeZone.getDefault
+    DateTimeZone.setDefault(DateTimeZone.UTC)
+    try {
+      val record = new GenericData.Record(projected("id", "amount"))
+      record.put("id", 1L)
+      record.put("amount", 15.0d)
+      assertEquals("1970-01-01", timestampKeyGenerator().getPartitionPath(record))
+    } finally {
+      DateTimeZone.setDefault(previousZone)
+    }
+  }
+
+  /**
+   * Without a record-key config KeyGenUtils#isAutoGeneratedRecordKeysEnabled is true, so the delegate
+   * is wrapped in an AutoRecordGenWrapperKeyGenerator. That wrapper is a BaseKeyGenerator, so it now
+   * takes the direct arm and getPartitionPath no longer consumes a generated sequence id as a side
+   * effect of building a HoodieKey. Uniqueness does not depend on the stride, but the change is
+   * pinned here rather than left as an unexercised side effect.
+   */
+  @Test
+  def testAutoRecordKeyDelegateStillResolvesThePartitionPath(): Unit = {
+    val record = new GenericData.Record(schema)
+    record.put("amount", 15.0d)
+    record.put("dt", "2026-08-11")
+    val keyGen = keyGenerator(withRecordKey = false)
+    assertEquals("2026-08-11", keyGen.getPartitionPath(record))
+    assertEquals("2026-08-11", keyGen.getPartitionPath(record))
   }
 
   /**
@@ -105,21 +185,14 @@ class TestSqlKeyGenerator {
    * value, and it predates this change: getKey called the very same getPartitionPath, so the
    * substitution already happened whenever the record key resolved. Pinned here so the behaviour is
    * explicit, because the fix does widen when it is observable, see the sibling test below.
+   *
+   * NOTE this is the behaviour TestSimpleKeyGenerator marks with "TODO this should throw as well" on
+   * the Avro path, its Row-path twin already asserting HoodieException. If that TODO is addressed,
+   * this expectation changes with it; the sibling test below is the one that discriminates the fix.
    */
   @Test
   def testPartitionFieldMissingFromTheSchemaYieldsTheDefaultPartition(): Unit = {
-    val partialSchema = new Schema.Parser().parse(
-      s"""
-         |{
-         |  "type": "record",
-         |  "name": "test_record",
-         |  "fields": [
-         |    {"name": "id", "type": ["null", "long"], "default": null},
-         |    {"name": "amount", "type": ["null", "double"], "default": null}
-         |  ]
-         |}
-       """.stripMargin)
-    val record = new GenericData.Record(partialSchema)
+    val record = new GenericData.Record(projected("id", "amount"))
     record.put("id", 1L)
     record.put("amount", 15.0d)
     assertEquals(PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH, keyGenerator().getPartitionPath(record))
@@ -133,17 +206,7 @@ class TestSqlKeyGenerator {
    */
   @Test
   def testPartitionAndRecordKeyBothMissingYieldTheDefaultPartition(): Unit = {
-    val partialSchema = new Schema.Parser().parse(
-      s"""
-         |{
-         |  "type": "record",
-         |  "name": "test_record",
-         |  "fields": [
-         |    {"name": "amount", "type": ["null", "double"], "default": null}
-         |  ]
-         |}
-       """.stripMargin)
-    val record = new GenericData.Record(partialSchema)
+    val record = new GenericData.Record(projected("amount"))
     record.put("amount", 15.0d)
     assertEquals(PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH, keyGenerator().getPartitionPath(record))
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestSqlKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestSqlKeyGenerator.scala
@@ -21,7 +21,7 @@ import org.apache.hudi.common.config.TimestampKeyGeneratorConfig
 import org.apache.hudi.common.config.TypedProperties
 import org.apache.hudi.common.util.PartitionPathEncodeUtils
 import org.apache.hudi.exception.HoodieKeyException
-import org.apache.hudi.keygen.{SimpleKeyGenerator, TimestampBasedKeyGenerator}
+import org.apache.hudi.keygen.{KeyGenUtils, SimpleKeyGenerator, TimestampBasedKeyGenerator}
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions
 
 import org.apache.avro.Schema
@@ -39,6 +39,12 @@ import scala.collection.JavaConverters._
  * carries only the fields named in `UPDATE SET`. `HoodieIndexUtils#inferPartitionPath` then asks
  * the key generator for that record's partition path, so a record key absent from the assignments
  * is legitimately unset at that point and must not fail partition resolution.
+ *
+ * The fixtures set `hoodie.sql.partition.schema` by default because production always does, at
+ * every construction site (`ProvidesHoodieConfig` and both `MergeIntoHoodieTableCommand` copies).
+ * Leaving it unset makes `convertPartitionPathToSqlType` return its input immediately, which skips
+ * the default-partition guard, the fragment-count early-out and hive-style handling, so the cases
+ * named after those behaviours would never reach them.
  */
 class TestSqlKeyGenerator {
 
@@ -55,6 +61,9 @@ class TestSqlKeyGenerator {
        |}
      """.stripMargin)
 
+  /** 2026-08-11 00:00:00 UTC in microseconds, which is what the GenericRecord path assumes. */
+  private val timestampMicros = String.valueOf(1786406400000000L)
+
   /** The same record shape with only the named fields, as a partial update produces. */
   private def projected(fieldNames: String*): Schema = {
     val fields = schema.getFields.asScala
@@ -63,7 +72,7 @@ class TestSqlKeyGenerator {
     Schema.createRecord("test_record", null, null, false, fields.asJava)
   }
 
-  private def keyGenerator(partitionSchema: Option[String] = None,
+  private def keyGenerator(partitionSchema: Option[String] = Some("dt string"),
                            withRecordKey: Boolean = true): SqlKeyGenerator = {
     val props = new TypedProperties()
     props.put(SqlKeyGenerator.ORIGINAL_KEYGEN_CLASS_NAME, classOf[SimpleKeyGenerator].getName)
@@ -71,14 +80,17 @@ class TestSqlKeyGenerator {
       props.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key, "id")
     }
     props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key, "dt")
-    // Spark SQL always sets this (see MergeIntoHoodieTableCommand), and it is what drives
-    // convertPartitionPathToSqlType, so cover it rather than leaving it None.
+    // Production sets both whenever record keys are auto-generated (HoodieCreateRecordUtils), so
+    // without them the auto-record-key delegate fails on the missing property rather than on the
+    // behaviour under test.
+    props.put(KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG, "100")
+    props.put(KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG, 1)
     partitionSchema.foreach(ps => props.put(SqlKeyGenerator.PARTITION_SCHEMA, ps))
     new SqlKeyGenerator(props)
   }
 
   /** Delegates to a TimestampBasedKeyGenerator rather than a SimpleKeyGenerator. */
-  private def timestampKeyGenerator(partitionSchema: Option[String] = None): SqlKeyGenerator = {
+  private def timestampKeyGenerator(partitionSchema: Option[String]): SqlKeyGenerator = {
     val props = new TypedProperties()
     props.put(SqlKeyGenerator.ORIGINAL_KEYGEN_CLASS_NAME, classOf[TimestampBasedKeyGenerator].getName)
     props.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key, "id")
@@ -96,6 +108,21 @@ class TestSqlKeyGenerator {
     record.put("amount", 15.0d)
     record.put("dt", "2026-08-11")
     record
+  }
+
+  /** A partial-update shape: the partition field is not in the schema at all. */
+  private def recordMissingThePartitionField: GenericData.Record = {
+    val record = new GenericData.Record(projected("id", "amount"))
+    record.put("id", 1L)
+    record.put("amount", 15.0d)
+    record
+  }
+
+  /** Runs `f` with the default timezone pinned, since the timestamp arms format in it. */
+  private def inUtc[T](f: => T): T = {
+    val previousZone = DateTimeZone.getDefault
+    DateTimeZone.setDefault(DateTimeZone.UTC)
+    try f finally DateTimeZone.setDefault(previousZone)
   }
 
   @Test
@@ -121,25 +148,29 @@ class TestSqlKeyGenerator {
   }
 
   /**
-   * Drives convertPartitionPathToSqlType's TimestampType arm, which is the only arm that does any
-   * work: a `dt string` partition schema takes the identity case, so it pins nothing. The value is
-   * microseconds because that is what the GenericRecord path assumes when
-   * hoodie.datasource.write.keygenerator.consistent.logical.timestamp.enabled is off. Timezone is
-   * pinned because the output is formatted in the default zone.
+   * Drives convertPartitionPathToSqlType's TimestampType arm, the only arm that rewrites the value.
+   * The expected string was captured from a run rather than derived.
    */
   @Test
-  def testGetPartitionPathConvertsATimestampPartitionValue(): Unit = {
-    val previousZone = DateTimeZone.getDefault
-    DateTimeZone.setDefault(DateTimeZone.UTC)
-    try {
-      val record = new GenericData.Record(schema)
-      record.put("id", 1L)
-      // 2026-08-11 00:00:00 UTC expressed in microseconds.
-      record.put("dt", String.valueOf(1786406400000000L))
-      assertEquals("2026-08-11 00%3A00%3A00", keyGenerator(Some("dt timestamp")).getPartitionPath(record))
-    } finally {
-      DateTimeZone.setDefault(previousZone)
-    }
+  def testGetPartitionPathConvertsATimestampPartitionValue(): Unit = inUtc {
+    val record = new GenericData.Record(schema)
+    record.put("id", 1L)
+    record.put("dt", timestampMicros)
+    assertEquals("2026-08-11 00%3A00%3A00",
+      keyGenerator(Some("dt timestamp")).getPartitionPath(record))
+  }
+
+  /**
+   * The one shape that legitimately supplies no partition schema is a non-partitioned table, where
+   * convertPartitionPathToSqlType returns its input untouched. Paired with the case above on the
+   * same value, so the conversion is shown to be skipped rather than merely absent.
+   */
+  @Test
+  def testNonPartitionedTableLeavesThePartitionValueUnconverted(): Unit = inUtc {
+    val record = new GenericData.Record(schema)
+    record.put("id", 1L)
+    record.put("dt", timestampMicros)
+    assertEquals(timestampMicros, keyGenerator(partitionSchema = None).getPartitionPath(record))
   }
 
   /**
@@ -147,36 +178,50 @@ class TestSqlKeyGenerator {
    * absent partition field: it formats the epoch instead, so the HUDI-8315 guard in
    * convertPartitionPathToSqlType never fires for it. Pinned because this change makes the case
    * reachable, where previously the record-key exception pre-empted it.
+   *
+   * All three partition-schema spellings are pinned separately below because they diverge, and the
+   * divergence is the point: a `timestamp` column turns the epoch string into a bare
+   * NumberFormatException, while a `string` column silently accepts the epoch partition.
    */
   @Test
-  def testTimestampDelegateResolvesAnAbsentPartitionFieldToTheEpoch(): Unit = {
-    val previousZone = DateTimeZone.getDefault
-    DateTimeZone.setDefault(DateTimeZone.UTC)
-    try {
-      val record = new GenericData.Record(projected("id", "amount"))
-      record.put("id", 1L)
-      record.put("amount", 15.0d)
-      assertEquals("1970-01-01", timestampKeyGenerator().getPartitionPath(record))
-    } finally {
-      DateTimeZone.setDefault(previousZone)
-    }
+  def testTimestampDelegateResolvesAnAbsentPartitionFieldToTheEpoch(): Unit = inUtc {
+    assertEquals("1970-01-01",
+      timestampKeyGenerator(None).getPartitionPath(recordMissingThePartitionField))
+  }
+
+  @Test
+  def testTimestampDelegateSilentlyAcceptsTheEpochUnderAStringPartitionSchema(): Unit = inUtc {
+    assertEquals("1970-01-01",
+      timestampKeyGenerator(Some("dt string")).getPartitionPath(recordMissingThePartitionField))
+  }
+
+  @Test
+  def testTimestampDelegateThrowsUnderATimestampPartitionSchema(): Unit = inUtc {
+    // The epoch string the delegate produced is not microseconds, so the TimestampType arm cannot
+    // parse it. NumberFormatException rather than a Hudi exception is what the code does today.
+    assertThrows(classOf[NumberFormatException],
+      () => timestampKeyGenerator(Some("dt timestamp")).getPartitionPath(recordMissingThePartitionField))
   }
 
   /**
    * Without a record-key config KeyGenUtils#isAutoGeneratedRecordKeysEnabled is true, so the delegate
    * is wrapped in an AutoRecordGenWrapperKeyGenerator. That wrapper is a BaseKeyGenerator, so it now
    * takes the direct arm and getPartitionPath no longer consumes a generated sequence id as a side
-   * effect of building a HoodieKey. Uniqueness does not depend on the stride, but the change is
-   * pinned here rather than left as an unexercised side effect.
+   * effect of building a HoodieKey.
+   *
+   * The record key is asserted after two partition lookups to pin that stride: the sequence id is
+   * `instantTime_partitionId_rowId`, so it reads 100_1_0 here and 100_1_2 before the change.
+   * Uniqueness never depended on the stride, but it is now a pinned decision.
    */
   @Test
-  def testAutoRecordKeyDelegateStillResolvesThePartitionPath(): Unit = {
+  def testAutoRecordKeyDelegateDoesNotConsumeSequenceIdsOnPartitionLookups(): Unit = {
     val record = new GenericData.Record(schema)
     record.put("amount", 15.0d)
     record.put("dt", "2026-08-11")
     val keyGen = keyGenerator(withRecordKey = false)
     assertEquals("2026-08-11", keyGen.getPartitionPath(record))
     assertEquals("2026-08-11", keyGen.getPartitionPath(record))
+    assertEquals("100_1_0", keyGen.getRecordKey(record))
   }
 
   /**
@@ -192,10 +237,8 @@ class TestSqlKeyGenerator {
    */
   @Test
   def testPartitionFieldMissingFromTheSchemaYieldsTheDefaultPartition(): Unit = {
-    val record = new GenericData.Record(projected("id", "amount"))
-    record.put("id", 1L)
-    record.put("amount", 15.0d)
-    assertEquals(PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH, keyGenerator().getPartitionPath(record))
+    assertEquals(PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH,
+      keyGenerator().getPartitionPath(recordMissingThePartitionField))
   }
 
   /**
@@ -208,6 +251,7 @@ class TestSqlKeyGenerator {
   def testPartitionAndRecordKeyBothMissingYieldTheDefaultPartition(): Unit = {
     val record = new GenericData.Record(projected("amount"))
     record.put("amount", 15.0d)
-    assertEquals(PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH, keyGenerator().getPartitionPath(record))
+    assertEquals(PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH,
+      keyGenerator().getPartitionPath(record))
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestSqlKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestSqlKeyGenerator.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hudi.command
 
 import org.apache.hudi.common.config.TypedProperties
+import org.apache.hudi.common.util.PartitionPathEncodeUtils
 import org.apache.hudi.exception.HoodieKeyException
 import org.apache.hudi.keygen.SimpleKeyGenerator
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions
@@ -50,11 +51,14 @@ class TestSqlKeyGenerator {
        |}
      """.stripMargin)
 
-  private def keyGenerator: SqlKeyGenerator = {
+  private def keyGenerator(partitionSchema: Option[String] = None): SqlKeyGenerator = {
     val props = new TypedProperties()
     props.put(SqlKeyGenerator.ORIGINAL_KEYGEN_CLASS_NAME, classOf[SimpleKeyGenerator].getName)
     props.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key, "id")
     props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key, "dt")
+    // Spark SQL always sets this (see MergeIntoHoodieTableCommand), and it is what makes
+    // convertPartitionPathToSqlType do any work, so cover it rather than leaving it None.
+    partitionSchema.foreach(schema => props.put(SqlKeyGenerator.PARTITION_SCHEMA, schema))
     new SqlKeyGenerator(props)
   }
 
@@ -70,21 +74,77 @@ class TestSqlKeyGenerator {
   def testGetPartitionPathDoesNotRequireRecordKey(): Unit = {
     // Before the fix this threw HoodieKeyException, because getPartitionPath delegated to
     // BaseKeyGenerator#getKey, which builds the whole HoodieKey and so validates the record key.
-    assertEquals("2026-08-11", keyGenerator.getPartitionPath(recordWithoutRecordKey))
+    assertEquals("2026-08-11", keyGenerator().getPartitionPath(recordWithoutRecordKey))
   }
 
   @Test
   def testGetRecordKeyStillRejectsAMissingRecordKey(): Unit = {
     // Scope guard: the fix must not weaken record-key validation, only stop getPartitionPath from
     // triggering it. A record key that is genuinely required and absent is still an error.
-    assertThrows(classOf[HoodieKeyException], () => keyGenerator.getRecordKey(recordWithoutRecordKey))
+    assertThrows(classOf[HoodieKeyException], () => keyGenerator().getRecordKey(recordWithoutRecordKey))
   }
 
   @Test
   def testGetPartitionPathAndRecordKeyOnACompleteRecord(): Unit = {
     val record = recordWithoutRecordKey
     record.put("id", 1L)
-    assertEquals("2026-08-11", keyGenerator.getPartitionPath(record))
-    assertEquals("1", keyGenerator.getRecordKey(record))
+    assertEquals("2026-08-11", keyGenerator().getPartitionPath(record))
+    assertEquals("1", keyGenerator().getRecordKey(record))
+  }
+
+  @Test
+  def testGetPartitionPathResolvesThroughTheSqlPartitionSchema(): Unit = {
+    val record = recordWithoutRecordKey
+    record.put("id", 1L)
+    assertEquals("2026-08-11", keyGenerator(Some("dt string")).getPartitionPath(record))
+  }
+
+  /**
+   * An unresolvable partition field yields the default partition rather than an error. That is
+   * KeyGenUtils#getPartitionPath substituting HUDI_DEFAULT_PARTITION_PATH for a null or absent
+   * value, and it predates this change: getKey called the very same getPartitionPath, so the
+   * substitution already happened whenever the record key resolved. Pinned here so the behaviour is
+   * explicit, because the fix does widen when it is observable, see the sibling test below.
+   */
+  @Test
+  def testPartitionFieldMissingFromTheSchemaYieldsTheDefaultPartition(): Unit = {
+    val partialSchema = new Schema.Parser().parse(
+      s"""
+         |{
+         |  "type": "record",
+         |  "name": "test_record",
+         |  "fields": [
+         |    {"name": "id", "type": ["null", "long"], "default": null},
+         |    {"name": "amount", "type": ["null", "double"], "default": null}
+         |  ]
+         |}
+       """.stripMargin)
+    val record = new GenericData.Record(partialSchema)
+    record.put("id", 1L)
+    record.put("amount", 15.0d)
+    assertEquals(PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH, keyGenerator().getPartitionPath(record))
+  }
+
+  /**
+   * With BOTH the record key and the partition field unresolvable, the record-key exception no
+   * longer pre-empts the default-partition substitution. This is the one behaviour this change
+   * widens, and it is the shape a MOR partial update produces, so it is stated rather than left to
+   * be discovered: resolving a partition path is not a validity check on the record.
+   */
+  @Test
+  def testPartitionAndRecordKeyBothMissingYieldTheDefaultPartition(): Unit = {
+    val partialSchema = new Schema.Parser().parse(
+      s"""
+         |{
+         |  "type": "record",
+         |  "name": "test_record",
+         |  "fields": [
+         |    {"name": "amount", "type": ["null", "double"], "default": null}
+         |  ]
+         |}
+       """.stripMargin)
+    val record = new GenericData.Record(partialSchema)
+    record.put("amount", 15.0d)
+    assertEquals(PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH, keyGenerator().getPartitionPath(record))
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestSqlKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/command/TestSqlKeyGenerator.scala
@@ -84,7 +84,7 @@ class TestSqlKeyGenerator {
     // without them the auto-record-key delegate fails on the missing property rather than on the
     // behaviour under test.
     props.put(KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG, "100")
-    props.put(KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG, 1)
+    props.put(KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG, "1")
     partitionSchema.foreach(ps => props.put(SqlKeyGenerator.PARTITION_SCHEMA, ps))
     new SqlKeyGenerator(props)
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Addresses #19708

**Do not merge this on its own — land it with or after #19713.** On its own this change can turn a
loud failure into a silent wrong row: see the Risk Level section. Deliberately not `Closes`, because
the issue's repro still fails until #19713 lands.

### Summary and Changelog

Two key generators read from a record that a MOR partial update leaves shorter than they expect.

**`SqlKeyGenerator#getPartitionPath(GenericRecord)`** resolved the partition path through
`BaseKeyGenerator#getKey`, which is `new HoodieKey(getRecordKey(record), getPartitionPath(record))`,
so asking for a partition path also validated the record key. That broke `MERGE INTO` with a partial
`UPDATE SET` on MOR with a global bloom or simple index and `update.partition.path` disabled, where
`HoodieIndexUtils#inferPartitionPath` asks for the partition path of a merged record materialised
against `WRITE_PARTIAL_UPDATE_SCHEMA` (only the assigned columns), leaving the record key
legitimately unset. It now resolves the partition path directly when the delegate is a
`BaseKeyGenerator`, keeping the previous `getKey` path otherwise, since `SparkKeyGeneratorInterface`
exposes no Avro accessor beyond `getKey`. `getPartitionPathFields` in this class already uses that
construct.

**`MergeIntoKeyGenerator`** resolves both the record key and the partition path by meta-field
ordinal (2 and 3), falling back to `SqlKeyGenerator` when the meta field is unpopulated. The same
partial-update record can be shorter than the ordinal, so the read raised
`ArrayIndexOutOfBoundsException` from inside the key generator, naming nothing about the statement
that caused it. Both Avro arms now bounds-check the schema length first and fall through to the
existing fallback. This is a bounds check, not a proof that the field at the ordinal is a meta
field: a long record whose schema is not meta-prefixed still reads data there, as before.

`getRecordKey(GenericRecord)` is deliberately unchanged. A symmetric version of the first change was
proposed in review and reverted: it is a second behaviour change unrelated to this issue, so it goes
to a follow-up together with the case that discriminates it.

Note on reproducing it: `update.partition.path` defaults to `true` for both global bloom and global
simple, and disabling it is also what allows MOR partial updates in the first place, since
`isPartialUpdateActionForMOR` requires `!useGlobalIndex`. With the defaults left alone the statement
does not reach this path. The record-index spellings default that flag to `false` but pass
`mayContainDuplicateLookup = false`, so they never enter the merge stage either.

Tests: `TestSqlKeyGenerator` (11 cases) and a new `TestMergeIntoKeyGenerator` (4 cases).

### Impact

Fixes partial-update `MERGE INTO` on the affected configuration, and replaces an
`ArrayIndexOutOfBoundsException` out of `MergeIntoKeyGenerator` with the existing fallback.
`getRecordKey` and `getKey` are untouched, so record-key validation is unchanged and no call that
already succeeded behaves differently.

Three narrow notes, all covered by tests. When the partition field is *also* unresolvable from the
record, the default-partition substitution in `KeyGenUtils#getPartitionPath` is no longer pre-empted
by the record-key exception. That substitution predates this change, since `getKey` called the same
`getPartitionPath`: the test for a missing partition field with the record key present passes on the
parent commit, and only the both-missing case is newly observable. Resolving a partition path is not
a validity check on the record, so a caller needing the partition to be genuinely present has to
assert that itself.

Under auto-generated record keys, `getPartitionPath` no longer increments
`AutoRecordGenWrapperKeyGenerator`'s row counter as a side effect of building a `HoodieKey`, so
generated keys advance by one per row rather than two. Still unique and monotonic, since uniqueness
needs only `(instantTime, partitionId)`.

A `TimestampBasedKeyGenerator` delegate resolves an absent partition field to the formatted epoch
rather than `HUDI_DEFAULT_PARTITION_PATH`, so the HUDI-8315 guard in `convertPartitionPathToSqlType`
never fires for it. Under a `timestamp` partition schema the epoch string then reaches
`_partitionValue.toLong` and throws a bare `NumberFormatException`; under a `string` schema the row
silently takes the epoch partition. Both were previously pre-empted by the record-key exception, and
all three spellings are now pinned. The tests state today's behaviour there, not desired behaviour.

### Risk Level

low

Two methods in one class plus two in another, all strictly more permissive.

Verified on this branch: 15 cases pass here, and **5 of the 15 fail on the parent commit** with the
symptom each is meant to catch:

    testGetPartitionPathDoesNotRequireRecordKey             HoodieKeyException, id null
    testPartitionAndRecordKeyBothMissingYieldTheDefault...  HoodieKeyException, id null
    testAutoRecordKeyDelegateDoesNotConsumeSequenceIds...   expected <100_1_0> but was <100_1_2>
    testGetRecordKeyFallsBackOnARecordShorterThan...        expected HoodieKeyException, got AIOOBE
    testGetPartitionPathFallsBackOnARecordShorterThan...    AIOOBE, index 3 against length 2

The other 10 pass on the parent commit. They pin behaviour (the timestamp arms, the non-partitioned
path, the meta-prefixed regression cases) rather than guarding a regression, so they are coverage,
not proof of the fix. `TestPartialUpdateForMergeInto`, `TestMergeIntoTable` and `TestMergeIntoTable2`
pass (62 tests); checkstyle and scalastyle clean.

Fixing this exposes a second problem on the same path, tracked as #19712 and fixed by #19713: the
partial-update merged record is wrapped against the full write schema, so `prependMetaFields` infers
the meta-field count by subtraction and the assigned values land at the wrong indices.

**Correcting an earlier version of this section**, which claimed the intermediate state is always
loud. It is not. Whether the shift is caught depends on whether the shifted column types disagree:

    Table (id bigint, name string, amount double, ts bigint, dt string), UPDATE SET amount, ts
      -> double reaches a ["null","long"] slot -> UnresolvedUnionException, loud

    Table (id bigint, name string, city string, ts bigint, dt string), UPDATE SET name
      -> prependMetaFields infers metaFieldSize 9 (correct: 5)
      -> avroToBytes succeeds, no exception
      -> name written as null, the assigned value shifted into dt
      -> _hoodie_partition_path = __HIVE_DEFAULT_PARTITION__

The second shape writes a wrong row silently. On master both are pre-empted by the
`HoodieKeyException` this change removes, so merging this alone would widen a crash into possible
data corruption for schemas whose shifted types happen to agree. Hence the merge-order note at the
top. Credit to @voonhous for constructing that case; my own repro used the type-mismatching shape and
I generalised from it.

**Also correcting the test claims in an earlier version of this section**, which read "of the six new
tests, two fail on the parent commit". Review found that the fixture left
`hoodie.sql.partition.schema` unset while production sets it at every construction site, so
`convertPartitionPathToSqlType` returned its input before the default-partition guard and most of
those cases never reached the code they were named for; and one case was red on the parent commit
only because the fixture omitted a property `HoodieCreateRecordUtils` always sets, so it failed on
the harness rather than on the behaviour it claimed to pin. Both are fixed, and the red run is now
checked per case against the expected symptom rather than by suite-level pass count.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
