### PR TITLE
fix(core): reject a second INSERT_OVERWRITE of a partition already overwritten by a concurrent writer

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -38,6 +38,7 @@ import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
@@ -145,6 +146,21 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
       log.info("Found conflicting writes between first operation = {}, second operation = {} , intersecting file ids {}", thisOperation, otherOperation, intersection);
       return true;
     }
+    // Two overwrites of the same partition replace each other's file groups only if they saw them at planning
+    // time. Once one of them has completed, a second overwrite of that partition that did not replace the
+    // first one's files would leave both copies of the data live, so it is rejected even though the two
+    // share no file id. Pending overwrites keep file-id semantics: first to commit wins.
+    if (WriteOperationType.isOverwrite(thisOperation.getOperationType())
+        && WriteOperationType.isOverwrite(otherOperation.getOperationType())
+        && HoodieInstant.State.COMPLETED.name().equals(otherOperation.getInstantActionState())) {
+      Set<String> overlappingPartitions = getMutatedPartitions(thisOperation);
+      overlappingPartitions.retainAll(getMutatedPartitions(otherOperation));
+      if (!overlappingPartitions.isEmpty()) {
+        log.info("Found conflicting writes between first operation = {}, second operation = {} , overwritten partitions {}",
+            thisOperation, otherOperation, overlappingPartitions);
+        return true;
+      }
+    }
     return false;
   }
 
