### PR TITLE
test(sync): cover the meta-sync completion-time watermark end to end

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -961,7 +961,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
         .getLatestCompletionTime();
     if (lastCommitSynced.isPresent()) {
       try {
-        HashMap<String, String> propertyMap = new HashMap<>();
+        Map<String, String> propertyMap = new HashMap<>();
         propertyMap.put(HOODIE_LAST_COMMIT_TIME_SYNC, lastCommitSynced.get());
         if (lastCommitCompletionSynced.isPresent()) {
           propertyMap.put(HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC, lastCommitCompletionSynced.get());
@@ -971,7 +971,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
         throw new HoodieGlueSyncException("Fail to update last sync commit time for " + tableId(databaseName, tableName), e);
       }
     } else {
-      log.info("No commit in active timeline.");
+      log.info("No commit in active timeline for table {}.", tableId(databaseName, tableName));
     }
     try {
       // as a side effect, we also refresh the partition indexes if needed

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -941,11 +941,10 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
   @Override
   public Option<String> getLastCommitCompletionTimeSynced(String tableName) {
-    // Get the last commit completion time from the TBLproperties
     try {
       return Option.ofNullable(getInitialTable(tableName).parameters().getOrDefault(HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC, null));
     } catch (Exception e) {
-      throw new HoodieGlueSyncException("Failed to get the last commit completion time synced from the table " + tableName, e);
+      throw new HoodieGlueSyncException("Fail to get last commit completion time synced for " + tableId(databaseName, tableName), e);
     }
   }
 

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -892,7 +892,8 @@ class TestAWSGlueSyncClient {
     List<Column> partitionKeys = Collections.singletonList(GlueTestUtil.getColumn("city", "string", "person's city"));
     CompletableFuture<UpdateTableResponse> mockUpdateTableResponse = mock(CompletableFuture.class);
     Mockito.when(mockUpdateTableResponse.get()).thenReturn(UpdateTableResponse.builder().build());
-    Mockito.when(mockAwsGlue.getTable(any(GetTableRequest.class))).thenReturn(getTableWithDefaultProps(tableName, columns, partitionKeys));
+    Mockito.when(mockAwsGlue.getTable(any(GetTableRequest.class)))
+        .thenReturn(getTableWithProps(tableName, columns, partitionKeys, Collections.singletonMap("EXTERNAL", "TRUE")));
     Mockito.when(mockAwsGlue.updateTable(any(UpdateTableRequest.class))).thenReturn(mockUpdateTableResponse);
 
     // A second commit whose instant time sorts below the fixture's but whose completion time is later:
@@ -913,6 +914,8 @@ class TestAWSGlueSyncClient {
     assertEquals(GlueTestUtil.INSTANT_TIME, params.get(HOODIE_LAST_COMMIT_TIME_SYNC));
     assertEquals(earlierInstantCompletionTime, params.get(HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC),
         "incremental sync needs the completion-time watermark to pick up commits that complete out of instant-time order");
+    assertEquals("TRUE", params.get("EXTERNAL"),
+        "updating the watermarks must merge into the existing table parameters, not replace them");
   }
 
   @Test

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.config.GlueCatalogSyncClientConfig;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.sync.common.model.FieldSchema;
 import org.apache.hudi.sync.common.model.Partition;
@@ -82,6 +83,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -90,6 +92,8 @@ import java.util.concurrent.ExecutionException;
 import static org.apache.hudi.aws.testutils.GlueTestUtil.glueSyncProps;
 import static org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME;
 import static org.apache.hudi.common.table.HoodieTableConfig.HOODIE_TABLE_NAME_KEY;
+import static org.apache.hudi.sync.common.HoodieMetaSyncOperations.HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC;
+import static org.apache.hudi.sync.common.HoodieMetaSyncOperations.HOODIE_LAST_COMMIT_TIME_SYNC;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
@@ -881,13 +885,81 @@ class TestAWSGlueSyncClient {
     assertTrue(ex.getMessage().contains(HoodieVersion.get()), "exception message should mention the writer version");
   }
 
+  @Test
+  void testUpdateLastCommitTimeSyncedPersistsCompletionTimeWatermark() throws ExecutionException, InterruptedException, IOException {
+    String tableName = "test";
+    List<Column> columns = Collections.singletonList(GlueTestUtil.getColumn("name", "string", "person's name"));
+    List<Column> partitionKeys = Collections.singletonList(GlueTestUtil.getColumn("city", "string", "person's city"));
+    CompletableFuture<UpdateTableResponse> mockUpdateTableResponse = mock(CompletableFuture.class);
+    Mockito.when(mockUpdateTableResponse.get()).thenReturn(UpdateTableResponse.builder().build());
+    Mockito.when(mockAwsGlue.getTable(any(GetTableRequest.class))).thenReturn(getTableWithDefaultProps(tableName, columns, partitionKeys));
+    Mockito.when(mockAwsGlue.updateTable(any(UpdateTableRequest.class))).thenReturn(mockUpdateTableResponse);
+
+    // A second commit whose instant time sorts below the fixture's but whose completion time is later:
+    // the instant-time watermark must come from the fixture commit and the completion-time watermark from this one.
+    String earlierInstant = "100";
+    String earlierInstantCompletionTime = "20250101000001000";
+    GlueTestUtil.createCommitFile(earlierInstant, earlierInstantCompletionTime);
+    // fresh client so its lazily loaded timeline sees both commits
+    String basePath = GlueTestUtil.getHiveSyncConfig().getString(META_SYNC_BASE_PATH);
+    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, GlueTestUtil.getHiveSyncConfig(),
+        HoodieTableMetaClient.builder().setConf(HadoopFSUtils.getStorageConf(GlueTestUtil.getHadoopConf())).setBasePath(basePath).build());
+
+    awsGlueSyncClient.updateLastCommitTimeSynced(tableName);
+
+    ArgumentCaptor<UpdateTableRequest> captor = ArgumentCaptor.forClass(UpdateTableRequest.class);
+    verify(mockAwsGlue, times(1)).updateTable(captor.capture());
+    Map<String, String> params = captor.getValue().tableInput().parameters();
+    assertEquals(GlueTestUtil.INSTANT_TIME, params.get(HOODIE_LAST_COMMIT_TIME_SYNC));
+    assertEquals(earlierInstantCompletionTime, params.get(HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC),
+        "incremental sync needs the completion-time watermark to pick up commits that complete out of instant-time order");
+  }
+
+  @Test
+  void testUpdateLastCommitTimeSyncedWithNoCompletedCommit() throws IOException {
+    String tableName = "test";
+    GlueTestUtil.deleteCommitFile(GlueTestUtil.INSTANT_TIME, GlueTestUtil.INSTANT_COMPLETION_TIME);
+    String basePath = GlueTestUtil.getHiveSyncConfig().getString(META_SYNC_BASE_PATH);
+    awsGlueSyncClient = new AWSGlueCatalogSyncClient(mockAwsGlue, mockSts, GlueTestUtil.getHiveSyncConfig(),
+        HoodieTableMetaClient.builder().setConf(HadoopFSUtils.getStorageConf(GlueTestUtil.getHadoopConf())).setBasePath(basePath).build());
+
+    awsGlueSyncClient.updateLastCommitTimeSynced(tableName);
+
+    verify(mockAwsGlue, never()).updateTable(any(UpdateTableRequest.class));
+  }
+
+  @Test
+  void testGetLastCommitCompletionTimeSyncedWhenAbsent() {
+    String tableName = "test";
+    List<Column> columns = Collections.singletonList(GlueTestUtil.getColumn("name", "string", "person's name"));
+    List<Column> partitionKeys = Collections.singletonList(GlueTestUtil.getColumn("city", "string", "person's city"));
+    Mockito.when(mockAwsGlue.getTable(any(GetTableRequest.class))).thenReturn(getTableWithDefaultProps(tableName, columns, partitionKeys));
+    assertFalse(awsGlueSyncClient.getLastCommitCompletionTimeSynced(tableName).isPresent());
+  }
+
+  @Test
+  void testGetLastCommitCompletionTimeSyncedWhenPresent() {
+    String tableName = "test";
+    List<Column> columns = Collections.singletonList(GlueTestUtil.getColumn("name", "string", "person's name"));
+    List<Column> partitionKeys = Collections.singletonList(GlueTestUtil.getColumn("city", "string", "person's city"));
+    HashMap<String, String> props = new HashMap<>();
+    props.put(HOODIE_LAST_COMMIT_TIME_SYNC, "101");
+    props.put(HOODIE_LAST_COMMIT_COMPLETION_TIME_SYNC, "20260101000000000");
+    Mockito.when(mockAwsGlue.getTable(any(GetTableRequest.class))).thenReturn(getTableWithProps(tableName, columns, partitionKeys, props));
+    assertEquals("101", awsGlueSyncClient.getLastCommitTimeSynced(tableName).get());
+    assertEquals("20260101000000000", awsGlueSyncClient.getLastCommitCompletionTimeSynced(tableName).get());
+  }
+
   private CompletableFuture<GetTableResponse> getTableWithDefaultProps(String tableName, List<Column> columns, List<Column> partitionColumns) {
+    return getTableWithProps(tableName, columns, partitionColumns, new HashMap<>());
+  }
+
+  private CompletableFuture<GetTableResponse> getTableWithProps(String tableName, List<Column> columns, List<Column> partitionColumns, Map<String, String> extraTableProperties) {
     String databaseName = "testdb";
     String inputFormatClass = "inputFormat";
     String outputFormatClass = "outputFormat";
     String serdeClass = "serde";
     HashMap<String, String> serdeProperties = new HashMap<>();
-    HashMap<String, String> tableProperties = new HashMap<>();
     software.amazon.awssdk.services.glue.model.StorageDescriptor storageDescriptor = software.amazon.awssdk.services.glue.model.StorageDescriptor.builder()
         .serdeInfo(SerDeInfo.builder().serializationLibrary(serdeClass).parameters(serdeProperties).build())
         .inputFormat(inputFormatClass)
@@ -901,7 +973,7 @@ class TestAWSGlueSyncClient {
         .parameters(new HashMap<>())
         .storageDescriptor(storageDescriptor)
         .partitionKeys(partitionColumns)
-        .parameters(tableProperties)
+        .parameters(extraTableProperties)
         .databaseName(databaseName)
         .build();
     GetTableResponse response = GetTableResponse.builder()

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/testutils/GlueTestUtil.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/testutils/GlueTestUtil.java
@@ -58,6 +58,10 @@ public class GlueTestUtil {
   public static TypedProperties glueSyncProps;
   public static final String DB_NAME = "testdb";
   public static final String TABLE_NAME = "test1";
+  /** Instant time of the single completed commit that {@link #createHoodieTable} seeds the fixture table with. */
+  public static final String INSTANT_TIME = "101";
+  /** Completion time of the fixture commit; commits completing later use a greater value. */
+  public static final String INSTANT_COMPLETION_TIME = "20250101000000000";
   private static String basePath;
   public static FileSystem fileSystem;
   private static HiveSyncConfig hiveSyncConfig;
@@ -110,9 +114,20 @@ public class GlueTestUtil {
         .setPayloadClass(HoodieAvroPayload.class)
         .initTable(HadoopFSUtils.getStorageConf(new Configuration()), basePath);
 
-    String instantTime = "101";
-    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata(false);
-    createMetaFile(basePath, new DefaultInstantFileNameGenerator().makeCommitFileName(instantTime), commitMetadata);
+    createCommitFile(INSTANT_TIME, INSTANT_COMPLETION_TIME);
+  }
+
+  /** Writes a completed commit whose completion time is carried in the file name, as the 1.x timeline expects. */
+  public static void createCommitFile(String instantTime, String completionTime) throws IOException {
+    createMetaFile(basePath,
+        new DefaultInstantFileNameGenerator().makeCommitFileName(instantTime + "_" + completionTime),
+        new HoodieCommitMetadata(false));
+  }
+
+  public static void deleteCommitFile(String instantTime, String completionTime) throws IOException {
+    Path fullPath = new Path(timelinePath(basePath),
+        new DefaultInstantFileNameGenerator().makeCommitFileName(instantTime + "_" + completionTime));
+    fileSystem.delete(fullPath, false);
   }
 
   public static HoodieSchema getSimpleSchema() {
@@ -126,10 +141,14 @@ public class GlueTestUtil {
   private static void createMetaFile(String basePath, String fileName, HoodieCommitMetadata metadata)
       throws IOException {
     byte[] bytes = metadata.toJsonString().getBytes(StandardCharsets.UTF_8);
-    Path fullPath = new Path(basePath + "/" + METAFOLDER_NAME + "/" + fileName);
+    Path fullPath = new Path(timelinePath(basePath), fileName);
     FSDataOutputStream fsout = fileSystem.create(fullPath, true);
     fsout.write(bytes);
     fsout.close();
+  }
+
+  private static String timelinePath(String basePath) {
+    return basePath + "/" + METAFOLDER_NAME + "/" + HoodieTableMetaClient.TIMELINEFOLDER_NAME;
   }
 
   public static Column getColumn(String name, String type, String comment) {

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -229,6 +229,14 @@ public class TestHiveSyncTool {
     HiveTestUtil.clear();
   }
 
+  @Test
+  public void testUpdateLastCommitTimeSyncedWithNoCompletedCommit() {
+    hiveSyncProps.setProperty(HIVE_SYNC_MODE.key(), "hms");
+    // created-but-never-written table: the active timeline has no completed instant, the update must no-op
+    reInitHiveSyncClient();
+    assertDoesNotThrow(() -> hiveClient.updateLastCommitTimeSynced(HiveTestUtil.TABLE_NAME));
+  }
+
   @ParameterizedTest
   @MethodSource({"syncModeAndSchemaFromCommitMetadata"})
   public void testUpdateBasePath(boolean useSchemaFromCommitMetadata, String syncMode, String enablePushDown) throws Exception {

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -235,6 +235,7 @@ public class TestHiveSyncTool {
     // created-but-never-written table: the active timeline has no completed instant, the update must no-op
     reInitHiveSyncClient();
     assertDoesNotThrow(() -> hiveClient.updateLastCommitTimeSynced(HiveTestUtil.TABLE_NAME));
+    assertFalse(hiveClient.tableExists(HiveTestUtil.TABLE_NAME), "the no-op must not create or alter the metastore table");
   }
 
   @ParameterizedTest

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolLongRunningWriteWatermark.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolLongRunningWriteWatermark.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive;
+
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.hive.testutils.HiveTestUtil;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_MODE;
+import static org.apache.hudi.hive.testutils.HiveTestUtil.TABLE_NAME;
+import static org.apache.hudi.hive.testutils.HiveTestUtil.hiveSyncProps;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A partition written by a long-running INSERT_OVERWRITE must still be registered when the incremental
+ * sync's watermark moved past the write's instant time while it was in flight. That only works when the
+ * sync client persists and reads the commit completion-time watermark ({@code last_commit_completion_time_sync}),
+ * which drives the "hollow instant" lookup in {@code TimelineUtils.getCommitsTimelineAfter}; a client that
+ * tracks {@code last_commit_time_sync} alone silently and permanently drops the partition.
+ */
+public class TestHiveSyncToolLongRunningWriteWatermark {
+
+  private static final String EXISTING_PARTITION_INSTANT = "100";
+  private static final String LONG_RUNNING_INSERT_OVERWRITE_INSTANT = "101";
+  private static final String EMPTY_COMMIT_DURING_WRITE = "102";
+  private static final String EMPTY_COMMIT_AFTER_WRITE = "103";
+  private static final String NEW_PARTITION = "2026/08/04";
+
+  private HiveSyncTool hiveSyncTool;
+  private HoodieHiveSyncClient hiveClient;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    HiveTestUtil.setUp(Option.empty(), true);
+    hiveSyncProps.setProperty(HIVE_SYNC_MODE.key(), "hms");
+  }
+
+  @AfterEach
+  void teardown() throws Exception {
+    closeHiveSyncTool();
+    HiveTestUtil.clear();
+  }
+
+  @AfterAll
+  static void cleanUpClass() throws IOException {
+    HiveTestUtil.shutdown();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testPartitionOfWriteCompletingAfterWatermarkAdvanced(boolean clientPersistsCompletionTime) throws Exception {
+    // t=100: table with one partition, synced. Watermark = 100.
+    HiveTestUtil.createCOWTable(EXISTING_PARTITION_INSTANT, 1, true);
+    reSyncHiveTable(clientPersistsCompletionTime);
+    assertEquals(1, hiveClient.getAllPartitions(TABLE_NAME).size());
+    assertEquals(EXISTING_PARTITION_INSTANT, hiveClient.getLastCommitTimeSynced(TABLE_NAME).get());
+
+    // t=101: INSERT_OVERWRITE into a brand-new partition starts (requested + inflight, files on storage)
+    // and keeps running for a long time.
+    HoodieReplaceCommitMetadata longRunningWrite =
+        HiveTestUtil.startInsertOverwritePartition(NEW_PARTITION, LONG_RUNNING_INSERT_OVERWRITE_INSTANT);
+
+    // t=102: a concurrent writer lands an empty commit (no partitions) while 101 is still in flight.
+    HiveTestUtil.addEmptyCommit(EMPTY_COMMIT_DURING_WRITE);
+
+    // The periodic sync runs now: 101 is pending so it is invisible, and the watermark jumps to 102.
+    reSyncHiveTable(clientPersistsCompletionTime);
+    assertEquals(1, hiveClient.getAllPartitions(TABLE_NAME).size(), "pending write must not be synced yet");
+    assertEquals(EMPTY_COMMIT_DURING_WRITE, hiveClient.getLastCommitTimeSynced(TABLE_NAME).get());
+
+    // 101 completes: its instant time is now BELOW the watermark, while its completion time (stamped into
+    // the completed file's name at creation) is later than 102's.
+    HiveTestUtil.createReplaceCommitFile(longRunningWrite, LONG_RUNNING_INSERT_OVERWRITE_INSTANT);
+    assertTrue(HiveTestUtil.fileSystem.exists(new Path(HiveTestUtil.basePath, NEW_PARTITION)),
+        "partition data is on storage");
+
+    // Next sync cycle.
+    reSyncHiveTable(clientPersistsCompletionTime);
+    int partitionsAfterCompletion = hiveClient.getAllPartitions(TABLE_NAME).size();
+
+    // t=103: more unrelated commits keep arriving; every later sync advances the watermark further.
+    HiveTestUtil.addEmptyCommit(EMPTY_COMMIT_AFTER_WRITE);
+    reSyncHiveTable(clientPersistsCompletionTime);
+    int partitionsAfterLaterSyncs = hiveClient.getAllPartitions(TABLE_NAME).size();
+    assertEquals(EMPTY_COMMIT_AFTER_WRITE, hiveClient.getLastCommitTimeSynced(TABLE_NAME).get());
+
+    if (clientPersistsCompletionTime) {
+      // Stock Hive client: the completion-time watermark rescues the hollow instant.
+      assertEquals(2, partitionsAfterCompletion, "hollow instant rescued by completion-time watermark");
+      assertEquals(2, partitionsAfterLaterSyncs);
+    } else {
+      // Instant-time-only client: the partition is on storage with a completed replacecommit, yet it is
+      // never added - and the watermark keeps moving, so no future incremental sync will add it.
+      assertEquals(1, partitionsAfterCompletion, "partition of the late-completing write was skipped");
+      assertEquals(1, partitionsAfterLaterSyncs, "partition is permanently lost to incremental sync");
+      // read through a stock client to show the completion key was never written to the metastore
+      try (HiveSyncTool stockTool = new HiveSyncTool(hiveSyncProps, HiveTestUtil.getHiveConf())) {
+        assertFalse(((HoodieHiveSyncClient) stockTool.syncClient).getLastCommitCompletionTimeSynced(TABLE_NAME).isPresent());
+      }
+    }
+  }
+
+  /** One cycle of a periodic sync job: a fresh tool (fresh timeline snapshot) per run. */
+  private void reSyncHiveTable(boolean clientPersistsCompletionTime) {
+    reInitHiveSyncClient(clientPersistsCompletionTime);
+    hiveSyncTool.syncHoodieTable();
+    reInitHiveSyncClient(clientPersistsCompletionTime);
+  }
+
+  private void reInitHiveSyncClient(boolean clientPersistsCompletionTime) {
+    closeHiveSyncTool();
+    hiveSyncTool = clientPersistsCompletionTime
+        ? new HiveSyncTool(hiveSyncProps, HiveTestUtil.getHiveConf())
+        : new InstantTimeWatermarkHiveSyncTool(hiveSyncProps, HiveTestUtil.getHiveConf());
+    hiveClient = (HoodieHiveSyncClient) hiveSyncTool.syncClient;
+  }
+
+  private void closeHiveSyncTool() {
+    if (hiveSyncTool != null) {
+      hiveSyncTool.close();
+      hiveSyncTool = null;
+    }
+  }
+
+  /** {@link HiveSyncTool} whose client tracks only the instant-time watermark. */
+  private static class InstantTimeWatermarkHiveSyncTool extends HiveSyncTool {
+    InstantTimeWatermarkHiveSyncTool(Properties props, Configuration hadoopConf) {
+      super(props, hadoopConf);
+    }
+
+    @Override
+    protected void initSyncClient(HiveSyncConfig config, HoodieTableMetaClient metaClient) {
+      this.syncClient = new InstantTimeWatermarkSyncClient(config, metaClient);
+    }
+  }
+
+  /** Writes only {@code last_commit_time_sync} and leaves {@code getLastCommitCompletionTimeSynced} at its default. */
+  private static class InstantTimeWatermarkSyncClient extends HoodieHiveSyncClient {
+    InstantTimeWatermarkSyncClient(HiveSyncConfig config, HoodieTableMetaClient metaClient) {
+      super(config, metaClient);
+    }
+
+    @Override
+    public Option<String> getLastCommitCompletionTimeSynced(String tableName) {
+      return Option.empty();
+    }
+
+    @Override
+    public void updateLastCommitTimeSynced(String tableName) {
+      getActiveTimeline().lastInstant().ifPresent(last ->
+          updateTableProperties(tableName, Collections.singletonMap(HOODIE_LAST_COMMIT_TIME_SYNC, last.requestedTime())));
+    }
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolLongRunningWriteWatermark.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolLongRunningWriteWatermark.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.hive.testutils.HiveTestUtil;
+import org.apache.hudi.sync.common.model.Partition;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -33,6 +34,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_MODE;
@@ -56,6 +58,8 @@ public class TestHiveSyncToolLongRunningWriteWatermark {
   private static final String EMPTY_COMMIT_DURING_WRITE = "102";
   private static final String EMPTY_COMMIT_AFTER_WRITE = "103";
   private static final String NEW_PARTITION = "2026/08/04";
+  /** {@link org.apache.hudi.hive.SlashEncodedDayPartitionValueExtractor} maps {@link #NEW_PARTITION} to this datestr value. */
+  private static final List<String> NEW_PARTITION_VALUES = Collections.singletonList("2026-08-04");
 
   private HiveSyncTool hiveSyncTool;
   private HoodieHiveSyncClient hiveClient;
@@ -107,23 +111,27 @@ public class TestHiveSyncToolLongRunningWriteWatermark {
 
     // Next sync cycle.
     reSyncHiveTable(clientPersistsCompletionTime);
-    int partitionsAfterCompletion = hiveClient.getAllPartitions(TABLE_NAME).size();
+    List<Partition> partitionsAfterCompletion = hiveClient.getAllPartitions(TABLE_NAME);
 
     // t=103: more unrelated commits keep arriving; every later sync advances the watermark further.
     HiveTestUtil.addEmptyCommit(EMPTY_COMMIT_AFTER_WRITE);
     reSyncHiveTable(clientPersistsCompletionTime);
-    int partitionsAfterLaterSyncs = hiveClient.getAllPartitions(TABLE_NAME).size();
+    List<Partition> partitionsAfterLaterSyncs = hiveClient.getAllPartitions(TABLE_NAME);
     assertEquals(EMPTY_COMMIT_AFTER_WRITE, hiveClient.getLastCommitTimeSynced(TABLE_NAME).get());
 
     if (clientPersistsCompletionTime) {
       // Stock Hive client: the completion-time watermark rescues the hollow instant.
-      assertEquals(2, partitionsAfterCompletion, "hollow instant rescued by completion-time watermark");
-      assertEquals(2, partitionsAfterLaterSyncs);
+      assertEquals(2, partitionsAfterCompletion.size(), "hollow instant rescued by completion-time watermark");
+      assertTrue(containsNewPartition(partitionsAfterCompletion), "the registered partition is the INSERT_OVERWRITE's");
+      assertEquals(2, partitionsAfterLaterSyncs.size());
+      assertTrue(containsNewPartition(partitionsAfterLaterSyncs));
     } else {
       // Instant-time-only client: the partition is on storage with a completed replacecommit, yet it is
       // never added - and the watermark keeps moving, so no future incremental sync will add it.
-      assertEquals(1, partitionsAfterCompletion, "partition of the late-completing write was skipped");
-      assertEquals(1, partitionsAfterLaterSyncs, "partition is permanently lost to incremental sync");
+      assertEquals(1, partitionsAfterCompletion.size(), "partition of the late-completing write was skipped");
+      assertFalse(containsNewPartition(partitionsAfterCompletion));
+      assertEquals(1, partitionsAfterLaterSyncs.size(), "partition is permanently lost to incremental sync");
+      assertFalse(containsNewPartition(partitionsAfterLaterSyncs));
       // read through a stock client to show the completion key was never written to the metastore
       try (HiveSyncTool stockTool = new HiveSyncTool(hiveSyncProps, HiveTestUtil.getHiveConf())) {
         assertFalse(((HoodieHiveSyncClient) stockTool.syncClient).getLastCommitCompletionTimeSynced(TABLE_NAME).isPresent());
@@ -144,6 +152,10 @@ public class TestHiveSyncToolLongRunningWriteWatermark {
         ? new HiveSyncTool(hiveSyncProps, HiveTestUtil.getHiveConf())
         : new InstantTimeWatermarkHiveSyncTool(hiveSyncProps, HiveTestUtil.getHiveConf());
     hiveClient = (HoodieHiveSyncClient) hiveSyncTool.syncClient;
+  }
+
+  private static boolean containsNewPartition(List<Partition> partitions) {
+    return partitions.stream().anyMatch(partition -> NEW_PARTITION_VALUES.equals(partition.getValues()));
   }
 
   private void closeHiveSyncTool() {

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -367,6 +367,30 @@ public class HiveTestUtil {
     createReplaceCommitFile(replaceCommitMetadata, instantTime);
   }
 
+  /**
+   * Writes the data files and the requested + inflight markers of an INSERT_OVERWRITE replacecommit
+   * but not the completed file, i.e. a write that is still running. Complete it with
+   * {@link #createReplaceCommitFile}.
+   */
+  public static HoodieReplaceCommitMetadata startInsertOverwritePartition(String partitionPath, String instantTime)
+      throws IOException, URISyntaxException {
+    HoodieCommitMetadata commitMetadata = createPartition(partitionPath, true, true, instantTime);
+    HoodieReplaceCommitMetadata replaceCommitMetadata = new HoodieReplaceCommitMetadata();
+    commitMetadata.getPartitionToWriteStats().forEach((p, stats) -> stats.forEach(s -> replaceCommitMetadata.addWriteStat(p, s)));
+    replaceCommitMetadata.setOperationType(WriteOperationType.INSERT_OVERWRITE);
+    replaceCommitMetadata.setPartitionToReplaceFileIds(Collections.singletonMap(partitionPath, new ArrayList<>()));
+    commitMetadata.getExtraMetadata().forEach(replaceCommitMetadata::addMetadata);
+    createMetaFile(basePath, INSTANT_FILE_NAME_GENERATOR.makeRequestedReplaceFileName(instantTime), Option.empty());
+    createMetaFile(basePath, INSTANT_FILE_NAME_GENERATOR.makeInflightReplaceFileName(instantTime), Option.empty());
+    createdTablesSet.add(DB_NAME + "." + TABLE_NAME);
+    return replaceCommitMetadata;
+  }
+
+  /** A completed commit that touched no partition, like a streaming writer's empty micro-batch. */
+  public static void addEmptyCommit(String instantTime) throws IOException {
+    createCommitFileWithSchema(new HoodieCommitMetadata(), instantTime, true);
+  }
+
   public static void addRollbackInstantToTable(String instantTime, String commitToRollback)
       throws IOException {
     HoodieRollbackMetadata rollbackMetadata = HoodieRollbackMetadata.newBuilder()


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

closes #19725

HUDI-7494 taught the meta-sync clients to persist and read `last_commit_completion_time_sync` so incremental sync can register a commit that completes after the instant-time watermark has already moved past it. The mechanism has no test coverage on the sync clients: nothing fails if the completion watermark stops being written, is computed with the wrong ordering, or is never consulted on read. Separately, the Glue test fixture writes its seed commit into `.hoodie/` while the version-8 timeline reads `.hoodie/timeline/`, so every Glue test has been running against an empty active timeline.

### Summary and Changelog

Test-only coverage for the completion-time watermark, plus one error-message fix.

- `TestAWSGlueSyncClient`: four new tests. The watermark test seeds a second commit whose instant time sorts below the fixture's but whose completion time is later, and asserts the two watermarks come from the two different instants; mutating the client to persist the completion time of the instant-time-latest instant fails it (`expected: <20250101000001000> but was: <20250101000000000>`). Also: no-op when the timeline has no completed commit, and both read-back paths of `getLastCommitCompletionTimeSynced`.
- `TestHiveSyncToolLongRunningWriteWatermark` (new): end-to-end on `HiveSyncTool`, parameterized over the client. A long-running INSERT_OVERWRITE completes after two sync cycles advanced the watermark past its instant time: the stock client registers the partition through the hollow-instant lookup in `TimelineUtils.getCommitsTimelineAfter`; an instant-time-only client silently and permanently drops it.
- `TestHiveSyncTool`: `updateLastCommitTimeSynced` on a created-but-never-written table must no-op.
- `HiveTestUtil`: `startInsertOverwritePartition` (requested + inflight markers and data files, no completed file) and `addEmptyCommit` helpers.
- `GlueTestUtil`: the fixture commit is now written into the timeline folder with an explicit completion time in the file name, so the fixture timeline is actually visible; `createCommitFile` / `deleteCommitFile` helpers.
- `AWSGlueCatalogSyncClient`: the `getLastCommitCompletionTimeSynced` failure message and the no-commit log line now name the database-qualified table like their siblings, and the watermark property map is typed to the `Map` interface.

Test code adapted from the 0.x backport of HUDI-7494.

### Impact

None on production behavior; one exception message now includes the database name.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

