### PR TITLE
feat(spark): support bucket index for LSM tables

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/BucketSortBulkInsertPartitioner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/BucketSortBulkInsertPartitioner.java
@@ -19,6 +19,8 @@
 package org.apache.hudi.table;
 
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode;
 
 /**
@@ -32,10 +34,23 @@ public abstract class BucketSortBulkInsertPartitioner<T> implements BulkInsertPa
 
   public BucketSortBulkInsertPartitioner(HoodieTable table, String sortString) {
     this.table = table;
+    validateCustomSortColumns(table, sortString);
     if (!StringUtils.isNullOrEmpty(sortString)) {
       this.sortColumnNames = sortString.split(",");
     } else {
       this.sortColumnNames = null;
+    }
+  }
+
+  public static void validateCustomSortColumns(HoodieTable table, String sortString) {
+    boolean hasConfiguredSortColumns = table.getConfig().contains(
+        HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_SORT_COLUMNS)
+        && !StringUtils.isNullOrEmpty(table.getConfig().getString(
+            HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_SORT_COLUMNS));
+    if (table.getMetaClient().getTableConfig().isLSMTreeStorageLayout()
+        && (!StringUtils.isNullOrEmpty(sortString) || hasConfiguredSortColumns)) {
+      throw new HoodieException("Custom sort columns are not supported for bucket index on LSM tables because "
+          + "LSM files must be ordered by record key");
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/BucketSortBulkInsertPartitioner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/BucketSortBulkInsertPartitioner.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.table;
 
 import org.apache.hudi.common.util.StringUtils;
-import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode;
 
@@ -34,23 +33,15 @@ public abstract class BucketSortBulkInsertPartitioner<T> implements BulkInsertPa
 
   public BucketSortBulkInsertPartitioner(HoodieTable table, String sortString) {
     this.table = table;
-    validateCustomSortColumns(table, sortString);
+    if (table.getMetaClient().getTableConfig().isLSMTreeStorageLayout()
+        && !StringUtils.isNullOrEmpty(sortString)) {
+      throw new HoodieException("Custom sort columns are not supported for bucket index on LSM tables because "
+          + "LSM files must be ordered by record key");
+    }
     if (!StringUtils.isNullOrEmpty(sortString)) {
       this.sortColumnNames = sortString.split(",");
     } else {
       this.sortColumnNames = null;
-    }
-  }
-
-  public static void validateCustomSortColumns(HoodieTable table, String sortString) {
-    boolean hasConfiguredSortColumns = table.getConfig().contains(
-        HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_SORT_COLUMNS)
-        && !StringUtils.isNullOrEmpty(table.getConfig().getString(
-            HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_SORT_COLUMNS));
-    if (table.getMetaClient().getTableConfig().isLSMTreeStorageLayout()
-        && (!StringUtils.isNullOrEmpty(sortString) || hasConfiguredSortColumns)) {
-      throw new HoodieException("Custom sort columns are not supported for bucket index on LSM tables because "
-          + "LSM files must be ordered by record key");
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BucketIndexBulkInsertPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BucketIndexBulkInsertPartitionerWithRows.java
@@ -40,9 +40,21 @@ public class BucketIndexBulkInsertPartitionerWithRows implements BulkInsertParti
   private FileSystemViewStorageConfig viewConfig;
 
   public BucketIndexBulkInsertPartitionerWithRows(String indexKeyFields,
+                                                  HoodieWriteConfig writeConfig) {
+    this(indexKeyFields, writeConfig, false);
+  }
+
+  public BucketIndexBulkInsertPartitionerWithRows(String indexKeyFields,
                                                   HoodieWriteConfig writeConfig,
                                                   boolean sortByRecordKey) {
     this(writeConfig, NumBucketsFunction.fromWriteConfig(writeConfig), indexKeyFields, sortByRecordKey);
+  }
+
+  public BucketIndexBulkInsertPartitionerWithRows(HoodieWriteConfig writeConfig,
+                                                  String expressions,
+                                                  String rule,
+                                                  int bucketNumber) {
+    this(writeConfig, expressions, rule, bucketNumber, false);
   }
 
   public BucketIndexBulkInsertPartitionerWithRows(HoodieWriteConfig writeConfig,

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BucketIndexBulkInsertPartitionerWithRows.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/BucketIndexBulkInsertPartitionerWithRows.java
@@ -36,20 +36,32 @@ public class BucketIndexBulkInsertPartitionerWithRows implements BulkInsertParti
   private final String indexKeyFields;
   private final NumBucketsFunction numBucketsFunction;
   private final HoodieWriteConfig writeConfig;
+  private final boolean sortByRecordKey;
   private FileSystemViewStorageConfig viewConfig;
 
-  public BucketIndexBulkInsertPartitionerWithRows(String indexKeyFields, HoodieWriteConfig writeConfig) {
-    this(writeConfig, NumBucketsFunction.fromWriteConfig(writeConfig), indexKeyFields);
+  public BucketIndexBulkInsertPartitionerWithRows(String indexKeyFields,
+                                                  HoodieWriteConfig writeConfig,
+                                                  boolean sortByRecordKey) {
+    this(writeConfig, NumBucketsFunction.fromWriteConfig(writeConfig), indexKeyFields, sortByRecordKey);
   }
 
-  public BucketIndexBulkInsertPartitionerWithRows(HoodieWriteConfig writeConfig, String expressions, String rule, int bucketNumber) {
-    this(writeConfig, new NumBucketsFunction(expressions, rule, bucketNumber), writeConfig.getBucketIndexHashFieldWithDefault());
+  public BucketIndexBulkInsertPartitionerWithRows(HoodieWriteConfig writeConfig,
+                                                  String expressions,
+                                                  String rule,
+                                                  int bucketNumber,
+                                                  boolean sortByRecordKey) {
+    this(writeConfig, new NumBucketsFunction(expressions, rule, bucketNumber),
+        writeConfig.getBucketIndexHashFieldWithDefault(), sortByRecordKey);
   }
 
-  private BucketIndexBulkInsertPartitionerWithRows(HoodieWriteConfig writeConfig, NumBucketsFunction numBucketsFunction, String indexKeyFields) {
+  private BucketIndexBulkInsertPartitionerWithRows(HoodieWriteConfig writeConfig,
+                                                   NumBucketsFunction numBucketsFunction,
+                                                   String indexKeyFields,
+                                                   boolean sortByRecordKey) {
     this.indexKeyFields = indexKeyFields;
     this.numBucketsFunction = numBucketsFunction;
     this.writeConfig = writeConfig;
+    this.sortByRecordKey = sortByRecordKey;
     if (writeConfig.isUsingRemotePartitioner()) {
       this.viewConfig = writeConfig.getViewStorageConfig();
     }
@@ -60,7 +72,8 @@ public class BucketIndexBulkInsertPartitionerWithRows implements BulkInsertParti
     Partitioner partitioner = writeConfig.isUsingRemotePartitioner() && writeConfig.isEmbeddedTimelineServerEnabled()
         ? BucketPartitionUtils$.MODULE$.getRemotePartitioner(viewConfig, numBucketsFunction, outputPartitions) 
         : BucketPartitionUtils$.MODULE$.getLocalePartitioner(numBucketsFunction, outputPartitions);
-    return BucketPartitionUtils$.MODULE$.createDataFrame(rows, indexKeyFields, numBucketsFunction, partitioner);
+    return BucketPartitionUtils$.MODULE$.createDataFrame(
+        rows, indexKeyFields, numBucketsFunction, partitioner, sortByRecordKey);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDBucketIndexPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDBucketIndexPartitioner.java
@@ -122,10 +122,9 @@ public abstract class RDDBucketIndexPartitioner<T> extends BucketIndexBulkInsert
       LOG.warn("Bucket index does not support global sort mode, the sort will only be done within each data partition");
     }
 
-    boolean lsmTable = table.getMetaClient().getTableConfig().isLSMTreeStorageLayout();
-    Comparator<HoodieKey> comparator = (Comparator<HoodieKey> & Serializable) (t1, t2) -> lsmTable
-        ? StringUtils.compareUtf8Bytes(t1.getRecordKey(), t2.getRecordKey())
-        : t1.getRecordKey().compareTo(t2.getRecordKey());
+    Comparator<HoodieKey> comparator = table.getMetaClient().getTableConfig().isLSMTreeStorageLayout()
+        ? (Comparator<HoodieKey> & Serializable) (t1, t2) -> StringUtils.compareUtf8Bytes(t1.getRecordKey(), t2.getRecordKey())
+        : (Comparator<HoodieKey> & Serializable) (t1, t2) -> t1.getRecordKey().compareTo(t2.getRecordKey());
 
     return records.mapToPair(record -> new Tuple2<>(record.getKey(), record))
         .repartitionAndSortWithinPartitions(partitioner, comparator)

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDBucketIndexPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/RDDBucketIndexPartitioner.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.FlatLists;
 import org.apache.hudi.table.BucketIndexBulkInsertPartitioner;
 import org.apache.hudi.table.HoodieTable;
@@ -121,7 +122,10 @@ public abstract class RDDBucketIndexPartitioner<T> extends BucketIndexBulkInsert
       LOG.warn("Bucket index does not support global sort mode, the sort will only be done within each data partition");
     }
 
-    Comparator<HoodieKey> comparator = (Comparator<HoodieKey> & Serializable) (t1, t2) -> t1.getRecordKey().compareTo(t2.getRecordKey());
+    boolean lsmTable = table.getMetaClient().getTableConfig().isLSMTreeStorageLayout();
+    Comparator<HoodieKey> comparator = (Comparator<HoodieKey> & Serializable) (t1, t2) -> lsmTable
+        ? StringUtils.compareUtf8Bytes(t1.getRecordKey(), t2.getRecordKey())
+        : t1.getRecordKey().compareTo(t2.getRecordKey());
 
     return records.mapToPair(record -> new Tuple2<>(record.getKey(), record))
         .repartitionAndSortWithinPartitions(partitioner, comparator)

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/BucketPartitionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/BucketPartitionUtils.scala
@@ -65,9 +65,8 @@ object BucketPartitionUtils extends SparkAdapterSupport {
       // Scala derives the record-key ordering from HoodieUTF8String's Comparable implementation,
       // which uses binary UTF-8 ordering for both Spark 3 and Spark 4.
       val keyedRows = internalRows.keyBy(row => {
-        // InternalRow may reuse its mutable backing buffer, so keep an independent key for shuffle.
         val recordKey = utf8StringFactory.wrapUTF8String(
-          row.getUTF8String(HoodieRecord.RECORD_KEY_META_FIELD_ORD).copy())
+          row.getUTF8String(HoodieRecord.RECORD_KEY_META_FIELD_ORD))
         (getPartitionKey(row), recordKey)
       })
       // The record key participates only in sorting; bucket routing remains unchanged.

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/BucketPartitionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/BucketPartitionUtils.scala
@@ -18,7 +18,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.hudi.SparkAdapterSupport
+import org.apache.hudi.{HoodieUTF8String, SparkAdapterSupport}
 import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig
 import org.apache.hudi.common.util.{Functions, RemotePartitionHelper}
@@ -32,6 +32,14 @@ import org.apache.spark.sql.catalyst.InternalRow
 
 object BucketPartitionUtils extends SparkAdapterSupport {
   def createDataFrame(df: DataFrame, indexKeyFields: String, numBucketsFunction: NumBucketsFunction, partitioner: Partitioner): DataFrame = {
+    createDataFrame(df, indexKeyFields, numBucketsFunction, partitioner, sortByRecordKey = false)
+  }
+
+  def createDataFrame(df: DataFrame,
+                      indexKeyFields: String,
+                      numBucketsFunction: NumBucketsFunction,
+                      partitioner: Partitioner,
+                      sortByRecordKey: Boolean): DataFrame = {
     // parse the comma-separated config once outside the per-row closure; the list is a
     // serializable java.util.List, safe to capture
     val indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeyFields)
@@ -49,10 +57,35 @@ object BucketPartitionUtils extends SparkAdapterSupport {
 
     val getPartitionKey = getPartitionKeyExtractor()
     // use internalRow to avoid extra convert.
-    val reRdd = df.queryExecution.toRdd
-      .keyBy(row => getPartitionKey(row))
-      .repartitionAndSortWithinPartitions(partitioner)
-      .values
+    val internalRows = df.queryExecution.toRdd
+    val reRdd = if (sortByRecordKey) {
+      val utf8StringFactory = sparkAdapter.getUTF8StringFactory
+      // Use (bucket route, record key) as the shuffle key. Tuple ordering groups rows by
+      // (partition path, bucket id) first, then orders each bucket by the full record key.
+      // Scala derives the record-key ordering from HoodieUTF8String's Comparable implementation,
+      // which uses binary UTF-8 ordering for both Spark 3 and Spark 4.
+      val keyedRows = internalRows.keyBy(row => {
+        // InternalRow may reuse its mutable backing buffer, so keep an independent key for shuffle.
+        val recordKey = utf8StringFactory.wrapUTF8String(
+          row.getUTF8String(HoodieRecord.RECORD_KEY_META_FIELD_ORD).copy())
+        (getPartitionKey(row), recordKey)
+      })
+      // The record key participates only in sorting; bucket routing remains unchanged.
+      val bucketRoutePartitioner = new Partitioner {
+        override def numPartitions: Int = partitioner.numPartitions
+
+        override def getPartition(key: Any): Int = {
+          val bucketRoute = key.asInstanceOf[((String, Int), HoodieUTF8String)]._1
+          partitioner.getPartition(bucketRoute)
+        }
+      }
+      keyedRows.repartitionAndSortWithinPartitions(bucketRoutePartitioner).values
+    } else {
+      internalRows
+        .keyBy(row => getPartitionKey(row))
+        .repartitionAndSortWithinPartitions(partitioner)
+        .values
+    }
     sparkAdapter.internalCreateDataFrame(df.sparkSession, reRdd, df.schema)
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
@@ -44,6 +44,7 @@ import org.apache.hudi.execution.bulkinsert.BulkInsertInternalPartitionerWithRow
 import org.apache.hudi.execution.bulkinsert.ConsistentBucketIndexBulkInsertPartitionerWithRows;
 import org.apache.hudi.execution.bulkinsert.NonSortPartitionerWithRows;
 import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.table.BucketSortBulkInsertPartitioner;
 import org.apache.hudi.table.BulkInsertPartitioner;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
@@ -140,8 +141,11 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
   protected BulkInsertPartitioner<Dataset<Row>> getPartitioner(boolean populateMetaFields, boolean isTablePartitioned) {
     if (populateMetaFields) {
       if (writeConfig.getIndexType() == HoodieIndex.IndexType.BUCKET) {
+        BucketSortBulkInsertPartitioner.validateCustomSortColumns(table, null);
         if (writeConfig.getBucketIndexEngineType() == HoodieIndex.BucketIndexEngineType.SIMPLE) {
-          return new BucketIndexBulkInsertPartitionerWithRows(writeConfig.getBucketIndexHashFieldWithDefault(), table.getConfig());
+          return new BucketIndexBulkInsertPartitionerWithRows(
+              writeConfig.getBucketIndexHashFieldWithDefault(), table.getConfig(),
+              table.getMetaClient().getTableConfig().isLSMTreeStorageLayout());
         } else {
           return new ConsistentBucketIndexBulkInsertPartitionerWithRows(table, Collections.emptyMap(), true);
         }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
@@ -44,7 +44,6 @@ import org.apache.hudi.execution.bulkinsert.BulkInsertInternalPartitionerWithRow
 import org.apache.hudi.execution.bulkinsert.ConsistentBucketIndexBulkInsertPartitionerWithRows;
 import org.apache.hudi.execution.bulkinsert.NonSortPartitionerWithRows;
 import org.apache.hudi.index.HoodieIndex;
-import org.apache.hudi.table.BucketSortBulkInsertPartitioner;
 import org.apache.hudi.table.BulkInsertPartitioner;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
@@ -141,7 +140,6 @@ public abstract class BaseDatasetBulkInsertCommitActionExecutor implements Seria
   protected BulkInsertPartitioner<Dataset<Row>> getPartitioner(boolean populateMetaFields, boolean isTablePartitioned) {
     if (populateMetaFields) {
       if (writeConfig.getIndexType() == HoodieIndex.IndexType.BUCKET) {
-        BucketSortBulkInsertPartitioner.validateCustomSortColumns(table, null);
         if (writeConfig.getBucketIndexEngineType() == HoodieIndex.BucketIndexEngineType.SIMPLE) {
           return new BucketIndexBulkInsertPartitionerWithRows(
               writeConfig.getBucketIndexHashFieldWithDefault(), table.getConfig(),

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBucketRescaleCommitActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/DatasetBucketRescaleCommitActionExecutor.java
@@ -57,7 +57,9 @@ public class DatasetBucketRescaleCommitActionExecutor extends DatasetBulkInsertO
    */
   @Override
   protected BulkInsertPartitioner<Dataset<Row>> getPartitioner(boolean populateMetaFields, boolean isTablePartitioned) {
-    return new BucketIndexBulkInsertPartitionerWithRows(writeClient.getConfig(), expression, rule, bucketNumber);
+    return new BucketIndexBulkInsertPartitionerWithRows(
+        writeClient.getConfig(), expression, rule, bucketNumber,
+        table.getMetaClient().getTableConfig().isLSMTreeStorageLayout());
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestLSMBulkInsertPartitioner.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestLSMBulkInsertPartitioner.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.table.BulkInsertPartitioner;
@@ -130,6 +131,36 @@ public class TestLSMBulkInsertPartitioner extends HoodieSparkClientTestHarness {
         row.getAs(HoodieRecord.RECORD_KEY_METADATA_FIELD)));
     assertDistributionSemantics(sortMode, actual.javaRDD());
     assertTrue(partitioner.arePartitionRecordsSorted());
