### PR TITLE
[MINOR] Release every client resource on close even when an earlier one fails

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -151,10 +151,40 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
    */
   @Override
   public void close() {
-    stopEmbeddedServerView(true);
-    this.context.setJobStatus("", "");
-    this.heartbeatClient.close();
-    this.txnManager.close();
+    // Each step owns a resource the others do not, and the transaction manager holds the write
+    // lock, so an earlier failure must not stop the rest from being released.
+    Exception failure = null;
+    try {
+      stopEmbeddedServerView(true);
+    } catch (Exception e) {
+      failure = e;
+    }
+    try {
+      this.context.setJobStatus("", "");
+    } catch (Exception e) {
+      failure = appendFailure(failure, e);
+    }
+    try {
+      this.heartbeatClient.close();
+    } catch (Exception e) {
+      failure = appendFailure(failure, e);
+    }
+    try {
+      this.txnManager.close();
+    } catch (Exception e) {
+      failure = appendFailure(failure, e);
+    }
+    if (failure != null) {
+      throw failure instanceof RuntimeException ? (RuntimeException) failure : new HoodieException(failure);
+    }
+  }
+
+  private static Exception appendFailure(Exception previousFailure, Exception failure) {
+    if (previousFailure == null) {
+      return failure;
+    }
+    previousFailure.addSuppressed(failure);
+    return previousFailure;
   }
 
   private synchronized void stopEmbeddedServerView(boolean resetViewStorageConfig) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -142,8 +142,37 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
     this.metrics = new HoodieMetrics(config, storage);
     this.txnManager = transactionManager;
     this.timeGenerator = timeGenerator;
-    startEmbeddedServerView();
-    runClientInitCallbacks();
+    try {
+      startEmbeddedServerView();
+      runClientInitCallbacks();
+    } catch (RuntimeException | Error e) {
+      // The constructor is not returning, so no caller ever gets an instance to close(): release here or leak.
+      releaseAfterFailedInit(e);
+      throw e;
+    }
+  }
+
+  /**
+   * Releases what the constructor already acquired, for the case where it cannot hand back an instance.
+   * This mirrors {@link #close()} but must not call it, because subclasses override close() and it would
+   * then run against a half-built object.
+   */
+  private void releaseAfterFailedInit(Throwable initFailure) {
+    try {
+      stopEmbeddedServerView(true);
+    } catch (Exception e) {
+      initFailure.addSuppressed(e);
+    }
+    try {
+      this.heartbeatClient.close();
+    } catch (Exception e) {
+      initFailure.addSuppressed(e);
+    }
+    try {
+      this.txnManager.close();
+    } catch (Exception e) {
+      initFailure.addSuppressed(e);
+    }
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -155,9 +155,10 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
   /**
    * Releases what the constructor already acquired, for the case where it cannot hand back an instance.
    * This mirrors {@link #close()} but must not call it, because subclasses override close() and it would
-   * then run against a half-built object.
+   * then run against a half-built object. Subclasses call this from their own constructor once they have
+   * released whatever they added on top.
    */
-  private void releaseAfterFailedInit(Throwable initFailure) {
+  protected final void releaseAfterFailedInit(Throwable initFailure) {
     try {
       stopEmbeddedServerView(true);
     } catch (Exception e) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1661,12 +1661,35 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
 
   @Override
   public void close() {
-    // Stop timeline-server if running
-    super.close();
-    // Calling this here releases any resources used by your index, so make sure to finish any related operations
-    // before this point
-    this.index.close();
-    this.tableServiceClient.close();
+    // The index and the table service client are this class's own resources; a failure while the
+    // base client releases its own must not leave them open.
+    Exception failure = null;
+    try {
+      // Stop timeline-server if running
+      super.close();
+    } catch (Exception e) {
+      failure = e;
+    }
+    try {
+      // Calling this here releases any resources used by your index, so make sure to finish any related operations
+      // before this point
+      this.index.close();
+    } catch (Exception e) {
+      failure = failure == null ? e : addSuppressed(failure, e);
+    }
+    try {
+      this.tableServiceClient.close();
+    } catch (Exception e) {
+      failure = failure == null ? e : addSuppressed(failure, e);
+    }
+    if (failure != null) {
+      throw failure instanceof RuntimeException ? (RuntimeException) failure : new HoodieException(failure);
+    }
+  }
+
+  private static Exception addSuppressed(Exception previousFailure, Exception failure) {
+    previousFailure.addSuppressed(failure);
+    return previousFailure;
   }
 
   public void setWriteTimer(String commitType) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -182,10 +182,17 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
                                Option<EmbeddedTimelineService> timelineService,
                                SupportsUpgradeDowngrade upgradeDowngradeHelper) {
     super(context, writeConfig, timelineService);
-    this.index = createIndex(writeConfig);
-    this.upgradeDowngradeHelper = upgradeDowngradeHelper;
-    this.metrics.emitVersionMetrics();
-    this.metrics.emitIndexTypeMetrics(config.getIndexType().ordinal());
+    HoodieIndex<?, ?> createdIndex = null;
+    try {
+      createdIndex = createIndex(writeConfig);
+      this.index = createdIndex;
+      this.upgradeDowngradeHelper = upgradeDowngradeHelper;
+      this.metrics.emitVersionMetrics();
+      this.metrics.emitIndexTypeMetrics(config.getIndexType().ordinal());
+    } catch (RuntimeException | Error e) {
+      releaseAfterFailedInit(createdIndex, e);
+      throw e;
+    }
   }
 
   @VisibleForTesting
@@ -196,9 +203,32 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
                         TransactionManager transactionManager,
                         TimeGenerator timeGenerator) {
     super(context, writeConfig, timelineService, transactionManager, timeGenerator);
-    this.index = createIndex(writeConfig);
-    this.upgradeDowngradeHelper = upgradeDowngradeHelper;
-    this.metrics.emitIndexTypeMetrics(config.getIndexType().ordinal());
+    HoodieIndex<?, ?> createdIndex = null;
+    try {
+      createdIndex = createIndex(writeConfig);
+      this.index = createdIndex;
+      this.upgradeDowngradeHelper = upgradeDowngradeHelper;
+      this.metrics.emitIndexTypeMetrics(config.getIndexType().ordinal());
+    } catch (RuntimeException | Error e) {
+      releaseAfterFailedInit(createdIndex, e);
+      throw e;
+    }
+  }
+
+  /**
+   * The base constructor has already returned, so its resources are live but close() is still
+   * unreachable. Release the index this class had got as far as creating, then let the base release
+   * its own.
+   */
+  private void releaseAfterFailedInit(HoodieIndex<?, ?> createdIndex, Throwable initFailure) {
+    if (createdIndex != null) {
+      try {
+        createdIndex.close();
+      } catch (Exception e) {
+        initFailure.addSuppressed(e);
+      }
+    }
+    releaseAfterFailedInit(initFailure);
   }
 
   protected abstract HoodieIndex<?, ?> createIndex(HoodieWriteConfig writeConfig);
@@ -1675,19 +1705,22 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       // before this point
       this.index.close();
     } catch (Exception e) {
-      failure = failure == null ? e : addSuppressed(failure, e);
+      failure = appendFailure(failure, e);
     }
     try {
       this.tableServiceClient.close();
     } catch (Exception e) {
-      failure = failure == null ? e : addSuppressed(failure, e);
+      failure = appendFailure(failure, e);
     }
     if (failure != null) {
       throw failure instanceof RuntimeException ? (RuntimeException) failure : new HoodieException(failure);
     }
   }
 
