### PR TITLE
feat(metadata): add standalone metadata table services tool

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -46,6 +46,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
@@ -96,6 +97,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1531,13 +1533,25 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    */
   @Override
   public void performTableServices(Option<String> inFlightInstantTimestamp, boolean requiresTimelineRefresh) {
+    MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.SCHEDULE_AND_EXECUTE)
+        .build();
+    runTableServicesInternal(request, requiresTimelineRefresh);
+  }
+
+  private void runTableServicesInternal(MetadataTableServiceRequest request,
+                                        boolean requiresTimelineRefresh) {
     HoodieTimer metadataTableServicesTimer = HoodieTimer.start();
     boolean allTableServicesExecutedSuccessfullyOrSkipped = true;
     BaseHoodieWriteClient<?, I, ?, O> writeClient = getWriteClient();
     try {
+      HoodieActiveTimeline activeTimeline = requiresTimelineRefresh
+          ? metadataMetaClient.reloadActiveTimeline() : metadataMetaClient.getActiveTimeline();
       // Run any pending table services operations and return the active timeline
-      HoodieActiveTimeline activeTimeline = runPendingTableServicesOperationsAndRefreshTimeline(
-          metadataMetaClient, writeClient, requiresTimelineRefresh, metrics);
+      if (request.getMode().includesExecute()
+          && executePendingCompactionServices(request, activeTimeline, writeClient)) {
+        activeTimeline = metadataMetaClient.reloadActiveTimeline();
+      }
 
       Option<HoodieInstant> lastInstant = activeTimeline.getDeltaCommitTimeline()
           .filterCompletedInstants()
@@ -1545,15 +1559,30 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       if (!lastInstant.isPresent()) {
         return;
       }
+
       // Check and run clean operations.
-      cleanIfNecessary(writeClient, lastInstant.get().requestedTime());
-      // Do timeline validation before scheduling compaction/logCompaction operations.
-      if (validateCompactionScheduling(inFlightInstantTimestamp, lastInstant.get().requestedTime())) {
-        String latestDeltacommitTime = lastInstant.get().requestedTime();
-        LOG.info("Latest deltacommit time found is {}, running compaction operations.", latestDeltacommitTime);
-        compactIfNecessary(writeClient, Option.of(latestDeltacommitTime));
+      String latestDeltaCommitTime = lastInstant.get().requestedTime();
+      if (request.getMode().includesExecute()
+          && request.includes(TableServiceType.CLEAN)
+          && !shouldDelegateExecution(request, TableServiceType.CLEAN)) {
+        runCleanService(writeClient, latestDeltaCommitTime);
       }
-      writeClient.archive();
+
+      if (request.getMode().includesSchedule()
+          && (request.includes(TableServiceType.COMPACT) || request.includes(TableServiceType.LOG_COMPACT))
+          // Do timeline validation before scheduling compaction/logCompaction operations.
+          && validateCompactionScheduling(latestDeltaCommitTime)) {
+        LOG.info("Latest delta commit time found is {}, scheduling compaction operations.", latestDeltaCommitTime);
+        runCompactionServicesIfNecessary(writeClient, Option.of(latestDeltaCommitTime), request);
+      }
+
+      if (request.getMode().includesExecute() && request.includes(TableServiceType.ARCHIVE)) {
+        if (shouldDelegateExecution(request, TableServiceType.ARCHIVE)) {
+          LOG.info("Skipping archival on MDT as it is delegated to table service manager.");
+        } else {
+          writeClient.archive();
+        }
+      }
       LOG.info("All the table services operations on MDT completed successfully");
     } catch (Exception e) {
       LOG.error("Exception in running table services on metadata table", e);
@@ -1580,35 +1609,97 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
   }
 
-  static HoodieActiveTimeline runPendingTableServicesOperationsAndRefreshTimeline(HoodieTableMetaClient metadataMetaClient,
-                                                                                  BaseHoodieWriteClient<?, ?, ?, ?> writeClient,
-                                                                                  boolean initialTimelineRequiresRefresh,
-                                                                                  Option<HoodieMetadataMetrics> metricsOption) {
+  @Override
+  public void scheduleTableServices(MetadataTableServiceRequest request) {
+    MetadataTableServiceRequest scheduleRequest = request.copy(MetadataTableServiceMode.SCHEDULE);
+    runTableServicesInternal(scheduleRequest, true);
+  }
+
+  @Override
+  public void executeTableServices(MetadataTableServiceRequest request) {
+    MetadataTableServiceRequest executeRequest = request.copy(MetadataTableServiceMode.EXECUTE);
+    runTableServicesInternal(executeRequest, true);
+  }
+
+  private boolean executePendingCompactionServices(MetadataTableServiceRequest request,
+                                                   HoodieActiveTimeline activeTimeline,
+                                                   BaseHoodieWriteClient<?, I, ?, O> writeClient) {
+    boolean ranServices = false;
     try {
-      HoodieActiveTimeline activeTimeline = initialTimelineRequiresRefresh ? metadataMetaClient.reloadActiveTimeline() : metadataMetaClient.getActiveTimeline();
-      // finish off any pending log compaction or compactions operations if any from previous attempt.
-      boolean ranServices = false;
-      if (activeTimeline.filterPendingCompactionTimeline().countInstants() > 0) {
-        if (writeClient.shouldDelegateToTableServiceManager(writeClient.getConfig(), ActionType.compaction)) {
+      if (request.includes(TableServiceType.COMPACT)
+          && activeTimeline.filterPendingCompactionTimeline().countInstants() > 0) {
+        if (shouldDelegateExecution(request, TableServiceType.COMPACT)) {
           LOG.info("Skipping pending compactions on MDT as they are delegated to table service manager.");
+        } else if (request.getInstantTime().isPresent()) {
+          writeClient.compact(request.getInstantTime().get(), true);
+          ranServices = true;
         } else {
           writeClient.runAnyPendingCompactions();
           ranServices = true;
         }
       }
-      if (activeTimeline.filterPendingLogCompactionTimeline().countInstants() > 0) {
-        if (writeClient.shouldDelegateToTableServiceManager(writeClient.getConfig(), ActionType.logcompaction)) {
+      if (request.includes(TableServiceType.LOG_COMPACT)
+          && activeTimeline.filterPendingLogCompactionTimeline().countInstants() > 0) {
+        if (shouldDelegateExecution(request, TableServiceType.LOG_COMPACT)) {
           LOG.info("Skipping pending log compactions on MDT as they are delegated to table service manager.");
+        } else if (request.getInstantTime().isPresent()) {
+          writeClient.logCompact(request.getInstantTime().get(), true);
+          ranServices = true;
         } else {
           writeClient.runAnyPendingLogCompactions();
           ranServices = true;
         }
       }
-      return ranServices ? metadataMetaClient.reloadActiveTimeline() : activeTimeline;
+      return ranServices;
     } catch (Exception e) {
-      metricsOption.ifPresent(m -> m.incrementMetric(
-          HoodieMetadataMetrics.PENDING_COMPACTIONS_FAILURES, 1));
+      metrics.ifPresent(m -> m.incrementMetric(HoodieMetadataMetrics.PENDING_COMPACTIONS_FAILURES, 1));
       throw e;
+    }
+  }
+
+  private void runCleanService(BaseHoodieWriteClient<?, I, ?, O> writeClient,
+                               String latestDeltaCommitTime) {
+    if (shouldRunClean()) {
+      executeClean(writeClient, latestDeltaCommitTime);
+      writeClient.lazyRollbackFailedIndexing();
+    }
+  }
+
+  protected boolean shouldDelegateExecution(MetadataTableServiceRequest request, TableServiceType service) {
+    return shouldDelegate(request, service,
+        config -> config.getTableServiceManagerConfig().getTableServiceManagerActions());
+  }
+
+  protected boolean shouldDelegateScheduling(MetadataTableServiceRequest request, TableServiceType service) {
+    return shouldDelegate(request, service,
+        config -> config.getMetadataConfig().getTableServiceManagerScheduleActions());
+  }
+
+  private boolean shouldDelegate(MetadataTableServiceRequest request, TableServiceType service,
+                                 Function<HoodieWriteConfig, String> actionsProvider) {
+    if (request.shouldDisableTableServiceManagerDelegation()
+        || metadataWriteConfig == null
+        || !metadataWriteConfig.getTableServiceManagerConfig().isTableServiceManagerEnabled()) {
+      return false;
+    }
+    String action = actionName(service);
+    return Arrays.stream(actionsProvider.apply(metadataWriteConfig).split(","))
+        .map(String::trim)
+        .anyMatch(action::equals);
+  }
+
+  private static String actionName(TableServiceType service) {
+    switch (service) {
+      case COMPACT:
+        return ActionType.compaction.name();
+      case LOG_COMPACT:
+        return ActionType.logcompaction.name();
+      case CLEAN:
+        return ActionType.clean.name();
+      case ARCHIVE:
+        return "archive";
+      default:
+        throw new IllegalArgumentException("Unsupported MDT table service: " + service);
     }
   }
 
@@ -1622,7 +1713,9 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    * 2. In multi-writer scenario, a parallel operation with a greater instantTime may have completed creating a
    * deltacommit.
    */
-  void compactIfNecessary(BaseHoodieWriteClient<?,I,?,O> writeClient, Option<String> latestDeltaCommitTimeOpt) {
+  protected void runCompactionServicesIfNecessary(BaseHoodieWriteClient<?, I, ?, O> writeClient,
+                                                  Option<String> latestDeltaCommitTimeOpt,
+                                                  MetadataTableServiceRequest request) {
     // IMPORTANT: Trigger compaction with max instant time that is smaller than(or equals) the earliest pending instant from DT.
     // The compaction planner will manage to filter out the log files that finished with greater completion time.
     // see BaseHoodieCompactionPlanGenerator.generateCompactionPlan for more details.
@@ -1643,43 +1736,57 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     try {
       if (skipCompactions) {
         LOG.info("Compaction with same {} time is already present in the timeline.", compactionInstantTime);
-      } else if (writeClient.scheduleCompactionAtInstant(compactionInstantTime, Option.empty())) {
-        LOG.info("Compaction is scheduled for timestamp {}", compactionInstantTime);
-        if (shouldDelegateToTableServiceManager(metadataWriteConfig, ActionType.compaction)) {
-          LOG.info("Skipping execution of compaction on MDT as it is delegated to table service manager.");
-        } else {
-          writeClient.compact(compactionInstantTime, true);
+      } else if (request.includes(TableServiceType.COMPACT)
+          && request.getMode().includesSchedule()) {
+        if (shouldDelegateScheduling(request, TableServiceType.COMPACT)) {
+          LOG.info("Skipping scheduling of compaction on MDT as it is delegated to table service manager.");
+        } else if (writeClient.scheduleCompactionAtInstant(compactionInstantTime, Option.empty())) {
+          LOG.info("Compaction is scheduled for timestamp {}", compactionInstantTime);
+          if (request.getMode().includesExecute()) {
+            if (shouldDelegateExecution(request, TableServiceType.COMPACT)) {
+              LOG.info("Skipping execution of compaction on MDT as it is delegated to table service manager.");
+            } else {
+              writeClient.compact(compactionInstantTime, true);
+            }
+          }
         }
       }
     } catch (Exception e) {
       metrics.ifPresent(m -> m.incrementMetric(HoodieMetadataMetrics.COMPACTION_FAILURES, 1));
-      LOG.error("Error in scheduling and executing compaction in metadata table", e);
+      LOG.error("Error running compaction service in metadata table", e);
       throw e;
     }
 
     try {
       if (skipCompactions) {
         LOG.info("Compaction with same {} time is already present in the timeline.", compactionInstantTime);
-      } else if (metadataWriteConfig.isLogCompactionEnabled()) {
-        // Schedule and execute log compaction with new instant time.
-        Option<String> scheduledLogCompaction = writeClient.scheduleLogCompaction(Option.empty());
-        if (scheduledLogCompaction.isPresent()) {
-          LOG.info("Log compaction is scheduled for timestamp {}", scheduledLogCompaction.get());
-          if (shouldDelegateToTableServiceManager(metadataWriteConfig, ActionType.logcompaction)) {
-            LOG.info("Skipping execution of log compaction on MDT as it is delegated to table service manager.");
-          } else {
-            writeClient.logCompact(scheduledLogCompaction.get(), true);
+      } else if (request.includes(TableServiceType.LOG_COMPACT)
+          && request.getMode().includesSchedule()
+          && metadataWriteConfig.isLogCompactionEnabled()) {
+        if (shouldDelegateScheduling(request, TableServiceType.LOG_COMPACT)) {
+          LOG.info("Skipping scheduling of log compaction on MDT as it is delegated to table service manager.");
+        } else {
+          Option<String> scheduledLogCompactionInstant = writeClient.scheduleLogCompaction(Option.empty());
+          if (scheduledLogCompactionInstant.isPresent()) {
+            LOG.info("Log compaction is scheduled for timestamp {}", scheduledLogCompactionInstant.get());
+            if (request.getMode().includesExecute()) {
+              if (shouldDelegateExecution(request, TableServiceType.LOG_COMPACT)) {
+                LOG.info("Skipping execution of log compaction on MDT as it is delegated to table service manager.");
+              } else {
+                writeClient.logCompact(scheduledLogCompactionInstant.get(), true);
+              }
+            }
           }
         }
       }
     } catch (Exception e) {
       metrics.ifPresent(m -> m.incrementMetric(HoodieMetadataMetrics.LOG_COMPACTION_FAILURES, 1));
-      LOG.error("Error in scheduling and executing logcompaction in metadata table", e);
+      LOG.error("Error running log compaction service in metadata table", e);
       throw e;
     }
   }
 
-  protected void cleanIfNecessary(BaseHoodieWriteClient writeClient, String instantTime) {
+  private boolean shouldRunClean() {
     Option<HoodieInstant> lastCompletedCompactionInstant = metadataMetaClient.getActiveTimeline()
         .getCommitAndReplaceTimeline().filterCompletedInstants().lastInstant();
     if (lastCompletedCompactionInstant.isPresent()
@@ -1691,13 +1798,9 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       // then a FileNotFoundException(for LogFormatReader) or NPE(for HFileReader) would throw.
 
       // 3 is a value that I think is enough for metadata table reader.
-      return;
+      return false;
     }
-    // Trigger cleaning with suffixes based on the same instant time. This ensures that any future
-    // delta commits synced over will not have an instant time lesser than the last completed instant on the
-    // metadata table.
-    executeClean(writeClient, instantTime);
-    writeClient.lazyRollbackFailedIndexing();
+    return true;
   }
 
   protected void executeClean(BaseHoodieWriteClient writeClient, String instantTime) {
@@ -1707,7 +1810,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   /**
    * Validates the timeline for both main and metadata tables to ensure compaction on MDT can be scheduled.
    */
-  boolean validateCompactionScheduling(Option<String> inFlightInstantTimestamp, String latestDeltaCommitTimeInMetadataTable) {
+  boolean validateCompactionScheduling(String latestDeltaCommitTimeInMetadataTable) {
     // Under the log compaction scope, the sequence of the log-compaction and compaction needs to be ensured because metadata items such as RLI
     // only has proc-time ordering semantics. For "ensured", it means the completion sequence of the log-compaction/compaction is the same as the start sequence.
     if (metadataWriteConfig.isLogCompactionEnabled()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -97,7 +97,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -111,7 +110,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.hudi.common.config.HoodieMetadataConfig.ARCHIVE_ACTION;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_POPULATE_META_FIELDS;
+import static org.apache.hudi.common.config.HoodieTableServiceManagerConfig.parseTableServiceActions;
 import static org.apache.hudi.common.table.HoodieTableConfig.TIMELINE_HISTORY_PATH;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
@@ -1536,11 +1537,11 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder()
         .withMode(MetadataTableServiceMode.SCHEDULE_AND_EXECUTE)
         .build();
-    runTableServicesInternal(request, requiresTimelineRefresh);
+    runTableServicesInternal(request, requiresTimelineRefresh, true);
   }
 
   private void runTableServicesInternal(MetadataTableServiceRequest request,
-                                        boolean requiresTimelineRefresh) {
+                                        boolean requiresTimelineRefresh, boolean isInline) {
     HoodieTimer metadataTableServicesTimer = HoodieTimer.start();
     boolean allTableServicesExecutedSuccessfullyOrSkipped = true;
     BaseHoodieWriteClient<?, I, ?, O> writeClient = getWriteClient();
@@ -1553,15 +1554,16 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
         activeTimeline = metadataMetaClient.reloadActiveTimeline();
       }
 
-      Option<HoodieInstant> lastInstant = activeTimeline.getDeltaCommitTimeline()
+      Option<String> latestDeltaCommitTime = activeTimeline.getDeltaCommitTimeline()
           .filterCompletedInstants()
-          .lastInstant();
-      if (!lastInstant.isPresent()) {
+          .lastInstant().map(HoodieInstant::requestedTime);
+      // Preserve inline behavior; explicit service requests need not depend on a delta commit.
+      if (isInline && !latestDeltaCommitTime.isPresent()) {
+        LOG.warn("Skipping inline MDT maintenance after pending services: no completed delta commit is available.");
         return;
       }
 
       // Check and run clean operations.
-      String latestDeltaCommitTime = lastInstant.get().requestedTime();
       if (request.getMode().includesExecute()
           && request.includes(TableServiceType.CLEAN)
           && !shouldDelegateExecution(request, TableServiceType.CLEAN)) {
@@ -1569,11 +1571,14 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       }
 
       if (request.getMode().includesSchedule()
-          && (request.includes(TableServiceType.COMPACT) || request.includes(TableServiceType.LOG_COMPACT))
+          && (request.includes(TableServiceType.COMPACT) || request.includes(TableServiceType.LOG_COMPACT))) {
+        if (!latestDeltaCommitTime.isPresent()) {
+          LOG.warn("Skipping requested MDT compaction/log-compaction scheduling: no completed delta commit is available.");
+        } else if (validateCompactionScheduling(latestDeltaCommitTime.get())) {
           // Do timeline validation before scheduling compaction/logCompaction operations.
-          && validateCompactionScheduling(latestDeltaCommitTime)) {
-        LOG.info("Latest delta commit time found is {}, scheduling compaction operations.", latestDeltaCommitTime);
-        runCompactionServicesIfNecessary(writeClient, Option.of(latestDeltaCommitTime), request);
+          LOG.info("Latest delta commit time found is {}, scheduling compaction operations.", latestDeltaCommitTime.get());
+          runCompactionServicesIfNecessary(writeClient, latestDeltaCommitTime, request);
+        }
       }
 
       if (request.getMode().includesExecute() && request.includes(TableServiceType.ARCHIVE)) {
@@ -1583,7 +1588,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
           writeClient.archive();
         }
       }
-      LOG.info("All the table services operations on MDT completed successfully");
+      LOG.info("Requested table services operations on MDT completed successfully or were skipped");
     } catch (Exception e) {
       LOG.error("Exception in running table services on metadata table", e);
       allTableServicesExecutedSuccessfullyOrSkipped = false;
@@ -1612,13 +1617,13 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   @Override
   public void scheduleTableServices(MetadataTableServiceRequest request) {
     MetadataTableServiceRequest scheduleRequest = request.copy(MetadataTableServiceMode.SCHEDULE);
-    runTableServicesInternal(scheduleRequest, true);
+    runTableServicesInternal(scheduleRequest, true, false);
   }
 
   @Override
   public void executeTableServices(MetadataTableServiceRequest request) {
     MetadataTableServiceRequest executeRequest = request.copy(MetadataTableServiceMode.EXECUTE);
-    runTableServicesInternal(executeRequest, true);
+    runTableServicesInternal(executeRequest, true, false);
   }
 
   private boolean executePendingCompactionServices(MetadataTableServiceRequest request,
@@ -1658,9 +1663,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   }
 
   private void runCleanService(BaseHoodieWriteClient<?, I, ?, O> writeClient,
-                               String latestDeltaCommitTime) {
-    if (shouldRunClean()) {
-      executeClean(writeClient, latestDeltaCommitTime);
+                               Option<String> latestDeltaCommitTime) {
+    if (shouldRunClean() && executeClean(writeClient, latestDeltaCommitTime)) {
       writeClient.lazyRollbackFailedIndexing();
     }
   }
@@ -1672,20 +1676,17 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
 
   protected boolean shouldDelegateScheduling(MetadataTableServiceRequest request, TableServiceType service) {
     return shouldDelegate(request, service,
-        config -> config.getMetadataConfig().getTableServiceManagerScheduleActions());
+        config -> config.getTableServiceManagerConfig().getTableServiceManagerScheduleActions());
   }
 
   private boolean shouldDelegate(MetadataTableServiceRequest request, TableServiceType service,
                                  Function<HoodieWriteConfig, String> actionsProvider) {
     if (request.shouldDisableTableServiceManagerDelegation()
-        || metadataWriteConfig == null
         || !metadataWriteConfig.getTableServiceManagerConfig().isTableServiceManagerEnabled()) {
       return false;
     }
     String action = actionName(service);
-    return Arrays.stream(actionsProvider.apply(metadataWriteConfig).split(","))
-        .map(String::trim)
-        .anyMatch(action::equals);
+    return parseTableServiceActions(actionsProvider.apply(metadataWriteConfig)).contains(action);
   }
 
   private static String actionName(TableServiceType service) {
@@ -1697,7 +1698,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       case CLEAN:
         return ActionType.clean.name();
       case ARCHIVE:
-        return "archive";
+        return ARCHIVE_ACTION;
       default:
         throw new IllegalArgumentException("Unsupported MDT table service: " + service);
     }
@@ -1803,8 +1804,12 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     return true;
   }
 
-  protected void executeClean(BaseHoodieWriteClient writeClient, String instantTime) {
+  /**
+   * Invokes clean if the table version's instant requirements are met, returning whether clean was invoked.
+   */
+  protected boolean executeClean(BaseHoodieWriteClient writeClient, Option<String> latestDeltaCommitTime) {
     writeClient.clean();
+    return true;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
@@ -23,9 +23,9 @@ import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
-import org.apache.hudi.common.model.ActionType;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -153,7 +153,7 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
    * Validates the timeline for both main and metadata tables to ensure compaction on MDT can be scheduled.
    */
   @Override
-  boolean validateCompactionScheduling(Option<String> inFlightInstantTimestamp, String latestDeltaCommitTimeInMetadataTable) {
+  boolean validateCompactionScheduling(String latestDeltaCommitTimeInMetadataTable) {
     // we need to find if there are any inflights in data table timeline before or equal to the latest delta commit in metadata table.
     // Whenever you want to change this logic, please ensure all below scenarios are considered.
     // a. There could be a chance that latest delta commit in MDT is committed in MDT, but failed in DT. And so findInstantsBeforeOrEquals() should be employed
@@ -289,7 +289,9 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
    * deltacommit.
    */
   @Override
-  void compactIfNecessary(BaseHoodieWriteClient<?,I,?,O> writeClient, Option<String> latestDeltaCommitTimeOpt) {
+  protected void runCompactionServicesIfNecessary(BaseHoodieWriteClient<?, I, ?, O> writeClient,
+                                                  Option<String> latestDeltaCommitTimeOpt,
+                                                  MetadataTableServiceRequest request) {
     // Trigger compaction with suffixes based on the same instant time. This ensures that any future
     // delta commits synced over will not have an instant time lesser than the last completed instant on the
     // metadata table.
@@ -299,29 +301,63 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
     // let's say we trigger compaction after C5 in MDT and so compaction completes with C4001. but C5 crashed before completing in MDT.
     // and again w/ C6, we will re-attempt compaction at which point latest delta commit is C4 in MDT.
     // and so we try compaction w/ instant C4001. So, we can avoid compaction if we already have compaction w/ same instant time.
+    boolean scheduledCompaction = false;
     if (metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(compactionInstantTime)) {
       LOG.info("Compaction with same {} time is already present in the timeline.", compactionInstantTime);
-    } else if (writeClient.scheduleCompactionAtInstant(compactionInstantTime, Option.empty())) {
-      LOG.info("Compaction is scheduled for timestamp {}", compactionInstantTime);
-      if (shouldDelegateToTableServiceManager(metadataWriteConfig, ActionType.compaction)) {
-        LOG.info("Skipping execution of compaction on MDT as it is delegated to table service manager.");
-      } else {
-        writeClient.compact(compactionInstantTime, true);
-      }
-    } else if (metadataWriteConfig.isLogCompactionEnabled()) {
-      // Schedule and execute log compaction with suffixes based on the same instant time. This ensures that any future
-      // delta commits synced over will not have an instant time lesser than the last completed instant on the
-      // metadata table.
-      final String logCompactionInstantTime = createLogCompactionTimestamp(latestDeltaCommitTimeOpt.get());
-      if (metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(logCompactionInstantTime)) {
-        LOG.info("Log compaction with same {} time is already present in the timeline.", logCompactionInstantTime);
-      } else if (writeClient.scheduleLogCompactionAtInstant(logCompactionInstantTime, Option.empty())) {
-        LOG.info("Log compaction is scheduled for timestamp {}", logCompactionInstantTime);
-        if (shouldDelegateToTableServiceManager(metadataWriteConfig, ActionType.logcompaction)) {
-          LOG.info("Skipping execution of log compaction on MDT as it is delegated to table service manager.");
-        } else {
-          writeClient.logCompact(logCompactionInstantTime, true);
+      return;
+    }
+
+    try {
+      if (request.includes(TableServiceType.COMPACT) && request.getMode().includesSchedule()) {
+        if (shouldDelegateScheduling(request, TableServiceType.COMPACT)) {
+          LOG.info("Skipping scheduling of compaction on MDT as it is delegated to table service manager.");
+        } else if (writeClient.scheduleCompactionAtInstant(compactionInstantTime, Option.empty())) {
+          LOG.info("Compaction is scheduled for timestamp {}", compactionInstantTime);
+          scheduledCompaction = true;
+          if (request.getMode().includesExecute()) {
+            if (shouldDelegateExecution(request, TableServiceType.COMPACT)) {
+              LOG.info("Skipping execution of compaction on MDT as it is delegated to table service manager.");
+            } else {
+              writeClient.compact(compactionInstantTime, true);
+            }
+          }
         }
+      }
+    } catch (Exception e) {
+      metrics.ifPresent(m -> m.incrementMetric(HoodieMetadataMetrics.COMPACTION_FAILURES, 1));
+      LOG.error("Error running compaction service in metadata table", e);
+      throw e;
+    }
+
+    if (!scheduledCompaction
+        && request.includes(TableServiceType.LOG_COMPACT)
+        && request.getMode().includesSchedule()
+        && metadataWriteConfig.isLogCompactionEnabled()) {
+      try {
+        if (shouldDelegateScheduling(request, TableServiceType.LOG_COMPACT)) {
+          LOG.info("Skipping scheduling of log compaction on MDT as it is delegated to table service manager.");
+        } else {
+          // Schedule and execute log compaction with suffixes based on the same instant time. This ensures that any future
+          // delta commits synced over will not have an instant time lesser than the last completed instant on the
+          // metadata table.
+          final String logCompactionInstantTime = createLogCompactionTimestamp(latestDeltaCommitTimeOpt.get());
+          if (metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(logCompactionInstantTime)) {
+            LOG.info("Log compaction with same {} time is already present in the timeline.", logCompactionInstantTime);
+          } else if (writeClient.scheduleLogCompactionAtInstant(logCompactionInstantTime, Option.empty())) {
+            LOG.info("Log compaction is scheduled for timestamp {}", logCompactionInstantTime);
+            if (request.getMode().includesExecute()) {
+              if (shouldDelegateExecution(request, TableServiceType.LOG_COMPACT)) {
+                LOG.info("Skipping execution of log compaction on MDT as it is delegated to table service manager.");
+              } else {
+                writeClient.logCompact(logCompactionInstantTime, true);
+              }
+            }
+          }
+        }
+      } catch (Exception e) {
+        metrics.ifPresent(m -> m.incrementMetric(HoodieMetadataMetrics.LOG_COMPACTION_FAILURES, 1));
+        LOG.error("Error running log compaction service in metadata table", e);
+        throw e;
       }
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
@@ -301,7 +301,7 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
     // let's say we trigger compaction after C5 in MDT and so compaction completes with C4001. but C5 crashed before completing in MDT.
     // and again w/ C6, we will re-attempt compaction at which point latest delta commit is C4 in MDT.
     // and so we try compaction w/ instant C4001. So, we can avoid compaction if we already have compaction w/ same instant time.
-    boolean scheduledCompaction = false;
+    boolean compactionSchedulingHandled = false;
     if (metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(compactionInstantTime)) {
       LOG.info("Compaction with same {} time is already present in the timeline.", compactionInstantTime);
       return;
@@ -311,9 +311,10 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
       if (request.includes(TableServiceType.COMPACT) && request.getMode().includesSchedule()) {
         if (shouldDelegateScheduling(request, TableServiceType.COMPACT)) {
           LOG.info("Skipping scheduling of compaction on MDT as it is delegated to table service manager.");
+          compactionSchedulingHandled = true;
         } else if (writeClient.scheduleCompactionAtInstant(compactionInstantTime, Option.empty())) {
           LOG.info("Compaction is scheduled for timestamp {}", compactionInstantTime);
-          scheduledCompaction = true;
+          compactionSchedulingHandled = true;
           if (request.getMode().includesExecute()) {
             if (shouldDelegateExecution(request, TableServiceType.COMPACT)) {
               LOG.info("Skipping execution of compaction on MDT as it is delegated to table service manager.");
@@ -329,7 +330,8 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
       throw e;
     }
 
-    if (!scheduledCompaction
+    // Preserve compaction priority when scheduling is delegated, but allow log-compaction-only requests.
+    if (!compactionSchedulingHandled
         && request.includes(TableServiceType.LOG_COMPACT)
         && request.getMode().includesSchedule()
         && metadataWriteConfig.isLogCompactionEnabled()) {
@@ -363,8 +365,13 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
   }
 
   @Override
-  protected void executeClean(BaseHoodieWriteClient writeClient, String instantTime) {
-    writeClient.clean(createCleanTimestamp(instantTime));
+  protected boolean executeClean(BaseHoodieWriteClient writeClient, Option<String> latestDeltaCommitTime) {
+    if (!latestDeltaCommitTime.isPresent()) {
+      LOG.warn("Skipping requested MDT clean for table version six: no completed delta commit is available to derive the clean instant.");
+      return false;
+    }
+    writeClient.clean(createCleanTimestamp(latestDeltaCommitTime.get()));
+    return true;
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -348,6 +348,8 @@ public class HoodieMetadataWriteUtils {
         String.valueOf(writeConfig.getMetadataConfig().isTableServiceManagerEnabled()));
     properties.put(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(),
         writeConfig.getMetadataConfig().getTableServiceManagerActions());
+    properties.put(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key(),
+        writeConfig.getMetadataConfig().getTableServiceManagerScheduleActions());
     if (nonEmpty(writeConfig.getMetricReporterMetricsNamePrefix())) {
       properties.put(HoodieMetricsConfig.METRICS_REPORTER_PREFIX.key(),
           writeConfig.getMetricReporterMetricsNamePrefix() + METADATA_TABLE_NAME_SUFFIX);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -343,12 +343,12 @@ public class HoodieMetadataWriteUtils {
     properties.put(HoodieTableConfig.TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
     properties.put(HoodieTableConfig.RECORDKEY_FIELDS.key(), RECORD_KEY_FIELD_NAME);
     properties.put("hoodie.datasource.write.recordkey.field", RECORD_KEY_FIELD_NAME);
-    // Pass table service manager config for MDT
+    // Map MDT delegation settings to the metadata write client's generic table service manager config.
     properties.put(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ENABLED.key(),
         String.valueOf(writeConfig.getMetadataConfig().isTableServiceManagerEnabled()));
     properties.put(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(),
         writeConfig.getMetadataConfig().getTableServiceManagerActions());
-    properties.put(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key(),
+    properties.put(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key(),
         writeConfig.getMetadataConfig().getTableServiceManagerScheduleActions());
     if (nonEmpty(writeConfig.getMetricReporterMetricsNamePrefix())) {
       properties.put(HoodieMetricsConfig.METRICS_REPORTER_PREFIX.key(),

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
@@ -179,6 +179,18 @@ public interface HoodieTableMetadataWriter<I,O> extends Serializable, AutoClosea
   }
 
   /**
+   * Schedule the requested metadata table services whose trigger conditions are met. External callers should
+   * hold the data-table lock and use a single-writer MDT client for this phase.
+   */
+  void scheduleTableServices(MetadataTableServiceRequest request);
+
+  /**
+   * Execute pending metadata table services selected by the request. Compaction execution can use an OCC MDT
+   * client without an outer data-table lock.
+   */
+  void executeTableServices(MetadataTableServiceRequest request);
+
+  /**
    * This returns true if the metadata table's partitions state is changed.
    */
   boolean hasPartitionsStateChanged();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
@@ -181,12 +181,19 @@ public interface HoodieTableMetadataWriter<I,O> extends Serializable, AutoClosea
   /**
    * Schedule the requested metadata table services whose trigger conditions are met. External callers should
    * hold the data-table lock and use a single-writer MDT client for this phase.
+   * The request is copied and validated in {@link MetadataTableServiceMode#SCHEDULE} mode without modifying
+   * the original. Requests containing an execution instant are rejected before any table-service work begins;
+   * callers must construct a separate request without an instant for scheduling.
+   *
+   * @throws IllegalArgumentException if the request is invalid in scheduling mode, including having an instant time
    */
   void scheduleTableServices(MetadataTableServiceRequest request);
 
   /**
    * Execute pending metadata table services selected by the request. Compaction execution can use an OCC MDT
    * client without an outer data-table lock.
+   * The request is copied and validated in {@link MetadataTableServiceMode#EXECUTE} mode without modifying
+   * the original. An optional instant is preserved and must select exactly one compaction or log-compaction service.
    */
   void executeTableServices(MetadataTableServiceRequest request);
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/MetadataTableServiceMode.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/MetadataTableServiceMode.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import java.util.Locale;
+
+/** Controls which phases of metadata table services are run. */
+public enum MetadataTableServiceMode {
+  SCHEDULE,
+  EXECUTE,
+  SCHEDULE_AND_EXECUTE;
+
+  public boolean includesSchedule() {
+    return this == SCHEDULE || this == SCHEDULE_AND_EXECUTE;
+  }
+
+  public boolean includesExecute() {
+    return this == EXECUTE || this == SCHEDULE_AND_EXECUTE;
+  }
+
+  public static MetadataTableServiceMode fromValue(String value) {
+    return valueOf(value.trim().replace('-', '_').toUpperCase(Locale.ROOT));
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/MetadataTableServiceRequest.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/MetadataTableServiceRequest.java
@@ -57,7 +57,13 @@ public final class MetadataTableServiceRequest implements Serializable {
     return disableTableServiceManagerDelegation;
   }
 
-  /** Returns a copy of this request with the specified mode. */
+  /**
+   * Returns a copy with the specified mode, preserving all other fields and validating the resulting request.
+   * The original request is unchanged. An instant time is never discarded: a request containing one can
+   * only be copied in {@link MetadataTableServiceMode#EXECUTE} mode.
+   *
+   * @throws IllegalArgumentException if the resulting request is invalid for the specified mode
+   */
   public MetadataTableServiceRequest copy(MetadataTableServiceMode mode) {
     return newBuilder()
         .withMode(mode)
@@ -91,6 +97,10 @@ public final class MetadataTableServiceRequest implements Serializable {
       return this;
     }
 
+    /**
+     * Sets an optional instant to execute. A present instant requires {@link MetadataTableServiceMode#EXECUTE}
+     * mode and exactly one service: compaction or log compaction. These constraints are checked by {@link #build()}.
+     */
     public Builder withInstantTime(Option<String> instantTime) {
       this.instantTime = instantTime;
       return this;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/MetadataTableServiceRequest.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/MetadataTableServiceRequest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.model.TableServiceType;
+import org.apache.hudi.common.util.Option;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/** Request for running one or more metadata table services. */
+public final class MetadataTableServiceRequest implements Serializable {
+
+  @Getter
+  private final MetadataTableServiceMode mode;
+  private final EnumSet<TableServiceType> services;
+  @Getter
+  private final Option<String> instantTime;
+  private final boolean disableTableServiceManagerDelegation;
+
+  private MetadataTableServiceRequest(Builder builder) {
+    this.mode = builder.mode;
+    this.services = builder.services.clone();
+    this.instantTime = builder.instantTime;
+    this.disableTableServiceManagerDelegation = builder.disableTableServiceManagerDelegation;
+  }
+
+  public Set<TableServiceType> getServices() {
+    return Collections.unmodifiableSet(services);
+  }
+
+  public boolean includes(TableServiceType service) {
+    return services.contains(service);
+  }
+
+  public boolean shouldDisableTableServiceManagerDelegation() {
+    return disableTableServiceManagerDelegation;
+  }
+
+  /** Returns a copy of this request with the specified mode. */
+  public MetadataTableServiceRequest copy(MetadataTableServiceMode mode) {
+    return newBuilder()
+        .withMode(mode)
+        .withServices(services)
+        .withInstantTime(instantTime)
+        .disableTableServiceManagerDelegation(disableTableServiceManagerDelegation)
+        .build();
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private MetadataTableServiceMode mode = MetadataTableServiceMode.SCHEDULE_AND_EXECUTE;
+    private EnumSet<TableServiceType> services = EnumSet.of(
+        TableServiceType.COMPACT, TableServiceType.LOG_COMPACT,
+        TableServiceType.CLEAN, TableServiceType.ARCHIVE);
+    private Option<String> instantTime = Option.empty();
+    private boolean disableTableServiceManagerDelegation;
+
+    public Builder withMode(MetadataTableServiceMode mode) {
+      this.mode = mode;
+      return this;
+    }
+
+    public Builder withServices(Set<TableServiceType> services) {
+      this.services = services.isEmpty()
+          ? EnumSet.noneOf(TableServiceType.class)
+          : EnumSet.copyOf(services);
+      return this;
+    }
+
+    public Builder withInstantTime(Option<String> instantTime) {
+      this.instantTime = instantTime;
+      return this;
+    }
+
+    public Builder disableTableServiceManagerDelegation(boolean disableDelegation) {
+      this.disableTableServiceManagerDelegation = disableDelegation;
+      return this;
+    }
+
+    public MetadataTableServiceRequest build() {
+      if (mode == null) {
+        throw new IllegalArgumentException("Metadata table service mode must be specified");
+      }
+      if (services.isEmpty()) {
+        throw new IllegalArgumentException("At least one metadata table service must be specified");
+      }
+      if (services.contains(TableServiceType.CLUSTER)) {
+        throw new IllegalArgumentException("Clustering is not supported as a metadata table service");
+      }
+      if (instantTime.isPresent()) {
+        long executableCompactionServices = services.stream()
+            .filter(service -> service == TableServiceType.COMPACT || service == TableServiceType.LOG_COMPACT)
+            .count();
+        if (mode != MetadataTableServiceMode.EXECUTE
+            || executableCompactionServices != 1
+            || services.size() != 1) {
+          throw new IllegalArgumentException(
+              "An instant time requires execute mode and exactly one of compaction or log compaction");
+        }
+      }
+      return new MetadataTableServiceRequest(this);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 
@@ -163,6 +164,8 @@ class TestHoodieBackedTableMetadataWriter {
     verify(writeClient, times(hasPendingLogCompaction ? 1 : 0)).runAnyPendingLogCompactions();
     int expectedTimelineReloads = (requiresRefresh ? 1 : 0) + (ranService ? 1 : 0);
     verify(metaClient, times(expectedTimelineReloads)).reloadActiveTimeline();
+    verify(writeClient, never()).clean();
+    verify(writeClient, never()).archive();
   }
 
   @Test
@@ -221,10 +224,102 @@ class TestHoodieBackedTableMetadataWriter {
     verify(metaClient, times(1)).reloadActiveTimeline();
   }
 
+  @ParameterizedTest
+  @CsvSource({
+      "false,false,CLEAN", "false,false,ARCHIVE",
+      "true,false,CLEAN", "true,false,ARCHIVE",
+      "false,true,CLEAN", "false,true,ARCHIVE",
+      "true,true,CLEAN", "true,true,ARCHIVE"
+  })
+  void executeMaintenanceWithOptionalDeltaCommit(boolean versionSix, boolean hasDeltaCommit, TableServiceType service) {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieActiveTimeline timeline = mock(HoodieActiveTimeline.class, RETURNS_DEEP_STUBS);
+    when(metaClient.reloadActiveTimeline()).thenReturn(timeline);
+    when(metaClient.getActiveTimeline()).thenReturn(timeline);
+    when(timeline.getDeltaCommitTimeline().filterCompletedInstants().lastInstant()).thenReturn(
+        hasDeltaCommit ? Option.of(INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED,
+            HoodieTimeline.DELTA_COMMIT_ACTION, "500")) : Option.empty());
+    when(timeline.getCommitAndReplaceTimeline().filterCompletedInstants().lastInstant()).thenReturn(Option.empty());
+    BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp/")
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().setFailOnTableServiceFailures(true).build()).build();
+    HoodieBackedTableMetadataWriter writer = createTableServicesWriter(metaClient, writeClient, writeConfig, versionSix);
+
+    writer.executeTableServices(MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.EXECUTE)
+        .withServices(EnumSet.of(service))
+        .build());
+
+    boolean shouldClean = service == TableServiceType.CLEAN && (!versionSix || hasDeltaCommit);
+    verify(writeClient, times(shouldClean && !versionSix ? 1 : 0)).clean();
+    verify(writeClient, times(shouldClean && versionSix ? 1 : 0)).clean("500002");
+    verify(writeClient, times(shouldClean ? 1 : 0)).lazyRollbackFailedIndexing();
+    verify(writeClient, times(service == TableServiceType.ARCHIVE ? 1 : 0)).archive();
+    verify(writer, never()).runCompactionServicesIfNecessary(any(), any(), any());
+  }
+
+  @ParameterizedTest
+  @CsvSource({"false,true", "true,true", "false,false", "true,false"})
+  void skipSchedulingWithoutDeltaCommitAndPreserveInlineBehavior(boolean versionSix, boolean inline) {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieActiveTimeline timeline = mock(HoodieActiveTimeline.class, RETURNS_DEEP_STUBS);
+    when(metaClient.reloadActiveTimeline()).thenReturn(timeline);
+    when(metaClient.getActiveTimeline()).thenReturn(timeline);
+    when(timeline.getDeltaCommitTimeline().filterCompletedInstants().lastInstant()).thenReturn(Option.empty());
+    BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp/")
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().setFailOnTableServiceFailures(true).build()).build();
+    HoodieBackedTableMetadataWriter writer = createTableServicesWriter(metaClient, writeClient, writeConfig, versionSix);
+
+    if (inline) {
+      writer.performTableServices(Option.empty(), true);
+    } else {
+      writer.scheduleTableServices(MetadataTableServiceRequest.newBuilder()
+          .withMode(MetadataTableServiceMode.SCHEDULE)
+          .withServices(EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT))
+          .build());
+    }
+
+    verify(writer, never()).validateCompactionScheduling(any());
+    verify(writer, never()).runCompactionServicesIfNecessary(any(), any(), any());
+    verify(writeClient, never()).clean();
+    verify(writeClient, never()).clean(any(String.class));
+    verify(writeClient, never()).lazyRollbackFailedIndexing();
+    verify(writeClient, never()).archive();
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = TableServiceType.class, names = {"COMPACT", "LOG_COMPACT"})
+  void scheduleTableServicesRejectsExecutionInstantBeforeStartingWork(TableServiceType service) {
+    HoodieBackedTableMetadataWriter writer = mock(HoodieBackedTableMetadataWriter.class, CALLS_REAL_METHODS);
+    MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.EXECUTE)
+        .withServices(EnumSet.of(service))
+        .withInstantTime(Option.of("instant"))
+        .build();
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> writer.scheduleTableServices(request));
+
+    assertTrue(exception.getMessage().contains("An instant time requires execute mode"));
+    verify(writer, never()).getWriteClient();
+    assertEquals(MetadataTableServiceMode.EXECUTE, request.getMode());
+    assertEquals(Option.of("instant"), request.getInstantTime());
+  }
+
   private HoodieBackedTableMetadataWriter createTableServicesWriter(HoodieTableMetaClient metaClient,
                                                                      BaseHoodieWriteClient writeClient,
                                                                      HoodieWriteConfig writeConfig) {
-    HoodieBackedTableMetadataWriter writer = mock(HoodieBackedTableMetadataWriter.class, CALLS_REAL_METHODS);
+    return createTableServicesWriter(metaClient, writeClient, writeConfig, false);
+  }
+
+  private HoodieBackedTableMetadataWriter createTableServicesWriter(HoodieTableMetaClient metaClient,
+                                                                     BaseHoodieWriteClient writeClient,
+                                                                     HoodieWriteConfig writeConfig,
+                                                                     boolean versionSix) {
+    HoodieBackedTableMetadataWriter writer = versionSix
+        ? mock(HoodieBackedTableMetadataWriterTableVersionSix.class, CALLS_REAL_METHODS)
+        : mock(HoodieBackedTableMetadataWriter.class, CALLS_REAL_METHODS);
     writer.metadataMetaClient = metaClient;
     writer.metadataWriteConfig = writeConfig;
     writer.dataWriteConfig = writeConfig;
@@ -490,7 +585,6 @@ class TestHoodieBackedTableMetadataWriter {
         HoodieTableServiceManagerConfig.newBuilder().fromProperties(tableServiceManagerProperties).build();
     HoodieWriteConfig metadataWriteConfig = mock(HoodieWriteConfig.class);
     when(metadataWriteConfig.getTableServiceManagerConfig()).thenReturn(tableServiceManagerConfig);
-    when(metadataWriteConfig.getMetadataConfig()).thenReturn(HoodieMetadataConfig.newBuilder().build());
     when(metadataWriteConfig.isLogCompactionEnabled()).thenReturn(true);
 
     HoodieTableMetaClient dataMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
@@ -605,8 +699,8 @@ class TestHoodieBackedTableMetadataWriter {
     writer.metadataWriteConfig = mock(HoodieWriteConfig.class);
     HoodieTableServiceManagerConfig tableServiceManagerConfig = mock(HoodieTableServiceManagerConfig.class);
     when(tableServiceManagerConfig.isTableServiceManagerEnabled()).thenReturn(true);
+    when(tableServiceManagerConfig.getTableServiceManagerScheduleActions()).thenReturn(metadataConfig.getTableServiceManagerScheduleActions());
     when(writer.metadataWriteConfig.getTableServiceManagerConfig()).thenReturn(tableServiceManagerConfig);
-    when(writer.metadataWriteConfig.getMetadataConfig()).thenReturn(metadataConfig);
     writer.metrics = Option.empty();
 
     BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
@@ -718,6 +812,7 @@ class TestHoodieBackedTableMetadataWriter {
 
     // Create a partial mock of HoodieBackedTableMetadataWriter
     HoodieBackedTableMetadataWriter writer = mock(HoodieBackedTableMetadataWriter.class);
+    writer.metadataWriteConfig = writeConfig;
 
     // Mock getWriteClient to return our mock write client
     when(writer.getWriteClient()).thenReturn(writeClient);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
@@ -60,6 +61,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -83,6 +85,7 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -135,13 +138,14 @@ class TestHoodieBackedTableMetadataWriter {
   void runPendingTableServicesOperations(boolean hasPendingCompaction, boolean hasPendingLogCompaction, boolean requiresRefresh, boolean ranService) {
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     HoodieActiveTimeline initialTimeline = mock(HoodieActiveTimeline.class, RETURNS_DEEP_STUBS);
+    HoodieActiveTimeline reloadedTimeline = mock(HoodieActiveTimeline.class, RETURNS_DEEP_STUBS);
     BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp/").build();
-    when(writeClient.getConfig()).thenReturn(writeConfig);
     if (requiresRefresh) {
-      when(metaClient.reloadActiveTimeline()).thenReturn(initialTimeline);
+      when(metaClient.reloadActiveTimeline()).thenReturn(initialTimeline, reloadedTimeline);
     } else {
       when(metaClient.getActiveTimeline()).thenReturn(initialTimeline);
+      when(metaClient.reloadActiveTimeline()).thenReturn(reloadedTimeline);
     }
     if (hasPendingCompaction) {
       when(initialTimeline.filterPendingCompactionTimeline().countInstants()).thenReturn(1);
@@ -149,16 +153,11 @@ class TestHoodieBackedTableMetadataWriter {
     if (hasPendingLogCompaction) {
       when(initialTimeline.filterPendingLogCompactionTimeline().countInstants()).thenReturn(1);
     }
-    HoodieActiveTimeline expectedResult;
-    if (ranService) {
-      HoodieActiveTimeline timelineReloadedAfterServicesRun = mock(HoodieActiveTimeline.class);
-      when(metaClient.reloadActiveTimeline()).thenReturn(timelineReloadedAfterServicesRun);
-      expectedResult = timelineReloadedAfterServicesRun;
-    } else {
-      expectedResult = initialTimeline;
-    }
-    assertSame(expectedResult, HoodieBackedTableMetadataWriter.runPendingTableServicesOperationsAndRefreshTimeline(
-        metaClient, writeClient, requiresRefresh, Option.empty()));
+    when(initialTimeline.getDeltaCommitTimeline().filterCompletedInstants().lastInstant()).thenReturn(Option.empty());
+    when(reloadedTimeline.getDeltaCommitTimeline().filterCompletedInstants().lastInstant()).thenReturn(Option.empty());
+
+    HoodieBackedTableMetadataWriter writer = createTableServicesWriter(metaClient, writeClient, writeConfig);
+    writer.performTableServices(Option.empty(), requiresRefresh);
 
     verify(writeClient, times(hasPendingCompaction ? 1 : 0)).runAnyPendingCompactions();
     verify(writeClient, times(hasPendingLogCompaction ? 1 : 0)).runAnyPendingLogCompactions();
@@ -176,21 +175,20 @@ class TestHoodieBackedTableMetadataWriter {
     tsmProps.put(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ENABLED.key(), "true");
     tsmProps.put(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), "compaction,logcompaction");
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp/").withProperties(tsmProps).build();
-    when(writeClient.getConfig()).thenReturn(writeConfig);
-    when(writeClient.shouldDelegateToTableServiceManager(any(), any())).thenCallRealMethod();
 
     when(metaClient.getActiveTimeline()).thenReturn(initialTimeline);
     when(initialTimeline.filterPendingCompactionTimeline().countInstants()).thenReturn(1);
     when(initialTimeline.filterPendingLogCompactionTimeline().countInstants()).thenReturn(1);
+    when(initialTimeline.getDeltaCommitTimeline().filterCompletedInstants().lastInstant()).thenReturn(Option.empty());
 
-    HoodieActiveTimeline result = HoodieBackedTableMetadataWriter.runPendingTableServicesOperationsAndRefreshTimeline(
-        metaClient, writeClient, false, Option.empty());
+    HoodieBackedTableMetadataWriter writer = createTableServicesWriter(metaClient, writeClient, writeConfig);
+    writer.performTableServices(Option.empty(), false);
 
     // TSM-delegated actions should not be executed
     verify(writeClient, times(0)).runAnyPendingCompactions();
     verify(writeClient, times(0)).runAnyPendingLogCompactions();
     // No services ran, so no timeline reload needed
-    assertSame(initialTimeline, result);
+    verify(metaClient, never()).reloadActiveTimeline();
   }
 
   @Test
@@ -204,23 +202,36 @@ class TestHoodieBackedTableMetadataWriter {
     tsmProps.put(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ENABLED.key(), "true");
     tsmProps.put(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), "compaction");
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp/").withProperties(tsmProps).build();
-    when(writeClient.getConfig()).thenReturn(writeConfig);
-    when(writeClient.shouldDelegateToTableServiceManager(any(), any())).thenCallRealMethod();
 
     when(metaClient.getActiveTimeline()).thenReturn(initialTimeline);
     when(initialTimeline.filterPendingCompactionTimeline().countInstants()).thenReturn(1);
     when(initialTimeline.filterPendingLogCompactionTimeline().countInstants()).thenReturn(1);
+    when(initialTimeline.getDeltaCommitTimeline().filterCompletedInstants().lastInstant()).thenReturn(Option.empty());
 
-    HoodieActiveTimeline reloadedTimeline = mock(HoodieActiveTimeline.class);
+    HoodieActiveTimeline reloadedTimeline = mock(HoodieActiveTimeline.class, RETURNS_DEEP_STUBS);
     when(metaClient.reloadActiveTimeline()).thenReturn(reloadedTimeline);
+    when(reloadedTimeline.getDeltaCommitTimeline().filterCompletedInstants().lastInstant()).thenReturn(Option.empty());
 
-    HoodieActiveTimeline result = HoodieBackedTableMetadataWriter.runPendingTableServicesOperationsAndRefreshTimeline(
-        metaClient, writeClient, false, Option.empty());
+    HoodieBackedTableMetadataWriter writer = createTableServicesWriter(metaClient, writeClient, writeConfig);
+    writer.performTableServices(Option.empty(), false);
 
     // Compaction delegated to TSM → skipped; logcompaction not delegated → executed
     verify(writeClient, times(0)).runAnyPendingCompactions();
     verify(writeClient, times(1)).runAnyPendingLogCompactions();
-    assertSame(reloadedTimeline, result);
+    verify(metaClient, times(1)).reloadActiveTimeline();
+  }
+
+  private HoodieBackedTableMetadataWriter createTableServicesWriter(HoodieTableMetaClient metaClient,
+                                                                     BaseHoodieWriteClient writeClient,
+                                                                     HoodieWriteConfig writeConfig) {
+    HoodieBackedTableMetadataWriter writer = mock(HoodieBackedTableMetadataWriter.class, CALLS_REAL_METHODS);
+    writer.metadataMetaClient = metaClient;
+    writer.metadataWriteConfig = writeConfig;
+    writer.dataWriteConfig = writeConfig;
+    writer.metrics = Option.empty();
+    when(writer.getWriteClient()).thenReturn(writeClient);
+    when(writeClient.getConfig()).thenReturn(writeConfig);
+    return writer;
   }
 
   @Test
@@ -464,11 +475,11 @@ class TestHoodieBackedTableMetadataWriter {
       doThrow(new HoodieException("close failed")).when(writer).close();
       writer.closeInternal();
     });
-    assertFalse(writer.validateCompactionScheduling(Option.empty(), "002"));
+    assertFalse(writer.validateCompactionScheduling("002"));
   }
 
   @Test
-  void compactIfNecessaryHandlesSkipDelegationAndFailures() {
+  void runCompactionServicesHandlesSkipDelegationAndFailures() {
     // Exercise skip, delegation, and failure propagation for both compaction types.
     Properties tableServiceManagerProperties = new Properties();
     tableServiceManagerProperties.put(
@@ -479,6 +490,7 @@ class TestHoodieBackedTableMetadataWriter {
         HoodieTableServiceManagerConfig.newBuilder().fromProperties(tableServiceManagerProperties).build();
     HoodieWriteConfig metadataWriteConfig = mock(HoodieWriteConfig.class);
     when(metadataWriteConfig.getTableServiceManagerConfig()).thenReturn(tableServiceManagerConfig);
+    when(metadataWriteConfig.getMetadataConfig()).thenReturn(HoodieMetadataConfig.newBuilder().build());
     when(metadataWriteConfig.isLogCompactionEnabled()).thenReturn(true);
 
     HoodieTableMetaClient dataMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
@@ -509,10 +521,112 @@ class TestHoodieBackedTableMetadataWriter {
         .thenReturn(Option.of("201"))
         .thenThrow(new HoodieException("log compaction failed"));
 
-    writer.compactIfNecessary(writeClient, Option.empty());
-    writer.compactIfNecessary(writeClient, Option.empty());
-    assertThrows(HoodieException.class, () -> writer.compactIfNecessary(writeClient, Option.empty()));
-    assertThrows(HoodieException.class, () -> writer.compactIfNecessary(writeClient, Option.empty()));
+    MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder().build();
+    writer.runCompactionServicesIfNecessary(writeClient, Option.empty(), request);
+    writer.runCompactionServicesIfNecessary(writeClient, Option.empty(), request);
+    assertThrows(HoodieException.class, () ->
+        writer.runCompactionServicesIfNecessary(writeClient, Option.empty(), request));
+    assertThrows(HoodieException.class, () ->
+        writer.runCompactionServicesIfNecessary(writeClient, Option.empty(), request));
+  }
+
+  @Test
+  void baseCompactionServicesHonorScheduleAndExecuteModes() {
+    HoodieTableMetaClient dataMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
+    when(dataMetaClient.reloadActiveTimeline().filterInflightsAndRequested()
+        .filter(any()).firstInstant()).thenReturn(Option.empty());
+    HoodieTableMetaClient metadataMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
+    when(metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(any(String.class)))
+        .thenReturn(false);
+
+    HoodieWriteConfig metadataWriteConfig = mock(HoodieWriteConfig.class);
+    when(metadataWriteConfig.isLogCompactionEnabled()).thenReturn(true);
+
+    HoodieBackedTableMetadataWriter<List<HoodieRecord>, List<?>> writer =
+        mock(HoodieBackedTableMetadataWriter.class, CALLS_REAL_METHODS);
+    writer.dataMetaClient = dataMetaClient;
+    writer.metadataMetaClient = metadataMetaClient;
+    writer.metadataWriteConfig = metadataWriteConfig;
+    writer.metrics = Option.empty();
+
+    BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
+    when(writeClient.createNewInstantTime(false)).thenReturn("100", "200");
+    when(writeClient.scheduleCompactionAtInstant("100", Option.empty())).thenReturn(true);
+    when(writeClient.scheduleCompactionAtInstant("200", Option.empty())).thenReturn(true);
+    when(writeClient.scheduleLogCompaction(Option.empty()))
+        .thenReturn(Option.of("101"), Option.of("201"));
+
+    MetadataTableServiceRequest scheduleRequest = MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.SCHEDULE)
+        .withServices(EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT))
+        .disableTableServiceManagerDelegation(true)
+        .build();
+    writer.runCompactionServicesIfNecessary(writeClient, Option.empty(), scheduleRequest);
+
+    verify(writeClient).scheduleCompactionAtInstant("100", Option.empty());
+    verify(writeClient).scheduleLogCompaction(Option.empty());
+    verify(writeClient, never()).compact(any(String.class), eq(true));
+    verify(writeClient, never()).logCompact(any(String.class), eq(true));
+
+    MetadataTableServiceRequest scheduleAndExecuteRequest = scheduleRequest.copy(
+        MetadataTableServiceMode.SCHEDULE_AND_EXECUTE);
+    writer.runCompactionServicesIfNecessary(writeClient, Option.empty(), scheduleAndExecuteRequest);
+
+    verify(writeClient).scheduleCompactionAtInstant("200", Option.empty());
+    verify(writeClient).compact("200", true);
+    verify(writeClient, times(2)).scheduleLogCompaction(Option.empty());
+    verify(writeClient).logCompact("201", true);
+  }
+
+  @Test
+  void schedulingDelegationIsOnlyAppliedToInlineRequests() {
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
+        .withTableServiceManagerEnabled(true)
+        .withTableServiceManagerScheduleActions("compaction")
+        .build();
+    HoodieWriteConfig dataWriteConfig = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp/table")
+        .withMetadataConfig(metadataConfig)
+        .build();
+
+    HoodieTableMetaClient dataMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
+    when(dataMetaClient.getTableConfig().getTableVersion()).thenReturn(HoodieTableVersion.NINE);
+    when(dataMetaClient.reloadActiveTimeline().filterInflightsAndRequested()
+        .filter(any()).firstInstant()).thenReturn(Option.empty());
+    HoodieTableMetaClient metadataMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
+    when(metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(any(String.class)))
+        .thenReturn(false);
+
+    HoodieBackedTableMetadataWriter<List<HoodieRecord>, List<?>> writer =
+        mock(HoodieBackedTableMetadataWriter.class, CALLS_REAL_METHODS);
+    writer.dataMetaClient = dataMetaClient;
+    writer.metadataMetaClient = metadataMetaClient;
+    writer.dataWriteConfig = dataWriteConfig;
+    writer.metadataWriteConfig = mock(HoodieWriteConfig.class);
+    HoodieTableServiceManagerConfig tableServiceManagerConfig = mock(HoodieTableServiceManagerConfig.class);
+    when(tableServiceManagerConfig.isTableServiceManagerEnabled()).thenReturn(true);
+    when(writer.metadataWriteConfig.getTableServiceManagerConfig()).thenReturn(tableServiceManagerConfig);
+    when(writer.metadataWriteConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    writer.metrics = Option.empty();
+
+    BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
+    when(writeClient.createNewInstantTime(false)).thenReturn("100", "101");
+    when(writeClient.scheduleCompactionAtInstant("101", Option.empty())).thenReturn(true);
+
+    MetadataTableServiceRequest inlineRequest = MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.SCHEDULE)
+        .withServices(EnumSet.of(TableServiceType.COMPACT))
+        .build();
+    writer.runCompactionServicesIfNecessary(writeClient, Option.empty(), inlineRequest);
+    verify(writeClient, never()).scheduleCompactionAtInstant("100", Option.empty());
+
+    MetadataTableServiceRequest externalRequest = MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.SCHEDULE)
+        .withServices(EnumSet.of(TableServiceType.COMPACT))
+        .disableTableServiceManagerDelegation(true)
+        .build();
+    writer.runCompactionServicesIfNecessary(writeClient, Option.empty(), externalRequest);
+    verify(writeClient).scheduleCompactionAtInstant("101", Option.empty());
   }
 
   private static void setField(Object target, String name, Object value) throws Exception {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriterTableVersionSix.java
@@ -35,6 +35,8 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieMetadataException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -316,7 +318,6 @@ class TestHoodieBackedTableMetadataWriterTableVersionSix {
             .build();
     HoodieWriteConfig metadataWriteConfig = mock(HoodieWriteConfig.class);
     when(metadataWriteConfig.getTableServiceManagerConfig()).thenReturn(tableServiceManagerConfig);
-    when(metadataWriteConfig.getMetadataConfig()).thenReturn(HoodieMetadataConfig.newBuilder().build());
     when(metadataWriteConfig.isLogCompactionEnabled()).thenReturn(true);
 
     HoodieTableMetaClient metadataMetaClient = mock(HoodieTableMetaClient.class);
@@ -358,12 +359,19 @@ class TestHoodieBackedTableMetadataWriterTableVersionSix {
     writer.runCompactionServicesIfNecessary(writeClient, Option.of("400"), request);
 
     verify(writeClient).scheduleCompactionAtInstant("200001", Option.empty());
+    verify(writeClient, never()).scheduleCompactionAtInstant("100001", Option.empty());
+    verify(writeClient, never()).scheduleLogCompactionAtInstant("100005", Option.empty());
+    verify(writeClient, never()).scheduleLogCompactionAtInstant("200005", Option.empty());
+    verify(writeClient, never()).compact("200001", true);
     verify(writeClient).scheduleLogCompactionAtInstant("300005", Option.empty());
     verify(writeClient).logCompact("300005", true);
+    verify(writeClient).scheduleLogCompactionAtInstant("400005", Option.empty());
+    verify(writeClient, never()).logCompact("400005", true);
   }
 
-  @Test
-  void testSchedulingDelegationAndExternalBypass() {
+  @ParameterizedTest
+  @EnumSource(value = MetadataTableServiceMode.class, names = {"SCHEDULE", "SCHEDULE_AND_EXECUTE"})
+  void testSchedulingDelegationAndExternalBypass(MetadataTableServiceMode mode) {
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
         .withTableServiceManagerEnabled(true)
         .withTableServiceManagerScheduleActions(ActionType.compaction.name())
@@ -378,11 +386,12 @@ class TestHoodieBackedTableMetadataWriterTableVersionSix {
         HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ENABLED.key(), "true");
     tableServiceManagerProperties.put(
         HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), ActionType.compaction.name());
+    tableServiceManagerProperties.put(
+        HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key(), metadataConfig.getTableServiceManagerScheduleActions());
     when(metadataWriteConfig.getTableServiceManagerConfig()).thenReturn(
         HoodieTableServiceManagerConfig.newBuilder()
             .fromProperties(tableServiceManagerProperties)
             .build());
-    when(metadataWriteConfig.getMetadataConfig()).thenReturn(metadataConfig);
     when(metadataWriteConfig.isLogCompactionEnabled()).thenReturn(true);
 
     HoodieTableMetaClient metadataMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
@@ -395,24 +404,43 @@ class TestHoodieBackedTableMetadataWriterTableVersionSix {
     writer.metadataMetaClient = metadataMetaClient;
 
     BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
-    when(writeClient.scheduleLogCompactionAtInstant("500005", Option.empty())).thenReturn(true);
     when(writeClient.scheduleCompactionAtInstant("600001", Option.empty())).thenReturn(true);
+    when(writeClient.scheduleLogCompactionAtInstant("700005", Option.empty())).thenReturn(true);
 
     MetadataTableServiceRequest inlineRequest = MetadataTableServiceRequest.newBuilder()
-        .withMode(MetadataTableServiceMode.SCHEDULE)
+        .withMode(mode)
         .withServices(EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT))
         .build();
     writer.runCompactionServicesIfNecessary(writeClient, Option.of("500"), inlineRequest);
     verify(writeClient, never()).scheduleCompactionAtInstant("500001", Option.empty());
-    verify(writeClient).scheduleLogCompactionAtInstant("500005", Option.empty());
+    verify(writeClient, never()).scheduleLogCompactionAtInstant("500005", Option.empty());
+    verify(writeClient, never()).compact("500001", true);
+    verify(writeClient, never()).logCompact("500005", true);
 
     MetadataTableServiceRequest externalRequest = MetadataTableServiceRequest.newBuilder()
-        .withMode(MetadataTableServiceMode.SCHEDULE)
+        .withMode(mode)
         .withServices(EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT))
         .disableTableServiceManagerDelegation(true)
         .build();
     writer.runCompactionServicesIfNecessary(writeClient, Option.of("600"), externalRequest);
     verify(writeClient).scheduleCompactionAtInstant("600001", Option.empty());
+    verify(writeClient, never()).scheduleLogCompactionAtInstant("600005", Option.empty());
+
+    // Compaction delegation must not block a request that only asks for log compaction.
+    MetadataTableServiceRequest logCompactionOnlyRequest = MetadataTableServiceRequest.newBuilder()
+        .withMode(mode)
+        .withServices(EnumSet.of(TableServiceType.LOG_COMPACT))
+        .build();
+    writer.runCompactionServicesIfNecessary(writeClient, Option.of("700"), logCompactionOnlyRequest);
+    verify(writeClient, never()).scheduleCompactionAtInstant("700001", Option.empty());
+    verify(writeClient).scheduleLogCompactionAtInstant("700005", Option.empty());
+    if (mode.includesExecute()) {
+      verify(writeClient).compact("600001", true);
+      verify(writeClient).logCompact("700005", true);
+    } else {
+      verify(writeClient, never()).compact("600001", true);
+      verify(writeClient, never()).logCompact("700005", true);
+    }
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriterTableVersionSix.java
@@ -22,6 +22,7 @@ import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieTableServiceManagerConfig;
 import org.apache.hudi.common.model.ActionType;
+import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -39,6 +40,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -51,6 +53,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -269,7 +272,7 @@ class TestHoodieBackedTableMetadataWriterTableVersionSix {
     when(metadataTimeline.filterPendingCompactionTimeline().firstInstant()).thenReturn(Option.of(pendingCompaction));
     writer.metadataMetaClient = metadataMetaClient;
 
-    assertFalse(writer.validateCompactionScheduling(Option.empty(), "20250101120000002"));
+    assertFalse(writer.validateCompactionScheduling("20250101120000002"));
   }
 
   @Test
@@ -296,11 +299,11 @@ class TestHoodieBackedTableMetadataWriterTableVersionSix {
         .build();
 
     assertThrows(HoodieMetadataException.class,
-        () -> writer.validateCompactionScheduling(Option.empty(), "20250101120000001"));
+        () -> writer.validateCompactionScheduling("20250101120000001"));
   }
 
   @Test
-  void testCompactIfNecessaryCoversExistingDelegatedAndLogCompactionPaths() {
+  void testRunCompactionServicesCoversExistingDelegatedAndLogCompactionPaths() {
     // Exercise completed, delegated, and log-compaction fallback paths.
     Properties tableServiceManagerProperties = new Properties();
     tableServiceManagerProperties.put(
@@ -313,6 +316,7 @@ class TestHoodieBackedTableMetadataWriterTableVersionSix {
             .build();
     HoodieWriteConfig metadataWriteConfig = mock(HoodieWriteConfig.class);
     when(metadataWriteConfig.getTableServiceManagerConfig()).thenReturn(tableServiceManagerConfig);
+    when(metadataWriteConfig.getMetadataConfig()).thenReturn(HoodieMetadataConfig.newBuilder().build());
     when(metadataWriteConfig.isLogCompactionEnabled()).thenReturn(true);
 
     HoodieTableMetaClient metadataMetaClient = mock(HoodieTableMetaClient.class);
@@ -335,9 +339,10 @@ class TestHoodieBackedTableMetadataWriterTableVersionSix {
     when(writeClient.scheduleLogCompactionAtInstant("300005", Option.empty())).thenReturn(true);
 
     // Version 6 derives compaction and log-compaction instants with fixed suffixes.
-    writer.compactIfNecessary(writeClient, Option.of("100"));
-    writer.compactIfNecessary(writeClient, Option.of("200"));
-    writer.compactIfNecessary(writeClient, Option.of("300"));
+    MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder().build();
+    writer.runCompactionServicesIfNecessary(writeClient, Option.of("100"), request);
+    writer.runCompactionServicesIfNecessary(writeClient, Option.of("200"), request);
+    writer.runCompactionServicesIfNecessary(writeClient, Option.of("300"), request);
 
     Properties allTableServicesProperties = new Properties();
     allTableServicesProperties.put(
@@ -350,11 +355,64 @@ class TestHoodieBackedTableMetadataWriterTableVersionSix {
             .build());
     when(writeClient.scheduleCompactionAtInstant("400001", Option.empty())).thenReturn(false);
     when(writeClient.scheduleLogCompactionAtInstant("400005", Option.empty())).thenReturn(true);
-    writer.compactIfNecessary(writeClient, Option.of("400"));
+    writer.runCompactionServicesIfNecessary(writeClient, Option.of("400"), request);
 
     verify(writeClient).scheduleCompactionAtInstant("200001", Option.empty());
     verify(writeClient).scheduleLogCompactionAtInstant("300005", Option.empty());
     verify(writeClient).logCompact("300005", true);
+  }
+
+  @Test
+  void testSchedulingDelegationAndExternalBypass() {
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
+        .withTableServiceManagerEnabled(true)
+        .withTableServiceManagerScheduleActions(ActionType.compaction.name())
+        .build();
+    HoodieWriteConfig dataWriteConfig = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp/table")
+        .withMetadataConfig(metadataConfig)
+        .build();
+    HoodieWriteConfig metadataWriteConfig = mock(HoodieWriteConfig.class);
+    Properties tableServiceManagerProperties = new Properties();
+    tableServiceManagerProperties.put(
+        HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ENABLED.key(), "true");
+    tableServiceManagerProperties.put(
+        HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), ActionType.compaction.name());
+    when(metadataWriteConfig.getTableServiceManagerConfig()).thenReturn(
+        HoodieTableServiceManagerConfig.newBuilder()
+            .fromProperties(tableServiceManagerProperties)
+            .build());
+    when(metadataWriteConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataWriteConfig.isLogCompactionEnabled()).thenReturn(true);
+
+    HoodieTableMetaClient metadataMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
+    when(metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(any(String.class)))
+        .thenReturn(false);
+    HoodieBackedTableMetadataWriterTableVersionSix<?, ?> writer =
+        mock(HoodieBackedTableMetadataWriterTableVersionSix.class, CALLS_REAL_METHODS);
+    writer.dataWriteConfig = dataWriteConfig;
+    writer.metadataWriteConfig = metadataWriteConfig;
+    writer.metadataMetaClient = metadataMetaClient;
+
+    BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
+    when(writeClient.scheduleLogCompactionAtInstant("500005", Option.empty())).thenReturn(true);
+    when(writeClient.scheduleCompactionAtInstant("600001", Option.empty())).thenReturn(true);
+
+    MetadataTableServiceRequest inlineRequest = MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.SCHEDULE)
+        .withServices(EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT))
+        .build();
+    writer.runCompactionServicesIfNecessary(writeClient, Option.of("500"), inlineRequest);
+    verify(writeClient, never()).scheduleCompactionAtInstant("500001", Option.empty());
+    verify(writeClient).scheduleLogCompactionAtInstant("500005", Option.empty());
+
+    MetadataTableServiceRequest externalRequest = MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.SCHEDULE)
+        .withServices(EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT))
+        .disableTableServiceManagerDelegation(true)
+        .build();
+    writer.runCompactionServicesIfNecessary(writeClient, Option.of("600"), externalRequest);
+    verify(writeClient).scheduleCompactionAtInstant("600001", Option.empty());
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
@@ -143,6 +143,25 @@ public class TestHoodieMetadataWriteUtils {
     assertEquals("snappy", metadataWriteConfig.getParquetCompressionCodec());
   }
 
+  @Test
+  void testCreateMetadataWriteConfigPropagatesTableServiceSchedulingDelegation() {
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
+        .withTableServiceManagerEnabled(true)
+        .withTableServiceManagerScheduleActions(ActionType.compaction.name())
+        .build();
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp/base_path/")
+        .withMetadataConfig(metadataConfig)
+        .build();
+
+    HoodieWriteConfig metadataWriteConfig = HoodieMetadataWriteUtils.createMetadataWriteConfig(
+        writeConfig, HoodieFailedWritesCleaningPolicy.EAGER, HoodieTableVersion.EIGHT);
+
+    assertTrue(metadataWriteConfig.getTableServiceManagerConfig().isTableServiceManagerEnabled());
+    assertEquals(ActionType.compaction.name(),
+        metadataWriteConfig.getMetadataConfig().getTableServiceManagerScheduleActions());
+  }
+
   @ParameterizedTest
   @EnumSource(value = MetricsReporterType.class, names = {
       "GRAPHITE", "JMX", "PROMETHEUS_PUSHGATEWAY", "M3", "PROMETHEUS"

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
@@ -24,6 +24,7 @@ import org.apache.hudi.client.transaction.lock.ZookeeperBasedImplicitBasePathLoc
 import org.apache.hudi.client.transaction.lock.ZookeeperBasedLockProvider;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.config.HoodieTableServiceManagerConfig;
 import org.apache.hudi.common.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.engine.TaskContextSupplier;
@@ -143,23 +144,32 @@ public class TestHoodieMetadataWriteUtils {
     assertEquals("snappy", metadataWriteConfig.getParquetCompressionCodec());
   }
 
-  @Test
-  void testCreateMetadataWriteConfigPropagatesTableServiceSchedulingDelegation() {
+  @ParameterizedTest
+  @EnumSource(value = HoodieTableVersion.class, names = {"SIX", "EIGHT"})
+  void testCreateMetadataWriteConfigPropagatesTableServiceSchedulingDelegation(HoodieTableVersion version) {
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
         .withTableServiceManagerEnabled(true)
         .withTableServiceManagerScheduleActions(ActionType.compaction.name())
         .build();
+    // DT-level manager settings must not replace MDT-specific delegation settings.
+    Properties dataTableManagerProperties = new Properties();
+    dataTableManagerProperties.setProperty(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), "clean");
+    dataTableManagerProperties.setProperty(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key(), "logcompaction");
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withPath("/tmp/base_path/")
+        .withProperties(dataTableManagerProperties)
         .withMetadataConfig(metadataConfig)
         .build();
 
     HoodieWriteConfig metadataWriteConfig = HoodieMetadataWriteUtils.createMetadataWriteConfig(
-        writeConfig, HoodieFailedWritesCleaningPolicy.EAGER, HoodieTableVersion.EIGHT);
+        writeConfig, HoodieFailedWritesCleaningPolicy.EAGER, version);
 
     assertTrue(metadataWriteConfig.getTableServiceManagerConfig().isTableServiceManagerEnabled());
     assertEquals(ActionType.compaction.name(),
-        metadataWriteConfig.getMetadataConfig().getTableServiceManagerScheduleActions());
+        metadataWriteConfig.getTableServiceManagerConfig().getTableServiceManagerScheduleActions());
+    assertEquals("", metadataWriteConfig.getTableServiceManagerConfig().getTableServiceManagerActions());
+    assertEquals("", metadataWriteConfig.getMetadataConfig().getTableServiceManagerScheduleActions());
+    assertEquals("logcompaction", writeConfig.getTableServiceManagerConfig().getTableServiceManagerScheduleActions());
   }
 
   @ParameterizedTest
@@ -387,6 +397,7 @@ public class TestHoodieMetadataWriteUtils {
         writeConfig, HoodieFailedWritesCleaningPolicy.EAGER, HoodieTableVersion.EIGHT);
     assertFalse(metadataWriteConfig.getTableServiceManagerConfig().isTableServiceManagerEnabled());
     assertFalse(metadataWriteConfig.getTableServiceManagerConfig().isEnabledAndActionSupported(ActionType.compaction));
+    assertEquals("", metadataWriteConfig.getTableServiceManagerConfig().getTableServiceManagerScheduleActions());
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestMetadataTableServiceRequest.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestMetadataTableServiceRequest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.common.model.TableServiceType;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestMetadataTableServiceRequest {
+
+  @Test
+  void defaultsToAllServicesAndBothPhases() {
+    MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder().build();
+
+    assertEquals(MetadataTableServiceMode.SCHEDULE_AND_EXECUTE, request.getMode());
+    assertEquals(EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT,
+        TableServiceType.CLEAN, TableServiceType.ARCHIVE), request.getServices());
+    assertFalse(request.shouldDisableTableServiceManagerDelegation());
+  }
+
+  @Test
+  void preservesExecutionInstantAndDelegationFlag() {
+    MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.EXECUTE)
+        .withServices(EnumSet.of(TableServiceType.COMPACT))
+        .withInstantTime(Option.of("compaction-instant"))
+        .disableTableServiceManagerDelegation(true)
+        .build();
+
+    assertEquals("compaction-instant", request.getInstantTime().get());
+    assertTrue(request.shouldDisableTableServiceManagerDelegation());
+  }
+
+  @Test
+  void copiesRequestWithDifferentMode() {
+    MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder()
+        .withServices(EnumSet.of(TableServiceType.COMPACT))
+        .disableTableServiceManagerDelegation(true)
+        .build();
+
+    MetadataTableServiceRequest copy = request.copy(MetadataTableServiceMode.EXECUTE);
+
+    assertEquals(MetadataTableServiceMode.EXECUTE, copy.getMode());
+    assertEquals(request.getServices(), copy.getServices());
+    assertTrue(copy.shouldDisableTableServiceManagerDelegation());
+  }
+
+  @Test
+  void rejectsUnsupportedOrAmbiguousRequests() {
+    assertThrows(IllegalArgumentException.class, () -> MetadataTableServiceRequest.newBuilder()
+        .withServices(EnumSet.of(TableServiceType.CLUSTER))
+        .build());
+    assertThrows(IllegalArgumentException.class, () -> MetadataTableServiceRequest.newBuilder()
+        .withInstantTime(Option.of("instant"))
+        .build());
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestMetadataTableServiceRequest.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestMetadataTableServiceRequest.java
@@ -22,6 +22,9 @@ import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.EnumSet;
 
@@ -77,5 +80,43 @@ class TestMetadataTableServiceRequest {
     assertThrows(IllegalArgumentException.class, () -> MetadataTableServiceRequest.newBuilder()
         .withInstantTime(Option.of("instant"))
         .build());
+  }
+
+  @ParameterizedTest
+  @CsvSource({"COMPACT,SCHEDULE", "COMPACT,SCHEDULE_AND_EXECUTE",
+      "LOG_COMPACT,SCHEDULE", "LOG_COMPACT,SCHEDULE_AND_EXECUTE"})
+  void rejectsCopyingExecutionInstantToSchedulingMode(TableServiceType service, MetadataTableServiceMode mode) {
+    MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.EXECUTE)
+        .withServices(EnumSet.of(service))
+        .withInstantTime(Option.of("instant"))
+        .disableTableServiceManagerDelegation(true)
+        .build();
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> request.copy(mode));
+
+    assertTrue(exception.getMessage().contains("An instant time requires execute mode"));
+    assertEquals(MetadataTableServiceMode.EXECUTE, request.getMode());
+    assertEquals(Option.of("instant"), request.getInstantTime());
+    assertEquals(EnumSet.of(service), request.getServices());
+    assertTrue(request.shouldDisableTableServiceManagerDelegation());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = TableServiceType.class, names = {"COMPACT", "LOG_COMPACT"})
+  void preservesInstantWhenCopyingExecutionRequest(TableServiceType service) {
+    MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder()
+        .withMode(MetadataTableServiceMode.EXECUTE)
+        .withServices(EnumSet.of(service))
+        .withInstantTime(Option.of("instant"))
+        .disableTableServiceManagerDelegation(true)
+        .build();
+
+    MetadataTableServiceRequest copy = request.copy(MetadataTableServiceMode.EXECUTE);
+
+    assertEquals(MetadataTableServiceMode.EXECUTE, copy.getMode());
+    assertEquals(request.getInstantTime(), copy.getInstantTime());
+    assertEquals(request.getServices(), copy.getServices());
+    assertTrue(copy.shouldDisableTableServiceManagerDelegation());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -35,7 +35,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +42,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.config.HoodieTableServiceManagerConfig.parseTableServiceActions;
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
@@ -98,10 +98,15 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .defaultValue(false)
       .markAdvanced()
       .withDocumentation("If true, delegate the configured metadata table service scheduling and/or execution actions "
-          + "to a separate table service manager instead of running them inline.");
+          + "to a separate table service manager instead of running them inline. "
+          + "Users must arrange external execution, for example by scheduling HoodieMetadataTableServicesTool; "
+          + "this setting alone does not deploy or start an external job.");
+
+  /** Metadata service delegation name; archival has no corresponding timeline action. */
+  public static final String ARCHIVE_ACTION = "archive";
 
   private static final Set<String> SUPPORTED_TABLE_SERVICE_MANAGER_EXECUTION_ACTIONS = CollectionUtils.createImmutableSet(
-      ActionType.compaction.name(), ActionType.logcompaction.name(), ActionType.clean.name(), "archive");
+      ActionType.compaction.name(), ActionType.logcompaction.name(), ActionType.clean.name(), ARCHIVE_ACTION);
 
   private static final Set<String> SUPPORTED_TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS = CollectionUtils.createImmutableSet(
       ActionType.compaction.name(), ActionType.logcompaction.name());
@@ -112,7 +117,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Comma-separated list of table service actions on the metadata table "
           + "whose inline execution should be delegated to the table service manager. "
-          + "Supported actions are: compaction, logcompaction, clean, archive.");
+          + "Supported actions are: compaction, logcompaction, clean, archive. "
+          + "Clean and archive extend the previously supported compaction and logcompaction actions; existing valid configurations retain their behavior. "
+          + "When metadata table service delegation is enabled, adding clean or archive disables that service's inline execution. "
+          + "Users must run it externally, for example with HoodieMetadataTableServicesTool. "
+          + "Delegating clean or archive does not submit an HTTP table-service-manager request or start an external job.");
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS = ConfigProperty
       .key(METADATA_PREFIX + ".table.service.manager.schedule.actions")
@@ -1515,16 +1524,6 @@ public final class HoodieMetadataConfig extends HoodieConfig {
         }
       }
     }
-  }
-
-  private static Set<String> parseTableServiceActions(String actions) {
-    if (StringUtils.isNullOrEmpty(actions)) {
-      return Collections.emptySet();
-    }
-    return Arrays.stream(actions.split(","))
-        .map(String::trim)
-        .filter(action -> !action.isEmpty())
-        .collect(Collectors.toSet());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.model.ActionType;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieNotSupportedException;
@@ -34,7 +35,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.EnumSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -96,19 +97,30 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".table.service.manager.enabled")
       .defaultValue(false)
       .markAdvanced()
-      .withDocumentation("If true, delegate specified table service actions on the metadata table to the table service manager "
-          + "instead of executing them inline. This prevents the current writer from executing compaction/logcompaction "
-          + "on the metadata table, allowing a separate async pipeline to handle them.");
+      .withDocumentation("If true, delegate the configured metadata table service scheduling and/or execution actions "
+          + "to a separate table service manager instead of running them inline.");
 
-  public static final Set<ActionType> SUPPORTED_TABLE_SERVICE_MANAGER_ACTIONS =
-      EnumSet.of(ActionType.compaction, ActionType.logcompaction);
+  private static final Set<String> SUPPORTED_TABLE_SERVICE_MANAGER_EXECUTION_ACTIONS = CollectionUtils.createImmutableSet(
+      ActionType.compaction.name(), ActionType.logcompaction.name(), ActionType.clean.name(), "archive");
+
+  private static final Set<String> SUPPORTED_TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS = CollectionUtils.createImmutableSet(
+      ActionType.compaction.name(), ActionType.logcompaction.name());
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_ACTIONS = ConfigProperty
       .key(METADATA_PREFIX + ".table.service.manager.actions")
       .defaultValue("")
       .markAdvanced()
       .withDocumentation("Comma-separated list of table service actions on the metadata table "
-          + "that should be delegated to the table service manager. Currently supported actions are: compaction, logcompaction.");
+          + "whose inline execution should be delegated to the table service manager. "
+          + "Supported actions are: compaction, logcompaction, clean, archive.");
+
+  public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS = ConfigProperty
+      .key(METADATA_PREFIX + ".table.service.manager.schedule.actions")
+      .defaultValue("")
+      .markAdvanced()
+      .withDocumentation("Comma-separated list of table service actions on the metadata table "
+          + "whose inline scheduling should be delegated to the table service manager. "
+          + "Supported actions are: compaction, logcompaction.");
 
   public static final ConfigProperty<Integer> STREAMING_WRITE_DATATABLE_WRITE_STATUSES_COALESCE_DIVISOR = ConfigProperty
       .key(METADATA_PREFIX + ".streaming.write.datatable.write.statuses.coalesce.divisor")
@@ -750,6 +762,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getString(TABLE_SERVICE_MANAGER_ACTIONS);
   }
 
+  public String getTableServiceManagerScheduleActions() {
+    return getString(TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS);
+  }
+
   public int getStreamingWritesCoalesceDivisorForDataTableWrites() {
     return getInt(HoodieMetadataConfig.STREAMING_WRITE_DATATABLE_WRITE_STATUSES_COALESCE_DIVISOR);
   }
@@ -1102,9 +1118,17 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withTableServiceManagerActions(String actions) {
       if (!actions.isEmpty()) {
-        validateTableServiceManagerActions(actions);
+        validateTableServiceManagerActions(actions, SUPPORTED_TABLE_SERVICE_MANAGER_EXECUTION_ACTIONS);
       }
       metadataConfig.setValue(TABLE_SERVICE_MANAGER_ACTIONS, actions);
+      return this;
+    }
+
+    public Builder withTableServiceManagerScheduleActions(String actions) {
+      if (!actions.isEmpty()) {
+        validateTableServiceManagerActions(actions, SUPPORTED_TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS);
+      }
+      metadataConfig.setValue(TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS, actions);
       return this;
     }
 
@@ -1416,14 +1440,17 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       metadataConfig.setDefaults(HoodieMetadataConfig.class.getName());
 
       String tsmActions = metadataConfig.getString(TABLE_SERVICE_MANAGER_ACTIONS);
-      if (tsmActions != null && !tsmActions.isEmpty()) {
-        validateTableServiceManagerActions(tsmActions);
-      }
+      Set<String> parsedTsmActions = parseTableServiceActions(tsmActions);
+      validateTableServiceManagerActions(parsedTsmActions, SUPPORTED_TABLE_SERVICE_MANAGER_EXECUTION_ACTIONS);
+      String tsmScheduleActions = metadataConfig.getString(TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS);
+      Set<String> parsedTsmScheduleActions = parseTableServiceActions(tsmScheduleActions);
+      validateTableServiceManagerActions(parsedTsmScheduleActions, SUPPORTED_TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS);
       if (metadataConfig.getBoolean(TABLE_SERVICE_MANAGER_ENABLED)
-          && (tsmActions == null || tsmActions.isEmpty())) {
+          && parsedTsmActions.isEmpty()
+          && parsedTsmScheduleActions.isEmpty()) {
         throw new IllegalArgumentException(TABLE_SERVICE_MANAGER_ENABLED.key() + " is set to true but "
-            + TABLE_SERVICE_MANAGER_ACTIONS.key() + " is empty. Specify at least one action to delegate"
-            + " (supported: " + SUPPORTED_TABLE_SERVICE_MANAGER_ACTIONS + ").");
+            + TABLE_SERVICE_MANAGER_ACTIONS.key() + " and " + TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key()
+            + " are empty. Specify at least one action to delegate.");
       }
       return metadataConfig;
     }
@@ -1476,22 +1503,28 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       }
     }
 
-    private static void validateTableServiceManagerActions(String actions) {
-      for (String action : actions.split(",")) {
-        String trimmed = action.trim();
-        ActionType actionType;
-        try {
-          actionType = ActionType.valueOf(trimmed);
-        } catch (IllegalArgumentException e) {
-          throw new IllegalArgumentException("Unknown metadata table service manager action: " + trimmed
-              + ". Supported actions are: " + SUPPORTED_TABLE_SERVICE_MANAGER_ACTIONS, e);
-        }
-        if (!SUPPORTED_TABLE_SERVICE_MANAGER_ACTIONS.contains(actionType)) {
-          throw new IllegalArgumentException("Unsupported metadata table service manager action: " + trimmed
-              + ". Supported actions are: " + SUPPORTED_TABLE_SERVICE_MANAGER_ACTIONS);
+    private static void validateTableServiceManagerActions(String actions, Set<String> supportedActions) {
+      validateTableServiceManagerActions(parseTableServiceActions(actions), supportedActions);
+    }
+
+    private static void validateTableServiceManagerActions(Set<String> actions, Set<String> supportedActions) {
+      for (String action : actions) {
+        if (!supportedActions.contains(action)) {
+          throw new IllegalArgumentException("Unsupported metadata table service manager action: " + action
+              + ". Supported actions are: " + supportedActions);
         }
       }
     }
+  }
+
+  private static Set<String> parseTableServiceActions(String actions) {
+    if (StringUtils.isNullOrEmpty(actions)) {
+      return Collections.emptySet();
+    }
+    return Arrays.stream(actions.split(","))
+        .map(String::trim)
+        .filter(action -> !action.isEmpty())
+        .collect(Collectors.toSet());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieTableServiceManagerConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieTableServiceManagerConfig.java
@@ -19,13 +19,13 @@
 package org.apache.hudi.common.config;
 
 import org.apache.hudi.common.model.ActionType;
+import org.apache.hudi.common.util.StringUtils;
 
 import javax.annotation.concurrent.Immutable;
 
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Configurations used by the Hudi Table Service Manager.
@@ -57,6 +57,16 @@ public class HoodieTableServiceManagerConfig extends HoodieConfig {
       .markAdvanced()
       .sinceVersion("0.13.0")
       .withDocumentation("The actions deployed on table service manager, such as compaction or clean.");
+
+  public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS = ConfigProperty
+      .key(TABLE_SERVICE_MANAGER_PREFIX + ".schedule.actions")
+      .defaultValue("")
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("Comma-separated actions whose scheduling is delegated to a table service manager. "
+          + "Currently consumed by the metadata table writer for compaction and logcompaction; "
+          + "it is derived from hoodie.metadata.table.service.manager.schedule.actions. "
+          + "Setting this key on a data-table writer does not enable data-table scheduling delegation.");
 
   public static final ConfigProperty<String> TABLE_SERVICE_MANAGER_DEPLOY_USERNAME = ConfigProperty
       .key(TABLE_SERVICE_MANAGER_PREFIX + ".deploy.username")
@@ -137,6 +147,10 @@ public class HoodieTableServiceManagerConfig extends HoodieConfig {
     return getStringOrDefault(TABLE_SERVICE_MANAGER_ACTIONS);
   }
 
+  public String getTableServiceManagerScheduleActions() {
+    return getStringOrDefault(TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS);
+  }
+
   public String getDeployUsername() {
     return getStringOrDefault(TABLE_SERVICE_MANAGER_DEPLOY_USERNAME);
   }
@@ -174,15 +188,17 @@ public class HoodieTableServiceManagerConfig extends HoodieConfig {
   }
 
   public boolean isEnabledAndActionSupported(ActionType actionType) {
-    Set<String> actions = Arrays.stream(getTableServiceManagerActions().split(","))
-        .map(String::trim)
-        .filter(s -> !s.isEmpty())
-        .collect(Collectors.toSet());
+    Set<String> actions = parseTableServiceActions(getTableServiceManagerActions());
     boolean isActionSupported = actions.contains(actionType.name());
     if (actionType.equals(ActionType.clustering)) {
       isActionSupported = isActionSupported || actions.contains(ActionType.replacecommit.name());
     }
     return isTableServiceManagerEnabled() && isActionSupported;
+  }
+
+  /** Parses comma-separated service names, trimming whitespace and ignoring empty entries. */
+  public static Set<String> parseTableServiceActions(String actions) {
+    return new HashSet<>(StringUtils.split(actions, ","));
   }
 
   public static class Builder {

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
@@ -217,9 +217,9 @@ class TestHoodieMetadataConfig {
     assertEquals("", config.getTableServiceManagerActions());
 
     HoodieMetadataConfig configWithActions = HoodieMetadataConfig.newBuilder()
-        .withTableServiceManagerActions("compaction,logcompaction")
+        .withTableServiceManagerActions("compaction,logcompaction,clean,archive")
         .build();
-    assertEquals("compaction,logcompaction", configWithActions.getTableServiceManagerActions());
+    assertEquals("compaction,logcompaction,clean,archive", configWithActions.getTableServiceManagerActions());
 
     Properties props = new Properties();
     props.put(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), "compaction");
@@ -233,17 +233,12 @@ class TestHoodieMetadataConfig {
   void testTableServiceManagerActionsRejectsUnsupportedActions() {
     assertThrows(IllegalArgumentException.class, () ->
         HoodieMetadataConfig.newBuilder()
-            .withTableServiceManagerActions("clean")
-            .build());
-
-    assertThrows(IllegalArgumentException.class, () ->
-        HoodieMetadataConfig.newBuilder()
             .withTableServiceManagerActions("clustering")
             .build());
 
     assertThrows(IllegalArgumentException.class, () ->
         HoodieMetadataConfig.newBuilder()
-            .withTableServiceManagerActions("compaction,clean")
+            .withTableServiceManagerActions("compaction,savepoint")
             .build());
 
     assertThrows(IllegalArgumentException.class, () ->
@@ -255,10 +250,25 @@ class TestHoodieMetadataConfig {
   @Test
   void testTableServiceManagerActionsValidatedInBuildFromProperties() {
     Properties props = new Properties();
-    props.put(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), "clean");
+    props.put(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), "clustering");
     assertThrows(IllegalArgumentException.class, () ->
         HoodieMetadataConfig.newBuilder()
             .fromProperties(props)
+            .build());
+  }
+
+  @Test
+  void testTableServiceManagerScheduleActions() {
+    HoodieMetadataConfig config = HoodieMetadataConfig.newBuilder()
+        .withTableServiceManagerEnabled(true)
+        .withTableServiceManagerScheduleActions("compaction,logcompaction")
+        .build();
+
+    assertEquals("compaction,logcompaction", config.getTableServiceManagerScheduleActions());
+
+    assertThrows(IllegalArgumentException.class, () ->
+        HoodieMetadataConfig.newBuilder()
+            .withTableServiceManagerScheduleActions("clean")
             .build());
   }
 
@@ -267,6 +277,21 @@ class TestHoodieMetadataConfig {
     assertThrows(IllegalArgumentException.class, () ->
         HoodieMetadataConfig.newBuilder()
             .withTableServiceManagerEnabled(true)
+            .build());
+
+    assertThrows(IllegalArgumentException.class, () ->
+        HoodieMetadataConfig.newBuilder()
+            .withTableServiceManagerEnabled(true)
+            .withTableServiceManagerActions(" , ")
+            .build());
+
+    Properties props = new Properties();
+    props.put(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_ENABLED.key(), "true");
+    props.put(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), " , ");
+    props.put(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key(), " , ");
+    assertThrows(IllegalArgumentException.class, () ->
+        HoodieMetadataConfig.newBuilder()
+            .fromProperties(props)
             .build());
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieTableServiceManagerConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieTableServiceManagerConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import org.apache.hudi.common.model.ActionType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestHoodieTableServiceManagerConfig {
+  @Test
+  void parsesWhitespaceEmptyTokensAndExactActionNames() {
+    assertEquals(Collections.emptySet(), HoodieTableServiceManagerConfig.parseTableServiceActions(null));
+    assertEquals(Collections.emptySet(), HoodieTableServiceManagerConfig.parseTableServiceActions(" , , "));
+    assertEquals(Collections.singleton("compaction"),
+        HoodieTableServiceManagerConfig.parseTableServiceActions(" compaction, ,compaction, "));
+    assertFalse(HoodieTableServiceManagerConfig.parseTableServiceActions("logcompaction,").contains("compaction"));
+  }
+
+  @Test
+  void schedulingDelegationDefaultsToEmpty() {
+    HoodieTableServiceManagerConfig config = HoodieTableServiceManagerConfig.newBuilder().build();
+
+    assertEquals("hoodie.table.service.manager.schedule.actions",
+        HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key());
+    assertEquals("", config.getTableServiceManagerScheduleActions());
+    assertFalse(config.isTableServiceManagerEnabled());
+  }
+
+  @Test
+  void schedulingAndExecutionActionsAreIndependent() {
+    Properties properties = new Properties();
+    properties.setProperty(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ENABLED.key(), "true");
+    properties.setProperty(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), "clean");
+    properties.setProperty(HoodieTableServiceManagerConfig.TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key(), "compaction,logcompaction");
+    HoodieTableServiceManagerConfig config = HoodieTableServiceManagerConfig.newBuilder().fromProperties(properties).build();
+
+    assertEquals("compaction,logcompaction", config.getTableServiceManagerScheduleActions());
+    assertEquals("clean", config.getTableServiceManagerActions());
+    assertTrue(config.isEnabledAndActionSupported(ActionType.clean));
+    assertFalse(config.isEnabledAndActionSupported(ActionType.compaction));
+    assertFalse(config.isEnabledAndActionSupported(ActionType.logcompaction));
+  }
+}

--- a/hudi-utilities/README.md
+++ b/hudi-utilities/README.md
@@ -1,0 +1,49 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Metadata table services tool
+
+`org.apache.hudi.utilities.HoodieMetadataTableServicesTool` is a standalone
+Spark-submit entry point for MDT maintenance. It calls MDT writer APIs directly;
+it does not require an HTTP Table Service Manager server.
+
+## Delegation and compatibility
+
+`hoodie.metadata.table.service.manager.actions` retains its execution-delegation
+meaning and now additionally accepts `clean` and `archive`, alongside the existing
+`compaction` and `logcompaction` values. Previously valid configurations keep their
+behavior. Delegation remains disabled by default, so existing inline clean/archive
+behavior does not change unless users explicitly opt in.
+
+For example, to delegate only clean and archive, set these on the ingestion writer:
+
+```properties
+hoodie.metadata.table.service.manager.enabled=true
+hoodie.metadata.table.service.manager.actions=clean,archive
+```
+
+This skips inline clean/archive; it does **not** submit an HTTP manager request or
+automatically launch a replacement job. Users must separately deploy and schedule
+the tool with `--services clean,archive --mode execute`, or provide another external
+executor. Without one, the delegated maintenance will not run, potentially allowing
+obsolete files and the active timeline to accumulate.
+
+The tool follows its requested services and mode, bypassing ingestion-side
+delegation checks so it does not delegate the work again. Scheduling delegation is
+controlled separately by `hoodie.metadata.table.service.manager.schedule.actions`,
+which supports only `compaction` and `logcompaction`.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableServicesTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableServicesTool.java
@@ -82,7 +82,7 @@ public class HoodieMetadataTableServicesTool {
         .build();
     this.services = parseServices(cfg.services);
     this.mode = MetadataTableServiceMode.fromValue(cfg.mode);
-    validateRequest();
+    validateRequest(mode, services, cfg.instantTime);
   }
 
   public void run() {
@@ -115,8 +115,7 @@ public class HoodieMetadataTableServicesTool {
         scheduleAndExecuteCompactionService(TableServiceType.LOG_COMPACT, compactionServices);
       } else {
         // Pure scheduling only publishes plans while holding the data-table lock.
-        runLockedSingleWriterPhase(writer ->
-            writer.scheduleTableServices(newRequest(MetadataTableServiceMode.SCHEDULE, compactionServices)));
+        scheduleTableServicesPhase(compactionServices);
       }
     }
 
@@ -133,8 +132,7 @@ public class HoodieMetadataTableServicesTool {
     }
     Set<TableServiceType> serviceSet = EnumSet.of(service);
     // Publish the plan under the data-table lock, then release it before expensive OCC execution.
-    runLockedSingleWriterPhase(writer ->
-        writer.scheduleTableServices(newRequest(MetadataTableServiceMode.SCHEDULE, serviceSet)));
+    scheduleTableServicesPhase(serviceSet);
     executeTableServicesPhase(serviceSet);
   }
 
@@ -149,7 +147,7 @@ public class HoodieMetadataTableServicesTool {
     }
   }
 
-  private void runLockedSingleWriterPhase(WriterOperation operation) {
+  private void scheduleTableServicesPhase(Set<TableServiceType> schedulingServices) {
     // The outer transaction owns the shared data-table lock; the SINGLE_WRITER MDT writer must not reacquire it.
     HoodieWriteConfig schedulingConfig = buildWriteConfig(WriteConcurrencyMode.SINGLE_WRITER);
     try (TransactionManager transactionManager = createTransactionManager(schedulingConfig)) {
@@ -157,7 +155,7 @@ public class HoodieMetadataTableServicesTool {
       // Close the writer before releasing the lock, preserving any primary failure if either close fails.
       try (AutoCloseable lock = () -> transactionManager.endStateChange(Option.empty());
            HoodieTableMetadataWriter writer = createWriter(schedulingConfig)) {
-        operation.run(writer);
+        writer.scheduleTableServices(newRequest(MetadataTableServiceMode.SCHEDULE, schedulingServices));
       } catch (Exception e) {
         throw new HoodieException("Failed to run lock-protected metadata table services", e);
       }
@@ -225,29 +223,18 @@ public class HoodieMetadataTableServicesTool {
     HoodieLockConfig.deriveLockConfigForDifferentTable(lockProviderClass, writeConfig);
   }
 
-  private void validateRequest() {
-    validateRequest(mode, services, cfg.instantTime);
-  }
-
   static void validateRequest(MetadataTableServiceMode mode,
                               Set<TableServiceType> services,
                               String instantTime) {
-    if (services.isEmpty()) {
-      throw new IllegalArgumentException("At least one metadata table service must be selected");
-    }
-    boolean containsCompactionService = services.contains(TableServiceType.COMPACT)
-        || services.contains(TableServiceType.LOG_COMPACT);
+    MetadataTableServiceRequest request = MetadataTableServiceRequest.newBuilder()
+        .withMode(mode)
+        .withServices(services)
+        .withInstantTime(Option.ofNullable(instantTime))
+        .build();
+    boolean containsCompactionService = request.includes(TableServiceType.COMPACT)
+        || request.includes(TableServiceType.LOG_COMPACT);
     if (mode == MetadataTableServiceMode.SCHEDULE && !containsCompactionService) {
       throw new IllegalArgumentException("Schedule mode requires compaction or logcompaction");
-    }
-    if (instantTime != null) {
-      long executableCompactionServices = services.stream()
-          .filter(service -> service == TableServiceType.COMPACT || service == TableServiceType.LOG_COMPACT)
-          .count();
-      if (mode != MetadataTableServiceMode.EXECUTE || executableCompactionServices != 1 || services.size() != 1) {
-        throw new IllegalArgumentException(
-            "--instant-time requires execute mode and exactly one of compaction or logcompaction");
-      }
     }
     if (mode == MetadataTableServiceMode.SCHEDULE) {
       Set<TableServiceType> skippedServices = EnumSet.copyOf(services);
@@ -284,11 +271,6 @@ public class HoodieMetadataTableServicesTool {
       }
     }
     return result;
-  }
-
-  @FunctionalInterface
-  private interface WriterOperation {
-    void run(HoodieTableMetadataWriter writer);
   }
 
   /** CLI configuration. */

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableServicesTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableServicesTool.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import org.apache.hudi.SparkAdapterSupport$;
+import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.client.transaction.TransactionManager;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.TableServiceType;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.HoodieTableMetadataWriter;
+import org.apache.hudi.metadata.MetadataTableServiceMode;
+import org.apache.hudi.metadata.MetadataTableServiceRequest;
+import org.apache.hudi.metadata.SparkMetadataWriterFactory;
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.JavaSparkContext;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Standalone Spark tool for scheduling and executing metadata table services. */
+@Slf4j
+public class HoodieMetadataTableServicesTool {
+
+  private final Config cfg;
+  private final TypedProperties props;
+  private final HoodieSparkEngineContext engineContext;
+  private final HadoopStorageConfiguration storageConf;
+  private final HoodieTableMetaClient dataMetaClient;
+  private final Set<TableServiceType> services;
+  private final MetadataTableServiceMode mode;
+
+  public HoodieMetadataTableServicesTool(Config cfg, JavaSparkContext jsc) {
+    this(cfg, jsc, UtilHelpers.buildProperties(jsc.hadoopConfiguration(), cfg.propsFilePath, cfg.configs));
+  }
+
+  HoodieMetadataTableServicesTool(Config cfg, JavaSparkContext jsc, TypedProperties props) {
+    this.cfg = cfg;
+    this.props = props;
+    this.engineContext = new HoodieSparkEngineContext(jsc);
+    this.storageConf = new HadoopStorageConfiguration(jsc.hadoopConfiguration());
+    this.dataMetaClient = HoodieTableMetaClient.builder()
+        .setConf(storageConf)
+        .setBasePath(cfg.basePath)
+        .build();
+    this.services = parseServices(cfg.services);
+    this.mode = MetadataTableServiceMode.fromValue(cfg.mode);
+    validateRequest();
+  }
+
+  public void run() {
+    dataMetaClient.reloadTableConfig();
+    if (!dataMetaClient.getTableConfig().isMetadataTableAvailable()) {
+      log.warn("Metadata table is not initialized for data table {}, skipping table services", cfg.basePath);
+      return;
+    }
+
+    Set<TableServiceType> compactionServices = services.stream()
+        .filter(service -> service == TableServiceType.COMPACT || service == TableServiceType.LOG_COMPACT)
+        .collect(Collectors.toCollection(() -> EnumSet.noneOf(TableServiceType.class)));
+
+    validateDataTableLockConfiguration(buildWriteConfig(WriteConcurrencyMode.SINGLE_WRITER));
+
+    // Finish plans left pending by a previous run before cleaning or publishing new plans.
+    if (mode.includesExecute() && !compactionServices.isEmpty()) {
+      executeTableServicesPhase(compactionServices);
+    }
+
+    // Execute clean with the OCC writer so its own transaction manager controls the required lock scope.
+    if (mode.includesExecute() && services.contains(TableServiceType.CLEAN)) {
+      executeTableServicesPhase(EnumSet.of(TableServiceType.CLEAN));
+    }
+
+    if (mode.includesSchedule() && !compactionServices.isEmpty()) {
+      if (mode == MetadataTableServiceMode.SCHEDULE_AND_EXECUTE) {
+        // Preserve inline ordering: fully process compaction before log compaction.
+        scheduleAndExecuteCompactionService(TableServiceType.COMPACT, compactionServices);
+        scheduleAndExecuteCompactionService(TableServiceType.LOG_COMPACT, compactionServices);
+      } else {
+        // Pure scheduling only publishes plans while holding the data-table lock.
+        runLockedSingleWriterPhase(writer ->
+            writer.scheduleTableServices(newRequest(MetadataTableServiceMode.SCHEDULE, compactionServices)));
+      }
+    }
+
+    // Archive after all requested compaction services have completed.
+    if (mode.includesExecute() && services.contains(TableServiceType.ARCHIVE)) {
+      executeTableServicesPhase(EnumSet.of(TableServiceType.ARCHIVE));
+    }
+  }
+
+  private void scheduleAndExecuteCompactionService(TableServiceType service,
+                                                   Set<TableServiceType> requestedServices) {
+    if (!requestedServices.contains(service)) {
+      return;
+    }
+    Set<TableServiceType> serviceSet = EnumSet.of(service);
+    // Publish the plan under the data-table lock, then release it before expensive OCC execution.
+    runLockedSingleWriterPhase(writer ->
+        writer.scheduleTableServices(newRequest(MetadataTableServiceMode.SCHEDULE, serviceSet)));
+    executeTableServicesPhase(serviceSet);
+  }
+
+  private void executeTableServicesPhase(Set<TableServiceType> executionServices) {
+    // Let the OCC writer's transaction manager acquire the shared data-table logical lock only where required.
+    // With no explicit instant, compaction services execute every pending plan for the requested service types.
+    HoodieWriteConfig executionConfig = buildWriteConfig(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL);
+    try (HoodieTableMetadataWriter writer = createWriter(executionConfig)) {
+      writer.executeTableServices(newRequest(MetadataTableServiceMode.EXECUTE, executionServices));
+    } catch (Exception e) {
+      throw new HoodieException("Failed to execute metadata table services " + executionServices, e);
+    }
+  }
+
+  private void runLockedSingleWriterPhase(WriterOperation operation) {
+    // The outer transaction owns the shared data-table lock; the SINGLE_WRITER MDT writer must not reacquire it.
+    HoodieWriteConfig schedulingConfig = buildWriteConfig(WriteConcurrencyMode.SINGLE_WRITER);
+    try (TransactionManager transactionManager = new TransactionManager(schedulingConfig, dataMetaClient.getStorage())) {
+      transactionManager.beginStateChange(Option.empty(), Option.empty());
+      try (HoodieTableMetadataWriter writer = createWriter(schedulingConfig)) {
+        operation.run(writer);
+      } catch (Exception e) {
+        throw new HoodieException("Failed to run lock-protected metadata table services", e);
+      } finally {
+        transactionManager.endStateChange(Option.empty());
+      }
+    }
+  }
+
+  private HoodieTableMetadataWriter createWriter(HoodieWriteConfig writeConfig) {
+    HoodieTableMetadataWriter writer = SparkMetadataWriterFactory.create(
+        storageConf, writeConfig, engineContext, Option.empty(), dataMetaClient.getTableConfig());
+    if (!writer.isInitialized()) {
+      try {
+        writer.close();
+      } catch (Exception e) {
+        log.warn("Failed to close an uninitialized metadata table writer", e);
+      }
+      throw new HoodieException("Metadata table writer could not be initialized for " + cfg.basePath);
+    }
+    return writer;
+  }
+
+  private HoodieWriteConfig buildWriteConfig(WriteConcurrencyMode metadataConcurrencyMode) {
+    Properties profileProps = new Properties();
+    profileProps.putAll(props);
+    profileProps.setProperty(HoodieMetadataConfig.ENABLE.key(), "true");
+    profileProps.setProperty(HoodieMetadataConfig.STREAMING_WRITE_ENABLED.key(), "false");
+    // A standalone table-service job must fail visibly so that the scheduler can retry or alert.
+    profileProps.setProperty(HoodieMetadataConfig.FAIL_ON_TABLE_SERVICE_FAILURES.key(), "true");
+    profileProps.setProperty(HoodieMetadataConfig.METADATA_WRITE_CONCURRENCY_MODE.key(), metadataConcurrencyMode.name());
+    // The tool is the table-service manager and must not delegate its own requests.
+    profileProps.setProperty(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_ENABLED.key(), "false");
+    profileProps.setProperty(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), "");
+    profileProps.setProperty(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key(), "");
+    return HoodieWriteConfig.newBuilder()
+        .combineInput(true, true)
+        .withPath(cfg.basePath)
+        .forTable(dataMetaClient.getTableConfig().getTableName())
+        .withProps(profileProps)
+        .build();
+  }
+
+  private MetadataTableServiceRequest newRequest(MetadataTableServiceMode requestMode,
+                                                 Set<TableServiceType> requestServices) {
+    return MetadataTableServiceRequest.newBuilder()
+        .withMode(requestMode)
+        .withServices(requestServices)
+        .withInstantTime(Option.ofNullable(cfg.instantTime))
+        .disableTableServiceManagerDelegation(true)
+        .build();
+  }
+
+  static void validateDataTableLockConfiguration(HoodieWriteConfig writeConfig) {
+    if (!writeConfig.getWriteConcurrencyMode().isOptimisticConcurrencyControl()) {
+      throw new HoodieException("Running metadata table services concurrently requires the data table write concurrency mode to be "
+          + WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL);
+    }
+    String lockProviderClass = writeConfig.getLockProviderClass();
+    if (lockProviderClass == null) {
+      throw new HoodieException("A distributed data table lock provider is required to run metadata table services concurrently");
+    }
+    // Validate that an OCC MDT writer can derive a lock configuration sharing the data-table logical lock.
+    HoodieLockConfig.deriveLockConfigForDifferentTable(lockProviderClass, writeConfig);
+  }
+
+  private void validateRequest() {
+    validateRequest(mode, services, cfg.instantTime);
+  }
+
+  static void validateRequest(MetadataTableServiceMode mode,
+                              Set<TableServiceType> services,
+                              String instantTime) {
+    if (services.isEmpty()) {
+      throw new IllegalArgumentException("At least one metadata table service must be selected");
+    }
+    boolean containsCompactionService = services.contains(TableServiceType.COMPACT)
+        || services.contains(TableServiceType.LOG_COMPACT);
+    if (mode == MetadataTableServiceMode.SCHEDULE && !containsCompactionService) {
+      throw new IllegalArgumentException("Schedule mode requires compaction or logcompaction");
+    }
+    if (instantTime != null) {
+      long executableCompactionServices = services.stream()
+          .filter(service -> service == TableServiceType.COMPACT || service == TableServiceType.LOG_COMPACT)
+          .count();
+      if (mode != MetadataTableServiceMode.EXECUTE || executableCompactionServices != 1 || services.size() != 1) {
+        throw new IllegalArgumentException(
+            "--instant-time requires execute mode and exactly one of compaction or logcompaction");
+      }
+    }
+  }
+
+  static Set<TableServiceType> parseServices(String value) {
+    if (value == null || value.trim().isEmpty() || "all".equalsIgnoreCase(value.trim())) {
+      return EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT,
+          TableServiceType.CLEAN, TableServiceType.ARCHIVE);
+    }
+    EnumSet<TableServiceType> result = EnumSet.noneOf(TableServiceType.class);
+    for (String service : value.split(",")) {
+      switch (service.trim().toLowerCase(Locale.ROOT).replace("-", "")) {
+        case "compaction":
+          result.add(TableServiceType.COMPACT);
+          break;
+        case "logcompaction":
+          result.add(TableServiceType.LOG_COMPACT);
+          break;
+        case "clean":
+          result.add(TableServiceType.CLEAN);
+          break;
+        case "archive":
+          result.add(TableServiceType.ARCHIVE);
+          break;
+        default:
+          throw new IllegalArgumentException("Unsupported metadata table service: " + service);
+      }
+    }
+    return result;
+  }
+
+  @FunctionalInterface
+  private interface WriterOperation {
+    void run(HoodieTableMetadataWriter writer);
+  }
+
+  /** CLI configuration. */
+  public static class Config implements Serializable {
+
+    @Parameter(names = {"--base-path"}, description = "Base path of the data table", required = true)
+    public String basePath;
+
+    @Parameter(names = {"--services"}, description = "Comma-separated services: compaction,logcompaction,clean,archive")
+    public String services = "all";
+
+    @Parameter(names = {"--mode"}, description = "schedule, execute, or schedule-and-execute")
+    public String mode = "schedule-and-execute";
+
+    @Parameter(names = {"--instant-time"}, description = "Optional compaction or log-compaction instant to execute")
+    public String instantTime;
+
+    @Parameter(names = {"--props"}, description = "Path to a properties file containing write and lock configurations")
+    public String propsFilePath;
+
+    @Parameter(names = {"--hoodie-conf"}, description = "Additional Hoodie configuration in key=value form",
+        splitter = IdentitySplitter.class)
+    public List<String> configs = new ArrayList<>();
+
+    @Parameter(names = {"--spark-master"}, description = "Spark master")
+    public String sparkMaster = "local[2]";
+
+    @Parameter(names = {"--enable-hive-support", "-ehs"}, description = "Enable Hive support")
+    public Boolean enableHiveSupport = false;
+
+    @Parameter(names = {"--help", "-h"}, help = true)
+    public Boolean help = false;
+  }
+
+  public static void main(String[] args) {
+    Config cfg = new Config();
+    JCommander cmd = new JCommander(cfg, null, args);
+    if (cfg.help || args.length == 0) {
+      cmd.usage();
+      return;
+    }
+
+    String tableName = new Path(cfg.basePath).getName();
+    JavaSparkContext jsc = UtilHelpers.buildSparkContext(
+        "hoodie-metadata-table-services-" + tableName, cfg.sparkMaster, cfg.enableHiveSupport);
+    int exitCode = 0;
+    try {
+      new HoodieMetadataTableServicesTool(cfg, jsc).run();
+    } catch (Throwable throwable) {
+      exitCode = 1;
+      throw new HoodieException("Failed to run metadata table services for " + cfg.basePath, throwable);
+    } finally {
+      SparkAdapterSupport$.MODULE$.sparkAdapter().stopSparkContext(jsc, exitCode);
+    }
+    log.info("Metadata table services completed successfully");
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableServicesTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableServicesTool.java
@@ -51,7 +51,11 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-/** Standalone Spark tool for scheduling and executing metadata table services. */
+/**
+ * Standalone Spark tool for scheduling and executing metadata table services directly through MDT writer APIs.
+ * This tool does not require an HTTP table-service-manager server. Users must submit and schedule the job
+ * separately; enabling ingestion-side metadata table service delegation does not launch it automatically.
+ */
 @Slf4j
 public class HoodieMetadataTableServicesTool {
 
@@ -148,19 +152,23 @@ public class HoodieMetadataTableServicesTool {
   private void runLockedSingleWriterPhase(WriterOperation operation) {
     // The outer transaction owns the shared data-table lock; the SINGLE_WRITER MDT writer must not reacquire it.
     HoodieWriteConfig schedulingConfig = buildWriteConfig(WriteConcurrencyMode.SINGLE_WRITER);
-    try (TransactionManager transactionManager = new TransactionManager(schedulingConfig, dataMetaClient.getStorage())) {
+    try (TransactionManager transactionManager = createTransactionManager(schedulingConfig)) {
       transactionManager.beginStateChange(Option.empty(), Option.empty());
-      try (HoodieTableMetadataWriter writer = createWriter(schedulingConfig)) {
+      // Close the writer before releasing the lock, preserving any primary failure if either close fails.
+      try (AutoCloseable lock = () -> transactionManager.endStateChange(Option.empty());
+           HoodieTableMetadataWriter writer = createWriter(schedulingConfig)) {
         operation.run(writer);
       } catch (Exception e) {
         throw new HoodieException("Failed to run lock-protected metadata table services", e);
-      } finally {
-        transactionManager.endStateChange(Option.empty());
       }
     }
   }
 
-  private HoodieTableMetadataWriter createWriter(HoodieWriteConfig writeConfig) {
+  TransactionManager createTransactionManager(HoodieWriteConfig writeConfig) {
+    return new TransactionManager(writeConfig, dataMetaClient.getStorage());
+  }
+
+  HoodieTableMetadataWriter createWriter(HoodieWriteConfig writeConfig) {
     HoodieTableMetadataWriter writer = SparkMetadataWriterFactory.create(
         storageConf, writeConfig, engineContext, Option.empty(), dataMetaClient.getTableConfig());
     if (!writer.isInitialized()) {
@@ -174,7 +182,7 @@ public class HoodieMetadataTableServicesTool {
     return writer;
   }
 
-  private HoodieWriteConfig buildWriteConfig(WriteConcurrencyMode metadataConcurrencyMode) {
+  HoodieWriteConfig buildWriteConfig(WriteConcurrencyMode metadataConcurrencyMode) {
     Properties profileProps = new Properties();
     profileProps.putAll(props);
     profileProps.setProperty(HoodieMetadataConfig.ENABLE.key(), "true");
@@ -239,6 +247,14 @@ public class HoodieMetadataTableServicesTool {
       if (mode != MetadataTableServiceMode.EXECUTE || executableCompactionServices != 1 || services.size() != 1) {
         throw new IllegalArgumentException(
             "--instant-time requires execute mode and exactly one of compaction or logcompaction");
+      }
+    }
+    if (mode == MetadataTableServiceMode.SCHEDULE) {
+      Set<TableServiceType> skippedServices = EnumSet.copyOf(services);
+      skippedServices.retainAll(EnumSet.of(TableServiceType.CLEAN, TableServiceType.ARCHIVE));
+      if (!skippedServices.isEmpty()) {
+        log.warn("Skipping services {} in schedule-only mode; clean and archive require execute or schedule-and-execute mode",
+            skippedServices);
       }
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableServicesTool.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableServicesTool.java
@@ -106,6 +106,35 @@ class TestHoodieMetadataTableServicesTool {
   }
 
   @Test
+  void validatesInstantRequests() {
+    for (TableServiceType service : EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT)) {
+      assertDoesNotThrow(() -> HoodieMetadataTableServicesTool.validateRequest(
+          MetadataTableServiceMode.EXECUTE, EnumSet.of(service), "instant"));
+      for (MetadataTableServiceMode mode : EnumSet.of(
+          MetadataTableServiceMode.SCHEDULE, MetadataTableServiceMode.SCHEDULE_AND_EXECUTE)) {
+        assertThrows(IllegalArgumentException.class, () -> HoodieMetadataTableServicesTool.validateRequest(
+            mode, EnumSet.of(service), "instant"));
+      }
+      assertThrows(IllegalArgumentException.class, () -> HoodieMetadataTableServicesTool.validateRequest(
+          MetadataTableServiceMode.EXECUTE, EnumSet.of(service, TableServiceType.CLEAN), "instant"));
+    }
+    assertThrows(IllegalArgumentException.class, () -> HoodieMetadataTableServicesTool.validateRequest(
+        MetadataTableServiceMode.EXECUTE, EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT), "instant"));
+    for (TableServiceType service : EnumSet.of(TableServiceType.CLEAN, TableServiceType.ARCHIVE)) {
+      assertThrows(IllegalArgumentException.class, () -> HoodieMetadataTableServicesTool.validateRequest(
+          MetadataTableServiceMode.EXECUTE, EnumSet.of(service), "instant"));
+    }
+  }
+
+  @Test
+  void rejectsEmptyServiceRequests() {
+    for (MetadataTableServiceMode mode : MetadataTableServiceMode.values()) {
+      assertThrows(IllegalArgumentException.class, () -> HoodieMetadataTableServicesTool.validateRequest(
+          mode, EnumSet.noneOf(TableServiceType.class), null));
+    }
+  }
+
+  @Test
   void validatesSharedDataTableLockConfiguration() {
     HoodieWriteConfig singleWriterConfig = HoodieWriteConfig.newBuilder()
         .withPath("/tmp/data-table")

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableServicesTool.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableServicesTool.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider;
+import org.apache.hudi.common.model.TableServiceType;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.MetadataTableServiceMode;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestHoodieMetadataTableServicesTool {
+
+  @Test
+  void parsesAllAndSelectedServices() {
+    assertEquals(EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT,
+        TableServiceType.CLEAN, TableServiceType.ARCHIVE),
+        HoodieMetadataTableServicesTool.parseServices("all"));
+    assertEquals(EnumSet.of(TableServiceType.COMPACT, TableServiceType.LOG_COMPACT),
+        HoodieMetadataTableServicesTool.parseServices("compaction,log-compaction"));
+  }
+
+  @Test
+  void rejectsUnsupportedServices() {
+    assertThrows(IllegalArgumentException.class,
+        () -> HoodieMetadataTableServicesTool.parseServices("clustering"));
+  }
+
+  @Test
+  void validatesScheduleRequests() {
+    assertThrows(IllegalArgumentException.class, () ->
+        HoodieMetadataTableServicesTool.validateRequest(
+            MetadataTableServiceMode.SCHEDULE, EnumSet.of(TableServiceType.CLEAN), null));
+    assertDoesNotThrow(() ->
+        HoodieMetadataTableServicesTool.validateRequest(
+            MetadataTableServiceMode.SCHEDULE, EnumSet.of(TableServiceType.COMPACT), null));
+  }
+
+  @Test
+  void validatesSharedDataTableLockConfiguration() {
+    HoodieWriteConfig singleWriterConfig = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp/data-table")
+        .build();
+    assertThrows(HoodieException.class, () ->
+        HoodieMetadataTableServicesTool.validateDataTableLockConfiguration(singleWriterConfig));
+
+    HoodieWriteConfig occConfig = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp/data-table")
+        .withWriteConcurrencyMode(WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL)
+        .withLockConfig(HoodieLockConfig.newBuilder()
+            .withLockProvider(FileSystemBasedLockProvider.class)
+            .withFileSystemLockPath("/tmp/data-table-lock")
+            .build())
+        .build();
+    assertDoesNotThrow(() ->
+        HoodieMetadataTableServicesTool.validateDataTableLockConfiguration(occConfig));
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableServicesTool.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableServicesTool.java
@@ -26,15 +26,59 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metadata.MetadataTableServiceMode;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestHoodieMetadataTableServicesTool {
+
+  @Test
+  void warnsWhenScheduleModeSkipsCleanAndArchive() {
+    Logger logger = (Logger) LogManager.getLogger(HoodieMetadataTableServicesTool.class);
+    Level originalLevel = logger.getLevel();
+    List<LogEvent> events = new ArrayList<>();
+    AbstractAppender appender = new AbstractAppender("metadata-services-test", null, null, false, null) {
+      @Override
+      public void append(LogEvent event) {
+        events.add(event.toImmutable());
+      }
+    };
+    appender.start();
+    logger.addAppender(appender);
+    logger.setLevel(Level.WARN);
+    try {
+      HoodieMetadataTableServicesTool.validateRequest(MetadataTableServiceMode.SCHEDULE,
+          EnumSet.of(TableServiceType.COMPACT, TableServiceType.CLEAN, TableServiceType.ARCHIVE), null);
+      assertEquals(1, events.size());
+      assertEquals(Level.WARN, events.get(0).getLevel());
+      String message = events.get(0).getMessage().getFormattedMessage();
+      assertTrue(message.contains("CLEAN"));
+      assertTrue(message.contains("ARCHIVE"));
+      assertTrue(message.contains("schedule-only"));
+      events.clear();
+      HoodieMetadataTableServicesTool.validateRequest(MetadataTableServiceMode.SCHEDULE,
+          EnumSet.of(TableServiceType.COMPACT), null);
+      HoodieMetadataTableServicesTool.validateRequest(MetadataTableServiceMode.EXECUTE,
+          EnumSet.of(TableServiceType.CLEAN, TableServiceType.ARCHIVE), null);
+      assertTrue(events.isEmpty());
+    } finally {
+      logger.removeAppender(appender);
+      logger.setLevel(originalLevel);
+      appender.stop();
+    }
+  }
 
   @Test
   void parsesAllAndSelectedServices() {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableServicesToolExecution.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableServicesToolExecution.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.client.transaction.TransactionManager;
+import org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.HoodieMetadataWriteUtils;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.HoodieTableMetadataWriter;
+import org.apache.hudi.metadata.MetadataTableServiceRequest;
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
+import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class TestHoodieMetadataTableServicesToolExecution extends UtilitiesTestBase {
+  @TempDir
+  Path tempDir;
+
+  @BeforeAll
+  static void startSpark() throws Exception {
+    initTestServices(false, false, false);
+  }
+
+  private HoodieMetadataTableServicesTool.Config config(String mode, String services) {
+    HoodieMetadataTableServicesTool.Config cfg = new HoodieMetadataTableServicesTool.Config();
+    cfg.basePath = tempDir.resolve("table").toString();
+    cfg.mode = mode;
+    cfg.services = services;
+    return cfg;
+  }
+
+  private TypedProperties properties() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodieWriteConfig.WRITE_CONCURRENCY_MODE.key(), WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL.name());
+    props.setProperty(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key(), FileSystemBasedLockProvider.class.getName());
+    props.setProperty(HoodieLockConfig.FILESYSTEM_LOCK_PATH.key(), tempDir.resolve("dt-lock").toString());
+    props.setProperty(HoodieLockConfig.LOCK_ACQUIRE_CLIENT_RETRY_WAIT_TIME_IN_MILLIS.key(), "10");
+    props.setProperty(HoodieLockConfig.LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS.key(), "10");
+    props.setProperty(HoodieLockConfig.LOCK_ACQUIRE_CLIENT_NUM_RETRIES.key(), "1000");
+    props.setProperty(HoodieLockConfig.LOCK_ACQUIRE_WAIT_TIMEOUT_MS.key(), "10000");
+    return props;
+  }
+
+  private HoodieTableMetaClient initTable(HoodieMetadataTableServicesTool.Config cfg, boolean metadataAvailable) throws Exception {
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.newTableBuilder()
+        .setTableName("metadata_services_test")
+        .setTableType(HoodieTableType.MERGE_ON_READ)
+        .setRecordKeyFields("_row_key")
+        .setPartitionFields("partition_path")
+        .setTableVersion(HoodieTableVersion.EIGHT)
+        .initTable(new HadoopStorageConfiguration(jsc.hadoopConfiguration()), cfg.basePath);
+    if (metadataAvailable) {
+      // Orchestration tests substitute the writer; only the availability guard needs a persisted flag.
+      metaClient.getTableConfig().setMetadataPartitionState(metaClient, "files", true);
+    }
+    return metaClient;
+  }
+
+  @Test
+  void skipsUninitializedMetadataWithoutCreatingWriter() throws Exception {
+    HoodieMetadataTableServicesTool.Config cfg = config("schedule-and-execute", "all");
+    initTable(cfg, false);
+    HoodieMetadataTableServicesTool tool = spy(new HoodieMetadataTableServicesTool(cfg, jsc, properties()));
+    tool.run();
+    verify(tool, never()).createWriter(any());
+    verify(tool, never()).createTransactionManager(any());
+  }
+
+  @Test
+  void buildsIsolatedWriterProfilesSharingTheDataTableLock() throws Exception {
+    HoodieMetadataTableServicesTool.Config cfg = config("schedule", "compaction");
+    initTable(cfg, true);
+    TypedProperties props = properties();
+    props.setProperty(HoodieMetadataConfig.FAIL_ON_TABLE_SERVICE_FAILURES.key(), "false");
+    props.setProperty(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_ENABLED.key(), "true");
+    props.setProperty(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_ACTIONS.key(), "clean,archive");
+    props.setProperty(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_SCHEDULE_ACTIONS.key(), "compaction");
+    HoodieMetadataTableServicesTool tool = new HoodieMetadataTableServicesTool(cfg, jsc, props);
+    for (WriteConcurrencyMode mode : Arrays.asList(WriteConcurrencyMode.SINGLE_WRITER,
+        WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL)) {
+      HoodieWriteConfig config = tool.buildWriteConfig(mode);
+      assertEquals(cfg.basePath, config.getBasePath());
+      assertEquals(mode.name(), config.getMetadataConfig().getWriteConcurrencyMode());
+      assertTrue(config.getMetadataConfig().shouldFailOnTableServiceFailures());
+      assertFalse(config.getMetadataConfig().isTableServiceManagerEnabled());
+      assertEquals("", config.getMetadataConfig().getTableServiceManagerActions());
+      assertEquals("", config.getMetadataConfig().getTableServiceManagerScheduleActions());
+      HoodieWriteConfig mdtConfig = HoodieMetadataWriteUtils.createMetadataWriteConfig(
+          config, HoodieFailedWritesCleaningPolicy.LAZY, HoodieTableVersion.EIGHT);
+      assertEquals(mode, mdtConfig.getWriteConcurrencyMode());
+      if (mode.supportsMultiWriter()) {
+        assertEquals(config.getString(HoodieLockConfig.FILESYSTEM_LOCK_PATH), mdtConfig.getString(HoodieLockConfig.FILESYSTEM_LOCK_PATH));
+      } else {
+        assertFalse(mdtConfig.isLockRequired());
+      }
+    }
+    assertEquals("false", props.getProperty(HoodieMetadataConfig.FAIL_ON_TABLE_SERVICE_FAILURES.key()));
+    assertEquals("true", props.getProperty(HoodieMetadataConfig.TABLE_SERVICE_MANAGER_ENABLED.key()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"schedule", "execute", "schedule-and-execute"})
+  void runsRequestedPhasesInOrder(String mode) throws Exception {
+    HoodieMetadataTableServicesTool.Config cfg = config(mode, "all");
+    initTable(cfg, true);
+    HoodieMetadataTableServicesTool tool = spy(new HoodieMetadataTableServicesTool(cfg, jsc, properties()));
+    HoodieTableMetadataWriter writer = mock(HoodieTableMetadataWriter.class);
+    List<String> calls = new ArrayList<>();
+    List<WriteConcurrencyMode> profiles = new ArrayList<>();
+    doAnswer(invocation -> {
+      HoodieWriteConfig writeConfig = invocation.getArgument(0);
+      profiles.add(WriteConcurrencyMode.valueOf(writeConfig.getMetadataConfig().getWriteConcurrencyMode()));
+      return writer;
+    }).when(tool).createWriter(any());
+    doAnswer(invocation -> {
+      MetadataTableServiceRequest request = invocation.getArgument(0);
+      assertTrue(request.shouldDisableTableServiceManagerDelegation());
+      calls.add("schedule:" + request.getServices());
+      return null;
+    }).when(writer).scheduleTableServices(any());
+    doAnswer(invocation -> {
+      MetadataTableServiceRequest request = invocation.getArgument(0);
+      assertTrue(request.shouldDisableTableServiceManagerDelegation());
+      calls.add("execute:" + request.getServices());
+      return null;
+    }).when(writer).executeTableServices(any());
+    tool.run();
+    if (mode.equals("schedule")) {
+      assertEquals(Arrays.asList("schedule:[COMPACT, LOG_COMPACT]"), calls);
+    } else if (mode.equals("execute")) {
+      assertEquals(Arrays.asList("execute:[COMPACT, LOG_COMPACT]", "execute:[CLEAN]", "execute:[ARCHIVE]"), calls);
+    } else {
+      assertEquals(Arrays.asList("execute:[COMPACT, LOG_COMPACT]", "execute:[CLEAN]", "schedule:[COMPACT]",
+          "execute:[COMPACT]", "schedule:[LOG_COMPACT]", "execute:[LOG_COMPACT]", "execute:[ARCHIVE]"), calls);
+    }
+    for (int index = 0; index < calls.size(); index++) {
+      assertEquals(calls.get(index).startsWith("schedule:") ? WriteConcurrencyMode.SINGLE_WRITER
+          : WriteConcurrencyMode.OPTIMISTIC_CONCURRENCY_CONTROL, profiles.get(index));
+    }
+    verify(writer, times(calls.size())).close();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"operation", "create", "close", "unlock-only"})
+  void preservesPrimaryFailureWhenUnlockAlsoFails(String failurePhase) throws Exception {
+    HoodieMetadataTableServicesTool.Config cfg = config("schedule", "compaction");
+    initTable(cfg, true);
+    HoodieMetadataTableServicesTool tool = spy(new HoodieMetadataTableServicesTool(cfg, jsc, properties()));
+    HoodieTableMetadataWriter writer = mock(HoodieTableMetadataWriter.class);
+    TransactionManager transactionManager = mock(TransactionManager.class);
+    doReturn(transactionManager).when(tool).createTransactionManager(any());
+    doReturn(writer).when(tool).createWriter(any());
+    RuntimeException primary = new IllegalStateException("primary failure");
+    RuntimeException unlock = new IllegalStateException("unlock failure");
+    doThrow(unlock).when(transactionManager).endStateChange(Option.empty());
+    if (failurePhase.equals("operation")) {
+      doThrow(primary).when(writer).scheduleTableServices(any());
+    } else if (failurePhase.equals("create")) {
+      doThrow(primary).when(tool).createWriter(any());
+    } else if (failurePhase.equals("close")) {
+      doThrow(primary).when(writer).close();
+    }
+    HoodieException failure = assertThrows(HoodieException.class, tool::run);
+    if (failurePhase.equals("unlock-only")) {
+      assertSame(unlock, failure.getCause());
+    } else {
+      assertSame(primary, failure.getCause());
+      assertEquals(1, primary.getSuppressed().length);
+      assertSame(unlock, primary.getSuppressed()[0]);
+    }
+    verify(transactionManager).endStateChange(Option.empty());
+    verify(transactionManager).close();
+  }
+
+  @Test
+  void schedulingWaitsForDataTableLock() throws Exception {
+    HoodieMetadataTableServicesTool.Config cfg = config("schedule", "compaction");
+    HoodieTableMetaClient metaClient = initTable(cfg, true);
+    HoodieMetadataTableServicesTool tool = spy(new HoodieMetadataTableServicesTool(cfg, jsc, properties()));
+    HoodieTableMetadataWriter writer = mock(HoodieTableMetadataWriter.class);
+    doReturn(writer).when(tool).createWriter(any());
+    CountDownLatch attemptingLock = new CountDownLatch(1);
+    doAnswer(invocation -> {
+      TransactionManager transactionManager = spy((TransactionManager) invocation.callRealMethod());
+      doAnswer(begin -> {
+        attemptingLock.countDown();
+        return begin.callRealMethod();
+      }).when(transactionManager).beginStateChange(any(), any());
+      return transactionManager;
+    }).when(tool).createTransactionManager(any());
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try (TransactionManager dataTransaction = new TransactionManager(
+        tool.buildWriteConfig(WriteConcurrencyMode.SINGLE_WRITER), metaClient.getStorage())) {
+      dataTransaction.beginStateChange(Option.empty(), Option.empty());
+      Future<?> run;
+      try {
+        run = executor.submit(tool::run);
+        assertTrue(attemptingLock.await(10, TimeUnit.SECONDS));
+        assertThrows(TimeoutException.class, () -> run.get(200, TimeUnit.MILLISECONDS));
+        verify(writer, never()).scheduleTableServices(any());
+      } finally {
+        dataTransaction.endStateChange(Option.empty());
+      }
+      run.get(30, TimeUnit.SECONDS);
+      verify(writer).scheduleTableServices(any());
+    } finally {
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  void compactsRealMetadataWithoutAddingDataTableCommits() throws Exception {
+    HoodieMetadataTableServicesTool.Config cfg = config("schedule-and-execute", "compaction");
+    HoodieTableMetaClient metaClient = initTable(cfg, false);
+    TypedProperties props = properties();
+    props.setProperty("hoodie.metadata.index.column.stats.enable", "false");
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(cfg.basePath).forTable("metadata_services_test").withSchema(TRIP_EXAMPLE_SCHEMA).withPreCombineField("timestamp")
+        .withWriteTableVersion(8).withParallelism(2, 2)
+        .withProps(props)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).withStreamingWriteEnabled(false)
+            .withMaxNumDeltaCommitsBeforeCompaction(1)
+            .withTableServiceManagerEnabled(true)
+            .withTableServiceManagerActions("compaction,logcompaction,clean,archive")
+            .withTableServiceManagerScheduleActions("compaction,logcompaction").build())
+        .build();
+    try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
+         SparkRDDWriteClient client = new SparkRDDWriteClient(context, writeConfig)) {
+      for (int index = 0; index < 2; index++) {
+        String instant = client.startCommit();
+        List<WriteStatus> statuses = client.insert(jsc.parallelize(dataGen.generateInserts(instant, 20), 2), instant).collect();
+        assertTrue(statuses.stream().noneMatch(WriteStatus::hasErrors));
+        assertTrue(client.commit(instant, jsc.parallelize(statuses, 2)));
+      }
+    }
+    metaClient.reloadTableConfig();
+    assertTrue(metaClient.getTableConfig().isMetadataTableAvailable());
+    List<HoodieInstant> dataTimelineBefore = new ArrayList<>(metaClient.reloadActiveTimeline().getInstants());
+    HoodieTableMetaClient metadataMetaClient = HoodieTableMetaClient.builder()
+        .setConf(new HadoopStorageConfiguration(jsc.hadoopConfiguration()))
+        .setBasePath(HoodieTableMetadata.getMetadataTableBasePath(cfg.basePath)).build();
+    int completedCompactionsBefore = metadataMetaClient.getActiveTimeline().getCommitTimeline().filterCompletedInstants().countInstants();
+
+    new HoodieMetadataTableServicesTool(cfg, jsc, TypedProperties.copy(writeConfig.getProps())).run();
+
+    assertEquals(completedCompactionsBefore + 1,
+        metadataMetaClient.reloadActiveTimeline().getCommitTimeline().filterCompletedInstants().countInstants());
+    assertTrue(metadataMetaClient.getActiveTimeline().filterPendingCompactionTimeline().empty());
+    assertEquals(dataTimelineBefore, metaClient.reloadActiveTimeline().getInstants());
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19025.

Metadata table services currently run through `HoodieBackedTableMetadataWriter#performTableServices`, which requires a data-table write even when the only goal is to maintain the metadata table. This can lead users to generate empty commits to trigger MDT compaction, log compaction, cleaning, and archival.

This change provides a standalone Spark-submit tool and reusable metadata-writer APIs so an external service can schedule and execute MDT table services without writing to the data table. Scheduling and timeline publication are serialized with data-table writers through the shared data-table lock, while expensive compaction execution uses the MDT OCC path added by #18295.

### Summary and Changelog

- Add `HoodieMetadataTableServicesTool` under `hudi-utilities` with schedule, execute, and schedule-and-execute modes for MDT compaction, log compaction, cleaning, and archival.
- Add reusable `scheduleTableServices` and `executeTableServices` APIs, backed by `MetadataTableServiceRequest`, to `HoodieTableMetadataWriter`.
- Refactor inline MDT table services to use the shared request-driven implementation while preserving table-version-specific compaction semantics.
- Add separate scheduling delegation through `hoodie.metadata.table.service.manager.schedule.actions` while retaining the existing execution delegation behavior.
- Derive MDT OCC lock configuration from the data-table lock so external execution shares the same logical data-table lock during timeline transitions and completion.

### Impact

This adds public metadata-writer APIs, a new Spark-submit utility, and a new advanced scheduling-delegation configuration. Existing inline table-service behavior remains the default. Users can opt into external MDT maintenance without producing empty data-table commits.

Scheduling and short timeline publication/finalization sections contend on the existing data-table lock. Compaction and log-compaction execution do not hold that lock for the full execution duration.

### Risk Level

Medium. The change affects MDT table-service orchestration and concurrent-writer locking. The implementation preserves the existing inline order, keeps table-version-six fallback behavior, reuses existing MDT write-client APIs, and includes focused coverage for request modes, delegation, lock derivation, failure propagation, and table-version-specific scheduling.

### Documentation Update

Document the new `HoodieMetadataTableServicesTool` invocation and scheduling-delegation configuration before the feature is finalized.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
