### PR TITLE
fix(common): escape dots in single-level hive-style partition column names

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/PartitionPathEncodeUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/PartitionPathEncodeUtils.java
@@ -79,6 +79,10 @@ public class PartitionPathEncodeUtils {
     return c >= 0 && c < charToEscapeFilename.size() && charToEscapeFilename.get(c);
   }
 
+  static boolean needsEscapingFilenameWithDot(char c) {
+    return c == '.' || needsEscapingFilename(c);
+  }
+
   public static String escapePathName(String path) {
     return escapePathName(path, null);
   }
@@ -118,9 +122,25 @@ public class PartitionPathEncodeUtils {
     return sb.toString();
   }
 
+  /**
+   * Escapes a filename derived from a partition path for use in metadata-table file ids.
+   * For a single-level hive-style segment (like "fare.currency=USD"), dots in the column name
+   * (before the first '=') are escaped, since a literal dot there makes the metadata log file
+   * name unparseable by the log-file pattern. Dots in the partition value (after '=') are left
+   * as-is. Partition values that contain dots, and nested or non-hive-style dotted paths, are
+   * not handled here.
+   */
   public static String escapeFileName(String filename) {
     if (filename == null || filename.length() == 0) {
       return filename;
+    }
+    int eqIdx = filename.indexOf('=');
+    if (eqIdx > 0) {
+      // Hive-style partition path: escape dots only in the column name (before '=')
+      String columnName = filename.substring(0, eqIdx);
+      String value = filename.substring(eqIdx); // includes '='
+      return doEscape(columnName, PartitionPathEncodeUtils::needsEscapingFilenameWithDot)
+          + doEscape(value, PartitionPathEncodeUtils::needsEscapingFilename);
     }
     return doEscape(filename, PartitionPathEncodeUtils::needsEscapingFilename);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestPartitionPathEncodeUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestPartitionPathEncodeUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for {@link PartitionPathEncodeUtils}.
+ */
+public class TestPartitionPathEncodeUtils {
+
+  @Test
+  public void testEscapeFileNameWithDotInColumnName() {
+    // Dot in column name should be escaped
+    assertEquals("fare%2Ecurrency%3DUSD", PartitionPathEncodeUtils.escapeFileName("fare.currency=USD"));
+  }
+
+  @Test
+  public void testEscapeFileNamePreservesDotInValue() {
+    // Dot in partition value should NOT be escaped (backward compatibility)
+    assertEquals("date%3D2024.01.01", PartitionPathEncodeUtils.escapeFileName("date=2024.01.01"));
+    assertEquals("version%3D1.2.3", PartitionPathEncodeUtils.escapeFileName("version=1.2.3"));
+  }
+
+  @Test
+  public void testEscapeFileNameWithDotInBothColumnAndValue() {
+    // Dot in column name escaped, dot in value preserved
+    assertEquals("col%2Ename%3Dval.ue", PartitionPathEncodeUtils.escapeFileName("col.name=val.ue"));
+  }
+
+  @Test
+  public void testEscapeFileNameWithoutEquals() {
+    // No '=' means no hive-style partitioning; dots are NOT escaped (no column name to protect)
+    assertEquals("simple", PartitionPathEncodeUtils.escapeFileName("simple"));
+    assertEquals("path.with.dots", PartitionPathEncodeUtils.escapeFileName("path.with.dots"));
+  }
+
+  @Test
+  public void testEscapeFileNameNullAndEmpty() {
+    assertNull(PartitionPathEncodeUtils.escapeFileName(null));
+    assertEquals("", PartitionPathEncodeUtils.escapeFileName(""));
+  }
+
+  @Test
+  public void testEscapeFileNameNoDotsHiveStyle() {
+    // Standard hive-style without dots
+    assertEquals("country%3DUS", PartitionPathEncodeUtils.escapeFileName("country=US"));
+  }
+
+  @Test
+  public void testUnescapeRoundTrip() {
+    String original = "fare.currency=USD";
+    String escaped = PartitionPathEncodeUtils.escapeFileName(original);
+    assertEquals("fare%2Ecurrency%3DUSD", escaped);
+    assertEquals(original, PartitionPathEncodeUtils.unescapePathName(escaped));
+  }
+
+  @Test
+  public void testUnescapeRoundTripWithDotInValue() {
+    String original = "date=2024.01.01";
+    String escaped = PartitionPathEncodeUtils.escapeFileName(original);
+    assertEquals("date%3D2024.01.01", escaped);
+    assertEquals(original, PartitionPathEncodeUtils.unescapePathName(escaped));
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

closes #19750

### Summary and Changelog

Partitioned record-level index (RLI) breaks for a single-level hive-style partition whose column NAME contains a dot (for example a column `fare.currency`, segment `fare.currency=USD`): the literal dot in the column name makes the metadata-table log file name unparseable by the log-file pattern (`InvalidHoodiePathException`).

`PartitionPathEncodeUtils.escapeFileName` now, for a single-level hive-style segment, escapes dots in the column name (before the first `=`) while leaving dots in the partition value (after `=`) as-is. `TestPartitionPathEncodeUtils` covers the escaping.

Scope and limitations (deliberately narrow): this handles only the single-level dotted-column-name case. Partition VALUES that contain dots (e.g. `date=2024.01.01`), nested hive-style partitions (e.g. `region=US/fare.currency=USD`, only the first `=` is handled), and non-hive-style dotted paths remain unhandled and still fail. #18378 takes the broader escape-all-dots approach that also covers those cases; that is the more complete fix. Opening this to compare the two.

### Impact

`escapeFileName` escapes dots in single-level hive-style partition column names. Partition values are unchanged. Does not fully fix partitioned RLI for value-dots or nested/non-hive dotted partitions.

### Risk Level

low. Confined to file-name escaping and covered by unit tests.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
