### PR TITLE
[MINOR] Do not return a negative Spark partition when a hash is Integer.MIN_VALUE

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/CoalescingPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/CoalescingPartitioner.java
@@ -41,7 +41,9 @@ public class CoalescingPartitioner extends Partitioner {
     if (numPartitions == 1) {
       return 0;
     } else {
-      return Math.abs(key.hashCode()) % numPartitions;
+      // Math.abs leaves Integer.MIN_VALUE negative, and a Partitioner must answer in
+      // [0, numPartitions). floorMod is non-negative for every input.
+      return Math.floorMod(key.hashCode(), numPartitions);
     }
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRDDPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/execution/bulkinsert/PartitionPathRDDPartitioner.java
@@ -47,6 +47,8 @@ public class PartitionPathRDDPartitioner extends Partitioner implements Serializ
   @SuppressWarnings("unchecked")
   @Override
   public int getPartition(Object o) {
-    return Math.abs(Objects.hash(partitionPathExtractor.apply(o))) % numPartitions;
+    // Math.abs leaves Integer.MIN_VALUE negative, and a Partitioner must answer in
+    // [0, numPartitions). floorMod is non-negative for every input.
+    return Math.floorMod(Objects.hash(partitionPathExtractor.apply(o)), numPartitions);
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCoalescingPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCoalescingPartitioner.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.testutils.HoodieClientTestBase;
 
+import org.apache.spark.HashPartitioner;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
@@ -186,18 +187,39 @@ public class TestCoalescingPartitioner extends HoodieClientTestBase {
   }
 
   /**
-   * "polygenelubricants" hashes to Integer.MIN_VALUE, which Math.abs leaves negative, so a
-   * partitioner deriving its answer that way returns an index Spark cannot use. Asserting the
-   * fixture first, so this stops silently passing if String.hashCode ever changes.
+   * Spark's own HashPartitioner routes with Utils.nonNegativeMod, which is floorMod. Pinning the
+   * exact index against it is a real oracle: asserting only that the index is in range would pass
+   * for abs-mod too, and abs-mod differs from floorMod for roughly half of all negative hashes.
    */
   @Test
-  public void testPartitionIsInRangeForMinValueHash() {
-    String key = "polygenelubricants";
-    assertEquals(Integer.MIN_VALUE, key.hashCode());
+  public void testPartitionMatchesSparkHashPartitioner() {
+    String minValueHashKey = "polygenelubricants";
+    assertEquals(Integer.MIN_VALUE, minValueHashKey.hashCode());
+    // Integer.MIN_VALUE % 2^k == 0, so only 3, 5, 6 and 7 fail on the old Math.abs expression;
+    // trimming this list to powers of two would stop it exercising the fix.
     for (int numPartitions : new int[] {1, 2, 3, 4, 5, 6, 7, 8, 16}) {
-      int partition = new CoalescingPartitioner(numPartitions).getPartition(key);
-      assertTrue(partition >= 0 && partition < numPartitions,
-          "partition " + partition + " out of range for numPartitions " + numPartitions);
+      HashPartitioner oracle = new HashPartitioner(numPartitions);
+      for (Object key : new Object[] {minValueHashKey, -1, -2, -3, -5, -100, 0, 1, 100}) {
+        int partition = new CoalescingPartitioner(numPartitions).getPartition(key);
+        assertTrue(partition >= 0 && partition < numPartitions,
+            "partition " + partition + " out of range for numPartitions " + numPartitions);
+        assertEquals(oracle.getPartition(key), partition,
+            "key " + key + " at numPartitions " + numPartitions);
+      }
     }
   }
+
+  /**
+   * The assertions above only call getPartition. This drives a real shuffle so the failure the old
+   * expression produced is visible end to end: BypassMergeSortShuffleWriter indexes its
+   * partitionWriters array with whatever getPartition answers, unguarded.
+   */
+  @Test
+  public void testShuffleSucceedsForMinValueHashKey() {
+    JavaRDD<String> keys = jsc.parallelize(Collections.singletonList("polygenelubricants"), 1);
+    assertEquals(1, keys.mapToPair(key -> new Tuple2<>(key, key))
+        .partitionBy(new CoalescingPartitioner(3))
+        .count());
+  }
+
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCoalescingPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCoalescingPartitioner.java
@@ -184,4 +184,20 @@ public class TestCoalescingPartitioner extends HoodieClientTestBase {
       return booleanIntegerTuple2._2;
     }
   }
+
+  /**
+   * "polygenelubricants" hashes to Integer.MIN_VALUE, which Math.abs leaves negative, so a
+   * partitioner deriving its answer that way returns an index Spark cannot use. Asserting the
+   * fixture first, so this stops silently passing if String.hashCode ever changes.
+   */
+  @Test
+  public void testPartitionIsInRangeForMinValueHash() {
+    String key = "polygenelubricants";
+    assertEquals(Integer.MIN_VALUE, key.hashCode());
+    for (int numPartitions : new int[] {1, 2, 3, 4, 5, 6, 7, 8, 16}) {
+      int partition = new CoalescingPartitioner(numPartitions).getPartition(key);
+      assertTrue(partition >= 0 && partition < numPartitions,
+          "partition " + partition + " out of range for numPartitions " + numPartitions);
+    }
+  }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestPartitionPathRDDPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestPartitionPathRDDPartitioner.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.execution.bulkinsert;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestPartitionPathRDDPartitioner {
+
+  /**
+   * Objects.hash(x) is 31 + x.hashCode(), so this partition path overflows it to
+   * Integer.MIN_VALUE, which Math.abs leaves negative.
+   */
+  private static final String MIN_VALUE_HASH_PATH = "xfjfxsf";
+
+  @Test
+  void assertFixtureStillOverflowsToMinValue() {
+    assertEquals(Integer.MIN_VALUE, Objects.hash(MIN_VALUE_HASH_PATH));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 16})
+  void assertPartitionIsInRangeForMinValueHash(int numPartitions) {
+    PartitionPathRDDPartitioner partitioner =
+        new PartitionPathRDDPartitioner(o -> MIN_VALUE_HASH_PATH, numPartitions);
+    int partition = partitioner.getPartition(new Object());
+    assertTrue(partition >= 0 && partition < numPartitions,
+        "partition " + partition + " out of range for numPartitions " + numPartitions);
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestPartitionPathRDDPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestPartitionPathRDDPartitioner.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.execution.bulkinsert;
 
-import org.junit.jupiter.api.Test;
+import org.apache.spark.HashPartitioner;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -31,22 +31,24 @@ class TestPartitionPathRDDPartitioner {
 
   /**
    * Objects.hash(x) is 31 + x.hashCode(), so this partition path overflows it to
-   * Integer.MIN_VALUE, which Math.abs leaves negative.
+   * Integer.MIN_VALUE. The partitioner hashes that sum rather than the string, so the oracle is
+   * fed the boxed int. Spark's HashPartitioner routes with Utils.nonNegativeMod, i.e. floorMod.
    */
-  private static final String MIN_VALUE_HASH_PATH = "xfjfxsf";
-
-  @Test
-  void assertFixtureStillOverflowsToMinValue() {
-    assertEquals(Integer.MIN_VALUE, Objects.hash(MIN_VALUE_HASH_PATH));
-  }
-
+  // Integer.MIN_VALUE % 2^k == 0, so only 3, 5, 6 and 7 fail on the old Math.abs expression;
+  // trimming this list to powers of two would stop it exercising the fix.
   @ParameterizedTest
   @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 16})
-  void assertPartitionIsInRangeForMinValueHash(int numPartitions) {
+  void testPartitionMatchesSparkHashPartitioner(int numPartitions) {
+    String minValueHashPath = "xfjfxsf";
+    assertEquals(Integer.MIN_VALUE, Objects.hash(minValueHashPath));
+
     PartitionPathRDDPartitioner partitioner =
-        new PartitionPathRDDPartitioner(o -> MIN_VALUE_HASH_PATH, numPartitions);
+        new PartitionPathRDDPartitioner(o -> minValueHashPath, numPartitions);
     int partition = partitioner.getPartition(new Object());
     assertTrue(partition >= 0 && partition < numPartitions,
         "partition " + partition + " out of range for numPartitions " + numPartitions);
+    assertEquals(new HashPartitioner(numPartitions).getPartition(Objects.hash(minValueHashPath)),
+        partition, "numPartitions " + numPartitions);
   }
+
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Two Spark `Partitioner` implementations derive the partition index as `Math.abs(hash) % numPartitions`:

```java
// CoalescingPartitioner:44
return Math.abs(key.hashCode()) % numPartitions;

// PartitionPathRDDPartitioner:50
return Math.abs(Objects.hash(partitionPathExtractor.apply(o))) % numPartitions;
```

`Math.abs(Integer.MIN_VALUE)` is `Integer.MIN_VALUE`, so the expression stays negative whenever `numPartitions` does not divide 2^31 — that is, for every parallelism that is not a power of two. `Partitioner#getPartition` has to answer inside `[0, numPartitions)`.

Both are reachable from ordinary data:

| partitioner | input | 2 | 3 | 4 | 5 | 7 | 8 |
|---|---|---|---|---|---|---|---|
| `CoalescingPartitioner` | key `"polygenelubricants"` (`hashCode` is `Integer.MIN_VALUE`) | 0 | **-2** | 0 | **-3** | **-2** | 0 |
| `PartitionPathRDDPartitioner` | partition path `"xfjfxsf"` | 0 | **-2** | 0 | **-3** | **-2** | 0 |

`Objects.hash(x)` is `31 + x.hashCode()`, so the second one needs a partition path hashing to `2147483617` for the sum to overflow to `Integer.MIN_VALUE`; `"xfjfxsf"` is such a value.

### Summary and Changelog

Both now use `Math.floorMod`, which is non-negative for every input. This is the same expression Spark's own `HashPartitioner` uses (`Utils.nonNegativeMod`), and the one `JavaUpsertPartitioner` already uses; `BucketIndexUtil` avoids `Math.abs` the same way with `(hash & Integer.MAX_VALUE) % parallelism`.

Tests, both asserting against `org.apache.spark.HashPartitioner` as the oracle rather than only checking the index is in range — a range check passes for the old expression too on most inputs, which is not a strong enough assertion here:

- `TestCoalescingPartitioner#testPartitionMatchesSparkHashPartitioner` — added to the existing class; asserts the fixture still hashes to `Integer.MIN_VALUE` first, so it cannot silently stop exercising that case, then compares against the oracle for negative and non-negative keys at 1..16 partitions.
- `TestPartitionPathRDDPartitioner` — new, `@ParameterizedTest` over the same parallelisms, asserting `Objects.hash` still overflows for the fixture.
- `TestCoalescingPartitioner#testShuffleSucceedsForMinValueHashKey` — drives a real `partitionBy` over `jsc` so the failure is visible end to end rather than only through `getPartition`.

Reverting the source change turns them red with the exact index, e.g. `key polygenelubricants at numPartitions 3 ==> expected: <1> but was: <-2>`, and the shuffle test with `ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 3` from `BypassMergeSortShuffleWriter`, which indexes `partitionWriters` with the answer unguarded.

`mvn test -pl hudi-client/hudi-spark-client -Dtest='*Partitioner*'` — 59 tests, all passing. `checkstyle:check` clean.

### Impact

No public API, config, or on-disk change.

An earlier version of this description claimed the two expressions agree except at `Integer.MIN_VALUE`, and that power-of-two parallelism routes unchanged. That is wrong, and thanks to @voonhous for catching it. `Math.abs(h) % n` and `Math.floorMod(h, n)` agree for every non-negative `h`, but for negative `h` they agree only when `n` divides `h` (or, for even `n`, when the remainder is exactly `n/2`). Measured over negative hashes:

| numPartitions | 1 | 2 | 3 | 4 | 5 | 7 | 8 | 16 |
|---|---|---|---|---|---|---|---|---|
| negative hashes that reroute | 0% | 0% | 66.7% | 50% | 80% | 85.7% | 75% | 87.5% |

So roughly half of all keys move to a different partition, at every parallelism above two — `Math.abs(-1) % 8` is `1` where `Math.floorMod(-1, 8)` is `7`.

That is a shuffle-placement change, not a correctness or compatibility one. Both partitioners are used only to route records within a single write job (`SparkStreamingMetadataWriteHandler` and the three bulk-insert repartition partitioners); the index is never persisted or compared across runs, and both expressions are deterministic functions of the hash, so records sharing a key or partition path still land together. Both expressions spread the full `int` domain evenly (measured: exactly one value in 2^32 comes out illegal under the old one), so the only behavioural difference is that a key hashing to `Integer.MIN_VALUE` now lands on a valid partition instead of failing the write.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable