### PR TITLE
fix(sync): drop the duplicate UpdateTable in updateTableSchema

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -628,7 +628,6 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
       if (cascade) {
         cascadeColumnsToPartitions(tableName, getAllPartitions(tableName));
       }
-      awsGlue.updateTable(request).get();
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to update definition for table " + tableId(databaseName, tableName), e);
     }

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -982,4 +982,32 @@ class TestAWSGlueSyncClient {
     inOrder.verify(mockAwsGlue).updateTable(any(UpdateTableRequest.class));
     inOrder.verify(mockAwsGlue).batchUpdatePartition(any(BatchUpdatePartitionRequest.class));
   }
+
+  @Test
+  void testUpdateTableSchema_issuesOneUpdateTable() {
+    String tableName = GlueTestUtil.TABLE_NAME;
+    Table table = Table.builder()
+        .name(tableName)
+        .databaseName(GlueTestUtil.DB_NAME)
+        .storageDescriptor(StorageDescriptor.builder()
+            .location("s3://base")
+            .columns(Column.builder().name("name").type("string").build())
+            .build())
+        .partitionKeys(Column.builder().name("datestr").type("string").build())
+        .build();
+    when(mockAwsGlue.getTable(any(GetTableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(GetTableResponse.builder().table(table).build()));
+    when(mockAwsGlue.updateTable(any(UpdateTableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(UpdateTableResponse.builder().build()));
+
+    HoodieSchema schema = GlueTestUtil.getSimpleSchema();
+    SchemaDifference schemaDiff = SchemaDifference.newBuilder(schema, new HashMap<>())
+        .addTableColumn("added", "string")
+        .build();
+
+    awsGlueSyncClient.updateTableSchema(tableName, schema, schemaDiff);
+
+    verify(mockAwsGlue, times(1)).updateTable(any(UpdateTableRequest.class));
+    verify(mockAwsGlue, never()).batchUpdatePartition(any(BatchUpdatePartitionRequest.class));
+  }
 }


### PR DESCRIPTION
Stacked on #19761, please review that one first. This PR shows both commits until it merges.

### Describe the issue this Pull Request addresses

`updateTableSchema` issues the same `UpdateTable` request object twice. The second call sits outside the `if (cascade)` block, so it fires unconditionally, including on non-partitioned tables. Nothing between the two calls mutates the request and the cascade branch writes partitions rather than the table, so the second call is a no-op that Glue still counts as a new table version. Every schema change therefore consumes two table versions where one would do.

### Summary and Changelog

Removes the second `awsGlue.updateTable(request).get()`. The first is kept rather than the second because the cascade re-reads the table to source the columns it propagates: with the update first it sees the new columns, whereas keeping only the second would have it propagate stale ones. Adds a test asserting exactly one `UpdateTable` per schema change.

### Impact

Halves the Glue table-version churn from this method. No behaviour change beyond the removed redundant write.

### Risk Level

low

One deleted line. The added test fails against unfixed code with `TooManyActualInvocations: Wanted 1 time but was 2`.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable