### PR TITLE
feat(flink): add new RocksDBPartitionedIndexBackend

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -361,7 +361,8 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("The backend used to serve record level index lookups. Supported values are "
           + "mdt (default), which reads the record level index directly from the metadata table, and "
           + "rocksdb, which uses a local RocksDB-based partitioned cache in front of the metadata table "
-          + "to accelerate lookups.");
+          + "to accelerate lookups. The rocksdb backend is not selectable yet: it does not bootstrap or "
+          + "fall back to the metadata table, so selecting it currently falls back to mdt.");
 
   @AdvancedConfig
   public static final ConfigOption<String> INDEX_RLI_CACHE_ROCKSDB_BASE_PATH = ConfigOptions

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/DynamicBucketAssignFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/DynamicBucketAssignFunction.java
@@ -28,9 +28,8 @@ import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.sink.event.Correspondent;
-import org.apache.hudi.sink.partitioner.index.DummyPartitionedIndexBackend;
 import org.apache.hudi.sink.partitioner.index.PartitionedIndexBackend;
-import org.apache.hudi.sink.partitioner.index.RecordLevelIndexBackend;
+import org.apache.hudi.sink.partitioner.index.PartitionedIndexBackendFactory;
 import org.apache.hudi.sink.partitioner.profile.WriteProfile;
 import org.apache.hudi.sink.partitioner.profile.WriteProfiles;
 import org.apache.hudi.table.action.commit.BucketInfo;
@@ -106,9 +105,8 @@ public class DynamicBucketAssignFunction
 
   @Override
   public void initializeState(FunctionInitializationContext context) {
-    this.indexBackend = isInsertOverwrite
-        ? new DummyPartitionedIndexBackend()
-        : new RecordLevelIndexBackend(conf, (partitionPath, recordKey, fileId) -> isRecordKeyOfThisTask(recordKey));
+    this.indexBackend = PartitionedIndexBackendFactory.create(
+        conf, isInsertOverwrite, (partitionPath, recordKey, fileId) -> isRecordKeyOfThisTask(recordKey));
     this.indexBackend.registerMetrics(getRuntimeContext().getMetricGroup());
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/PartitionedIndexBackendFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/PartitionedIndexBackendFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner.index;
+
+import org.apache.hudi.configuration.FlinkOptions;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Factory to create a {@link PartitionedIndexBackend} used by the dynamic bucket assign function.
+ */
+public class PartitionedIndexBackendFactory {
+  private static final String ROCKSDB_BACKEND_TYPE = "rocksdb";
+
+  /**
+   * Creates the partitioned index backend used to look up and record {@code recordKey -> fileGroupId}
+   * mappings for the partitioned record level index.
+   *
+   * @param conf Flink write configuration
+   * @param isInsertOverwrite whether the write operation is an insert overwrite, in which case indexing is skipped
+   * @param bootstrapFilter filter for deciding whether a bootstrapped RLI record belongs to this task,
+   *                        used only by the metadata-table-backed backend
+   * @return partitioned index backend for record-key lookups scoped to a data partition
+   */
+  public static PartitionedIndexBackend create(
+      Configuration conf,
+      boolean isInsertOverwrite,
+      RecordLevelIndexBackend.BootstrapFilter bootstrapFilter) {
+    if (isInsertOverwrite) {
+      return new DummyPartitionedIndexBackend();
+    }
+    String backendType = conf.get(FlinkOptions.INDEX_RLI_BACKEND_TYPE);
+    if (ROCKSDB_BACKEND_TYPE.equalsIgnoreCase(backendType)) {
+      return new RocksDBPartitionedIndexBackend(conf.get(FlinkOptions.INDEX_RLI_CACHE_ROCKSDB_BASE_PATH));
+    }
+    return new RecordLevelIndexBackend(conf, bootstrapFilter);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/PartitionedIndexBackendFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/PartitionedIndexBackendFactory.java
@@ -20,11 +20,13 @@ package org.apache.hudi.sink.partitioner.index;
 
 import org.apache.hudi.configuration.FlinkOptions;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.Configuration;
 
 /**
  * Factory to create a {@link PartitionedIndexBackend} used by the dynamic bucket assign function.
  */
+@Slf4j
 public class PartitionedIndexBackendFactory {
   private static final String ROCKSDB_BACKEND_TYPE = "rocksdb";
 
@@ -47,7 +49,12 @@ public class PartitionedIndexBackendFactory {
     }
     String backendType = conf.get(FlinkOptions.INDEX_RLI_BACKEND_TYPE);
     if (ROCKSDB_BACKEND_TYPE.equalsIgnoreCase(backendType)) {
-      return new RocksDBPartitionedIndexBackend(conf.get(FlinkOptions.INDEX_RLI_CACHE_ROCKSDB_BASE_PATH));
+      // TODO: RocksDBPartitionedIndexBackend does not yet bootstrap or fall back to the MDT-backed
+      // record level index, so on a non-empty table (or after a task/job restart) it would miss
+      // committed keys and mis-route them as inserts. Keep it unselectable until partition
+      // bootstrap / on-demand MDT loading is implemented.
+      log.warn("Backend type '{}' is not yet supported for selection; falling back to the metadata-table-backed "
+          + "record level index backend.", backendType);
     }
     return new RecordLevelIndexBackend(conf, bootstrapFilter);
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBPartitionedIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBPartitionedIndexBackend.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner.index;
+
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.collection.RocksDBDAO;
+
+import lombok.extern.slf4j.Slf4j;
+import org.rocksdb.RocksDB;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * An implementation of {@link PartitionedIndexBackend} based on RocksDB.
+ *
+ * <p>Each data partition is stored in its own RocksDB column family, so that a partition's mapping
+ * can be dropped as a unit. A partition is only registered as visible to {@link #get} in RocksDB's
+ * own {@code default} column family after its own column family has been created, so a lookup never
+ * sees a partition whose column family creation is still in flight.
+ *
+ * <p>This backend operates against an already-open RocksDB instance: it does not bootstrap partitions
+ * from the metadata table and does not implement TTL-based eviction of partitions.
+ */
+@Slf4j
+public class RocksDBPartitionedIndexBackend implements PartitionedIndexBackend {
+  private static final String PARTITION_COLUMN_FAMILY_PREFIX = "pcf_";
+  private static final String REGISTRY_COLUMN_FAMILY = StringUtils.fromUTF8Bytes(RocksDB.DEFAULT_COLUMN_FAMILY);
+
+  private final RocksDBDAO rocksDBDAO;
+
+  public RocksDBPartitionedIndexBackend(String rocksDbBasePath) {
+    this.rocksDBDAO = new RocksDBDAO("hudi-partitioned-index-backend", rocksDbBasePath, new ConcurrentHashMap<>(), true);
+  }
+
+  @Override
+  public String get(String partitionPath, String recordKey) {
+    if (!isPartitionRegistered(partitionPath)) {
+      return null;
+    }
+    return this.rocksDBDAO.get(partitionColumnFamily(partitionPath), recordKey);
+  }
+
+  @Override
+  public void update(String partitionPath, String recordKey, String fileId) {
+    String columnFamily = partitionColumnFamily(partitionPath);
+    if (!this.rocksDBDAO.columnFamilyExists(columnFamily)) {
+      this.rocksDBDAO.addColumnFamily(columnFamily);
+    }
+    this.rocksDBDAO.put(columnFamily, recordKey, fileId);
+    if (!isPartitionRegistered(partitionPath)) {
+      registerPartition(partitionPath);
+    }
+  }
+
+  /**
+   * Returns whether the given partition's column family has been fully created and is safe to read from.
+   *
+   * @param partitionPath the partition path to check
+   */
+  public boolean isPartitionRegistered(String partitionPath) {
+    Boolean registered = this.rocksDBDAO.get(REGISTRY_COLUMN_FAMILY, partitionPath);
+    return registered != null && registered;
+  }
+
+  /**
+   * Lists the partitions currently registered in this backend.
+   */
+  public List<String> listRegisteredPartitions() {
+    return this.rocksDBDAO.<Boolean>prefixSearch(REGISTRY_COLUMN_FAMILY, "")
+        .map(Pair::getKey)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Drops a partition's column family and removes it from the registry.
+   *
+   * @param partitionPath the partition path to delete
+   */
+  public void deletePartition(String partitionPath) {
+    String columnFamily = partitionColumnFamily(partitionPath);
+    if (this.rocksDBDAO.columnFamilyExists(columnFamily)) {
+      this.rocksDBDAO.dropColumnFamily(columnFamily);
+    }
+    this.rocksDBDAO.delete(REGISTRY_COLUMN_FAMILY, partitionPath);
+  }
+
+  private void registerPartition(String partitionPath) {
+    this.rocksDBDAO.put(REGISTRY_COLUMN_FAMILY, partitionPath, Boolean.TRUE);
+  }
+
+  private static String partitionColumnFamily(String partitionPath) {
+    return PARTITION_COLUMN_FAMILY_PREFIX + partitionPath;
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.rocksDBDAO.close();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestPartitionedIndexBackendFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestPartitionedIndexBackendFactory.java
@@ -73,4 +73,33 @@ public class TestPartitionedIndexBackendFactory {
       assertInstanceOf(RocksDBPartitionedIndexBackend.class, backend);
     }
   }
+
+  @Test
+  void testRocksDBBackendTypeIsCaseInsensitive() throws Exception {
+    conf.set(FlinkOptions.INDEX_RLI_BACKEND_TYPE, "RocksDB");
+    conf.set(FlinkOptions.INDEX_RLI_CACHE_ROCKSDB_BASE_PATH, tempFile.getAbsolutePath());
+    try (PartitionedIndexBackend backend = PartitionedIndexBackendFactory.create(
+        conf, false, (partitionPath, recordKey, fileId) -> true)) {
+      assertInstanceOf(RocksDBPartitionedIndexBackend.class, backend);
+    }
+  }
+
+  @Test
+  void testUnknownBackendTypeFallsBackToRecordLevelIndexBackend() throws Exception {
+    conf.set(FlinkOptions.INDEX_RLI_BACKEND_TYPE, "unknown");
+    try (PartitionedIndexBackend backend = PartitionedIndexBackendFactory.create(
+        conf, false, (partitionPath, recordKey, fileId) -> true)) {
+      assertInstanceOf(RecordLevelIndexBackend.class, backend);
+    }
+  }
+
+  @Test
+  void testInsertOverwriteTakesPrecedenceOverRocksDBBackendType() throws Exception {
+    conf.set(FlinkOptions.INDEX_RLI_BACKEND_TYPE, "rocksdb");
+    conf.set(FlinkOptions.INDEX_RLI_CACHE_ROCKSDB_BASE_PATH, tempFile.getAbsolutePath());
+    try (PartitionedIndexBackend backend = PartitionedIndexBackendFactory.create(
+        conf, true, (partitionPath, recordKey, fileId) -> true)) {
+      assertInstanceOf(DummyPartitionedIndexBackend.class, backend);
+    }
+  }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestPartitionedIndexBackendFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestPartitionedIndexBackendFactory.java
@@ -65,22 +65,22 @@ public class TestPartitionedIndexBackendFactory {
   }
 
   @Test
-  void testRocksDBBackendTypeReturnsRocksDBPartitionedIndexBackend() throws Exception {
+  void testRocksDBBackendTypeIsNotYetSelectableAndFallsBackToRecordLevelIndexBackend() throws Exception {
     conf.set(FlinkOptions.INDEX_RLI_BACKEND_TYPE, "rocksdb");
     conf.set(FlinkOptions.INDEX_RLI_CACHE_ROCKSDB_BASE_PATH, tempFile.getAbsolutePath());
     try (PartitionedIndexBackend backend = PartitionedIndexBackendFactory.create(
         conf, false, (partitionPath, recordKey, fileId) -> true)) {
-      assertInstanceOf(RocksDBPartitionedIndexBackend.class, backend);
+      assertInstanceOf(RecordLevelIndexBackend.class, backend);
     }
   }
 
   @Test
-  void testRocksDBBackendTypeIsCaseInsensitive() throws Exception {
+  void testRocksDBBackendTypeIsCaseInsensitivelyNotYetSelectable() throws Exception {
     conf.set(FlinkOptions.INDEX_RLI_BACKEND_TYPE, "RocksDB");
     conf.set(FlinkOptions.INDEX_RLI_CACHE_ROCKSDB_BASE_PATH, tempFile.getAbsolutePath());
     try (PartitionedIndexBackend backend = PartitionedIndexBackendFactory.create(
         conf, false, (partitionPath, recordKey, fileId) -> true)) {
-      assertInstanceOf(RocksDBPartitionedIndexBackend.class, backend);
+      assertInstanceOf(RecordLevelIndexBackend.class, backend);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestPartitionedIndexBackendFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestPartitionedIndexBackendFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner.index;
+
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.util.StreamerUtil;
+import org.apache.hudi.utils.TestConfigurations;
+
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Test cases for {@link PartitionedIndexBackendFactory}.
+ */
+public class TestPartitionedIndexBackendFactory {
+
+  private Configuration conf;
+
+  @TempDir
+  File tempFile;
+
+  @BeforeEach
+  public void before() throws Exception {
+    conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.setString("hadoop.fs.defaultFS", "file:///");
+    StreamerUtil.initTableIfNotExists(conf);
+  }
+
+  @Test
+  void testInsertOverwriteReturnsDummyBackend() throws Exception {
+    try (PartitionedIndexBackend backend = PartitionedIndexBackendFactory.create(
+        conf, true, (partitionPath, recordKey, fileId) -> true)) {
+      assertInstanceOf(DummyPartitionedIndexBackend.class, backend);
+    }
+  }
+
+  @Test
+  void testDefaultBackendTypeReturnsRecordLevelIndexBackend() throws Exception {
+    try (PartitionedIndexBackend backend = PartitionedIndexBackendFactory.create(
+        conf, false, (partitionPath, recordKey, fileId) -> true)) {
+      assertInstanceOf(RecordLevelIndexBackend.class, backend);
+    }
+  }
+
+  @Test
+  void testRocksDBBackendTypeReturnsRocksDBPartitionedIndexBackend() throws Exception {
+    conf.set(FlinkOptions.INDEX_RLI_BACKEND_TYPE, "rocksdb");
+    conf.set(FlinkOptions.INDEX_RLI_CACHE_ROCKSDB_BASE_PATH, tempFile.getAbsolutePath());
+    try (PartitionedIndexBackend backend = PartitionedIndexBackendFactory.create(
+        conf, false, (partitionPath, recordKey, fileId) -> true)) {
+      assertInstanceOf(RocksDBPartitionedIndexBackend.class, backend);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBPartitionedIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBPartitionedIndexBackend.java
@@ -18,14 +18,21 @@
 
 package org.apache.hudi.sink.partitioner.index;
 
+import org.apache.hudi.common.util.collection.RocksDBDAO;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -89,5 +96,67 @@ public class TestRocksDBPartitionedIndexBackend {
       // Deleting an already-absent partition should be a no-op, not an error.
       backend.deletePartition("par1");
     }
+  }
+
+  @Test
+  void testListRegisteredPartitionsReturnsAllRegisteredPartitions() throws Exception {
+    try (RocksDBPartitionedIndexBackend backend = new RocksDBPartitionedIndexBackend(tempFile.getAbsolutePath())) {
+      backend.update("par1", "key1", "file1");
+      backend.update("par2", "key1", "file2");
+      backend.update("par3", "key1", "file3");
+
+      List<String> registered = backend.listRegisteredPartitions();
+      assertEquals(3, registered.size());
+      assertTrue(registered.containsAll(Arrays.asList("par1", "par2", "par3")));
+    }
+  }
+
+  @Test
+  void testUpdateOverwritesExistingValueForSameKey() throws Exception {
+    try (RocksDBPartitionedIndexBackend backend = new RocksDBPartitionedIndexBackend(tempFile.getAbsolutePath())) {
+      backend.update("par1", "key1", "file1");
+      backend.update("par1", "key1", "file2");
+
+      assertEquals("file2", backend.get("par1", "key1"));
+    }
+  }
+
+  @Test
+  void testPartitionNotVisibleToGetUntilFullyRegistered() throws Exception {
+    try (RocksDBPartitionedIndexBackend backend = new RocksDBPartitionedIndexBackend(tempFile.getAbsolutePath())) {
+      RocksDBDAO dao = getRocksDBDAO(backend);
+      String columnFamily = partitionColumnFamily("par1");
+      dao.addColumnFamily(columnFamily);
+      dao.put(columnFamily, "key1", "file1");
+
+      // The column family has data, but the partition has not been registered yet, so it must stay invisible.
+      assertFalse(backend.isPartitionRegistered("par1"));
+      assertNull(backend.get("par1", "key1"));
+
+      backend.update("par1", "key1", "file1");
+      assertTrue(backend.isPartitionRegistered("par1"));
+      assertEquals("file1", backend.get("par1", "key1"));
+    }
+  }
+
+  @Test
+  void testOperationsAfterCloseThrow() throws Exception {
+    RocksDBPartitionedIndexBackend backend = new RocksDBPartitionedIndexBackend(tempFile.getAbsolutePath());
+    backend.update("par1", "key1", "file1");
+    backend.close();
+
+    assertThrows(IllegalArgumentException.class, () -> backend.get("par1", "key1"));
+  }
+
+  private static RocksDBDAO getRocksDBDAO(RocksDBPartitionedIndexBackend backend) throws Exception {
+    Field field = RocksDBPartitionedIndexBackend.class.getDeclaredField("rocksDBDAO");
+    field.setAccessible(true);
+    return (RocksDBDAO) field.get(backend);
+  }
+
+  private static String partitionColumnFamily(String partitionPath) throws Exception {
+    Method method = RocksDBPartitionedIndexBackend.class.getDeclaredMethod("partitionColumnFamily", String.class);
+    method.setAccessible(true);
+    return (String) method.invoke(null, partitionPath);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBPartitionedIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBPartitionedIndexBackend.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner.index;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for {@link RocksDBPartitionedIndexBackend}.
+ */
+public class TestRocksDBPartitionedIndexBackend {
+
+  @TempDir
+  File tempFile;
+
+  @Test
+  void testGetOnUnknownPartitionReturnsNull() throws Exception {
+    try (RocksDBPartitionedIndexBackend backend = new RocksDBPartitionedIndexBackend(tempFile.getAbsolutePath())) {
+      assertNull(backend.get("par1", "key1"));
+      assertFalse(backend.isPartitionRegistered("par1"));
+      assertTrue(backend.listRegisteredPartitions().isEmpty());
+    }
+  }
+
+  @Test
+  void testUpdateAndGetRoundTripAcrossPartitions() throws Exception {
+    try (RocksDBPartitionedIndexBackend backend = new RocksDBPartitionedIndexBackend(tempFile.getAbsolutePath())) {
+      backend.update("par1", "key1", "file1");
+      backend.update("par2", "key1", "file2");
+
+      assertEquals("file1", backend.get("par1", "key1"));
+      assertEquals("file2", backend.get("par2", "key1"));
+      assertNull(backend.get("par1", "key2"));
+      assertNull(backend.get("par3", "key1"));
+    }
+  }
+
+  @Test
+  void testCompletenessInvariantRegistersPartitionAfterUpdate() throws Exception {
+    try (RocksDBPartitionedIndexBackend backend = new RocksDBPartitionedIndexBackend(tempFile.getAbsolutePath())) {
+      assertFalse(backend.isPartitionRegistered("par1"));
+
+      backend.update("par1", "key1", "file1");
+      assertTrue(backend.isPartitionRegistered("par1"));
+      assertEquals(1, backend.listRegisteredPartitions().size());
+      assertTrue(backend.listRegisteredPartitions().contains("par1"));
+
+      // Repeated updates to an already-registered partition should not create duplicate registry entries.
+      backend.update("par1", "key2", "file1");
+      assertEquals(1, backend.listRegisteredPartitions().size());
+    }
+  }
+
+  @Test
+  void testDeletePartitionRemovesDataAndRegistration() throws Exception {
+    try (RocksDBPartitionedIndexBackend backend = new RocksDBPartitionedIndexBackend(tempFile.getAbsolutePath())) {
+      backend.update("par1", "key1", "file1");
+      assertTrue(backend.isPartitionRegistered("par1"));
+
+      backend.deletePartition("par1");
+
+      assertFalse(backend.isPartitionRegistered("par1"));
+      assertTrue(backend.listRegisteredPartitions().isEmpty());
+      assertNull(backend.get("par1", "key1"));
+
+      // Deleting an already-absent partition should be a no-op, not an error.
+      backend.deletePartition("par1");
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

add new RocksDBPartitionedIndexBackend that can manages record-key-to-fileId mapping for each partition in column family of RocksDB.

closes #19601 

### Summary and Changelog
1. Add RocksDBPartitionedIndexBackend, a RocksDB-based implementation of PartitionedIndexBackend that stores each data partition's record-key-to-fileId mapping in its own column family, enabling per-partition eviction.
2. Add PartitionedIndexBackendFactory to centralize selection between the dummy, record-level, and new RocksDB-backed index backends based on FlinkOptions.INDEX_RLI_BACKEND_TYPE.
3. Update DynamicBucketAssignFunction to use the new factory instead of inlining backend construction.
4. Add unit tests for the new factory and RocksDB backend.

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
