### PR TITLE
fix(reader): guard mixed-class ordering values in event-time record mergers

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/EventTimeFlinkRecordMerger.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/EventTimeFlinkRecordMerger.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.table.read.BufferedRecord;
+import org.apache.hudi.common.util.OrderingValues;
 
 import java.io.IOException;
 
@@ -46,7 +47,7 @@ public class EventTimeFlinkRecordMerger extends HoodieFlinkRecordMerger {
       return newer;
     }
 
-    if (older.getOrderingValue().compareTo(newer.getOrderingValue()) > 0) {
+    if (OrderingValues.isBaseOrderingHigher(older.getOrderingValue(), newer.getOrderingValue())) {
       return older;
     } else {
       return newer;

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/PartialUpdateFlinkRecordMerger.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/PartialUpdateFlinkRecordMerger.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.table.read.BufferedRecords;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.util.RowDataQueryContexts;
 
 import org.apache.flink.table.data.GenericRowData;
@@ -91,7 +92,7 @@ public class PartialUpdateFlinkRecordMerger extends HoodieFlinkRecordMerger {
       BufferedRecord<T> newer,
       RecordContext<T> recordContext,
       TypedProperties props) throws IOException {
-    if (older.getOrderingValue().compareTo(newer.getOrderingValue()) > 0) {
+    if (OrderingValues.isBaseOrderingHigher(older.getOrderingValue(), newer.getOrderingValue())) {
       if (older.isDelete() || newer.isDelete()) {
         return older;
       } else {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/DefaultSparkRecordMerger.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/DefaultSparkRecordMerger.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.read.BufferedRecord;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.merge.SparkRecordMergingUtils;
 
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -45,7 +46,7 @@ public class DefaultSparkRecordMerger extends HoodieSparkRecordMerger {
     if (HoodieRecordMerger.isCommitTimeOrderingDelete(older, newer)) {
       return newer;
     }
-    if (older.getOrderingValue().compareTo(newer.getOrderingValue()) > 0) {
+    if (OrderingValues.isBaseOrderingHigher(older.getOrderingValue(), newer.getOrderingValue())) {
       return older;
     } else {
       return newer;
@@ -57,7 +58,7 @@ public class DefaultSparkRecordMerger extends HoodieSparkRecordMerger {
     if (HoodieRecordMerger.isCommitTimeOrderingDelete(older, newer)) {
       return newer;
     }
-    if (older.getOrderingValue().compareTo(newer.getOrderingValue()) > 0) {
+    if (OrderingValues.isBaseOrderingHigher(older.getOrderingValue(), newer.getOrderingValue())) {
       if (older.isDelete() || newer.isDelete()) {
         return older;
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -218,6 +219,16 @@ public interface HoodieRecordMerger extends Serializable {
   static <T> Comparable maxOrderingValue(BufferedRecord<T> oldRecord, BufferedRecord<T> newRecord) {
     Comparable oldOrderingVal = oldRecord.getOrderingValue();
     Comparable newOrderingVal = newRecord.getOrderingValue();
+    // A commit-time ordering value (null or the default sentinel) ranks lowest, so the counterpart
+    // is the max. Different classes are not comparable through compareTo, so fall back to the base
+    // value rather than risk a ClassCastException.
+    if (OrderingValues.isCommitTimeOrderingValue(oldOrderingVal)) {
+      return newOrderingVal;
+    }
+    if (OrderingValues.isCommitTimeOrderingValue(newOrderingVal)
+        || !OrderingValues.isSameClass(oldOrderingVal, newOrderingVal)) {
+      return oldOrderingVal;
+    }
     return oldOrderingVal.compareTo(newOrderingVal) > 0 ? oldOrderingVal : newOrderingVal;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -291,11 +291,7 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
 
       Comparable curOrderingVal = oldRecord.getOrderingValue(this.readerSchema, this.hoodieTableMetaClient.getTableConfig().getProps(), orderingFields);
       Comparable deleteOrderingVal = deleteRecord.getOrderingValue();
-      // Checks the ordering value does not equal to 0
-      // because we use 0 as the default value which means natural order
-      boolean choosePrev = !OrderingValues.isDefault(deleteOrderingVal)
-          && OrderingValues.isSameClass(curOrderingVal, deleteOrderingVal)
-          && curOrderingVal.compareTo(deleteOrderingVal) > 0;
+      boolean choosePrev = OrderingValues.isBaseOrderingHigher(curOrderingVal, deleteOrderingVal);
       if (choosePrev) {
         // The DELETE message is obsolete if the old message has greater orderingVal.
         return;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecordMergerFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecordMergerFactory.java
@@ -264,7 +264,7 @@ public class BufferedRecordMergerFactory {
       Comparable oldOrderingValue = olderRecord.getOrderingValue();
       HoodieSchema newSchema = recordContext.getSchemaFromBufferRecord(newerRecord);
       if (!olderRecord.isCommitTimeOrderingDelete()
-          && oldOrderingValue.compareTo(newOrderingValue) > 0) {
+          && OrderingValues.isBaseOrderingHigher(oldOrderingValue, newOrderingValue)) {
         // Use old record as the base record since old record has higher ordering value.
         olderRecord = partialUpdateHandler.partialMerge(
             olderRecord,
@@ -494,11 +494,7 @@ public class BufferedRecordMergerFactory {
     }
     Comparable existingOrderingVal = existingRecord.getOrderingValue();
     Comparable deleteOrderingVal = recordContext.convertOrderingValueToEngineType(deleteRecord.getOrderingValue());
-    // Checks the ordering value does not equal to 0
-    // because we use 0 as the default value which means natural order
-    boolean chooseExisting = !OrderingValues.isDefault(deleteOrderingVal)
-        && OrderingValues.isSameClass(existingOrderingVal, deleteOrderingVal)
-        && existingOrderingVal.compareTo(deleteOrderingVal) > 0;
+    boolean chooseExisting = OrderingValues.isBaseOrderingHigher(existingOrderingVal, deleteOrderingVal);
     if (chooseExisting) {
       // The DELETE message is obsolete if the old message has greater orderingVal.
       return Option.empty();
@@ -512,6 +508,6 @@ public class BufferedRecordMergerFactory {
       // The orderingVal is constant 0 (int) and not guaranteed to match the type of the old or new record's ordering value.
       return true;
     }
-    return newRecord.getOrderingValue().compareTo(oldRecord.getOrderingValue()) >= 0;
+    return !OrderingValues.isBaseOrderingHigher(oldRecord.getOrderingValue(), newRecord.getOrderingValue());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/OrderingValues.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/OrderingValues.java
@@ -117,4 +117,20 @@ public class OrderingValues {
   public static boolean isCommitTimeOrderingValue(Comparable orderingValue) {
     return orderingValue == null || OrderingValues.isDefault(orderingValue);
   }
+
+  /**
+   * Returns whether {@code baseOrderingValue} strictly outranks {@code incomingOrderingValue} under
+   * event-time ordering. Evaluates to {@code false}, deferring to natural order so the incoming
+   * record wins, when either value is a commit-time ordering value (a {@code null} or the default
+   * sentinel) or the two values are of different classes. This keeps callers from comparing
+   * mismatched types through {@link Comparable#compareTo}, which throws {@link ClassCastException}
+   * (for example when a null ordering field is represented as the {@code int} default while its
+   * counterpart holds a {@code Long}).
+   */
+  public static boolean isBaseOrderingHigher(Comparable baseOrderingValue, Comparable incomingOrderingValue) {
+    return !isCommitTimeOrderingValue(incomingOrderingValue)
+        && !isCommitTimeOrderingValue(baseOrderingValue)
+        && isSameClass(baseOrderingValue, incomingOrderingValue)
+        && baseOrderingValue.compareTo(incomingOrderingValue) > 0;
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestBufferedRecordMergerFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestBufferedRecordMergerFactory.java
@@ -28,11 +28,16 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.table.PartialUpdateMode;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -80,5 +85,61 @@ class TestBufferedRecordMergerFactory {
     assertEquals(expected, BufferedRecordMergerFactory.create(
         context, mode, partialMerging, recordMerger, schema, payloadClasses, props, partialUpdateMode)
         .getClass().getSimpleName());
+  }
+
+  /**
+   * A null ordering field value is represented as {@link OrderingValues#getDefault()}, an
+   * {@code int}, while its counterpart in the same file group can hold the column's real value of
+   * another type, e.g. a {@code Long}. Comparing the two through {@code Comparable#compareTo} threw
+   * {@code ClassCastException}, which the write path surfaces as {@code HoodieUpsertException}.
+   */
+  @Test
+  void testMergeToleratesOrderingValuesOfDifferentClasses() throws IOException {
+    BufferedRecordMerger<String> merger = eventTimeMerger();
+
+    BufferedRecord<String> olderWithDefault = bufferedRecord("base", OrderingValues.getDefault());
+    BufferedRecord<String> newerWithLong = bufferedRecord("log", 1000L);
+    assertSame(newerWithLong, merger.finalMerge(olderWithDefault, newerWithLong));
+
+    BufferedRecord<String> olderWithLong = bufferedRecord("base", 1000L);
+    BufferedRecord<String> newerWithDefault = bufferedRecord("log", OrderingValues.getDefault());
+    assertSame(newerWithDefault, merger.finalMerge(olderWithLong, newerWithDefault));
+
+    Option<BufferedRecord<String>> delta = merger.deltaMerge(newerWithLong, olderWithDefault);
+    assertTrue(delta.isPresent());
+    assertSame(newerWithLong, delta.get());
+  }
+
+  /**
+   * Event-time ordering is unchanged for ordering values of the same class.
+   */
+  @Test
+  void testMergeRetainsEventTimeOrderingForSameClassOrderingValues() throws IOException {
+    BufferedRecordMerger<String> merger = eventTimeMerger();
+
+    BufferedRecord<String> newerWins = bufferedRecord("log", 2000L);
+    assertSame(newerWins, merger.finalMerge(bufferedRecord("base", 1000L), newerWins));
+
+    BufferedRecord<String> olderWins = bufferedRecord("base", 2000L);
+    assertSame(olderWins, merger.finalMerge(olderWins, bufferedRecord("log", 1000L)));
+
+    BufferedRecord<String> newerOnTie = bufferedRecord("log", 1000L);
+    assertSame(newerOnTie, merger.finalMerge(bufferedRecord("base", 1000L), newerOnTie));
+
+    BufferedRecord<String> newerWhenBothDefault = bufferedRecord("log", OrderingValues.getDefault());
+    assertSame(newerWhenBothDefault,
+        merger.finalMerge(bufferedRecord("base", OrderingValues.getDefault()), newerWhenBothDefault));
+  }
+
+  private static BufferedRecordMerger<String> eventTimeMerger() {
+    HoodieReaderContext<String> context = mock(HoodieReaderContext.class);
+    when(context.getRecordContext()).thenReturn(mock(RecordContext.class));
+    return BufferedRecordMergerFactory.create(
+        context, RecordMergeMode.EVENT_TIME_ORDERING, false, Option.of(mock(HoodieRecordMerger.class)),
+        HoodieSchema.create(HoodieSchemaType.STRING), Option.empty(), new TypedProperties(), Option.empty());
+  }
+
+  private static BufferedRecord<String> bufferedRecord(String value, Comparable orderingValue) {
+    return new BufferedRecord<>("key1", orderingValue, value, 1, null);
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestOrderingValues.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestOrderingValues.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestOrderingValues {
+
+  @Test
+  void isBaseOrderingHigherComparesSameClassValues() {
+    assertTrue(OrderingValues.isBaseOrderingHigher(2000L, 1000L));
+    assertFalse(OrderingValues.isBaseOrderingHigher(1000L, 2000L));
+    assertFalse(OrderingValues.isBaseOrderingHigher(1000L, 1000L));
+  }
+
+  @Test
+  void isBaseOrderingHigherDefersToNaturalOrderForDifferentClasses() {
+    // The default sentinel is an int; the counterpart is a Long. A raw compareTo would throw
+    // ClassCastException, so the mixed-class comparison resolves to natural order (not higher).
+    assertFalse(OrderingValues.isBaseOrderingHigher(OrderingValues.getDefault(), 1000L));
+    assertFalse(OrderingValues.isBaseOrderingHigher(1000L, OrderingValues.getDefault()));
+  }
+
+  @Test
+  void isBaseOrderingHigherTreatsCommitTimeOrderingValuesAsNotHigher() {
+    assertFalse(OrderingValues.isBaseOrderingHigher(OrderingValues.getDefault(), OrderingValues.getDefault()));
+    assertFalse(OrderingValues.isBaseOrderingHigher(null, 1000L));
+    assertFalse(OrderingValues.isBaseOrderingHigher(1000L, null));
+    assertFalse(OrderingValues.isBaseOrderingHigher(null, null));
+  }
+
+  @Test
+  void isBaseOrderingHigherHandlesMultiFieldOrderingValues() {
+    Comparable higher = OrderingValues.create(new Comparable[] {2L, 1L});
+    Comparable lower = OrderingValues.create(new Comparable[] {1L, 1L});
+    assertTrue(OrderingValues.isBaseOrderingHigher(higher, lower));
+    assertFalse(OrderingValues.isBaseOrderingHigher(lower, higher));
+    assertFalse(OrderingValues.isBaseOrderingHigher(OrderingValues.getDefault(), higher));
+    assertFalse(OrderingValues.isBaseOrderingHigher(higher, OrderingValues.getDefault()));
+  }
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java
@@ -249,7 +249,7 @@ public class TestCustomRecordMerger extends HoodieFileGroupReaderTestHarness {
       if (orderingFields == null) {
         this.orderingFields = ConfigUtils.getOrderingFields(props);
       }
-      if (newer.getOrderingValue().compareTo(older.getOrderingValue()) >= 0) {
+      if (!OrderingValues.isBaseOrderingHigher(older.getOrderingValue(), newer.getOrderingValue())) {
         if (newer.isDelete()) {
           return newer;
         }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/DefaultHiveRecordMerger.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/DefaultHiveRecordMerger.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.table.read.BufferedRecord;
+import org.apache.hudi.common.util.OrderingValues;
 
 import java.io.IOException;
 
@@ -36,7 +37,7 @@ public class DefaultHiveRecordMerger extends HoodieHiveRecordMerger {
     if (HoodieRecordMerger.isCommitTimeOrderingDelete(older, newer)) {
       return newer;
     }
-    if (older.getOrderingValue().compareTo(newer.getOrderingValue()) > 0) {
+    if (OrderingValues.isBaseOrderingHigher(older.getOrderingValue(), newer.getOrderingValue())) {
       return older;
     } else {
       return newer;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`OrderingValues#create` can represent a null ordering-field value as `HoodieRecord.DEFAULT_ORDERING_VALUE`, which is an `int`, while its counterpart in the same file group holds the column's real value of another type (for example a `Long`). Several event-time merge paths compared the two ordering values directly through `Comparable#compareTo`, which throws `ClassCastException: java.lang.Integer cannot be cast to java.lang.Long`, surfaced as `HoodieUpsertException`, which aborts the merge. The comment above `BufferedRecordMergerFactory.shouldKeepNewerRecord` already noted the hazard, but the guard it annotated applied only to DELETE records, and the same unguarded comparison existed in the other event-time record mergers.

### Summary and Changelog

Add `OrderingValues.isBaseOrderingHigher(base, incoming)`, which returns whether the base ordering value strictly outranks the incoming one and evaluates to false, deferring to natural order so the incoming record wins, when either value is a commit-time ordering value (a null or the default sentinel) or the two values are of different classes. This is the guard `deltaMergeDeleteRecord` and `HoodieMergedLogRecordScanner` already applied, now shared. The event-time record mergers and the delete and partial-update merge paths are routed through it: `BufferedRecordMergerFactory` (`shouldKeepNewerRecord`, the partial-update `finalMerge` branch, and `deltaMergeDeleteRecord`), `HoodieMergedLogRecordScanner`, `DefaultSparkRecordMerger`, `EventTimeFlinkRecordMerger`, `PartialUpdateFlinkRecordMerger`, and `DefaultHiveRecordMerger`. `HoodieRecordMerger.maxOrderingValue` is made null and mixed-class safe with magnitude semantics (a commit-time ordering value ranks lowest, so the counterpart is the max). For same-class, non-default ordering values behavior is unchanged.

### Impact

No public API, config, or default change. Tables whose ordering field is nullable no longer fail event-time merges with a ClassCastException.

### Risk Level

low

Added `TestOrderingValues` for the new helper (same-class, mixed-class in both directions, null, and default inputs) and two cases in `TestBufferedRecordMergerFactory` covering mixed-class `finalMerge` and `deltaMerge` and unchanged same-class event-time ordering. They fail with `ClassCastException` against the unfixed merge path and pass with the fix.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
