### PR TITLE
docs(cleaning): document partition TTL

### DIFF
--- a/website/docs/cleaning.md
+++ b/website/docs/cleaning.md
@@ -297,6 +297,11 @@ left for the next run, so a backlog drains across several runs rather than in on
 exactly those. When it is unset, TTL considers every partition in the table. Setting it is the safest way to try a
 retention policy on one partition before applying it everywhere.
 
+The list is used verbatim, so each entry has to match the partition path as it exists on storage. That layout depends on
+`hoodie.datasource.write.hive_style_partitioning`: with the default of `false` a partition folder is named for the value
+alone, such as `2026-01-01`, while with it enabled the folder is `event_date=2026-01-01`. Passing the wrong form selects a
+partition that does not exist, and TTL then deletes nothing while still reporting success.
+
 `hoodie.partition.ttl.strategy.stats.max.parallelism` bounds the parallelism used to collect each candidate partition's
 last commit time, defaulting to `200`; the effective value is the smaller of that and the candidate count. It matters
 mainly on that first run, where a table with many historical partitions may want a higher value. This config is new in
@@ -328,6 +333,8 @@ df.write.format("hudi")
   .option("hoodie.table.name", tableName)
   .option("hoodie.datasource.write.recordkey.field", "event_id")
   .option("hoodie.datasource.write.partitionpath.field", "event_date")
+  // partition folders are named event_date=<value>, which partition.selected below must match
+  .option("hoodie.datasource.write.hive_style_partitioning", "true")
   // enable TTL and give it a retention, without which it does nothing
   .option("hoodie.partition.ttl.inline", "true")
   .option("hoodie.partition.ttl.management.strategy.type", "KEEP_BY_TIME")

--- a/website/docs/cleaning.md
+++ b/website/docs/cleaning.md
@@ -264,11 +264,15 @@ existing table without enabling it on the writer:
 
 ```
 spark-submit --master local \
-  --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
-  --class org.apache.hudi.utilities.HoodieTTLJob `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
+  --class org.apache.hudi.utilities.HoodieTTLJob \
+  hudi-utilities-bundle_2.12-1.2.0.jar \
   --base-path file:///tmp/events_table \
   --hoodie-conf hoodie.partition.ttl.strategy.days.retain=30
 ```
+
+The utilities bundle is self-contained, so it is passed as the application jar and no `--packages` is needed. Download it
+from Maven Central, or build it locally and point at
+`packaging/hudi-utilities-bundle/target/hudi-utilities-bundle_2.12-*.jar`.
 
 **From Spark SQL**, with the [`run_ttl`](procedures.md#run_ttl) procedure, which is the easiest way to try TTL on a table
 before committing to running it on every write:
@@ -295,7 +299,9 @@ retention policy on one partition before applying it everywhere.
 
 `hoodie.partition.ttl.strategy.stats.max.parallelism` bounds the parallelism used to collect each candidate partition's
 last commit time, defaulting to `200`; the effective value is the smaller of that and the candidate count. It matters
-mainly on that first run, where a table with many historical partitions may want a higher value.
+mainly on that first run, where a table with many historical partitions may want a higher value. This config is new in
+1.3.0, so it has no effect on earlier releases and does not yet appear in the generated
+[configuration reference](https://hudi.apache.org/docs/next/configurations/); the other six configs above do.
 
 ### Partition TTL configs
 
@@ -307,7 +313,7 @@ mainly on that first run, where a table with many historical partitions may want
 | `hoodie.partition.ttl.strategy.days.retain` | `-1` | Days to retain. Nothing expires while this is `0` or less |
 | `hoodie.partition.ttl.strategy.partition.selected` | none | Comma-separated partition paths to restrict TTL to |
 | `hoodie.partition.ttl.strategy.max.delete.partitions` | `1000` | Maximum partitions deleted in one run |
-| `hoodie.partition.ttl.strategy.stats.max.parallelism` | `200` | Parallelism for collecting candidate partition commit times |
+| `hoodie.partition.ttl.strategy.stats.max.parallelism` | `200` | Parallelism for collecting candidate partition commit times. Since 1.3.0 |
 
 ### A worked example
 

--- a/website/docs/cleaning.md
+++ b/website/docs/cleaning.md
@@ -221,6 +221,127 @@ cleans run --sparkMaster local --hoodieConfigs hoodie.clean.policy=KEEP_LATEST_C
 
 You can find more details and the relevant code for these commands in [`org.apache.hudi.cli.commands.CleansCommand`](https://github.com/apache/hudi/blob/master/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CleansCommand.java) class. 
 
+## Partition TTL
+
+Cleaning bounds how many *versions* of a file are kept, but it never removes a partition: an old partition whose files
+have all been cleaned down to a single version still sits in the table forever. Partition TTL (time to live) is the
+complementary service. It works at partition granularity, and when a partition is judged expired it deletes the whole
+partition rather than trimming file versions inside it.
+
+Because it removes data outright, TTL is off by default and stays off until you set a retention period.
+
+### How a partition is judged expired
+
+TTL asks a strategy which partitions have expired. Two strategies ship with Hudi, selected through
+`hoodie.partition.ttl.management.strategy.type`:
+
+| Strategy | Ages a partition against |
+|---|---|
+| `KEEP_BY_TIME` (default) | The partition's last commit time, taken from the newest base instant among its latest file slices. A partition that is still being written to therefore stays. |
+| `KEEP_BY_CREATION_TIME` | The commit time the partition was created at, read from its partition metadata. Writing to a partition does not extend its life. |
+
+Both compare that timestamp against `hoodie.partition.ttl.strategy.days.retain`. A custom strategy can be supplied
+instead with `hoodie.partition.ttl.strategy.class`, pointing at a subclass of `PartitionTTLStrategy`; when both configs
+are present the class takes precedence over the type.
+
+:::caution
+`hoodie.partition.ttl.strategy.days.retain` defaults to `-1`, and the built-in strategies treat any value of `0` or less
+as "nothing expires". **TTL does nothing at all until you set a positive retention, even with TTL enabled.** This is
+deliberate, so that turning the service on cannot delete data by itself, but it does mean a misconfigured job looks like
+a working one: it runs, reports no expired partitions, and deletes nothing.
+:::
+
+Two other conditions make TTL a silent no-op regardless of retention: a table with no completed commit yet, and an
+unpartitioned table.
+
+### Ways to run partition TTL
+
+**Inline.** Setting `hoodie.partition.ttl.inline=true` runs TTL immediately after each commit, alongside the other inline
+table services.
+
+**As a standalone Spark job.** `org.apache.hudi.utilities.HoodieTTLJob`, in the utilities bundle, runs TTL against an
+existing table without enabling it on the writer:
+
+```
+spark-submit --master local \
+  --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
+  --class org.apache.hudi.utilities.HoodieTTLJob `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
+  --base-path file:///tmp/events_table \
+  --hoodie-conf hoodie.partition.ttl.strategy.days.retain=30
+```
+
+**From Spark SQL**, with the [`run_ttl`](procedures.md#run_ttl) procedure, which is the easiest way to try TTL on a table
+before committing to running it on every write:
+
+```sql
+call run_ttl(table => 'events_table', retain_days => 30);
+```
+
+However it is triggered, TTL writes a replace commit that drops the expired partitions, the same commit type used by the
+`delete_partition` operation.
+
+### Keeping a first run under control
+
+The first TTL run on an existing table is the risky one, because every historical partition becomes a candidate at once.
+Three configs bound it.
+
+`hoodie.partition.ttl.strategy.max.delete.partitions` caps how many partitions a single run may delete, defaulting to
+`1000`. The limit exists to keep one replace commit from growing unmanageably large; partitions over the cap are simply
+left for the next run, so a backlog drains across several runs rather than in one commit.
+
+`hoodie.partition.ttl.strategy.partition.selected` takes a comma-separated list of partition paths and restricts TTL to
+exactly those. When it is unset, TTL considers every partition in the table. Setting it is the safest way to try a
+retention policy on one partition before applying it everywhere.
+
+`hoodie.partition.ttl.strategy.stats.max.parallelism` bounds the parallelism used to collect each candidate partition's
+last commit time, defaulting to `200`; the effective value is the smaller of that and the candidate count. It matters
+mainly on that first run, where a table with many historical partitions may want a higher value.
+
+### Partition TTL configs
+
+| Config | Default | Description |
+|---|---|---|
+| `hoodie.partition.ttl.inline` | `false` | Run TTL immediately after each commit |
+| `hoodie.partition.ttl.management.strategy.type` | `KEEP_BY_TIME` | `KEEP_BY_TIME` or `KEEP_BY_CREATION_TIME` |
+| `hoodie.partition.ttl.strategy.class` | none | A `PartitionTTLStrategy` subclass; takes precedence over the type above |
+| `hoodie.partition.ttl.strategy.days.retain` | `-1` | Days to retain. Nothing expires while this is `0` or less |
+| `hoodie.partition.ttl.strategy.partition.selected` | none | Comma-separated partition paths to restrict TTL to |
+| `hoodie.partition.ttl.strategy.max.delete.partitions` | `1000` | Maximum partitions deleted in one run |
+| `hoodie.partition.ttl.strategy.stats.max.parallelism` | `200` | Parallelism for collecting candidate partition commit times |
+
+### A worked example
+
+Retaining 30 days on a date-partitioned event table, run inline, restricted on the first pass to a single partition so
+the effect can be checked before it is applied to the whole table:
+
+```scala
+val tableName = "events_table"
+val basePath = "file:///tmp/events_table"
+
+df.write.format("hudi")
+  .option("hoodie.table.name", tableName)
+  .option("hoodie.datasource.write.recordkey.field", "event_id")
+  .option("hoodie.datasource.write.partitionpath.field", "event_date")
+  // enable TTL and give it a retention, without which it does nothing
+  .option("hoodie.partition.ttl.inline", "true")
+  .option("hoodie.partition.ttl.management.strategy.type", "KEEP_BY_TIME")
+  .option("hoodie.partition.ttl.strategy.days.retain", "30")
+  // first pass: one partition only
+  .option("hoodie.partition.ttl.strategy.partition.selected", "event_date=2026-01-01")
+  .mode("append")
+  .save(basePath)
+```
+
+Once the deleted partitions look right, drop the `partition.selected` line to let TTL consider the whole table. On a
+table with a long history, expect the backlog to drain over several commits because of the
+`max.delete.partitions` cap.
+
+:::caution
+Partition TTL deletes data. A partition removed by TTL is gone from the table as of that replace commit, recoverable only
+for as long as the cleaner and archival have not yet removed the file versions and timeline entries a time travel query
+would need. Validate a retention policy with `run_ttl`, or with `partition.selected`, before enabling it inline.
+:::
+
 ## Related Resources
 
 <h3>Blogs</h3>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19141.

Partition TTL has existed since 1.0.0, but it appears **nowhere** in prose on the site. The only trace is the generated
config reference, which lists the keys and defaults without saying what they do together. Confirmed the gap rather than
assuming it: `partition.ttl` matches only `configurations.md` across `website/docs`, `website/versioned_docs` and
`website/learn`.

### Summary and Changelog

One file, `website/docs/cleaning.md` (+121). A **Partition TTL** section is added before Related Resources.

`cleaning.md` is the natural home: that page is already about retention, and TTL is the partition-level counterpart to
the cleaner's file-version retention. The section opens on exactly that contrast, since it is the thing most likely to
confuse someone who has already read the cleaner docs:

> Cleaning bounds how many *versions* of a file are kept, but it never removes a partition: an old partition whose files
> have all been cleaned down to a single version still sits in the table forever.

<img width="956" height="895" alt="image" src="https://github.com/user-attachments/assets/e28d9f46-59c5-42f7-8262-11f650ef8329" />


### The thing a config table cannot tell you

`hoodie.partition.ttl.strategy.days.retain` defaults to `-1`, and `KeepByTimeStrategy#getExpiredPartitionPaths` returns
an empty list whenever the resulting retention is zero or less:

```java
if (!lastCompletedInstant.isPresent() || ttlInMilis <= 0
    || !hoodieTable.getMetaClient().getTableConfig().getPartitionFields().isPresent()) {
  return Collections.emptyList();
}
```

So **TTL does nothing at all until a positive retention is set, even when enabled.** That gets a `:::caution`, phrased
around the failure mode rather than the default value: a misconfigured job looks like a working one, because it runs,
reports no expired partitions, and deletes nothing.

That same guard shows two further silent no-ops which the section also states: a table with no completed commit, and an
**unpartitioned** table.

### What the section covers beyond the configs

**Both built-in strategies, not just the default.** They age a partition against different timestamps, which is the
practically important difference:

| Strategy | Ages against |
|---|---|
| `KEEP_BY_TIME` (default) | The partition's last commit time, so an actively written partition survives |
| `KEEP_BY_CREATION_TIME` | The partition's created commit time, so writing to it does not extend its life |

Also that `hoodie.partition.ttl.strategy.class` takes precedence over the strategy type when both are set
(`PartitionTTLStrategyType#getPartitionTTLStrategyClassName`).

**All three ways to run TTL, not only the inline config.** Inline after each commit, the standalone
`org.apache.hudi.utilities.HoodieTTLJob`, and the `run_ttl` Spark SQL procedure. The procedure is cross-referenced to its
existing entry on the procedures page rather than duplicated. Whichever path is used, TTL lands as a replace commit, the
same commit type `delete_partition` uses (`startDeletePartitionCommit` then `managePartitionTTL`, committed with
`REPLACE_COMMIT_ACTION`).

**The three bounding configs framed around the first run**, which is where they matter, since every historical partition
becomes a candidate at once. `max.delete.partitions` caps a run at 1000 so one replace commit cannot grow unmanageably
large, and the code comment says exactly that ("Avoid a single replace commit too large") — a backlog therefore drains
over several runs. `partition.selected` restricts the candidate set and is the safe way to trial a policy.
`stats.max.parallelism` bounds the parallelism for collecting candidate commit times.

<img width="875" height="896" alt="image" src="https://github.com/user-attachments/assets/a9e35de3-4a3c-4c9d-a456-b70b14e3239a" />


**A config table and a worked example**, the example following the quick start guide's own `val tableName` /
`val basePath = "file:///tmp/..."` convention so it is runnable as written, and restricting the first pass to one
partition so the effect can be checked before it applies to the whole table. A closing caution states plainly that TTL
deletes data.

<img width="788" height="902" alt="image" src="https://github.com/user-attachments/assets/5e6ac4fc-c304-40a7-9def-da07f3843ad2" />

### One correction worth flagging

The max-partitions config is **`hoodie.partition.ttl.strategy.max.delete.partitions`**, not the shorter
`hoodie.partition.ttl.max.partitions.to.delete` form that circulates in discussion of this feature. Everything defined
through `PARTITION_TTL_STRATEGY_PARAM_PREFIX` carries the `strategy.` prefix, so `days.retain`, `partition.selected`,
`max.delete.partitions` and `stats.max.parallelism` all sit under it. Note also the asymmetry in Hudi's own naming, which
the section reproduces faithfully rather than tidying: the strategy **type** is
`hoodie.partition.ttl.management.strategy.type` while the strategy **class** is `hoodie.partition.ttl.strategy.class`.

### Version scope

`website/docs` only, deliberately. `hoodie.partition.ttl.strategy.stats.max.parallelism` is new in 1.3.0 (#19137) and is
**absent from release-1.2.0**, verified against the tag. The next docs are therefore the only place where every config
described here exists; versioned copies would each need that row removed, which I would rather do as a follow-up if
reviewers want it than ship as six near-duplicate sections.

### Verification

Everything read from **master**, not from the ticket: `HoodieTTLConfig` for the keys, defaults and since-versions,
`KeepByTimeStrategy` and `KeepByCreationTimeStrategy` for expiry semantics and the no-op guard, `PartitionTTLStrategy`
for candidate selection, `BaseHoodieTableServiceClient` for the inline trigger, `HoodieTTLJob` for the CLI parameters,
and `RunTTLProcedure` for the procedure name and its config mapping.

`npm run build` passes with the warning block **byte-identical** to a baseline built from the same base commit
(`5971a1ac3ba3`), 13,265 lines each. That parity also confirms the new `procedures.md#run_ttl` cross-reference resolves,
since a dangling anchor would have added a warning. Rendering checked under `npm run serve`: all six headings resolve
with unique anchors and 12 TOC entries, both cautions render, and the heading is `Partition TTL configs` rather than a
second `Configs`, which would have collided with the existing cleaning `### Configs` and produced a `#configs-1` anchor.

One limitation stated plainly: this is verified by reading the code, not by running TTL against a table. The claim I would
most like a committer to confirm is the practical consequence of the `days.retain` default, since that is the line
readers will act on.

### Impact

Documentation only. No code, config, or behaviour change.

### Risk Level

none

### Documentation Update

This PR is the documentation update — the cleaning page, `/docs/next/cleaning#partition-ttl`.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

cc @wangxianghu (who filed the issue), @yihua
