### PR TITLE
fix: ensure AmazonDynamoDBLockClient is always closed in DynamoDBBasedLockProviderBase.close()

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProviderBase.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProviderBase.java
@@ -150,9 +150,10 @@ public abstract class DynamoDBBasedLockProviderBase implements LockProvider<Lock
         }
         lock = null;
       }
-      this.client.close();
     } catch (Exception e) {
       LOG.error(generateLogStatement(LockState.FAILED_TO_RELEASE, generateLogSuffixString()));
+    } finally {
+      this.client.close();
     }
   }
 

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProviderBase.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProviderBase.java
@@ -153,7 +153,11 @@ public abstract class DynamoDBBasedLockProviderBase implements LockProvider<Lock
     } catch (Exception e) {
       LOG.error(generateLogStatement(LockState.FAILED_TO_RELEASE, generateLogSuffixString()));
     } finally {
-      this.client.close();
+      try {
+        this.client.close();
+      } catch (Exception ex) {
+        LOG.warn("Failed to close AmazonDynamoDBLockClient after failed lock release", ex);
+      }
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

In `DynamoDBBasedLockProviderBase.close()`, the `client.close()` call is placed inside the same `try` block as `client.releaseLock(lock)`. If `releaseLock()` throws an exception, execution jumps to the `catch` block and `client.close()` is never called.

This is particularly severe because `AmazonDynamoDBLockClient` is constructed with `withCreateHeartbeatBackgroundThread(true)`, meaning it maintains a background thread that periodically sends heartbeats to DynamoDB to renew the lock lease. If `client.close()` is never called, this heartbeat thread continues running indefinitely, consuming both local threads and AWS DynamoDB API quota. In enterprise deployments running many Hudi jobs, accumulated leaked clients can exhaust the thread pool and cause AWS throttling.

### Summary and Changelog

Fixed the `AmazonDynamoDBLockClient` resource leak in `DynamoDBBasedLockProviderBase.close()` by separating the lock release from the client cleanup using a `try-catch-finally` structure, ensuring `client.close()` is always called regardless of whether `releaseLock()` succeeds or throws.

- `DynamoDBBasedLockProviderBase.java`: Moved `this.client.close()` from the `try` block into a `finally` block, guaranteeing cleanup of the DynamoDB lock client and its background heartbeat thread on both normal and exceptional exit paths.

### Impact

No public API or user-facing change. Prevents background heartbeat thread leaks and AWS DynamoDB API quota exhaustion in long-running Hudi deployments using DynamoDB-based distributed locking.

### Risk Level

low — Single structural change to exception handling; no logic change to lock acquisition, release, or DynamoDB interaction.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable