### PR TITLE
fix(spark): skip record key config validation for table version 1

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -176,12 +176,14 @@ object HoodieWriterUtils {
       if (null != tableConfig) {
         val datasourceRecordKey = params.getOrElse(RECORDKEY_FIELD.key(), null)
         val tableConfigRecordKey = tableConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS)
-        if ((null != datasourceRecordKey && null != tableConfigRecordKey
-          && datasourceRecordKey != tableConfigRecordKey) || (null != datasourceRecordKey && datasourceRecordKey.nonEmpty
-          && tableConfigRecordKey == null)) {
-          // if both are non null, they should match.
-          // if incoming record key is non empty, table config should also be non empty.
-          diffConfigs.append(s"RecordKey:\t$datasourceRecordKey\t$tableConfigRecordKey\n")
+        if (tableConfig.contains(HoodieTableConfig.VERSION) && tableConfig.getInt(HoodieTableConfig.VERSION) > 1 ) {
+          if ((null != datasourceRecordKey && null != tableConfigRecordKey
+            && datasourceRecordKey != tableConfigRecordKey) || (null != datasourceRecordKey && datasourceRecordKey.nonEmpty
+            && tableConfigRecordKey == null)) {
+            // if both are non null, they should match.
+            // if incoming record key is non empty, table config should also be non empty.
+            diffConfigs.append(s"RecordKey:\t$datasourceRecordKey\t$tableConfigRecordKey\n")
+          }
         }
 
         val datasourcePreCombineKey = params.getOrElse(PRECOMBINE_FIELD.key(), null)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -232,16 +232,16 @@ class TestHoodieSparkSqlWriter extends HoodieSparkWriterTestBase {
 
     rewriteTableConfigAsVersionOne()
 
-    assert(HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, writeParams, newSingleRowDataFrame())._1)
+    assertTrue(HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, writeParams, newSingleRowDataFrame())._1)
 
     val upgradedConfig = loadTableConfig()
     assertEquals("uuid", upgradedConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS))
     assertEquals(partitionField, upgradedConfig.getString(HoodieTableConfig.PARTITION_FIELDS))
     assertEquals("PARQUET", upgradedConfig.getString(HoodieTableConfig.BASE_FILE_FORMAT))
-    assertTrue(upgradedConfig.getTableVersion.versionCode() >= HoodieTableVersion.TWO.versionCode())
+    assertEquals(HoodieTableVersion.SIX, upgradedConfig.getTableVersion)
 
     // the backfilled table configs must not conflict with the same write config on the next write
-    assert(HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, writeParams, newSingleRowDataFrame())._1)
+    assertTrue(HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, writeParams, newSingleRowDataFrame())._1)
   }
 
   /**
@@ -264,8 +264,8 @@ class TestHoodieSparkSqlWriter extends HoodieSparkWriterTestBase {
 
     val hoodieException = intercept[HoodieException](
       HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, writeParams, newSingleRowDataFrame()))
-    assert(hoodieException.getMessage.contains("Config conflict"))
-    assert(hoodieException.getMessage.contains("RecordKey:\tuuid\tnull"))
+    assertTrue(hoodieException.getMessage.contains("Config conflict"))
+    assertTrue(hoodieException.getMessage.contains("RecordKey:\tuuid\tnull"))
   }
 
   private def newSingleRowDataFrame(): DataFrame =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -19,7 +19,7 @@ package org.apache.hudi
 
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.common.model.{HoodieFileFormat, HoodieRecord, HoodieRecordPayload, HoodieTableType, WriteOperationType}
-import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, TableSchemaResolver}
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion, TableSchemaResolver}
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.config.{HoodieBootstrapConfig, HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.{HoodieException, SchemaCompatibilityException}
@@ -211,6 +211,83 @@ class TestHoodieSparkSqlWriter extends HoodieSparkWriterTestBase {
 
     //on same path try write with different RECORDKEY_FIELD_NAME and Overwrite SaveMode should be successful.
     assert(HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite, tableModifier2, dataFrame2)._1)
+  }
+
+  /**
+   * A table written before table version 2 has no hoodie.table.recordkey.fields, hoodie.table.partition.fields
+   * or hoodie.table.base.file.format in hoodie.properties, because those table configs only shipped with table
+   * version 2. Validation must tolerate their absence so that the version 1 to 2 upgrade can backfill them from
+   * the same write config; otherwise such a table can never be written to again.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = Array("", "ts"))
+  def testWriteToTableVersionOneMissingUpgradeBackfilledConfigs(partitionField: String): Unit = {
+    val keyGenClass = if (partitionField.isEmpty) classOf[NonpartitionedKeyGenerator] else classOf[SimpleKeyGenerator]
+    val writeParams = Map("path" -> tempBasePath,
+      HoodieWriteConfig.TBL_NAME.key -> hoodieFooTableName,
+      DataSourceWriteOptions.RECORDKEY_FIELD.key -> "uuid",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> partitionField,
+      DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> keyGenClass.getName)
+    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite, writeParams, newSingleRowDataFrame())
+
+    regressTableConfigToVersionOne()
+
+    assert(HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, writeParams, newSingleRowDataFrame())._1)
+
+    val upgradedConfig = loadTableConfig()
+    assertEquals("uuid", upgradedConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS))
+    assertEquals(partitionField, upgradedConfig.getString(HoodieTableConfig.PARTITION_FIELDS))
+    assertEquals("PARQUET", upgradedConfig.getString(HoodieTableConfig.BASE_FILE_FORMAT))
+    assertTrue(upgradedConfig.getTableVersion.versionCode() >= HoodieTableVersion.TWO.versionCode())
+
+    // the backfilled table configs must not conflict with the same write config on the next write
+    assert(HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, writeParams, newSingleRowDataFrame())._1)
+  }
+
+  /**
+   * From table version 2 onwards hoodie.table.recordkey.fields is expected to be present, so its absence still
+   * signals a genuine conflict rather than a config the table is too old to carry.
+   */
+  @Test
+  def testWriteToTableVersionTwoMissingRecordKeyStillConflicts(): Unit = {
+    val writeParams = Map("path" -> tempBasePath,
+      HoodieWriteConfig.TBL_NAME.key -> hoodieFooTableName,
+      DataSourceWriteOptions.RECORDKEY_FIELD.key -> "uuid",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+      DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> classOf[NonpartitionedKeyGenerator].getName)
+    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite, writeParams, newSingleRowDataFrame())
+
+    val metaClient = loadMetaClient()
+    HoodieTableConfig.delete(metaClient.getStorage, metaClient.getMetaPath,
+      Collections.singleton(HoodieTableConfig.RECORDKEY_FIELDS.key))
+
+    val hoodieException = intercept[HoodieException](
+      HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, writeParams, newSingleRowDataFrame()))
+    assert(hoodieException.getMessage.contains("Config conflict"))
+    assert(hoodieException.getMessage.contains("RecordKey:\tuuid\tnull"))
+  }
+
+  private def newSingleRowDataFrame(): DataFrame =
+    spark.createDataFrame(Seq(StringLongTest(UUID.randomUUID().toString, new Date().getTime)))
+
+  private def loadMetaClient(): HoodieTableMetaClient = createMetaClient(spark, tempBasePath)
+
+  private def loadTableConfig(): HoodieTableConfig = loadMetaClient().getTableConfig
+
+  /**
+   * Rewrites hoodie.properties to the shape a table version 1 writer would have left behind: the version pinned
+   * to 1 and every table config introduced at version 2 absent.
+   */
+  private def regressTableConfigToVersionOne(): Unit = {
+    val metaClient = loadMetaClient()
+    val deletedConfigs = new java.util.HashSet[String]()
+    deletedConfigs.add(HoodieTableConfig.RECORDKEY_FIELDS.key)
+    deletedConfigs.add(HoodieTableConfig.PARTITION_FIELDS.key)
+    deletedConfigs.add(HoodieTableConfig.BASE_FILE_FORMAT.key)
+    HoodieTableConfig.delete(metaClient.getStorage, metaClient.getMetaPath, deletedConfigs)
+    val versionProp = new java.util.Properties()
+    versionProp.setProperty(HoodieTableConfig.VERSION.key, String.valueOf(HoodieTableVersion.ONE.versionCode()))
+    HoodieTableConfig.update(metaClient.getStorage, metaClient.getMetaPath, versionProp)
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -230,7 +230,7 @@ class TestHoodieSparkSqlWriter extends HoodieSparkWriterTestBase {
       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> keyGenClass.getName)
     HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite, writeParams, newSingleRowDataFrame())
 
-    regressTableConfigToVersionOne()
+    rewriteTableConfigAsVersionOne()
 
     assert(HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, writeParams, newSingleRowDataFrame())._1)
 
@@ -245,8 +245,8 @@ class TestHoodieSparkSqlWriter extends HoodieSparkWriterTestBase {
   }
 
   /**
-   * From table version 2 onwards hoodie.table.recordkey.fields is expected to be present, so its absence still
-   * signals a genuine conflict rather than a config the table is too old to carry.
+   * Table version 2 is where hoodie.table.recordkey.fields starts being expected, so at that version its absence
+   * still signals a genuine conflict rather than a config the table is too old to carry.
    */
   @Test
   def testWriteToTableVersionTwoMissingRecordKeyStillConflicts(): Unit = {
@@ -260,6 +260,7 @@ class TestHoodieSparkSqlWriter extends HoodieSparkWriterTestBase {
     val metaClient = loadMetaClient()
     HoodieTableConfig.delete(metaClient.getStorage, metaClient.getMetaPath,
       Collections.singleton(HoodieTableConfig.RECORDKEY_FIELDS.key))
+    setTableVersion(HoodieTableVersion.TWO)
 
     val hoodieException = intercept[HoodieException](
       HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, writeParams, newSingleRowDataFrame()))
@@ -276,17 +277,31 @@ class TestHoodieSparkSqlWriter extends HoodieSparkWriterTestBase {
 
   /**
    * Rewrites hoodie.properties to the shape a table version 1 writer would have left behind: the version pinned
-   * to 1 and every table config introduced at version 2 absent.
+   * to 1 and every table config that a later upgrade handler backfills absent. hoodie.table.checksum is not in
+   * that set because storeProperties regenerates it on every write, so a table config file can never lack it.
    */
-  private def regressTableConfigToVersionOne(): Unit = {
+  private def rewriteTableConfigAsVersionOne(): Unit = {
     val metaClient = loadMetaClient()
     val deletedConfigs = new java.util.HashSet[String]()
+    // backfilled by OneToTwoUpgradeHandler
     deletedConfigs.add(HoodieTableConfig.RECORDKEY_FIELDS.key)
     deletedConfigs.add(HoodieTableConfig.PARTITION_FIELDS.key)
     deletedConfigs.add(HoodieTableConfig.BASE_FILE_FORMAT.key)
+    // backfilled by TwoToThreeUpgradeHandler
+    deletedConfigs.add(HoodieTableConfig.URL_ENCODE_PARTITIONING.key)
+    deletedConfigs.add(HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE.key)
+    deletedConfigs.add(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key)
+    // backfilled by ThreeToFourUpgradeHandler
+    deletedConfigs.add(HoodieTableConfig.DATABASE_NAME.key)
+    deletedConfigs.add(HoodieTableConfig.TABLE_METADATA_PARTITIONS.key)
     HoodieTableConfig.delete(metaClient.getStorage, metaClient.getMetaPath, deletedConfigs)
+    setTableVersion(HoodieTableVersion.ONE)
+  }
+
+  private def setTableVersion(version: HoodieTableVersion): Unit = {
+    val metaClient = loadMetaClient()
     val versionProp = new java.util.Properties()
-    versionProp.setProperty(HoodieTableConfig.VERSION.key, String.valueOf(HoodieTableVersion.ONE.versionCode()))
+    versionProp.setProperty(HoodieTableConfig.VERSION.key, String.valueOf(version.versionCode()))
     HoodieTableConfig.update(metaClient.getStorage, metaClient.getMetaPath, versionProp)
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -572,7 +572,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     HoodieDeltaStreamer.Config cfg = TestHelpers.makeConfig(tableBasePath, WriteOperationType.BULK_INSERT);
     syncAndAssertRecordCount(cfg, 1000, tableBasePath, "00000", 1);
 
-    regressTableConfigToVersionOne(tableBasePath);
+    rewriteTableConfigAsVersionOne(tableBasePath);
 
     HoodieDeltaStreamer.Config upsertCfg = TestHelpers.makeConfig(tableBasePath, WriteOperationType.UPSERT);
     upsertCfg.sourceLimit = 2000;
@@ -585,13 +585,23 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
 
   /**
    * Rewrites hoodie.properties to the shape a table version 1 writer would have left behind: the version pinned
-   * to 1 and every table config introduced at version 2 absent.
+   * to 1 and every table config that a later upgrade handler backfills absent. hoodie.table.checksum is not in
+   * that set because storeProperties regenerates it on every write, so a table config file can never lack it.
    */
-  private void regressTableConfigToVersionOne(String tableBasePath) {
+  private void rewriteTableConfigAsVersionOne(String tableBasePath) {
     HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(storage, tableBasePath);
-    HoodieTableConfig.delete(metaClient.getStorage(), metaClient.getMetaPath(),
-        new HashSet<>(Arrays.asList(HoodieTableConfig.RECORDKEY_FIELDS.key(),
-            HoodieTableConfig.PARTITION_FIELDS.key(), HoodieTableConfig.BASE_FILE_FORMAT.key())));
+    HoodieTableConfig.delete(metaClient.getStorage(), metaClient.getMetaPath(), new HashSet<>(Arrays.asList(
+        // backfilled by OneToTwoUpgradeHandler
+        HoodieTableConfig.RECORDKEY_FIELDS.key(),
+        HoodieTableConfig.PARTITION_FIELDS.key(),
+        HoodieTableConfig.BASE_FILE_FORMAT.key(),
+        // backfilled by TwoToThreeUpgradeHandler
+        HoodieTableConfig.URL_ENCODE_PARTITIONING.key(),
+        HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE.key(),
+        HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key(),
+        // backfilled by ThreeToFourUpgradeHandler
+        HoodieTableConfig.DATABASE_NAME.key(),
+        HoodieTableConfig.TABLE_METADATA_PARTITIONS.key())));
     Properties versionProp = new Properties();
     versionProp.setProperty(HoodieTableConfig.VERSION.key(), String.valueOf(HoodieTableVersion.ONE.versionCode()));
     HoodieTableConfig.update(metaClient.getStorage(), metaClient.getMetaPath(), versionProp);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -150,6 +150,7 @@ import java.sql.DriverManager;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -556,6 +557,44 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     syncAndAssertRecordCount(newCfg, 1950, tableBasePath, "00001", 2);
     List<Row> counts2 = countsPerCommit(tableBasePath, sqlContext);
     assertEquals(1950, counts2.stream().mapToLong(entry -> entry.getLong(1)).sum());
+  }
+
+  /**
+   * A table written before table version 2 has no hoodie.table.recordkey.fields in hoodie.properties, because
+   * that table config only shipped with table version 2. The stream must still initialize so that the version 1
+   * to 2 upgrade can backfill it from the same write config; validating it away in the StreamSyncService
+   * constructor kills the stream before that upgrade ever runs.
+   */
+  @Test
+  void testTableVersionOneMissingRecordKeyTableConfig() throws Exception {
+    String tableBasePath = basePath + "/test_table_version_one_configs";
+
+    HoodieDeltaStreamer.Config cfg = TestHelpers.makeConfig(tableBasePath, WriteOperationType.BULK_INSERT);
+    syncAndAssertRecordCount(cfg, 1000, tableBasePath, "00000", 1);
+
+    regressTableConfigToVersionOne(tableBasePath);
+
+    HoodieDeltaStreamer.Config upsertCfg = TestHelpers.makeConfig(tableBasePath, WriteOperationType.UPSERT);
+    upsertCfg.sourceLimit = 2000;
+    syncAndAssertRecordCount(upsertCfg, 1950, tableBasePath, "00001", 2);
+
+    HoodieTableConfig tableConfig = HoodieTestUtils.createMetaClient(storage, tableBasePath).getTableConfig();
+    assertEquals("_row_key", tableConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS));
+    assertTrue(tableConfig.getTableVersion().versionCode() >= HoodieTableVersion.TWO.versionCode());
+  }
+
+  /**
+   * Rewrites hoodie.properties to the shape a table version 1 writer would have left behind: the version pinned
+   * to 1 and every table config introduced at version 2 absent.
+   */
+  private void regressTableConfigToVersionOne(String tableBasePath) {
+    HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(storage, tableBasePath);
+    HoodieTableConfig.delete(metaClient.getStorage(), metaClient.getMetaPath(),
+        new HashSet<>(Arrays.asList(HoodieTableConfig.RECORDKEY_FIELDS.key(),
+            HoodieTableConfig.PARTITION_FIELDS.key(), HoodieTableConfig.BASE_FILE_FORMAT.key())));
+    Properties versionProp = new Properties();
+    versionProp.setProperty(HoodieTableConfig.VERSION.key(), String.valueOf(HoodieTableVersion.ONE.versionCode()));
+    HoodieTableConfig.update(metaClient.getStorage(), metaClient.getMetaPath(), versionProp);
   }
 
   private void syncAndAssertRecordCount(HoodieDeltaStreamer.Config cfg, Integer expected, String tableBasePath, String metadata, Integer totalCommits) throws Exception {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -580,7 +580,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
 
     HoodieTableConfig tableConfig = HoodieTestUtils.createMetaClient(storage, tableBasePath).getTableConfig();
     assertEquals("_row_key", tableConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS));
-    assertTrue(tableConfig.getTableVersion().versionCode() >= HoodieTableVersion.TWO.versionCode());
+    assertEquals(HoodieTableVersion.SIX, tableConfig.getTableVersion());
   }
 
   /**


### PR DESCRIPTION
closes #19723

### Change Logs

Backports HUDI-8795 (#12544) to `branch-0.x`, which the 0.x line never received. `hoodie.table.recordkey.fields` only shipped in 0.9.0, so a table at table version 1 does not carry it, and `validateTableConfig` rejected the write before `OneToTwoUpgradeHandler` could backfill it from the same write config. The cherry-picked commit skips that check below table version 2; from table version 2 onwards an absent record key is still a conflict.

The upstream commit shipped without tests, so this PR adds them: a parameterized datasource test covering the unpartitioned and partitioned cases, one asserting the check still fires at table version 2, and a DeltaStreamer test for the path where this actually bites, the `StreamSyncService` constructor. Without the fix the DeltaStreamer test fails at `HoodieStreamer.java:707` with `RecordKey: _row_key null`, which is the reported failure. The test fixture deletes every table config a later upgrade handler backfills (the 1->2, 2->3 and 3->4 sets), not just the record key, so it matches a real table version 1 table rather than a current-version one with three keys removed. That the write still succeeds with all of them absent is what backs the claim that the record key check is the only intolerant one.

### Impact

Tables at table version 1 can be written to and upgraded again on the 0.x line. No public API or format change.

### Risk level (write none, low medium or high below)

low

The behavior change is scoped to tables below table version 2. One thing worth flagging in review: the upstream condition is `contains(VERSION) && getInt(VERSION) > 1`, so a `hoodie.properties` carrying no version key at all now skips the record-key check entirely, including a genuine mismatch. In practice the version is always written at table creation, and this matches what `master` already runs, so this PR keeps the condition as-is rather than diverging.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed

