### PR TITLE
fix: ensure CuratorFramework is always closed in BaseZookeeperBasedLo…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/BaseZookeeperBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/BaseZookeeperBasedLockProvider.java
@@ -162,9 +162,10 @@ public abstract class BaseZookeeperBasedLockProvider implements LockProvider<Int
         lock.release();
         lock = null;
       }
-      this.curatorFrameworkClient.close();
     } catch (Exception e) {
       log.error(generateLogStatement(LockState.FAILED_TO_RELEASE, generateLogSuffixString()));
+    } finally {
+      this.curatorFrameworkClient.close();
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

In `BaseZookeeperBasedLockProvider.close()`, the `curatorFrameworkClient.close()` call is placed inside the same `try` block as `lock.release()`. If `lock.release()` throws an exception (e.g., due to a network disruption, a disappeared ZooKeeper node, or a session timeout), execution transfers immediately to the `catch` block and `curatorFrameworkClient.close()` is never reached.

This leaves the `CuratorFramework` client's background threads running and the ZooKeeper session open until ZooKeeper's own session timeout expires (typically 30–60 seconds per session). In enterprise multi-writer Hudi deployments where multiple executors hold and release locks, accumulated leaked sessions can exhaust ZooKeeper's maximum connection limit, causing distributed locking to fail across the entire data platform.

### Summary and Changelog

Fixed the `CuratorFramework` resource leak in `BaseZookeeperBasedLockProvider.close()` by separating the lock release from the client cleanup using a `try-catch-finally` structure, ensuring `curatorFrameworkClient.close()` is always called regardless of whether `lock.release()` succeeds or throws.

- `BaseZookeeperBasedLockProvider.java`: Moved `curatorFrameworkClient.close()` from the `try` block into a `finally` block, guaranteeing cleanup on both normal and exceptional exit paths.

### Impact

No public API or user-facing change. Prevents ZooKeeper session exhaustion in long-running multi-writer Hudi deployments when lock release fails during shutdown.

### Risk Level

low — Single structural change to exception handling; no logic change to lock acquisition, release, or ZooKeeper interaction.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable