### PR TITLE
feat(flink): Extend RocksDBDAO with generic column-family lifecycle operations

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
@@ -470,6 +470,22 @@ public class RocksDBDAO {
   }
 
   /**
+   * Returns whether a column family with the given name currently exists.
+   *
+   * @param columnFamilyName Column family name
+   */
+  public boolean columnFamilyExists(String columnFamilyName) {
+    return managedDescriptorMap.containsKey(columnFamilyName);
+  }
+
+  /**
+   * Lists the names of all currently managed column families.
+   */
+  public List<String> listColumnFamilies() {
+    return new ArrayList<>(managedDescriptorMap.keySet());
+  }
+
+  /**
    * Retrieves a numeric property aggregated across all column families.
    */
   public synchronized long getLongProperty(String property) throws RocksDBException {

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestRocksDBDAO.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestRocksDBDAO.java
@@ -347,6 +347,39 @@ public class TestRocksDBDAO {
     assertEquals(disableWAL, walFileSize == 0, "WAL log total size should be 0 when disableWAL=true");
   }
 
+  @Test
+  public void testColumnFamilyExistsAndListColumnFamilies() {
+    String family = "new_family";
+    assertFalse(dbManager.columnFamilyExists(family));
+    assertFalse(dbManager.listColumnFamilies().contains(family));
+
+    dbManager.addColumnFamily(family);
+    assertTrue(dbManager.columnFamilyExists(family));
+    assertTrue(dbManager.listColumnFamilies().contains(family));
+
+    // Adding again should be a no-op and not affect existence/listing.
+    dbManager.addColumnFamily(family);
+    assertTrue(dbManager.columnFamilyExists(family));
+    assertEquals(1, dbManager.listColumnFamilies().stream().filter(family::equals).count());
+
+    dbManager.dropColumnFamily(family);
+    assertFalse(dbManager.columnFamilyExists(family));
+    assertFalse(dbManager.listColumnFamilies().contains(family));
+  }
+
+  @Test
+  public void testListColumnFamiliesTracksMultipleFamilies() {
+    List<String> families = Arrays.asList("family_a", "family_b", "family_c");
+    families.forEach(family -> dbManager.addColumnFamily(family));
+
+    assertTrue(dbManager.listColumnFamilies().containsAll(families));
+
+    dbManager.dropColumnFamily(families.get(1));
+    assertTrue(dbManager.listColumnFamilies().contains(families.get(0)));
+    assertFalse(dbManager.listColumnFamilies().contains(families.get(1)));
+    assertTrue(dbManager.listColumnFamilies().contains(families.get(2)));
+  }
+
   /**
    * Payload key object.
    */


### PR DESCRIPTION
Extend RocksDBDAO with generic column-family lifecycle operations

### Describe the issue this Pull Request addresses

 Add columnFamilyExists and listColumnFamilies alongside the existing addColumnFamily/dropColumnFamily so callers can check existence and list managed column families; partition-aware naming and completeness tracking
belong in the Flink backend instead. Unit tests only; not wired into any operator yet.

closes #19600 
 
### Summary and Changelog

1. Extend RocksDBDAO with new APIs to manage column family
2. Add test cases for new apis 

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