@@ -177,6 +193,10 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
    */
   private boolean isRollbackOperation(ConcurrentOperation operation) {
     return ROLLBACK_ACTION.equals(operation.getInstantActionType());
+  }
+
+  private static Set<String> getMutatedPartitions(ConcurrentOperation operation) {
+    return operation.getMutatedPartitionAndFileIds().stream().map(Pair::getLeft).collect(Collectors.toSet());
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -20,13 +20,16 @@ package org.apache.hudi.client.transaction;
 
 import org.apache.hudi.client.WriteClientTestUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieWriteConflictException;
@@ -36,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -60,6 +64,44 @@ import static org.apache.hudi.client.transaction.TestConflictResolutionStrategyU
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 
 public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends HoodieCommonTestHarness {
+
+  @Test
+  public void testOverwritesOfTheSamePartitionConflictWithoutSharedFileIds() {
+    String partition = HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
+    HoodieInstant completed = INSTANT_GENERATOR.createNewInstant(State.COMPLETED, HoodieTimeline.REPLACE_COMMIT_ACTION, "001");
+    HoodieInstant pending = INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.REPLACE_COMMIT_ACTION, "002");
+    SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new SimpleConcurrentFileWritesConflictResolutionStrategy();
+
+    // Two overwrites planned against an empty partition: fresh file ids on both sides, nothing replaced on either.
+    ConcurrentOperation completedOverwrite = new ConcurrentOperation(completed, overwriteMetadata(partition, "file-a"));
+    ConcurrentOperation committingOverwrite = new ConcurrentOperation(pending, overwriteMetadata(partition, "file-b"));
+    Assertions.assertTrue(strategy.hasConflict(committingOverwrite, completedOverwrite));
+
+    // First to commit wins: a still-pending overwrite does not block the one committing now.
+    ConcurrentOperation otherPendingOverwrite = new ConcurrentOperation(
+        INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.REPLACE_COMMIT_ACTION, "003"), overwriteMetadata(partition, "file-c"));
+    Assertions.assertFalse(strategy.hasConflict(committingOverwrite, otherPendingOverwrite));
+
+    // Different partitions never conflict.
+    ConcurrentOperation completedOverwriteElsewhere = new ConcurrentOperation(completed,
+        overwriteMetadata(HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH, "file-d"));
+    Assertions.assertFalse(strategy.hasConflict(committingOverwrite, completedOverwriteElsewhere));
+
+    // Non-overwrite writes keep file-id semantics.
+    ConcurrentOperation insert = new ConcurrentOperation(
+        INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "004"), createCommitMetadata("004", "file-e"));
+    Assertions.assertFalse(strategy.hasConflict(insert, completedOverwrite));
+  }
+
+  private static HoodieReplaceCommitMetadata overwriteMetadata(String partition, String writtenFileId) {
+    HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setFileId(writtenFileId);
+    metadata.addWriteStat(partition, writeStat);
+    metadata.setPartitionToReplaceFileIds(Collections.singletonMap(partition, Collections.emptyList()));
+    metadata.setOperationType(WriteOperationType.INSERT_OVERWRITE);
+    return metadata;
+  }
 
   @Test
   public void testNoConcurrentWrites() throws Exception {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestConcurrentInsertOverwriteSamePartition.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestConcurrentInsertOverwriteSamePartition.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client;
+
+import org.apache.hudi.client.transaction.SimpleConcurrentFileWritesConflictResolutionStrategy;
+import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.marker.MarkerType;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieCleanConfig;
+import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieWriteConflictException;
+import org.apache.hudi.table.HoodieSparkTable;
+import org.apache.hudi.testutils.HoodieClientTestBase;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.model.HoodieRecord.RECORD_KEY_METADATA_FIELD;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two writers running INSERT_OVERWRITE of the same partition concurrently under OCC. When the partition is
+ * empty at planning time neither replaces any file id, so the file-id based conflict check alone would let
+ * both commit and leave every record in the partition twice.
+ */
+public class TestConcurrentInsertOverwriteSamePartition extends HoodieClientTestBase {
+
+  private static final String TARGET_PARTITION = DEFAULT_FIRST_PARTITION_PATH;
+  private static final String OTHER_PARTITION = DEFAULT_SECOND_PARTITION_PATH;
+  private static final int RECORDS_PER_WRITE = 100;
+
+  @Override
+  public SparkRDDWriteClient getHoodieWriteClient(HoodieWriteConfig cfg) {
+    return new SparkRDDWriteClient(context, cfg);
+  }
+
+  /** A retried load whose previous attempt is still running: both overwrites planned against an empty partition. */
+  @Test
+  public void testConcurrentInsertOverwriteOfEmptyPartitionIsRejected() throws Exception {
+    HoodieWriteConfig cfg = occWriteConfig();
+    // Seed the table with data in an unrelated partition so it is an existing, non-empty table.
+    try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
+      String seedTime = client.startCommit();
+      client.commit(seedTime, client.insert(jsc.parallelize(
+          dataGen.generateInsertsForPartition(seedTime, RECORDS_PER_WRITE, OTHER_PARTITION), 1), seedTime));
+    }
+
+    // Two writers, same payload, same target partition:
+    // both start (requested) before either finishes.
+    String replaceAction = HoodieTimeline.REPLACE_COMMIT_ACTION;
+    String firstInstant;
+    String secondInstant;
+
+    try (SparkRDDWriteClient writer1 = getHoodieWriteClient(cfg);
+         SparkRDDWriteClient writer2 = getHoodieWriteClient(cfg)) {
+      firstInstant = writer1.startCommit(replaceAction);
+      secondInstant = writer2.startCommit(replaceAction);
+      List<HoodieRecord> payload = dataGen.generateInsertsForPartition(firstInstant, RECORDS_PER_WRITE, TARGET_PARTITION);
+
+      HoodieWriteResult result1 = writer1.insertOverwrite(jsc.parallelize(payload, 1), firstInstant);
+      HoodieWriteResult result2 = writer2.insertOverwrite(jsc.parallelize(payload, 1), secondInstant);
+
+      assertTrue(writer1.commit(firstInstant, result1.getWriteStatuses(), Option.empty(),
+          replaceAction, result1.getPartitionToReplaceFileIds()), "first overwrite commits");
+      assertTrue(result1.getPartitionToReplaceFileIds().get(TARGET_PARTITION).isEmpty()
+          && result2.getPartitionToReplaceFileIds().get(TARGET_PARTITION).isEmpty(), "both planned against an empty partition");
+      assertThrows(HoodieWriteConflictException.class, () -> writer2.commit(secondInstant, result2.getWriteStatuses(),
+          Option.empty(), replaceAction, result2.getPartitionToReplaceFileIds()), "second overwrite of the same partition is rejected");
+    }
+
+    HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(storageConf, basePath);
+    HoodieTimeline replaceTimeline = metaClient.getActiveTimeline().getCompletedReplaceTimeline();
+    assertEquals(Arrays.asList(firstInstant),
+        replaceTimeline.getInstantsAsStream().map(HoodieInstant::requestedTime).collect(Collectors.toList()));
+    HoodieReplaceCommitMetadata md = metaClient.getActiveTimeline().readReplaceCommitMetadata(replaceTimeline.firstInstant().get());
+    assertEquals(WriteOperationType.INSERT_OVERWRITE, md.getOperationType());
+
+    List<HoodieBaseFile> latestBaseFiles = HoodieSparkTable.create(cfg, context, metaClient)
+        .getBaseFileOnlyView().getLatestBaseFiles(TARGET_PARTITION).collect(Collectors.toList());
+    assertEquals(1, latestBaseFiles.size(), "only the winning overwrite's file group is live");
+    Dataset<Row> rows = sqlContext.read().parquet(latestBaseFiles.stream().map(HoodieBaseFile::getPath).toArray(String[]::new));
+    assertEquals(RECORDS_PER_WRITE, rows.count());
+    assertEquals(RECORDS_PER_WRITE, rows.select(RECORD_KEY_METADATA_FIELD).distinct().count());
+  }
+
+  /** Contrast: when the partition already has file groups both writers replace the same ids, and OCC rejects the second. */
+  @Test
+  public void testConcurrentInsertOverwriteOfPopulatedPartitionIsRejected() throws Exception {
+    HoodieWriteConfig cfg = occWriteConfig();
+    try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
+      String seedTime = client.startCommit();
+      client.commit(seedTime, client.insert(jsc.parallelize(
+          dataGen.generateInsertsForPartition(seedTime, RECORDS_PER_WRITE, TARGET_PARTITION), 1), seedTime));
+    }
+
+    String replaceAction = HoodieTimeline.REPLACE_COMMIT_ACTION;
+    String firstInstant;
+    String secondInstant;
+
+    try (SparkRDDWriteClient writer1 = getHoodieWriteClient(cfg);
+         SparkRDDWriteClient writer2 = getHoodieWriteClient(cfg)) {
+      firstInstant = writer1.startCommit(replaceAction);
+      secondInstant = writer2.startCommit(replaceAction);
+      List<HoodieRecord> payload = dataGen.generateInsertsForPartition(firstInstant, RECORDS_PER_WRITE, TARGET_PARTITION);
+      HoodieWriteResult result1 = writer1.insertOverwrite(jsc.parallelize(payload, 1), firstInstant);
+      HoodieWriteResult result2 = writer2.insertOverwrite(jsc.parallelize(payload, 1), secondInstant);
+
+      assertTrue(writer1.commit(firstInstant, result1.getWriteStatuses(), Option.empty(),
+          replaceAction, result1.getPartitionToReplaceFileIds()));
+      assertThrows(HoodieWriteConflictException.class, () -> writer2.commit(secondInstant, result2.getWriteStatuses(),
+          Option.empty(), replaceAction, result2.getPartitionToReplaceFileIds()));
+    }
+  }
+
+  private HoodieWriteConfig occWriteConfig() throws IOException {
+    return getConfigBuilder()
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY)
+            .withAutoClean(false).build())
+        .withWriteConcurrencyMode(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL)
+        .withMarkersType(MarkerType.DIRECT.name())
+        .withLockConfig(HoodieLockConfig.newBuilder()
+            .withLockProvider(InProcessLockProvider.class)
+            .withConflictResolutionStrategy(new SimpleConcurrentFileWritesConflictResolutionStrategy())
+            .build())
+        .build();
+  }
+
+  @Override
+  public HoodieTableType getTableType() {
+    return HoodieTableType.MERGE_ON_READ;
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestConcurrentInsertOverwritePartition.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestConcurrentInsertOverwritePartition.scala
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.dml.insert
+
+import org.apache.hudi.common.model.{HoodieReplaceCommitMetadata, WriteOperationType}
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.exception.HoodieWriteConflictException
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
+
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+/**
+ * Two SQL sessions run INSERT OVERWRITE of the same, still empty, partition of a MOR table at the same time,
+ * the way a retried daily load does when the previous attempt is still running.
+ */
+class TestConcurrentInsertOverwritePartition extends HoodieSparkSqlTestBase {
+
+  private val targetPartition = "2026-08-04"
+  private val seededPartition = "2026-08-03"
+  private val rowsPerWriter = 200
+
+  test("Concurrent INSERT OVERWRITE of the same empty partition under OCC") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+      spark.sql(
+        s"""
+           | create table $tableName (
+           |   rank_source_id int,
+           |   locode string,
+           |   device string,
+           |   normalized_query string,
+           |   serp_item_position int,
+           |   url string,
+           |   modeled_ingested_at long,
+           |   day string
+           | ) using hudi
+           | partitioned by (day)
+           | tblproperties (
+           |   type = 'mor',
+           |   primaryKey = 'rank_source_id,locode,device,normalized_query,serp_item_position',
+           |   preCombineField = 'modeled_ingested_at',
+           |   hoodie.datasource.write.hive_style_partitioning = 'true',
+           |   hoodie.metadata.enable = 'true'
+           | )
+           | location '$basePath'
+       """.stripMargin)
+      // Seed an unrelated partition so the table has a completed commit older than both overwrites. On a
+      // brand-new table the loser's instant can sort below the first completed commit and its uncleaned
+      // files would then be read as if they belonged to an archived commit, hiding the outcome under test.
+      spark.sql(
+        s"""
+           | insert into $tableName partition (day = '$seededPartition')
+           | values (0, 'US', 'desktop', 'seed', 1, 'https://example.com/seed', 0L)
+       """.stripMargin)
+      // Source data lives in one file so each INSERT OVERWRITE runs the gate UDF in exactly one task.
+      val sourceTable = generateTableName
+      spark.sql(s"create table $sourceTable using parquet as select id from range(0, $rowsPerWriter, 1, 1)")
+
+      val pool = Executors.newFixedThreadPool(2)
+      val writers = try {
+        Seq("writer_1", "writer_2").map(name => pool.submit(() => Try {
+          runInsertOverwrite(name, tableName, sourceTable)
+        })).map(_.get(5, TimeUnit.MINUTES))
+      } finally {
+        pool.shutdownNow()
+      }
+      assertWriterOutcome(writers, basePath, tableName)
+    }
+  }
+
+  private def runInsertOverwrite(name: String, tableName: String, sourceTable: String): String = {
+    val session = spark.newSession()
+    session.udf.register("wait_for_other_writer", (id: Long) => {
+      TestConcurrentInsertOverwritePartition.bothWritersPlanned.countDown()
+      // Release only once both statements have started their write stage, i.e. both have
+      // initialised their table view and planned the overwrite against an empty partition.
+      assert(TestConcurrentInsertOverwritePartition.bothWritersPlanned.await(2, TimeUnit.MINUTES),
+        "the other writer never reached its write stage")
+      id
+    })
+    occSqlConf.foreach { case (k, v) => session.sql(s"set $k=$v") }
+    session.sql(
+      s"""
+         | insert overwrite table $tableName partition (day = '$targetPartition')
+         | select cast(id as int), 'US', 'desktop', concat('q', id), 1, concat('https://example.com/', id),
+         |        wait_for_other_writer(id) as modeled_ingested_at
+         | from $sourceTable
+     """.stripMargin)
+    name
+  }
+
+  private def assertWriterOutcome(writers: Seq[Try[String]], basePath: String, tableName: String): Unit = {
+    val metaClient = HoodieTableMetaClient.builder().setConf(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf())).setBasePath(basePath).build()
+    val completedOverwrites = metaClient.getActiveTimeline.getCompletedReplaceTimeline.getInstants.asScala
+      .map(i => (i, metaClient.getActiveTimeline.readReplaceCommitMetadata(i)))
+      .filter(_._2.getOperationType == WriteOperationType.INSERT_OVERWRITE)
+
+    val rowCount = spark.sql(s"select count(*) from $tableName where day = '$targetPartition'").head().getLong(0)
+    val keyCount = spark.sql(
+      s"select count(distinct rank_source_id, locode, device, normalized_query, serp_item_position) from $tableName where day = '$targetPartition'")
+      .head().getLong(0)
+
+    println(s"overwrites committed=${completedOverwrites.map { case (i, md) => s"$i replaced=${md.getPartitionToReplaceFileIds}" }} " +
+      s"rows=$rowCount distinctKeys=$keyCount writers=${writers.map(_.toString.take(200))}")
+    assertResult(rowsPerWriter)(keyCount)
+    // Exactly one overwrite wins the partition and it planned against the empty partition; the other is
+    // rejected by OCC. Whether the loser planned before or after the winner committed is timing dependent
+    // here, the write-client level test pins the empty-partition ordering deterministically.
+    assertResult(1, s"overwrites that committed: ${completedOverwrites.map(_._1)}")(completedOverwrites.size)
+    assert(completedOverwrites.head._2.getPartitionToReplaceFileIds.get(s"day=$targetPartition").isEmpty,
+      "the winning overwrite replaced nothing: the partition was empty when it planned")
+    assert(writers.count(_.isFailure) == 1 && writers.exists(_.failed.toOption.exists(isWriteConflict)),
+      s"one writer must fail with a write conflict, got: ${writers.map(_.failed.toOption.map(_.toString))}")
+    assertResult(rowsPerWriter)(rowCount)
+  }
+
+  private def isWriteConflict(t: Throwable): Boolean =
+    Iterator.iterate(t)(_.getCause).takeWhile(_ != null).exists(_.isInstanceOf[HoodieWriteConflictException])
+
+  private def occSqlConf: Seq[(String, String)] = Seq(
+    "hoodie.write.concurrency.mode" -> "optimistic_concurrency_control",
+    "hoodie.cleaner.policy.failed.writes" -> "LAZY",
+    "hoodie.write.lock.provider" -> "org.apache.hudi.client.transaction.lock.InProcessLockProvider",
+    "hoodie.write.lock.wait_time_ms" -> "60000",
+    "hoodie.write.lock.num_retries" -> "3",
+    "hoodie.timestamp.ordering.validate.enable" -> "true",
+    "hoodie.table.services.enabled" -> "false"
+  )
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    TestConcurrentInsertOverwritePartition.bothWritersPlanned = new CountDownLatch(2)
+  }
+}
+
+object TestConcurrentInsertOverwritePartition {
+  @volatile var bothWritersPlanned: CountDownLatch = new CountDownLatch(2)
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Under OCC, `SimpleConcurrentFileWritesConflictResolutionStrategy.hasConflict` only reports a conflict when two operations share a (partition, file id) pair. Two `INSERT_OVERWRITE` writers that both planned against an empty partition replace nothing and write fresh file ids, so both commit and every row of the partition is present twice; clean, clustering and compaction then keep both copies. `INSERT_OVERWRITE` has partition semantics but OCC only records it as file ids.

### Summary and Changelog

Two overwrite operations (`INSERT_OVERWRITE` / `INSERT_OVERWRITE_TABLE`) that touch a common partition now conflict once the other one has completed, regardless of file ids. Scope, deliberately narrow:

- only when the other overwrite is already completed (first to commit wins, as elsewhere in OCC). Matching pending overwrites too would make both writers fail each other and would let an abandoned pending overwrite block every later overwrite of that partition until lazy cleaning rolls it back;
- only overwrite against overwrite. A plain insert that lands in a partition a concurrent overwrite completed on keeps today's file-level semantics.

Known conservative case: an `INSERT_OVERWRITE` of partition P that planned after a concurrent `INSERT_OVERWRITE_TABLE` completed is now rejected as well (the reverse ordering already was, via file ids). Not in this PR: `BucketIndexConcurrentFileWritesConflictResolutionStrategy` overrides `hasConflict` entirely and does not get this rule.

Changes:
- `SimpleConcurrentFileWritesConflictResolutionStrategy.hasConflict`: partition-level check for a completed overwrite of a common partition.
- `TestSimpleConcurrentFileWritesConflictResolutionStrategy`: predicate-level test (same partition / pending other / different partition / non-overwrite).
- `TestConcurrentInsertOverwriteSamePartition`: two `SparkRDDWriteClient`s overwriting the same empty partition, plus a populated-partition contrast.
- `TestConcurrentInsertOverwritePartition`: two Spark SQL sessions running `INSERT OVERWRITE ... PARTITION` concurrently.

No code copied.

### Impact

A second concurrent `INSERT OVERWRITE` of the same partition now fails with `HoodieWriteConflictException` instead of silently duplicating the partition's data. No API or config change. Inherited by strategies that subclass `SimpleConcurrentFileWritesConflictResolutionStrategy` without overriding `hasConflict`.

### Risk Level

Low. Tests at three levels, all red on the old predicate (see Changelog). `TestHoodieClientMultiWriter` passes unchanged.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
