### PR TITLE
fix(spark-sql): lay meta fields over the partial-update schema in the global-index merge

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.index;
 
+import org.apache.hudi.common.avro.HoodieAvroUtils;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.data.HoodieData;
@@ -377,6 +378,9 @@ public class HoodieIndexUtils {
       HoodieRecord<R> existing,
       HoodieSchema writeSchema,
       HoodieSchema writeSchemaWithMetaFields,
+      HoodieSchema mergedSchema,
+      HoodieSchema mergedSchemaWithMetaFields,
+      boolean partitionResolvableFromRecord,
       HoodieWriteConfig config,
       BufferedRecordMerger<R> recordMerger,
       BaseKeyGenerator keyGenerator,
@@ -398,25 +402,60 @@ public class HoodieIndexUtils {
     }
 
     //record is inserted or updated
-    String partitionPath = inferPartitionPath(incoming, existing, writeSchemaWithMetaFields, keyGenerator, existingRecordContext, mergeResult);
+    String partitionPath = inferPartitionPath(incoming, existing, mergedSchemaWithMetaFields, keyGenerator,
+        existingRecordContext, mergeResult, partitionResolvableFromRecord);
     HoodieRecord<R> result = existingRecordContext.constructHoodieRecord(mergeResult, partitionPath);
-    HoodieRecord<R> withMeta = result.prependMetaFields(writeSchema, writeSchemaWithMetaFields,
+    HoodieRecord<R> withMeta = result.prependMetaFields(mergedSchema, mergedSchemaWithMetaFields,
         new MetadataValues().setRecordKey(incoming.getRecordKey()).setPartitionPath(partitionPath), properties);
-    return Option.of(withMeta.wrapIntoHoodieRecordPayloadWithParams(writeSchemaWithMetaFields, properties, Option.empty(),
-        config.allowOperationMetadataField(), Option.empty(), false, Option.of(writeSchema)));
+    return Option.of(withMeta.wrapIntoHoodieRecordPayloadWithParams(mergedSchemaWithMetaFields, properties, Option.empty(),
+        config.allowOperationMetadataField(), Option.empty(), false, Option.of(mergedSchema)));
   }
 
   private static <R> String inferPartitionPath(HoodieRecord<R> incoming, HoodieRecord<R> existing, HoodieSchema recordSchema, BaseKeyGenerator keyGenerator,
-                                               RecordContext<R> recordContext, BufferedRecord<R> resultingBufferedRecord) {
+                                               RecordContext<R> recordContext, BufferedRecord<R> resultingBufferedRecord,
+                                               boolean partitionResolvableFromRecord) {
     R record = resultingBufferedRecord.getRecord();
     if (record == incoming.getData()) {
       return incoming.getPartitionPath();
     } else if (record == existing.getData()) {
       return existing.getPartitionPath();
+    } else if (!partitionResolvableFromRecord) {
+      // A partial update carries only the fields named in the assignments, so the partition fields are
+      // absent. The merge cannot have changed a field the record does not carry, so the partition is the
+      // existing record's. Deriving it from the record instead resolves to the default partition,
+      // because KeyGenUtils#getPartitionPath substitutes it for a value it cannot find.
+      return existing.getPartitionPath();
     } else {
       // the merged record is not the same as either incoming or existing, so we need to compute the partition path
       return keyGenerator.getPartitionPath(recordContext.convertToAvroRecord(record, recordSchema));
     }
+  }
+
+  /**
+   * Whether the merged record can yield a partition path on its own. False only for a partial update whose
+   * schema omits a partition field; a full merge result always can, so those paths keep resolving through
+   * the key generator. Evaluated once per stage, not per record.
+   */
+  private static boolean isPartitionResolvableFromRecord(HoodieSchema recordSchema, BaseKeyGenerator keyGenerator) {
+    List<String> partitionPathFields = keyGenerator.getPartitionPathFields();
+    if (partitionPathFields == null || partitionPathFields.isEmpty()) {
+      // A non-partitioned table has nothing to resolve, so let the key generator answer as before.
+      return true;
+    }
+    return partitionPathFields.stream()
+        .map(HoodieIndexUtils::partitionFieldRootName)
+        .allMatch(rootField -> rootField.isEmpty() || recordSchema.getField(rootField).isPresent());
+  }
+
+  /**
+   * The schema field name a partition-path config entry refers to. The custom key generators keep the
+   * mandatory "field:TYPE" spec verbatim in getPartitionPathFields, so the type suffix is stripped before
+   * the nested path is reduced to its root.
+   */
+  private static String partitionFieldRootName(String partitionPathField) {
+    int typeSeparator = partitionPathField.indexOf(BaseKeyGenerator.CUSTOM_KEY_GENERATOR_SPLIT_REGEX);
+    String fieldName = typeSeparator < 0 ? partitionPathField : partitionPathField.substring(0, typeSeparator);
+    return HoodieAvroUtils.getRootLevelFieldName(fieldName);
   }
 
   /**
@@ -427,6 +466,9 @@ public class HoodieIndexUtils {
       HoodieRecord<R> existing,
       HoodieSchema writeSchema,
       HoodieSchema writeSchemaWithMetaFields,
+      HoodieSchema mergedSchema,
+      HoodieSchema mergedSchemaWithMetaFields,
+      boolean partitionResolvableFromRecord,
       HoodieWriteConfig config,
       BufferedRecordMerger<R> recordMerger,
       BaseKeyGenerator keyGenerator,
@@ -438,7 +480,9 @@ public class HoodieIndexUtils {
       DeleteContext deleteContext) throws IOException {
     if (isExpressionPayload) {
       return mergeIncomingWithExistingRecordWithExpressionPayload(incoming, existing, writeSchema,
-          writeSchemaWithMetaFields, config, recordMerger, keyGenerator, incomingRecordContext, existingRecordContext, orderingFieldNames, properties, deleteContext);
+          writeSchemaWithMetaFields, mergedSchema, mergedSchemaWithMetaFields, partitionResolvableFromRecord,
+          config, recordMerger, keyGenerator,
+          incomingRecordContext, existingRecordContext, orderingFieldNames, properties, deleteContext);
     } else {
       // prepend the hoodie meta fields as the incoming record does not have them
       BufferedRecord<R> incomingBufferedRecord = BufferedRecords.fromHoodieRecord(incoming, writeSchema, incomingRecordContext, properties, orderingFieldNames, deleteContext);
@@ -450,7 +494,8 @@ public class HoodieIndexUtils {
         // the record was deleted
         return Option.empty();
       }
-      String partitionPath = inferPartitionPath(incoming, existing, writeSchemaWithMetaFields, keyGenerator, existingRecordContext, mergeResult);
+      String partitionPath = inferPartitionPath(incoming, existing, writeSchemaWithMetaFields, keyGenerator,
+          existingRecordContext, mergeResult, true);
       if (config.isFileGroupReaderBasedMergeHandle() && HoodieRecordUtils.isPayloadClassDeprecated(ConfigUtils.getPayloadClass(properties))) {
         return Option.of(existingRecordContext.constructHoodieRecord(mergeResult, partitionPath));
       } else {
@@ -503,6 +548,21 @@ public class HoodieIndexUtils {
     HoodieSchema writerSchemaWithMetaFields = HoodieSchemaUtils.addMetadataFields(writerSchema, updatedConfig.allowOperationMetadataField());
     HoodieSchemaCache.intern(writerSchema);
     HoodieSchemaCache.intern(writerSchemaWithMetaFields);
+    // Under partial updates the merge produces a record carrying only the assigned columns, and the log
+    // block is written with that schema: HoodieAppendHandle and BaseWriteHelper both take it from this
+    // same config. Meta fields therefore have to be prepended onto the partial schema, not the full
+    // write schema, or they occupy the wrong positions. Resolves to the write schema otherwise.
+    HoodieSchema mergedRecordSchema = updatedConfig.shouldWritePartialUpdates()
+        ? HoodieSchemaCache.intern(HoodieSchema.parse(updatedConfig.getPartialUpdateSchema()))
+        : writerSchema;
+    HoodieSchema mergedRecordSchemaWithMetaFields = updatedConfig.shouldWritePartialUpdates()
+        ? HoodieSchemaCache.intern(
+            HoodieSchemaUtils.addMetadataFields(mergedRecordSchema, updatedConfig.allowOperationMetadataField()))
+        : writerSchemaWithMetaFields;
+    // Only a partial update can omit a partition field, so the full-schema paths keep resolving the
+    // partition through the key generator exactly as before. Hoisted out of the per-record loop.
+    boolean partitionResolvableFromRecord = !updatedConfig.shouldWritePartialUpdates()
+        || isPartitionResolvableFromRecord(mergedRecordSchemaWithMetaFields, keyGenerator);
     // Read the existing records with the meta fields and current writer schema as the output schema
     HoodieData<HoodieRecord<R>> existingRecords =
         getExistingRecords(globalLocations, keyGeneratorWriteConfigOpt.getLeft(), hoodieTable, readerContextFactoryForExistingRecords, writerSchemaWithMetaFields);
@@ -531,7 +591,8 @@ public class HoodieIndexUtils {
           HoodieRecord<R> existing = existingOpt.get();
 
           Option<HoodieRecord<R>> mergedOpt = mergeIncomingWithExistingRecord(
-              incoming, existing, writerSchema, writerSchemaWithMetaFields, updatedConfig,
+              incoming, existing, writerSchema, writerSchemaWithMetaFields,
+              mergedRecordSchema, mergedRecordSchemaWithMetaFields, partitionResolvableFromRecord, updatedConfig,
               recordMerger, keyGenerator, incomingRecordContext, existingRecordContext, orderingFieldsArray, properties, isExpressionPayload, deleteContext);
           if (!mergedOpt.isPresent()) {
             // merge resulted in delete: force tag the incoming to the old partition

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -495,7 +495,7 @@ public class HoodieIndexUtils {
         return Option.empty();
       }
       String partitionPath = inferPartitionPath(incoming, existing, writeSchemaWithMetaFields, keyGenerator,
-          existingRecordContext, mergeResult, true);
+          existingRecordContext, mergeResult, /* partitionResolvableFromRecord */ true);
       if (config.isFileGroupReaderBasedMergeHandle() && HoodieRecordUtils.isPayloadClassDeprecated(ConfigUtils.getPayloadClass(properties))) {
         return Option.of(existingRecordContext.constructHoodieRecord(mergeResult, partitionPath));
       } else {
@@ -552,17 +552,17 @@ public class HoodieIndexUtils {
     // block is written with that schema: HoodieAppendHandle and BaseWriteHelper both take it from this
     // same config. Meta fields therefore have to be prepended onto the partial schema, not the full
     // write schema, or they occupy the wrong positions. Resolves to the write schema otherwise.
-    HoodieSchema mergedRecordSchema = updatedConfig.shouldWritePartialUpdates()
+    HoodieSchema mergedSchema = updatedConfig.shouldWritePartialUpdates()
         ? HoodieSchemaCache.intern(HoodieSchema.parse(updatedConfig.getPartialUpdateSchema()))
         : writerSchema;
-    HoodieSchema mergedRecordSchemaWithMetaFields = updatedConfig.shouldWritePartialUpdates()
+    HoodieSchema mergedSchemaWithMetaFields = updatedConfig.shouldWritePartialUpdates()
         ? HoodieSchemaCache.intern(
-            HoodieSchemaUtils.addMetadataFields(mergedRecordSchema, updatedConfig.allowOperationMetadataField()))
+            HoodieSchemaUtils.addMetadataFields(mergedSchema, updatedConfig.allowOperationMetadataField()))
         : writerSchemaWithMetaFields;
     // Only a partial update can omit a partition field, so the full-schema paths keep resolving the
     // partition through the key generator exactly as before. Hoisted out of the per-record loop.
     boolean partitionResolvableFromRecord = !updatedConfig.shouldWritePartialUpdates()
-        || isPartitionResolvableFromRecord(mergedRecordSchemaWithMetaFields, keyGenerator);
+        || isPartitionResolvableFromRecord(mergedSchemaWithMetaFields, keyGenerator);
     // Read the existing records with the meta fields and current writer schema as the output schema
     HoodieData<HoodieRecord<R>> existingRecords =
         getExistingRecords(globalLocations, keyGeneratorWriteConfigOpt.getLeft(), hoodieTable, readerContextFactoryForExistingRecords, writerSchemaWithMetaFields);
@@ -592,7 +592,7 @@ public class HoodieIndexUtils {
 
           Option<HoodieRecord<R>> mergedOpt = mergeIncomingWithExistingRecord(
               incoming, existing, writerSchema, writerSchemaWithMetaFields,
-              mergedRecordSchema, mergedRecordSchemaWithMetaFields, partitionResolvableFromRecord, updatedConfig,
+              mergedSchema, mergedSchemaWithMetaFields, partitionResolvableFromRecord, updatedConfig,
               recordMerger, keyGenerator, incomingRecordContext, existingRecordContext, orderingFieldsArray, properties, isExpressionPayload, deleteContext);
           if (!mergedOpt.isPresent()) {
             // merge resulted in delete: force tag the incoming to the old partition

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestPartialUpdateForMergeInto.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestPartialUpdateForMergeInto.scala
@@ -732,12 +732,144 @@ class TestPartialUpdateForMergeInto extends HoodieSparkSqlTestBase {
     }
   }
 
+  // A partial update names only the columns being changed, so the record key is normally absent
+  // from the assignments. On MOR the global-index tagging stage merges the incoming record with its
+  // existing version and then asks the key generator for the merged record's partition path - and
+  // that merged record is materialised against WRITE_PARTIAL_UPDATE_SCHEMA, which carries only the
+  // assigned columns. Resolving the partition path must therefore not also require the record key.
+  //
+  // The index types split on whether that tagging stage runs at all: GLOBAL_BLOOM and GLOBAL_SIMPLE
+  // set mayContainDuplicateLookup on MOR and so reach it, while the record-index spellings pass
+  // false and short-circuit. Both cells are covered, so the fix is pinned where it applies and the
+  // already-working path is guarded against regression. The source projects the partition column in
+  // every case, to keep this independent of partition-column resolution (ENG-46864).
+  Seq(
+    ("GLOBAL_BLOOM re-keying", Map(
+      "hoodie.index.type" -> "GLOBAL_BLOOM",
+      "hoodie.bloom.index.update.partition.path" -> "false")),
+    ("GLOBAL_SIMPLE re-keying", Map(
+      "hoodie.index.type" -> "GLOBAL_SIMPLE",
+      "hoodie.simple.index.update.partition.path" -> "false")),
+    ("RECORD_INDEX", Map(
+      "hoodie.index.type" -> "RECORD_INDEX",
+      "hoodie.record.index.update.partition.path" -> "false",
+      "hoodie.metadata.enable" -> "true",
+      "hoodie.metadata.record.index.enable" -> "true")),
+    ("GLOBAL_RECORD_LEVEL_INDEX", Map(
+      "hoodie.index.type" -> "GLOBAL_RECORD_LEVEL_INDEX",
+      "hoodie.record.index.update.partition.path" -> "false",
+      "hoodie.metadata.enable" -> "true",
+      "hoodie.metadata.record.index.enable" -> "true"))
+  ).foreach { case (label, indexConfs) =>
+    test(s"Test MOR partial update on a global index without assigning the record key ($label)") {
+      withTempDir { tmp =>
+        withSQLConf(indexConfs.toSeq: _*) {
+          val tableName = generateTableName
+          val basePath = s"${tmp.getCanonicalPath}/$tableName"
+          spark.sql(
+            s"""
+               | create table $tableName (
+               |   id bigint,
+               |   name string,
+               |   amount double,
+               |   ts bigint,
+               |   dt string
+               | ) using hudi
+               | partitioned by (dt)
+               | location '$basePath'
+               | tblproperties (
+               |   type = 'mor',
+               |   primaryKey = 'id',
+               |   preCombineField = 'ts')
+             """.stripMargin)
+          spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+          // `id` is deliberately absent from the assignments - that is what makes it partial.
+          spark.sql(
+            s"""
+               | merge into $tableName as t
+               | using (
+               |   select 1L as id, 15.0 as amount, 200L as ts, '2026-08-11' as dt
+               | ) as s
+               | on t.id = s.id
+               | when matched then update set t.amount = s.amount, t.ts = s.ts
+             """.stripMargin)
+
+          // The assigned columns change, the unassigned ones keep their existing values, and the
+          // record stays in its own partition - asserted rather than merely checking row count,
+          // since a dropped record leaves a table that also "looks unchanged".
+          checkAnswer(s"select id, name, amount, ts, dt, _hoodie_partition_path from $tableName")(
+            Seq(1L, "a", 15.0, 200L, "2026-08-11", "dt=2026-08-11")
+          )
+
+          // The rows alone cannot distinguish a correct partial log block from a full-schema one, and
+          // this fix is precisely about which schema the block's meta fields are laid out against. So
+          // assert the block: IS_PARTIAL set, and the schema equal to the meta fields prepended onto
+          // the assigned columns only. Without the fix the meta count is inferred as
+          // targetSchema.size - record.size and the values land in the wrong slots.
+          validateLogBlock(basePath, 1, Seq(Seq("amount", "ts")), isPartial = true, "dt=2026-08-11")
+        }
+      }
+    }
+  }
+
+
+  // update.partition.path enabled is deliberately NOT in the matrix above: for GLOBAL_BLOOM and
+  // GLOBAL_SIMPLE it makes useGlobalIndex true, which disables MOR partial updates altogether
+  // (isPartialUpdateActionForMOR requires !useGlobalIndex), and MOR then requires the record key to be
+  // assigned. So the statement is rejected at analysis time rather than reaching the writer. Pinned
+  // here so the boundary is explicit and nobody mistakes this rejection for the partial-update defect.
+  //
+  // NOTE the exemption is not universal: isGlobalIndexEnabled maps only GLOBAL_SIMPLE, GLOBAL_BLOOM
+  // and RECORD_INDEX, so GLOBAL_RECORD_LEVEL_INDEX returns false there regardless of its
+  // update.partition.path value, while SparkMetadataTableGlobalRecordLevelIndex still honours that
+  // config. That combination therefore reaches the writer WITH partial updates enabled. The
+  // partition-resolution guard in HoodieIndexUtils covers it, and the missing enum mapping is being
+  // added separately, so this test asserts the rejection only for the spellings that actually reject.
+  test("Test MOR merge without assigning the record key is rejected when the global index updates the partition path") {
+    withTempDir { tmp =>
+      withSQLConf(
+        "hoodie.index.type" -> "GLOBAL_BLOOM",
+        "hoodie.bloom.index.update.partition.path" -> "true") {
+        val tableName = generateTableName
+        spark.sql(
+          s"""
+             | create table $tableName (
+             |   id bigint,
+             |   name string,
+             |   amount double,
+             |   ts bigint,
+             |   dt string
+             | ) using hudi
+             | partitioned by (dt)
+             | location '${tmp.getCanonicalPath}/$tableName'
+             | tblproperties (
+             |   type = 'mor',
+             |   primaryKey = 'id',
+             |   preCombineField = 'ts')
+           """.stripMargin)
+        spark.sql(s"insert into $tableName values (1, 'a', 10.0, 1, '2026-08-11')")
+
+        checkExceptionContain(
+          s"""
+             | merge into $tableName as t
+             | using (
+             |   select 1L as id, 15.0 as amount, 200L as ts, '2026-08-11' as dt
+             | ) as s
+             | on t.id = s.id
+             | when matched then update set t.amount = s.amount, t.ts = s.ts
+           """.stripMargin)("No matching assignment found for target table record key field")
+      }
+    }
+  }
+
   def validateLogBlock(basePath: String,
                        expectedNumLogFile: Int,
                        changedFields: Seq[Seq[String]],
-                       isPartial: Boolean): Unit = {
+                       isPartial: Boolean,
+                       partitionPath: String = ""): Unit = {
     val (metaClient, fsView) = getMetaClientAndFileSystemView(basePath)
-    val fileSlice: Optional[FileSlice] = fsView.getAllFileSlices("")
+    val fileSlice: Optional[FileSlice] = fsView.getAllFileSlices(partitionPath)
       .filter((fileSlice: FileSlice) => {
         HoodieTestUtils.getLogFileListFromFileSlice(fileSlice).size() == expectedNumLogFile
       })


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19712

#19709 is merged, so this PR is rebased onto master and its diff is now only this change: two methods in `HoodieIndexUtils` and the test file.

### Summary and Changelog

Under MOR partial updates the merge in `HoodieIndexUtils` produces a record carrying only the columns
named in `UPDATE SET`. That is the intended contract: `HoodieAppendHandle` takes the partial schema as
its writer schema and `BaseWriteHelper` does the same for dedup. But the global-index merge wrapped
that record against the **full** write schema, and `HoodieAvroIndexedRecord#prependMetaFields` infers
the meta-field count as `targetSchema.size() - record.size()`. For a two-field record against a
ten-field target that is 8, so `JoinedGenericRecord` treated eight slots as meta and the data landed
at indices 8 and 9 rather than 7 and 8.

Wrap the merged record against its own schema instead, taken from the same config the append handle
and dedup path read, resolved once in the caller rather than per record, falling back to the write
schema when partial updates are off. That makes `prependMetaFields`' existing inference correct, so
`HoodieAvroIndexedRecord` and `JoinedGenericRecord` are untouched.

Second change, required with the first: `inferPartitionPath` was deriving a partition from that same
merged record, and `KeyGenUtils#getPartitionPath` substitutes the default partition for a field it
cannot find, so the payload already carried `dt=__HIVE_DEFAULT_PARTITION__`. Harmless only because the
write failed first; fixing the schema alone would turn a loud failure into a silently mis-partitioned
row. A merge cannot change a field the record does not carry, so the existing record's partition is
correct by construction. Gated on partial updates so full-schema paths keep resolving through the key
generator, and the partition-field check strips the mandatory `field:TYPE` spec that the custom key
generators keep verbatim in `getPartitionPathFields`.

Tests: five parameterized cases over `GLOBAL_BLOOM`, `GLOBAL_SIMPLE`, `RECORD_INDEX` and
`GLOBAL_RECORD_LEVEL_INDEX`, plus a boundary case pinning the analysis-time rejection when the index
updates the partition path. They assert row values, `_hoodie_partition_path`, and the log block via
the existing `validateLogBlock`, which checks `IS_PARTIAL` and that the block schema is the meta
fields over the assigned columns only. `validateLogBlock` gained a defaulted `partitionPath`
parameter so it can address a partitioned table.

### Impact

Fixes `MERGE INTO` with a partial `UPDATE SET` on MOR with a global bloom or simple index. No
behaviour change when partial updates are off, since both new schemas then resolve to the write schema
and the partition guard is gated off.

Two points a reviewer may want to push on, stated rather than left to be found:

The partial schema is read from `config.getPartialUpdateSchema()`. `RecordContext#getSchemaFromBufferRecord`
would give the merged record's schema directly and be correct by construction; it returned null when
tried, because each `RecordContext` holds its own schema cache and the merger is built from the
incoming context. The config route mirrors `HoodieAppendHandle` and `BaseWriteHelper`, but the other
shape may be preferable and is easy to swap if so.

Relatedly, `WRITE_PARTIAL_UPDATE_SCHEMA` is the union across update clauses while each clause projects
only its own assignments, so config-equals-record holds for the single-clause shape the tests cover.
A divergent multi-clause statement faults earlier today, inside the payload's serializer, so this
change does not introduce that gap, but it is not an invariant either.

### Risk Level

low

Two methods in one file, gated so that only the partial-update path changes. Re-verified after the
rebase onto master, so the baseline below is plain master with #19709 in it rather than a stacked
parent: the two global bloom and simple cases fail there with the exception from #19712 and pass
here; `TestPartialUpdateForMergeInto`, `TestMergeIntoTable` and `TestMergeIntoTable2` pass together
(67 tests, `Expected test count is: 67`); checkstyle clean.

An earlier revision of the partition guard was not gated and checked the partition fields by raw name.
Since the custom key generators return `field:TYPE` verbatim, that would have silently disabled
partition re-keying for every table using them, including full-schema merges unrelated to partial
updates. Both the gate and the suffix stripping exist to close that.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