+  }
+
+  @Test
+  void testSimpleBucketRowPartitionerSortsByUtf8RecordKeyWithoutChangingSchema() {
+    StructType schema = new StructType()
+        .add(HoodieRecord.COMMIT_TIME_METADATA_FIELD, DataTypes.StringType, false)
+        .add(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, DataTypes.StringType, false)
+        .add(HoodieRecord.RECORD_KEY_METADATA_FIELD, DataTypes.StringType, false)
+        .add(HoodieRecord.PARTITION_PATH_METADATA_FIELD, DataTypes.StringType, false)
+        .add(HoodieRecord.FILENAME_METADATA_FIELD, DataTypes.StringType, false)
+        .add("value", DataTypes.IntegerType, false);
+    Dataset<Row> input = sqlContext.createDataFrame(
+        jsc.parallelize(createRowsWithMetaFields(), 3), schema);
+    HoodieWriteConfig config = createWriteConfig(BulkInsertSortMode.NONE, true);
+    config.setValue(HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD, "id");
+    config.setValue(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS, "1");
+
+    List<BulkInsertPartitioner<Dataset<Row>>> partitioners = Arrays.asList(
+        new BucketIndexBulkInsertPartitionerWithRows("id", config, true),
+        new BucketIndexBulkInsertPartitionerWithRows(config, "p1|p2|p3,1", "regex", 1, true));
+
+    for (BulkInsertPartitioner<Dataset<Row>> partitioner : partitioners) {
+      Dataset<Row> actual = partitioner.repartitionRecords(input, 1);
+
+      assertEquals(schema, actual.schema(), "Sorting must not add temporary columns");
+      assertEquals(1, actual.javaRDD().getNumPartitions());
+      assertSortedSparkPartitions(actual.javaRDD().glom().collect(), row -> new Tuple2<>(
+          row.getAs(HoodieRecord.PARTITION_PATH_METADATA_FIELD),
+          row.getAs(HoodieRecord.RECORD_KEY_METADATA_FIELD)));
+    }
   }
 
   @ParameterizedTest