-  private static Exception addSuppressed(Exception previousFailure, Exception failure) {
+  private static Exception appendFailure(Exception previousFailure, Exception failure) {
+    if (previousFailure == null) {
+      return failure;
+    }
     previousFailure.addSuppressed(failure);
     return previousFailure;
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
@@ -656,6 +656,36 @@ class TestBaseHoodieWriteClient extends HoodieCommonTestHarness {
     verify(transactionManager).close();
   }
 
+  /**
+   * The base constructor returns before the subclass constructor body runs, so its resources are
+   * already live while close() is still unreachable. Whatever the subclass does next has to release
+   * them if it throws.
+   */
+  @Test
+  void testResourcesAreReleasedWhenSubclassConstructionFails() throws IOException {
+    initMetaClient();
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withEmbeddedTimelineServerEnabled(false)
+        .build();
+
+    TransactionManager transactionManager = mock(TransactionManager.class);
+    TimeGenerator timeGenerator = mock(TimeGenerator.class);
+    RuntimeException indexFailure = new RuntimeException("index cannot be created");
+
+    RuntimeException thrown = assertThrows(RuntimeException.class,
+        () -> new TestWriteClient(writeConfig, mock(HoodieTable.class), Option.empty(),
+            mock(BaseHoodieTableServiceClient.class), transactionManager, timeGenerator) {
+              @Override
+              protected HoodieIndex<?, ?> createIndex(HoodieWriteConfig config) {
+                throw indexFailure;
+              }
+            });
+    assertSame(indexFailure, thrown);
+
+    verify(transactionManager).close();
+  }
+
   public static class ThrowingClientInitCallback implements HoodieClientInitCallback {
     @Override
     public void call(BaseHoodieClient hoodieClient) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
@@ -18,9 +18,11 @@
 
 package org.apache.hudi.client;
 
+import org.apache.hudi.callback.HoodieClientInitCallback;
 import org.apache.hudi.callback.common.WriteStatusValidator;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.transaction.TransactionManager;
+import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -86,6 +88,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -604,6 +607,62 @@ class TestBaseHoodieWriteClient extends HoodieCommonTestHarness {
     verify(transactionManager).close();
   }
 
+  /**
+   * A failure part way through the base close() chain must not stop the transaction manager, which
+   * holds the write lock, from being released.
+   */
+  @Test
+  void testCloseReleasesTransactionManagerWhenAnEarlierBaseStepFails() throws IOException {
+    initMetaClient();
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withEmbeddedTimelineServerEnabled(false)
+        .build();
+
+    HoodieLocalEngineContext context = spy(new HoodieLocalEngineContext(getDefaultStorageConf()));
+    RuntimeException jobStatusFailure = new RuntimeException("job status is wedged");
+    doThrow(jobStatusFailure).when(context).setJobStatus("", "");
+
+    TransactionManager transactionManager = mock(TransactionManager.class);
+    TimeGenerator timeGenerator = mock(TimeGenerator.class);
+    TestWriteClient writeClient = new TestWriteClient(context, writeConfig, mock(HoodieTable.class), Option.empty(),
+        mock(BaseHoodieTableServiceClient.class), transactionManager, timeGenerator);
+
+    RuntimeException thrown = assertThrows(RuntimeException.class, writeClient::close);
+    assertSame(jobStatusFailure, thrown);
+
+    verify(transactionManager).close();
+  }
+
+  /**
+   * When a client init callback throws, the constructor never returns, so no caller can reach close().
+   * Whatever the constructor already started has to be released before the exception leaves it.
+   */
+  @Test
+  void testResourcesAreReleasedWhenClientInitCallbackFails() throws IOException {
+    initMetaClient();
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withEmbeddedTimelineServerEnabled(false)
+        .withClientInitCallbackClassNames(ThrowingClientInitCallback.class.getName())
+        .build();
+
+    TransactionManager transactionManager = mock(TransactionManager.class);
+    TimeGenerator timeGenerator = mock(TimeGenerator.class);
+
+    assertThrows(HoodieException.class, () -> new TestWriteClient(writeConfig, mock(HoodieTable.class), Option.empty(),
+        mock(BaseHoodieTableServiceClient.class), transactionManager, timeGenerator));
+
+    verify(transactionManager).close();
+  }
+
+  public static class ThrowingClientInitCallback implements HoodieClientInitCallback {
+    @Override
+    public void call(BaseHoodieClient hoodieClient) {
+      throw new HoodieException("init callback failed");
+    }
+  }
+
   private static class TestWriteClient extends BaseHoodieWriteClient<String, String, String, String> {
     private final HoodieTable<String, String, String, String> table;
 
@@ -617,6 +676,14 @@ class TestBaseHoodieWriteClient extends HoodieCommonTestHarness {
     public TestWriteClient(HoodieWriteConfig writeConfig, HoodieTable<String, String, String, String> table, Option<EmbeddedTimelineService> timelineService,
                            BaseHoodieTableServiceClient<String, String, String> tableServiceClient, TransactionManager transactionManager, TimeGenerator timeGenerator) {
       super(new HoodieLocalEngineContext(getDefaultStorageConf()), writeConfig, timelineService, null, transactionManager, timeGenerator);
+      this.table = table;
+      this.tableServiceClient = tableServiceClient;
+    }
+
+    public TestWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig, HoodieTable<String, String, String, String> table,
+                           Option<EmbeddedTimelineService> timelineService, BaseHoodieTableServiceClient<String, String, String> tableServiceClient,
+                           TransactionManager transactionManager, TimeGenerator timeGenerator) {
+      super(context, writeConfig, timelineService, null, transactionManager, timeGenerator);
       this.table = table;
       this.tableServiceClient = tableServiceClient;
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieWriteClient.java
@@ -80,9 +80,11 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorage
 import static org.apache.hudi.testutils.Assertions.assertComplexKeyGeneratorValidationThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -560,6 +562,46 @@ class TestBaseHoodieWriteClient extends HoodieCommonTestHarness {
     inOrder.verify(transactionManager).beginStateChange(Option.empty(), Option.empty());
     inOrder.verify(timeGenerator).generateTime(true);
     inOrder.verify(transactionManager).endStateChange(Option.of(expectedInstant));
+  }
+
+
+  /**
+   * close() releases several independent resources in sequence. An index that fails to close must
+   * not stop the table service client behind it from being released.
+   */
+  @Test
+  void testCloseReleasesLaterResourcesWhenAnEarlierCloseFails() throws IOException {
+    initMetaClient();
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
+            .withStorageType(FileSystemViewStorageType.MEMORY)
+            .build())
+        .build();
+
+    HoodieIndex<?, ?> failingIndex = mock(HoodieIndex.class);
+    RuntimeException indexFailure = new RuntimeException("index is wedged");
+    doThrow(indexFailure).when(failingIndex).close();
+
+    TransactionManager transactionManager = mock(TransactionManager.class);
+    TimeGenerator timeGenerator = mock(TimeGenerator.class);
+    HoodieTable<String, String, String, String> table = mock(HoodieTable.class);
+    BaseHoodieTableServiceClient<String, String, String> tableServiceClient = mock(BaseHoodieTableServiceClient.class);
+
+    TestWriteClient writeClient =
+        new TestWriteClient(writeConfig, table, Option.empty(), tableServiceClient, transactionManager, timeGenerator) {
+          @Override
+          protected HoodieIndex<?, ?> createIndex(HoodieWriteConfig config) {
+            return failingIndex;
+          }
+        };
+
+    RuntimeException thrown = assertThrows(RuntimeException.class, writeClient::close);
+    assertSame(indexFailure, thrown);
+
+    // the resource behind the failing index is released anyway
+    verify(tableServiceClient).close();
+    verify(transactionManager).close();
   }
 
   private static class TestWriteClient extends BaseHoodieWriteClient<String, String, String, String> {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -80,9 +80,22 @@ public class SparkRDDWriteClient<T> extends
   public SparkRDDWriteClient(HoodieEngineContext context, HoodieWriteConfig writeConfig,
                              Option<EmbeddedTimelineService> timelineService) {
     super(context, writeConfig, timelineService, SparkUpgradeDowngradeHelper.getInstance());
-    DistributedRegistryUtil.createWrapperFileSystemRegistries(context, writeConfig);
-    this.tableServiceClient = new SparkRDDTableServiceClient<T>(context, writeConfig, getTimelineServer());
-    checkSpeculativeExecution();
+    try {
+      DistributedRegistryUtil.createWrapperFileSystemRegistries(context, writeConfig);
+      this.tableServiceClient = new SparkRDDTableServiceClient<T>(context, writeConfig, getTimelineServer());
+      // The speculative-execution guardrail throws from here, after the base client is fully built.
+      checkSpeculativeExecution();
+    } catch (RuntimeException | Error e) {
+      if (this.tableServiceClient != null) {
+        try {
+          this.tableServiceClient.close();
+        } catch (Exception closeFailure) {
+          e.addSuppressed(closeFailure);
+        }
+      }
+      releaseAfterFailedInit(e);
+      throw e;
+    }
   }
 
   @Override


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`BaseHoodieClient` acquires several independent resources, and gives them all back in one method:

```java
public void close() {
  stopEmbeddedServerView(true);
  this.context.setJobStatus("", "");
  this.heartbeatClient.close();
  this.txnManager.close();
}
```

Two ways that fails to release them.

**A failure part way through skips the rest.** These four are unrelated — an embedded HTTP server, the engine's job status, a heartbeat thread, and the transaction manager, which holds the write lock. If `stopEmbeddedServerView` throws, the write lock is never released and the next writer on that table blocks against a lock whose owner is gone. `BaseHoodieWriteClient.close()` has the same shape one level up, where an index that fails to close skips the table service client behind it.

**A constructor that cannot return means `close()` is never reachable at all.** The constructor ends with:

```java
startEmbeddedServerView();
runClientInitCallbacks();
```

`runClientInitCallbacks` throws when `hoodie.client.init.callback.classes` names a class that is not a `HoodieClientInitCallback`, when that class cannot be loaded, or when a real callback's `call()` throws. The constructor does not return, so no caller ever holds an instance, so nothing can call `close()`. The embedded timeline server started on the line above stays bound to its port with its thread pool running, the heartbeat client keeps its thread, and the transaction manager keeps the write lock — for the life of the driver JVM. `EmbeddedTimelineService.shutdownAllTimelineServers()` has no production caller and there is no shutdown hook, so nothing reclaims it. Retrying the write in the same driver leaks another one.

Reachable from `DataSourceUtils.java:186`, where the user's raw options map flows straight into `createHoodieConfig`, so a bad callback class in the write options is enough.

### Summary and Changelog

- `close()` in both classes now attempts every release step and rethrows the first failure with the rest attached as suppressed, instead of stopping at the first one.
- The constructor wraps `startEmbeddedServerView()` and `runClientInitCallbacks()`, and on failure releases the timeline server, the heartbeat client and the transaction manager before rethrowing. It mirrors `close()` rather than calling it: subclasses override `close()` and it must not run against a half-built object.

### Tests

Three cases in `TestBaseHoodieWriteClient`, each failing on `master`:

- `testCloseReleasesLaterResourcesWhenAnEarlierCloseFails` — an index whose `close()` throws; the table service client and the transaction manager behind it are still released, and the original index failure is what propagates.
- `testCloseReleasesTransactionManagerWhenAnEarlierBaseStepFails` — a failure part way through the base chain itself; the transaction manager still closes.
- `testResourcesAreReleasedWhenClientInitCallbackFails` — a callback that throws from inside the constructor; `verify(transactionManager).close()`.

Reverting the two source files turns all three red, e.g. `Wanted but not invoked: transactionManager.close(); Actually, there were zero interactions with this mock.`

`mvn test -pl hudi-client/hudi-client-common -Dtest=TestBaseHoodieWriteClient#...` — 3 tests, passing; `checkstyle:check` clean. I ran the three cases on their own rather than the whole class, because the full `TestBaseHoodieWriteClient` run exhausts the heap on my machine — it does so on an unmodified `master` checkout as well, so it is not something this change introduces.

### Impact

No public API or config change. A client whose construction fails no longer leaves an HTTP server and a held write lock behind, and a close() that hits one bad resource no longer abandons the others.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable