### PR TITLE
fix(hive-sync): call Driver.destroy() so HiveQL sync stops leaking Drivers into ShutdownHookManager

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -92,8 +92,12 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
         }
       }
       if (this.hiveDriver != null) {
-        this.hiveDriver.close();
-        this.hiveDriver.destroy();
+        try {
+          this.hiveDriver.close();
+        } catch (Exception driverCloseException) {
+          log.error("Error while closing Hive Driver", driverCloseException);
+        }
+        destroyQuietly(this.hiveDriver);
       }
       // driverPool (if present) was already constructed by the caller before this
       // ctor ran; since we're about to throw, no one else will call close() on it.
@@ -315,11 +319,27 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       Hive.closeCurrent();
     }
     if (hiveDriver != null) {
-      hiveDriver.close();
-      // A fresh HiveSyncTool, and therefore a fresh Driver, is built per sync. close() leaves
-      // behind the shutdown hook registered by Driver.compile(), so without destroy() every
-      // sync permanently adds a Driver to ShutdownHookManager.
-      hiveDriver.destroy();
+      try {
+        hiveDriver.close();
+      } finally {
+        destroyQuietly(hiveDriver);
+      }
+    }
+  }
+
+  /**
+   * Removes the shutdown hook that {@link Driver#compile} registered. A fresh HiveSyncTool, and
+   * therefore a fresh Driver, is built per sync, and close() leaves that hook in place, so without
+   * this every sync permanently adds a Driver to the static {@code ShutdownHookManager}. Runs even
+   * when close() failed, and reports rather than rethrows its own failure: destroy() ends up in
+   * {@code ShutdownHookManager.removeShutdownHook}, which refuses to run once JVM shutdown has
+   * begun, and by then the hook set no longer matters.
+   */
+  private static void destroyQuietly(Driver driver) {
+    try {
+      driver.destroy();
+    } catch (Exception e) {
+      log.warn("Error while destroying Hive Driver", e);
     }
   }
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -93,6 +93,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       }
       if (this.hiveDriver != null) {
         this.hiveDriver.close();
+        this.hiveDriver.destroy();
       }
       // driverPool (if present) was already constructed by the caller before this
       // ctor ran; since we're about to throw, no one else will call close() on it.
@@ -315,6 +316,10 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     }
     if (hiveDriver != null) {
       hiveDriver.close();
+      // A fresh HiveSyncTool, and therefore a fresh Driver, is built per sync. close() leaves
+      // behind the shutdown hook registered by Driver.compile(), so without destroy() every
+      // sync permanently adds a Driver to ShutdownHookManager.
+      hiveDriver.destroy();
     }
   }
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/util/HiveDriverPool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/util/HiveDriverPool.java
@@ -207,13 +207,18 @@ public class HiveDriverPool implements AutoCloseable {
           if (worker.driver != null) {
             try {
               worker.driver.close();
-              // close() releases the current query's resources but leaves the shutdown hook
-              // Driver.compile() registered; only destroy() removes it. Without this the
-              // static ShutdownHookManager keeps every pooled Driver -- and the Table and
-              // FieldSchema objects of its last query -- alive for the life of the JVM.
-              worker.driver.destroy();
             } catch (Exception e) {
               LOG.warn("Error closing pooled Driver", e);
+            }
+            // close() releases the current query's resources but leaves the shutdown hook
+            // Driver.compile() registered; only destroy() removes it. Without this the
+            // static ShutdownHookManager keeps every pooled Driver -- and the Table and
+            // FieldSchema objects of its last query -- alive for the life of the JVM. This
+            // gets its own try so a failing close() cannot skip the hook removal.
+            try {
+              worker.driver.destroy();
+            } catch (Exception e) {
+              LOG.warn("Error destroying pooled Driver", e);
             }
           }
           if (worker.sessionState != null) {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/util/HiveDriverPool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/util/HiveDriverPool.java
@@ -207,6 +207,11 @@ public class HiveDriverPool implements AutoCloseable {
           if (worker.driver != null) {
             try {
               worker.driver.close();
+              // close() releases the current query's resources but leaves the shutdown hook
+              // Driver.compile() registered; only destroy() removes it. Without this the
+              // static ShutdownHookManager keeps every pooled Driver -- and the Table and
+              // FieldSchema objects of its last query -- alive for the life of the JVM.
+              worker.driver.destroy();
             } catch (Exception e) {
               LOG.warn("Error closing pooled Driver", e);
             }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/util/TestHiveDriverPool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/util/TestHiveDriverPool.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link HiveDriverPool} that exercise bootstrap, dispatch, error
@@ -206,6 +207,30 @@ class TestHiveDriverPool {
     assertEquals(3, drivers.size());
     for (Driver d : drivers) {
       verify(d, times(1)).close();
+      verify(d, times(1)).destroy();
+    }
+  }
+
+  /**
+   * The hook removal is the whole point of destroy(), so a Driver whose close() blows up must
+   * still be destroyed -- otherwise the failure that made teardown interesting is also the one
+   * that leaks the Driver.
+   */
+  @Test
+  void closeDestroysPooledDriverEvenWhenCloseThrows() throws Exception {
+    HiveSyncConfig config = configWithEmptyHiveConf();
+    List<Driver> drivers = Collections.synchronizedList(new ArrayList<>());
+    HiveDriverPool.DriverFactory factory = (db) -> {
+      Driver d = mock(Driver.class);
+      when(d.close()).thenThrow(new RuntimeException("close failed"));
+      drivers.add(d);
+      return d;
+    };
+    HiveDriverPool pool = new HiveDriverPool(config, 2, factory);
+    pool.close();
+
+    assertEquals(2, drivers.size());
+    for (Driver d : drivers) {
       verify(d, times(1)).destroy();
     }
   }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/util/TestHiveDriverPool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/util/TestHiveDriverPool.java
@@ -185,6 +185,31 @@ class TestHiveDriverPool {
         () -> pool.dispatchAll(Arrays.asList("anything")));
   }
 
+  /**
+   * Driver.compile() registers a shutdown hook that Driver.close() does not remove -- only
+   * destroy() does. Closing a pooled Driver without destroying it therefore leaks it, and
+   * everything its last query referenced, into the static ShutdownHookManager for the life
+   * of the JVM. A long-running sync loop builds a pool per sync, so this grows without bound.
+   */
+  @Test
+  void closeDestroysEachPooledDriver() throws Exception {
+    HiveSyncConfig config = configWithEmptyHiveConf();
+    List<Driver> drivers = Collections.synchronizedList(new ArrayList<>());
+    HiveDriverPool.DriverFactory factory = (db) -> {
+      Driver d = mock(Driver.class);
+      drivers.add(d);
+      return d;
+    };
+    HiveDriverPool pool = new HiveDriverPool(config, 3, factory);
+    pool.close();
+
+    assertEquals(3, drivers.size());
+    for (Driver d : drivers) {
+      verify(d, times(1)).close();
+      verify(d, times(1)).destroy();
+    }
+  }
+
   @Test
   void invalidSizeRejected() {
     HiveSyncConfig config = configWithEmptyHiveConf();


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

HiveQL sync mode leaks a Hive `Driver` on every sync.

`Driver.compile()` registers a shutdown hook with `ShutdownHookManager`. `Driver.close()` does not remove it, only `Driver.destroy()` does, and Hive's own comment on `destroy()` notes it "is usually called after close() ... to end the driver life cycle". Since a fresh `HiveQueryDDLExecutor` (and, with batching enabled, a fresh `HiveDriverPool`) is built per sync, every sync permanently adds Drivers to the JVM-global hook set. Each retained Driver keeps its `QueryState`, semantic analyzer, and the `Table` / `ReadEntity` / `FieldSchema` objects of its last statement alive, so any process that syncs repeatedly in one JVM grows without bound.

This was found on a long-running Flink streaming job syncing every 10 minutes. Its JobManager heap climbed roughly 1 GB/hour and OOMed every few hours, on both a 4 GB and a 12 GB heap, more memory only bought time. Eclipse MAT on the resulting 8 GB dump attributed **3.78 GB, 81.08% of the heap**, to a single accumulation point:

    AppClassLoader -> Object[] -> ShutdownHookManager (static MGR)
      -> SynchronizedSet -> HashSet -> HashMap$Node[4096]     3.78 GB

Held there were 2,252 `ShutdownHookManager$HookEntry` retaining 2,292 `org.apache.hadoop.hive.ql.Driver`, which in turn retained 114,373 `hive.ql.metadata.Table`, 338,755 `StorageDescriptor`, and 12,296,367 `FieldSchema`. The Driver count matched the number of DDL statements the job had executed, confirming one permanently retained Driver per Driver ever created.

Note on scale: that dump comes from a deployment that constructs one Driver per statement, which is why the counts are so large. With `HiveDriverPool` the same defect leaks one Driver per pool worker per sync plus the session Driver, far slower, but still unbounded for a streaming sync loop.

### Summary and Changelog

Drivers are now destroyed, not just closed, so nothing is left behind in `ShutdownHookManager` after a sync completes.

- `HiveDriverPool` teardown: call `destroy()` after `close()` on each pooled worker Driver.
- `HiveQueryDDLExecutor.close()`: call `destroy()` after `close()` on the session Driver.
- `HiveQueryDDLExecutor` constructor failure path: same, so a partially constructed executor does not leak the Driver it already built.
- New test `TestHiveDriverPool#closeDestroysEachPooledDriver`: injects mock Drivers through the existing package-private `DriverFactory` seam and verifies every pooled Driver is both closed and destroyed on pool close.

`destroy()` is safe on a Driver that never compiled: `shutdownRunner` is null in that case and `ShutdownHookManager.removeShutdownHook` documents returning false for a null hook. That matters on the constructor path, where a throwing `destroy()` would otherwise mask the original construction failure.

### Impact

No public API or behavior change. HiveQL sync memory stays flat across syncs instead of growing with each one. This mainly benefits long-running processes such as Flink or Spark streaming jobs that sync repeatedly in the same JVM; one-shot sync jobs are unaffected in practice since the JVM exits regardless.

### Risk Level

Low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable