### PR TITLE
fix(hive-sync): pass the default partition through the slash-encoded value extractors

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/PartitionPathEncodeUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/PartitionPathEncodeUtils.java
@@ -29,6 +29,19 @@ public class PartitionPathEncodeUtils {
   public static final String DEPRECATED_DEFAULT_PARTITION_PATH = "default";
   public static final String DEFAULT_PARTITION_PATH = "__HIVE_DEFAULT_PARTITION__";
 
+  /**
+   * Returns whether {@code partitionValue} is the marker Hudi writes for a null or empty partition
+   * value. Both the current marker and the pre-0.12 {@code default} one are recognised, matching
+   * {@code PartitionPathParser#parseValue}. The value may be a whole partition directory, in which
+   * case a Hive-style column prefix (e.g. {@code datestr=__HIVE_DEFAULT_PARTITION__}) is stripped
+   * before comparing.
+   */
+  public static boolean isDefaultPartitionValue(String partitionValue) {
+    int separator = partitionValue.indexOf('=');
+    String value = separator < 0 ? partitionValue : partitionValue.substring(separator + 1);
+    return DEFAULT_PARTITION_PATH.equals(value) || DEPRECATED_DEFAULT_PARTITION_PATH.equals(value);
+  }
+
   static BitSet charToEscape = new BitSet(128);
   static BitSet charToEscapeFilename = new BitSet(128);
   static {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/SlashEncodedDayPartitionValueExtractor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/SlashEncodedDayPartitionValueExtractor.java
@@ -28,6 +28,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.hudi.common.util.PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH;
+import static org.apache.hudi.common.util.PartitionPathEncodeUtils.isDefaultPartitionValue;
+
 /**
  * HDFS Path contain hive partition values for the keys it is partitioned on. This mapping is not straight forward and
  * requires a pluggable implementation to extract the partition value from HDFS path.
@@ -52,6 +55,13 @@ public class SlashEncodedDayPartitionValueExtractor implements PartitionValueExt
 
   @Override
   public List<String> extractPartitionValuesInPath(String partitionPath) {
+    // NOTE: A null or empty partition value lands in the default-partition directory, which is a
+    //       single segment rather than the yyyy/mm/dd layout it would otherwise be. Hive uses this
+    //       same marker for a null partition value, so it is passed straight through. The
+    //       pre-0.12 "default" marker is recognised too, matching PartitionPathParser#parseValue
+    if (isDefaultPartitionValue(partitionPath)) {
+      return Collections.singletonList(DEFAULT_PARTITION_PATH);
+    }
     // partition path is expected to be in this format yyyy/mm/dd
     String[] splits = partitionPath.split("/");
     if (splits.length != 3) {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/SlashEncodedHourPartitionValueExtractor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/SlashEncodedHourPartitionValueExtractor.java
@@ -28,6 +28,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.hudi.common.util.PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH;
+import static org.apache.hudi.common.util.PartitionPathEncodeUtils.isDefaultPartitionValue;
+
 /**
  * HDFS Path contain hive partition values for the keys it is partitioned on. This mapping is not straight forward and
  * requires a pluggable implementation to extract the partition value from HDFS path.
@@ -52,6 +55,13 @@ public class SlashEncodedHourPartitionValueExtractor implements PartitionValueEx
 
   @Override
   public List<String> extractPartitionValuesInPath(String partitionPath) {
+    // NOTE: A null or empty partition value lands in the default-partition directory, which is a
+    //       single segment rather than the yyyy/mm/dd/HH layout it would otherwise be. Hive uses this
+    //       same marker for a null partition value, so it is passed straight through. The
+    //       pre-0.12 "default" marker is recognised too, matching PartitionPathParser#parseValue
+    if (isDefaultPartitionValue(partitionPath)) {
+      return Collections.singletonList(DEFAULT_PARTITION_PATH);
+    }
     // partition path is expected to be in this format yyyy/mm/dd/HH
     String[] splits = partitionPath.split("/");
     if (splits.length != 4) {

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestPartitionValueExtractor.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestPartitionValueExtractor.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.hudi.common.util.PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH;
+import static org.apache.hudi.common.util.PartitionPathEncodeUtils.DEPRECATED_DEFAULT_PARTITION_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -38,6 +40,48 @@ public class TestPartitionValueExtractor {
     assertEquals(hourPartition.extractPartitionValuesInPath("2020/12/20/01"), list);
     assertThrows(IllegalArgumentException.class, () -> hourPartition.extractPartitionValuesInPath("2020/12/20"));
     assertEquals(hourPartition.extractPartitionValuesInPath("update_time=2020/12/20/01"), list);
+    // a null partition value is written to the single-segment default-partition directory rather
+    // than the yyyy/mm/dd/HH layout, and has to survive the extractor rather than blow it up
+    assertEquals(
+        Collections.singletonList(DEFAULT_PARTITION_PATH),
+        hourPartition.extractPartitionValuesInPath(DEFAULT_PARTITION_PATH));
+    assertEquals(
+        Collections.singletonList(DEFAULT_PARTITION_PATH),
+        hourPartition.extractPartitionValuesInPath("update_time=" + DEFAULT_PARTITION_PATH));
+    // the pre-0.12 marker lands in a "default" directory and maps to the same Hive null marker
+    assertEquals(
+        Collections.singletonList(DEFAULT_PARTITION_PATH),
+        hourPartition.extractPartitionValuesInPath(DEPRECATED_DEFAULT_PARTITION_PATH));
+    assertEquals(
+        Collections.singletonList(DEFAULT_PARTITION_PATH),
+        hourPartition.extractPartitionValuesInPath("update_time=" + DEPRECATED_DEFAULT_PARTITION_PATH));
+  }
+
+  @Test
+  public void testDayPartition() {
+    SlashEncodedDayPartitionValueExtractor dayPartition = new SlashEncodedDayPartitionValueExtractor();
+    assertEquals(
+        Collections.singletonList("2026-01-05"),
+        dayPartition.extractPartitionValuesInPath("2026/01/05"));
+    assertEquals(
+        Collections.singletonList("2026-01-05"),
+        dayPartition.extractPartitionValuesInPath("datestr=2026/01/05"));
+    assertThrows(IllegalArgumentException.class, () -> dayPartition.extractPartitionValuesInPath("2026/01"));
+    // a null partition value is written to the single-segment default-partition directory rather
+    // than the yyyy/mm/dd layout, and has to survive the extractor rather than blow it up
+    assertEquals(
+        Collections.singletonList(DEFAULT_PARTITION_PATH),
+        dayPartition.extractPartitionValuesInPath(DEFAULT_PARTITION_PATH));
+    assertEquals(
+        Collections.singletonList(DEFAULT_PARTITION_PATH),
+        dayPartition.extractPartitionValuesInPath("datestr=" + DEFAULT_PARTITION_PATH));
+    // the pre-0.12 marker lands in a "default" directory and maps to the same Hive null marker
+    assertEquals(
+        Collections.singletonList(DEFAULT_PARTITION_PATH),
+        dayPartition.extractPartitionValuesInPath(DEPRECATED_DEFAULT_PARTITION_PATH));
+    assertEquals(
+        Collections.singletonList(DEFAULT_PARTITION_PATH),
+        dayPartition.extractPartitionValuesInPath("datestr=" + DEPRECATED_DEFAULT_PARTITION_PATH));
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19668.

`HoodieTableConfigUtils#inferPartitionValueExtractorClass` picks
`SlashEncodedDayPartitionValueExtractor` for a table written with
`hoodie.datasource.write.slash.separated.date.partitioning=true`. That extractor requires the
partition path to be exactly three segments and throws otherwise:

```java
String[] splits = partitionPath.split("/");
if (splits.length != 3) {
  throw new IllegalArgumentException("Partition path " + partitionPath + " is not in the form yyyy/mm/dd ");
}
```

A null or empty partition value is written to the single-segment `__HIVE_DEFAULT_PARTITION__`
directory, not to a `yyyy/MM/dd` one, so hive sync of a slash table that has ever seen a null
partition value fails with:

```
java.lang.IllegalArgumentException: Partition path __HIVE_DEFAULT_PARTITION__ is not in the form yyyy/mm/dd
```

A null partition value is ordinary — it is what every write path produces for a null or empty
date column, and #19648 adds coverage for exactly that directory.

### Summary and Changelog

Both slash-encoded extractors now recognise the default-partition directory and pass it through
instead of trying to parse it as a date. `__HIVE_DEFAULT_PARTITION__` is Hive's own representation
of a null partition value, so handing it back unchanged is what lets Hive map the partition to
NULL.

* `SlashEncodedDayPartitionValueExtractor#extractPartitionValuesInPath` returns
  `Collections.singletonList(DEFAULT_PARTITION_PATH)` for the default-partition directory, before
  the three-segment check.
* `SlashEncodedHourPartitionValueExtractor` gets the same treatment. It is not auto-inferred, but
  it carries the identical defect against its own four-segment check, is user-configurable, and is
  equally exposed to a null partition value — fixing one and leaving the other seemed worse than
  fixing both.
* The check tolerates a Hive-style prefix (`datestr=__HIVE_DEFAULT_PARTITION__`), matching the way
  the existing parsing already strips a `key=` prefix from each segment.

Tests in `TestPartitionValueExtractor`: the default-partition directory, bare and Hive-style
prefixed, for both extractors. `testDayPartition` is new — the day extractor had no test at all
despite being the auto-inferred one — and also pins the ordinary `yyyy/MM/dd` and
`datestr=yyyy/MM/dd` cases plus the existing rejection of a malformed path.

Both new cases fail on the unfixed code with the `IllegalArgumentException` quoted above.

### Impact

Hive sync of a slash-partitioned table containing a null partition value succeeds instead of
failing outright. No change for any other partition path: the new branch matches only the
default-partition marker, and everything else takes the pre-existing parsing.

The deprecated `default` marker is deliberately not handled here; the current write paths produce
`__HIVE_DEFAULT_PARTITION__`, and mapping legacy directories would be a separate behavior decision.

### Risk Level

low

One early-return in each of two extractors, matching a single constant, with the pre-existing
parsing untouched. Verified with `TestPartitionValueExtractor` (4 tests, all passing) and by
re-running the new cases against the unfixed code to confirm they fail there.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
