### PR TITLE
fix(flink): keep the declared joda-time in hudi-flink-bundle with flink-bundle-shade-hive2

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -742,6 +742,12 @@
                         <exclude>org/apache/parquet/**</exclude>
                         <exclude>com/google/protobuf/**</exclude>
                         <exclude>io/airlift/compress/**</exclude>
+                        <!-- hive-exec embeds joda-time 2.8.1 together with its (older) tz
+                             database index, so shade would otherwise drop the declared
+                             ${joda.version} classes. TimestampBasedAvroKeyGenerator resolves
+                             zone ids through that index. -->
+                        <exclude>org/joda/time/**</exclude>
+                        <exclude>META-INF/maven/joda-time/**</exclude>
                       </excludes>
                     </filter>
                   </filters>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

hive-exec 2.3.x is a fat jar that embeds joda-time 2.8.1 un-relocated, including its tz database index. Since hive-exec is shaded ahead of joda-time, its copy wins and the bundle ships 2.8.1 rather than the declared ${joda.version} (2.9.9), leaving ZoneInfoMap unable to resolve zone ids added after 2015, e.g. Asia/Barnaul, Asia/Famagusta, America/Fort_Nelson, which TimestampBasedAvroKeyGenerator relies on for partition path derivation. Exclude joda-time from hive-exec, as already done for avro, orc, parquet and protobuf.

The hive3 profile is unaffected: hive-exec 3.1.2 embeds joda-time 2.9.9.

### Summary and Changelog

Exclude joda-time being taken in from hive-exec dependencies

### Impact

Resolve conflict versions of joda-time in hive2 profile

### Risk Level

Low

### Documentation Update

N/A

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
