### PR TITLE
fix(streamer): route configured write table version into sample-writes flow

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
@@ -91,9 +91,13 @@ public class SparkSampleWritesUtils {
       throws IOException {
     String uniqueId = UUID.randomUUID().toString();
     final String sampleWritesBasePath = getSampleWritesBasePath(jsc, writeConfig, uniqueId);
+    // Propagate the user's configured write table version to the sample-writes shadow table so its
+    // on-disk layout matches the version the inherited write config (and the SparkRDDWriteClient
+    // below) operates with.
     HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.COPY_ON_WRITE)
         .setTableName(String.format("%s_samples_%s", writeConfig.getTableName(), uniqueId))
+        .setTableVersion(writeConfig.getWriteVersion())
         .setCDCEnabled(false)
         .initTable(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()), sampleWritesBasePath);
     TypedProperties props = writeConfig.getProps();
@@ -105,6 +109,7 @@ public class SparkSampleWritesUtils {
         .withSchemaEvolutionEnable(false)
         .withBulkInsertParallelism(1)
         .withPath(sampleWritesBasePath)
+        .withWriteTableVersion(writeConfig.getWriteVersion().versionCode())
         .build();
     Pair<Boolean, String> emptyRes = Pair.of(false, null);
     try (SparkRDDWriteClient sampleWriteClient = new SparkRDDWriteClient(new HoodieSparkEngineContext(jsc), sampleWriteConfig, Option.empty())) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 import org.apache.hudi.utilities.config.HoodieStreamerConfig;
 import org.apache.hudi.utilities.streamer.SparkSampleWritesUtils;
@@ -118,6 +119,7 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
     assertTrue(writeConfigOpt.isPresent());
     assertEquals(337.0, writeConfigOpt.get().getCopyOnWriteRecordSizeEstimate(), 10.0);
     assertSampleWritesNonPartitioned();
+    assertSampleWritesShadowTableVersion(tableVersion);
   }
 
   @Test
@@ -169,6 +171,27 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
       assertTrue(partitionDirs.isEmpty(),
           "Sample-writes run at " + run.getPath() + " should have no source partition subdirectories, but found: "
               + partitionDirs);
+    }
+  }
+
+  /**
+   * Fails if any sample-writes shadow table on disk was not created at the expected table version,
+   * i.e. verifies the configured write version was routed into the shadow table instead of
+   * defaulting to the current version.
+   */
+  private void assertSampleWritesShadowTableVersion(HoodieTableVersion expected) throws IOException {
+    Path sampleWritesPath = new Path(basePath(), SAMPLE_WRITES_FOLDER_PATH);
+    FileSystem fs = sampleWritesPath.getFileSystem(jsc().hadoopConfiguration());
+    assertTrue(fs.exists(sampleWritesPath), "Sample-writes folder should exist after a sample write.");
+    FileStatus[] runs = fs.listStatus(sampleWritesPath);
+    assertTrue(runs.length > 0, "Sample-writes folder should contain at least one run.");
+    for (FileStatus run : runs) {
+      HoodieTableMetaClient sampleMetaClient = HoodieTableMetaClient.builder()
+          .setConf(HadoopFSUtils.getStorageConfWithCopy(jsc().hadoopConfiguration()))
+          .setBasePath(run.getPath().toString())
+          .build();
+      assertEquals(expected, sampleMetaClient.getTableConfig().getTableVersion(),
+          "Sample-writes shadow table at " + run.getPath() + " should be created at the configured write version.");
     }
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.util.Option;
@@ -39,6 +40,8 @@ import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -92,17 +95,20 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
     assertEquals(originalRecordSize, originalWriteConfig.getCopyOnWriteRecordSizeEstimate(), "Original record size estimate should not be changed.");
   }
 
-  @Test
-  void overwriteRecordSizeEstimateForEmptyTable() throws IOException {
+  @ParameterizedTest
+  @EnumSource(value = HoodieTableVersion.class, names = {"SIX", "NINE"})
+  void overwriteRecordSizeEstimateForEmptyTable(HoodieTableVersion tableVersion) throws IOException {
     int originalRecordSize = 100;
     TypedProperties props = new TypedProperties();
     props.put(HoodieStreamerConfig.SAMPLE_WRITES_ENABLED.key(), "true");
     props.put(HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(originalRecordSize));
+    props.put(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), String.valueOf(tableVersion.versionCode()));
     HoodieWriteConfig originalWriteConfig = HoodieWriteConfig.newBuilder()
         .withProperties(props)
         .forTable("foo")
         .withPath(basePath())
         .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withWriteTableVersion(tableVersion.versionCode())
         .build();
 
     String commitTime = HoodieTestDataGenerator.getCommitTimeAtUTC(1);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

closes #19745

### Summary and Changelog

`SparkSampleWritesUtils.doSampleWrites` initialized the sample-writes shadow table without a table version, so it defaulted to `HoodieTableVersion.current()` even when the inherited write config carried a different `hoodie.write.table.version` (for example `6`). The shadow table layout then mismatched the `SparkRDDWriteClient` operating on it, which can surface as version-conditional failures during the sample write.

This routes the configured write version into both the shadow table and the sample-writes write config:
- `newTableBuilder().setTableVersion(writeConfig.getWriteVersion())` so the on-disk table matches the configured version.
- `HoodieWriteConfig.Builder.withWriteTableVersion(...)` so the client is anchored to that same version.

`TestSparkSampleWritesUtils.overwriteRecordSizeEstimateForEmptyTable` is parameterized across table versions `{SIX, NINE}` to exercise both paths.

### Impact

No public API change. Sample-writes-based record-size estimation now works when the table is written at a non-current table version.

### Risk Level

low. Covered by the parameterized unit test; the change only sets the version already present in the write config.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
