### PR TITLE
[MINOR] Guard mixed-class ordering values in event-time record merge

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecordMergerFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecordMergerFactory.java
@@ -512,6 +512,16 @@ public class BufferedRecordMergerFactory {
       // The orderingVal is constant 0 (int) and not guaranteed to match the type of the old or new record's ordering value.
       return true;
     }
-    return newRecord.getOrderingValue().compareTo(oldRecord.getOrderingValue()) >= 0;
+    Comparable oldOrderingVal = oldRecord.getOrderingValue();
+    Comparable newOrderingVal = newRecord.getOrderingValue();
+    // Checks the ordering value does not equal to 0
+    // because we use 0 as the default value which means natural order.
+    // OrderingValues#create coerces a null ordering field value to that default, so its class need
+    // not match the counterpart's real value and comparing the two directly would throw
+    // ClassCastException (e.g. Long.compareTo(Integer)).
+    boolean chooseOlder = !OrderingValues.isDefault(newOrderingVal)
+        && OrderingValues.isSameClass(oldOrderingVal, newOrderingVal)
+        && oldOrderingVal.compareTo(newOrderingVal) > 0;
+    return !chooseOlder;
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestBufferedRecordMergerFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestBufferedRecordMergerFactory.java
@@ -28,11 +28,16 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.table.PartialUpdateMode;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -80,5 +85,62 @@ class TestBufferedRecordMergerFactory {
     assertEquals(expected, BufferedRecordMergerFactory.create(
         context, mode, partialMerging, recordMerger, schema, payloadClasses, props, partialUpdateMode)
         .getClass().getSimpleName());
+  }
+
+  /**
+   * {@code OrderingValues#create} coerces a null ordering-field value to
+   * {@code HoodieRecord.DEFAULT_ORDERING_VALUE}, which is an {@code int}. Its counterpart in the
+   * same file group can hold the column's real value of another type, e.g. {@code Long}. Comparing
+   * the two through {@code Comparable#compareTo} threw {@code ClassCastException}, which the write
+   * path surfaces as {@code HoodieUpsertException}.
+   */
+  @Test
+  void testMergeToleratesOrderingValuesOfDifferentClasses() throws IOException {
+    BufferedRecordMerger<String> merger = eventTimeMerger();
+
+    BufferedRecord<String> olderWithDefault = bufferedRecord("base", OrderingValues.getDefault());
+    BufferedRecord<String> newerWithLong = bufferedRecord("log", 1000L);
+    assertSame(newerWithLong, merger.finalMerge(olderWithDefault, newerWithLong));
+
+    BufferedRecord<String> olderWithLong = bufferedRecord("base", 1000L);
+    BufferedRecord<String> newerWithDefault = bufferedRecord("log", OrderingValues.getDefault());
+    assertSame(newerWithDefault, merger.finalMerge(olderWithLong, newerWithDefault));
+
+    Option<BufferedRecord<String>> delta = merger.deltaMerge(newerWithLong, olderWithDefault);
+    assertTrue(delta.isPresent());
+    assertSame(newerWithLong, delta.get());
+  }
+
+  /**
+   * Event-time ordering is unchanged for ordering values of the same class.
+   */
+  @Test
+  void testMergeRetainsEventTimeOrderingForSameClassOrderingValues() throws IOException {
+    BufferedRecordMerger<String> merger = eventTimeMerger();
+
+    BufferedRecord<String> newerWins = bufferedRecord("log", 2000L);
+    assertSame(newerWins, merger.finalMerge(bufferedRecord("base", 1000L), newerWins));
+
+    BufferedRecord<String> olderWins = bufferedRecord("base", 2000L);
+    assertSame(olderWins, merger.finalMerge(olderWins, bufferedRecord("log", 1000L)));
+
+    BufferedRecord<String> newerOnTie = bufferedRecord("log", 1000L);
+    assertSame(newerOnTie, merger.finalMerge(bufferedRecord("base", 1000L), newerOnTie));
+
+    BufferedRecord<String> newerWhenBothDefault = bufferedRecord("log", OrderingValues.getDefault());
+    assertSame(newerWhenBothDefault,
+        merger.finalMerge(bufferedRecord("base", OrderingValues.getDefault()), newerWhenBothDefault));
+  }
+
+  private static BufferedRecordMerger<String> eventTimeMerger() {
+    HoodieReaderContext<String> context = mock(HoodieReaderContext.class);
+    when(context.getRecordContext()).thenReturn(mock(RecordContext.class));
+    return BufferedRecordMergerFactory.create(
+        context, RecordMergeMode.EVENT_TIME_ORDERING, false, Option.of(mock(HoodieRecordMerger.class)),
+        HoodieSchema.create(HoodieSchemaType.STRING), Option.empty(), new TypedProperties(), Option.empty());
+  }
+
+  private static BufferedRecord<String> bufferedRecord(String value, Comparable orderingValue) {
+    return new BufferedRecord<>("key1", orderingValue, value, 1, null);
   }
 }


### PR DESCRIPTION
### Change Logs

`OrderingValues#create` coerces a null ordering-field value to `HoodieRecord.DEFAULT_ORDERING_VALUE`, which is declared `int`. A record whose ordering column is `null` therefore holds `Integer(0)` while its counterpart in the same file group holds the column's real value, e.g. a `Long`. `BufferedRecordMergerFactory.shouldKeepNewerRecord` compared the two with a raw `Comparable#compareTo`, throwing `ClassCastException: java.lang.Integer cannot be cast to java.lang.Long`, which the write path wraps as `HoodieUpsertException`.

The comment above that comparison already notes the hazard, but the guard it annotates applies only to DELETE records, so a non-delete record holding the sentinel was unguarded.

This applies the guard `deltaMergeDeleteRecord` already uses in the same file (also used by `HoodieMergedLogRecordScanner` and `PartialUpdateAvroPayload`): skip the comparison when the incoming ordering value is the default sentinel or the two classes differ, falling back to natural order.

For same-class, non-default ordering values the result is unchanged: `!(old > new)` is `new >= old`. Only the inputs that previously threw behave differently.

### Impact

No API, config, or default change. Tables whose ordering field is nullable no longer fail merges.

### Risk level

low

Added two cases to `TestBufferedRecordMergerFactory` covering both mixed-class directions, `deltaMerge` and `finalMerge`, and same-class event-time ordering. They fail with `ClassCastException` against the unfixed method and pass with the fix (`Tests run: 3, Failures: 0, Errors: 0` in `hudi-common`).

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