@@ -290,6 +321,15 @@ public class TestLSMBulkInsertPartitioner extends HoodieSparkClientTestHarness {
     int value = 0;
     for (Tuple2<String, String> key : createKeys()) {
       rows.add(RowFactory.create(key._1, key._2, value++));
+    }
+    return rows;
+  }
+
+  private List<Row> createRowsWithMetaFields() {
+    List<Row> rows = new ArrayList<>();
+    int value = 0;
+    for (Tuple2<String, String> key : createKeys()) {
+      rows.add(RowFactory.create("001", "001_0", key._2, key._1, "", value++));
     }
     return rows;
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLSMDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLSMDataSource.scala
@@ -296,29 +296,6 @@ class TestLSMDataSource extends SparkClientFunctionalTestHarness {
   }
 
   @Test
-  def testLsmBucketRejectsCustomSortColumnsBeforeInflight(): Unit = {
-    Seq(false, true).foreach { enableRowWriter =>
-      val tablePath = s"${basePath}_cow_lsm_bucket_custom_sort_$enableRowWriter"
-      val options = baseOptions(HoodieTableType.COPY_ON_WRITE) ++ Map(
-        DataSourceWriteOptions.ENABLE_ROW_WRITER.key -> enableRowWriter.toString,
-        HoodieIndexConfig.INDEX_TYPE.key -> HoodieIndex.IndexType.BUCKET.name,
-        HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE.key -> HoodieIndex.BucketIndexEngineType.SIMPLE.name,
-        HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key -> "id",
-        HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key -> "1",
-        HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_SORT_COLUMNS.key -> "value")
-      val inserts = rows(Seq(("key-1", "v1", 1L, FirstPartition)))
-
-      val exception = assertThrows(classOf[HoodieException], () =>
-        write(inserts, tablePath, options, WriteOperationType.BULK_INSERT, SaveMode.Overwrite))
-      assertExceptionChainContains(exception, "Custom sort columns are not supported for bucket index on LSM tables")
-
-      val instants = createMetaClient(tablePath).reloadActiveTimeline().getInstants.asScala
-      assertEquals(1, instants.size)
-      assertEquals(org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED, instants.head.getState)
-    }
-  }
-
-  @Test
   def testCompactionProducesSortedBaseFile(): Unit = {
     val tablePath = s"${basePath}_mor_lsm_compaction"
     val options = baseOptions(HoodieTableType.MERGE_ON_READ) ++ Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLSMDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLSMDataSource.scala
@@ -25,9 +25,10 @@ import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.hudi.common.util.Option
 import org.apache.hudi.common.util.StringUtils
-import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
+import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, HoodieWriteConfig}
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.execution.bulkinsert.{BulkInsertSortMode, RowCustomColumnsSortPartitioner}
+import org.apache.hudi.index.HoodieIndex
 import org.apache.hudi.testutils.{HoodieClientTestUtils, SparkClientFunctionalTestHarness}
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
@@ -176,6 +177,57 @@ class TestLSMDataSource extends SparkClientFunctionalTestHarness {
   }
 
   @ParameterizedTest
+  @MethodSource(Array("bucketBulkInsertParams"))
+  def testBucketIndexBulkInsert(
+      tableType: HoodieTableType,
+      bucketEngineType: HoodieIndex.BucketIndexEngineType,
+      enableRowWriter: Boolean): Unit = {
+    val tablePath = s"${basePath}_${tableType.name.toLowerCase}_${bucketEngineType.name.toLowerCase}_$enableRowWriter"
+    val options = baseOptions(tableType) ++ Map(
+      DataSourceWriteOptions.ENABLE_ROW_WRITER.key -> enableRowWriter.toString,
+      HoodieWriteConfig.BULK_INSERT_SORT_MODE.key -> BulkInsertSortMode.NONE.name,
+      HoodieIndexConfig.INDEX_TYPE.key -> HoodieIndex.IndexType.BUCKET.name,
+      HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE.key -> bucketEngineType.name,
+      HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key -> "id",
+      HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key -> "1")
+    val inserts = rows(Seq(
+      ("😀-bucket-p1", "v1", 1L, FirstPartition),
+      ("Ａ-bucket-p1", "v1", 1L, FirstPartition),
+      ("middle-bucket-p1", "v1", 1L, FirstPartition),
+      ("😀-bucket-p2", "v1", 1L, SecondPartition),
+      ("Ａ-bucket-p2", "v1", 1L, SecondPartition)))
+
+    write(inserts, tablePath, options, WriteOperationType.BULK_INSERT, SaveMode.Overwrite)
+
+    assertLatestBaseFilesSorted(tablePath, WriteOperationType.BULK_INSERT)
+    val initialFileIds = latestBaseFiles(tablePath).map(_.getFileId).toSet
+    assertEquals(2, initialFileIds.size)
+    assertSnapshot(tablePath, Map(
+      "😀-bucket-p1" -> "v1",
+      "Ａ-bucket-p1" -> "v1",
+      "middle-bucket-p1" -> "v1",
+      "😀-bucket-p2" -> "v1",
+      "Ａ-bucket-p2" -> "v1"))
+
+    val upserts = rows(Seq(
+      ("😀-bucket-p1", "v2", 2L, FirstPartition),
+      ("Ａ-bucket-p1", "v2", 2L, FirstPartition),
+      ("middle-bucket-p1", "v2", 2L, FirstPartition),
+      ("ascii-new-p1", "new", 2L, FirstPartition)))
+    write(upserts, tablePath, options, WriteOperationType.UPSERT)
+
+    assertChangedFilesSorted(tablePath, tableType, WriteOperationType.UPSERT, "log")
+    assertEquals(initialFileIds, latestBaseFiles(tablePath).map(_.getFileId).toSet)
+    assertSnapshot(tablePath, Map(
+      "😀-bucket-p1" -> "v2",
+      "Ａ-bucket-p1" -> "v2",
+      "middle-bucket-p1" -> "v2",
+      "ascii-new-p1" -> "new",
+      "😀-bucket-p2" -> "v1",
+      "Ａ-bucket-p2" -> "v1"))
+  }
+
+  @ParameterizedTest
   @EnumSource(value = classOf[BulkInsertSortMode], names = Array(
     "NONE", "PARTITION_PATH_REPARTITION"))
   def testBulkInsertRejectsNonSortingModes(sortMode: BulkInsertSortMode): Unit = {
@@ -241,6 +293,29 @@ class TestLSMDataSource extends SparkClientFunctionalTestHarness {
     val instants = createMetaClient(tablePath).reloadActiveTimeline().getInstants.asScala
     assertEquals(1, instants.size)
     assertEquals(org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED, instants.head.getState)
+  }
+
+  @Test
+  def testLsmBucketRejectsCustomSortColumnsBeforeInflight(): Unit = {
+    Seq(false, true).foreach { enableRowWriter =>
+      val tablePath = s"${basePath}_cow_lsm_bucket_custom_sort_$enableRowWriter"
+      val options = baseOptions(HoodieTableType.COPY_ON_WRITE) ++ Map(
+        DataSourceWriteOptions.ENABLE_ROW_WRITER.key -> enableRowWriter.toString,
+        HoodieIndexConfig.INDEX_TYPE.key -> HoodieIndex.IndexType.BUCKET.name,
+        HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE.key -> HoodieIndex.BucketIndexEngineType.SIMPLE.name,
+        HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key -> "id",
+        HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key -> "1",
+        HoodieWriteConfig.BULKINSERT_USER_DEFINED_PARTITIONER_SORT_COLUMNS.key -> "value")
+      val inserts = rows(Seq(("key-1", "v1", 1L, FirstPartition)))
+
+      val exception = assertThrows(classOf[HoodieException], () =>
+        write(inserts, tablePath, options, WriteOperationType.BULK_INSERT, SaveMode.Overwrite))
+      assertExceptionChainContains(exception, "Custom sort columns are not supported for bucket index on LSM tables")
+
+      val instants = createMetaClient(tablePath).reloadActiveTimeline().getInstants.asScala
+      assertEquals(1, instants.size)
+      assertEquals(org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED, instants.head.getState)
+    }
   }
 
   @Test
@@ -429,6 +504,15 @@ class TestLSMDataSource extends SparkClientFunctionalTestHarness {
 }
 
 object TestLSMDataSource {
+
+  def bucketBulkInsertParams(): java.util.stream.Stream[Arguments] =
+    java.util.stream.Stream.of(
+      Arguments.of(HoodieTableType.COPY_ON_WRITE, HoodieIndex.BucketIndexEngineType.SIMPLE, Boolean.box(false)),
+      Arguments.of(HoodieTableType.COPY_ON_WRITE, HoodieIndex.BucketIndexEngineType.SIMPLE, Boolean.box(true)),
+      Arguments.of(HoodieTableType.MERGE_ON_READ, HoodieIndex.BucketIndexEngineType.SIMPLE, Boolean.box(false)),
+      Arguments.of(HoodieTableType.MERGE_ON_READ, HoodieIndex.BucketIndexEngineType.SIMPLE, Boolean.box(true)),
+      Arguments.of(HoodieTableType.MERGE_ON_READ, HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING, Boolean.box(false)),
+      Arguments.of(HoodieTableType.MERGE_ON_READ, HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING, Boolean.box(true)))
 
   def bulkInsertWithHoodieRecordPathParams(): java.util.stream.Stream[Arguments] =
     java.util.stream.Stream.of(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLSMDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLSMDataSource.scala
@@ -20,7 +20,8 @@ package org.apache.hudi.functional
 import org.apache.hudi.{DataSourceUtils, DataSourceWriteOptions}
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.common.config.HoodieStorageConfig
-import org.apache.hudi.common.model.{HoodieBaseFile, HoodieRecord, HoodieRecordPayload, HoodieTableType, WriteOperationType}
+import org.apache.hudi.common.fs.{FileNameParser, FSUtils}
+import org.apache.hudi.common.model.{HoodieBaseFile, HoodieConsistentHashingMetadata, HoodieRecord, HoodieRecordPayload, HoodieTableType, WriteOperationType}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.hudi.common.util.Option
@@ -29,6 +30,7 @@ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, Hoodie
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.execution.bulkinsert.{BulkInsertSortMode, RowCustomColumnsSortPartitioner}
 import org.apache.hudi.index.HoodieIndex
+import org.apache.hudi.index.bucket.{BucketIdentifier, ConsistentBucketIdentifier}
 import org.apache.hudi.testutils.{HoodieClientTestUtils, SparkClientFunctionalTestHarness}
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
@@ -182,6 +184,7 @@ class TestLSMDataSource extends SparkClientFunctionalTestHarness {
       tableType: HoodieTableType,
       bucketEngineType: HoodieIndex.BucketIndexEngineType,
       enableRowWriter: Boolean): Unit = {
+    val numBuckets = 2
     val tablePath = s"${basePath}_${tableType.name.toLowerCase}_${bucketEngineType.name.toLowerCase}_$enableRowWriter"
     val options = baseOptions(tableType) ++ Map(
       DataSourceWriteOptions.ENABLE_ROW_WRITER.key -> enableRowWriter.toString,
@@ -189,42 +192,37 @@ class TestLSMDataSource extends SparkClientFunctionalTestHarness {
       HoodieIndexConfig.INDEX_TYPE.key -> HoodieIndex.IndexType.BUCKET.name,
       HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE.key -> bucketEngineType.name,
       HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key -> "id",
-      HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key -> "1")
-    val inserts = rows(Seq(
+      HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key -> numBuckets.toString)
+    val insertValues = Seq(
       ("😀-bucket-p1", "v1", 1L, FirstPartition),
       ("Ａ-bucket-p1", "v1", 1L, FirstPartition),
       ("middle-bucket-p1", "v1", 1L, FirstPartition),
       ("😀-bucket-p2", "v1", 1L, SecondPartition),
-      ("Ａ-bucket-p2", "v1", 1L, SecondPartition)))
+      ("Ａ-bucket-p2", "v1", 1L, SecondPartition)) ++
+      routingRecords(bucketEngineType, numBuckets)
+    val inserts = rows(insertValues)
 
     write(inserts, tablePath, options, WriteOperationType.BULK_INSERT, SaveMode.Overwrite)
 
     assertLatestBaseFilesSorted(tablePath, WriteOperationType.BULK_INSERT)
+    assertBucketFileGroupRouting(tablePath, bucketEngineType, numBuckets)
     val initialFileIds = latestBaseFiles(tablePath).map(_.getFileId).toSet
-    assertEquals(2, initialFileIds.size)
-    assertSnapshot(tablePath, Map(
-      "😀-bucket-p1" -> "v1",
-      "Ａ-bucket-p1" -> "v1",
-      "middle-bucket-p1" -> "v1",
-      "😀-bucket-p2" -> "v1",
-      "Ａ-bucket-p2" -> "v1"))
+    assertEquals(numBuckets * 2, initialFileIds.size)
+    assertSnapshot(tablePath, insertValues.map(value => value._1 -> value._2).toMap)
 
-    val upserts = rows(Seq(
+    val upsertValues = Seq(
       ("😀-bucket-p1", "v2", 2L, FirstPartition),
       ("Ａ-bucket-p1", "v2", 2L, FirstPartition),
       ("middle-bucket-p1", "v2", 2L, FirstPartition),
-      ("ascii-new-p1", "new", 2L, FirstPartition)))
+      ("ascii-new-p1", "new", 2L, FirstPartition))
+    val upserts = rows(upsertValues)
     write(upserts, tablePath, options, WriteOperationType.UPSERT)
 
     assertChangedFilesSorted(tablePath, tableType, WriteOperationType.UPSERT, "log")
     assertEquals(initialFileIds, latestBaseFiles(tablePath).map(_.getFileId).toSet)
-    assertSnapshot(tablePath, Map(
-      "😀-bucket-p1" -> "v2",
-      "Ａ-bucket-p1" -> "v2",
-      "middle-bucket-p1" -> "v2",
-      "ascii-new-p1" -> "new",
-      "😀-bucket-p2" -> "v1",
-      "Ａ-bucket-p2" -> "v1"))
+    assertSnapshot(tablePath,
+      insertValues.map(value => value._1 -> value._2).toMap ++
+        upsertValues.map(value => value._1 -> value._2).toMap)
   }
 
   @ParameterizedTest
@@ -461,6 +459,63 @@ class TestLSMDataSource extends SparkClientFunctionalTestHarness {
         tablePath,
         metaClient.getStorage,
         s"$tablePath/$partitionPath/*").asScala
+    }
+  }
+
+  private def assertBucketFileGroupRouting(
+      tablePath: String,
+      bucketEngineType: HoodieIndex.BucketIndexEngineType,
+      numBuckets: Int): Unit = {
+    val actualFileIdsByPartition = spark.read.format("hudi").load(tablePath)
+      .select("id", HoodieRecord.PARTITION_PATH_METADATA_FIELD, HoodieRecord.FILENAME_METADATA_FIELD)
+      .collect()
+      .map { row =>
+        val recordKey = row.getString(0)
+        val partitionPath = row.getString(1)
+        val fileId = FSUtils.getFileId(row.getString(2))
+        val actualFileGroup = bucketEngineType match {
+          case HoodieIndex.BucketIndexEngineType.SIMPLE =>
+            BucketIdentifier.bucketIdStr(BucketIdentifier.bucketIdFromFileId(fileId))
+          case HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING =>
+            FileNameParser.getFileIdPfxFromFileId(fileId)
+        }
+        assertEquals(expectedFileGroup(recordKey, partitionPath, bucketEngineType, numBuckets), actualFileGroup,
+          s"Unexpected file group for record $recordKey in partition $partitionPath")
+        partitionPath -> actualFileGroup
+      }
+      .groupBy(_._1)
+
+    Seq(FirstPartition, SecondPartition).foreach { partitionPath =>
+      assertEquals(numBuckets, actualFileIdsByPartition(partitionPath).map(_._2).distinct.length,
+        s"Expected every bucket to be exercised in partition $partitionPath")
+    }
+  }
+
+  private def routingRecords(
+      bucketEngineType: HoodieIndex.BucketIndexEngineType,
+      numBuckets: Int): Seq[(String, String, Long, String)] = {
+    Seq(FirstPartition, SecondPartition).flatMap { partitionPath =>
+      val keysByFileGroup = (0 until 100)
+        .map(index => s"route-$index-$partitionPath")
+        .groupBy(recordKey => expectedFileGroup(recordKey, partitionPath, bucketEngineType, numBuckets))
+      assertEquals(numBuckets, keysByFileGroup.size,
+        s"Could not generate a routing key for every bucket in partition $partitionPath")
+      keysByFileGroup.values.map(_.head).toSeq
+        .map(recordKey => (recordKey, "v1", 1L, partitionPath))
+    }
+  }
+
+  private def expectedFileGroup(
+      recordKey: String,
+      partitionPath: String,
+      bucketEngineType: HoodieIndex.BucketIndexEngineType,
+      numBuckets: Int): String = {
+    bucketEngineType match {
+      case HoodieIndex.BucketIndexEngineType.SIMPLE =>
+        BucketIdentifier.bucketIdStr(BucketIdentifier.getBucketId(recordKey, "id", numBuckets))
+      case HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING =>
+        new ConsistentBucketIdentifier(new HoodieConsistentHashingMetadata(partitionPath, numBuckets))
+          .getBucket(recordKey, "id").getFileIdPrefix
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19439.

Spark bucket-index partitioners own file-group routing and file-id assignment, so LSM tables cannot replace them with the generic LSM bulk-insert partitioners. The existing bucket paths therefore need to preserve their routing behavior while guaranteeing UTF-8 record-key ordering inside every output bucket.

### Summary and Changelog

- Sort records within each LSM bucket by the full record key using UTF-8 ordering while preserving existing simple and consistent-hashing bucket routing and file-id assignment.
- Enable the ordering for both RDD and Dataset Row bulk-insert paths, including the Dataset bucket-rescale path, without changing non-LSM ordering behavior or the Row schema.
- Reject custom bucket sort columns for LSM tables before writes reach the inflight state.
- Add unit and functional coverage for non-ASCII record keys, COW and MOR tables, simple and consistent-hashing bucket indexes, RDD and Row writers, subsequent upserts, and file-id stability.

### Impact

This enables Spark LSM tables to use simple and consistent-hashing bucket indexes. It introduces no new public API or configuration. LSM Dataset Row simple-bucket writes now include the record key in the shuffle sort key, adding the key copy and comparisons required to maintain the LSM physical ordering invariant; other table layouts retain their existing behavior.

### Risk Level

Medium. The change affects Spark bucket-index write partitioning and ordering. The risk is mitigated by 14 passing partitioner tests and 7 passing targeted functional cases covering routing, UTF-8 ordering, schema preservation, custom-sort rejection, file-id stability, and snapshot correctness after upsert. Compilation, the relevant Checkstyle and Scalastyle checks, and `git diff --check` also completed without violations.

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
