### PR TITLE
feat(storage): support separate zstd level for native parquet logs

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
@@ -30,7 +30,6 @@ import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.core.io.HoodieParquetConfigInjector;
 import org.apache.hudi.core.io.storage.HoodieFileWriter;
 import org.apache.hudi.core.io.storage.HoodieFileWriterFactory;
 import org.apache.hudi.storage.HoodieStorage;
@@ -99,10 +98,8 @@ public class HoodieRowDataFileWriterFactory extends HoodieFileWriterFactory {
     boolean populateMetaFields = MetaFieldsMode.resolve(config).toLegacyPopulateMetaFields();
     boolean withOperation = config.getBooleanOrDefault(HoodieWriteConfig.ALLOW_OPERATION_METADATA_FIELD);
 
-    StorageConfiguration storageConf =
-        ParquetUtils.applyNativeLogZstdCompressionLevel(storagePath, storage.getConf(), config);
     Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
-        HoodieParquetConfigInjector.applyConfigInjector(storagePath, storageConf, config);
+        ParquetUtils.prepareParquetWriterConfigs(storagePath, storage.getConf(), config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
     HoodieConfig hoodieConfig = injectedConfigs.getRight();
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.MetaFieldsMode;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -98,7 +99,10 @@ public class HoodieRowDataFileWriterFactory extends HoodieFileWriterFactory {
     boolean populateMetaFields = MetaFieldsMode.resolve(config).toLegacyPopulateMetaFields();
     boolean withOperation = config.getBooleanOrDefault(HoodieWriteConfig.ALLOW_OPERATION_METADATA_FIELD);
 
-    Pair<StorageConfiguration, HoodieConfig> injectedConfigs = HoodieParquetConfigInjector.applyConfigInjector(storagePath, storage.getConf(), config);
+    StorageConfiguration storageConf =
+        ParquetUtils.applyNativeLogZstdCompressionLevel(storagePath, storage.getConf(), config);
+    Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
+        HoodieParquetConfigInjector.applyConfigInjector(storagePath, storageConf, config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
     HoodieConfig hoodieConfig = injectedConfigs.getRight();
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
@@ -99,7 +99,7 @@ public class HoodieRowDataFileWriterFactory extends HoodieFileWriterFactory {
     boolean withOperation = config.getBooleanOrDefault(HoodieWriteConfig.ALLOW_OPERATION_METADATA_FIELD);
 
     Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
-        ParquetUtils.prepareParquetWriterConfigs(storagePath, storage.getConf(), config);
+        ParquetUtils.injectParquetWriterConfigs(storagePath, storage.getConf(), config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
     HoodieConfig hoodieConfig = injectedConfigs.getRight();
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.MetaFieldsMode;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.core.io.HoodieParquetConfigInjector;
@@ -101,7 +102,10 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
       TaskContextSupplier taskContextSupplier) throws IOException {
     MetaFieldsMode metaFieldsMode = MetaFieldsMode.resolve(config);
 
-    Pair<StorageConfiguration, HoodieConfig> injectedConfigs = HoodieParquetConfigInjector.applyConfigInjector(path, storage.getConf(), config);
+    StorageConfiguration storageConf =
+        ParquetUtils.applyNativeLogZstdCompressionLevel(path, storage.getConf(), config);
+    Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
+        HoodieParquetConfigInjector.applyConfigInjector(path, storageConf, config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
     HoodieConfig hoodieConfig = injectedConfigs.getRight();
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
@@ -31,7 +31,6 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
-import org.apache.hudi.core.io.HoodieParquetConfigInjector;
 import org.apache.hudi.core.io.storage.HoodieFileWriter;
 import org.apache.hudi.core.io.storage.HoodieFileWriterFactory;
 import org.apache.hudi.core.io.storage.VariantShreddingInferenceFileWriter;
@@ -102,10 +101,8 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
       TaskContextSupplier taskContextSupplier) throws IOException {
     MetaFieldsMode metaFieldsMode = MetaFieldsMode.resolve(config);
 
-    StorageConfiguration storageConf =
-        ParquetUtils.applyNativeLogZstdCompressionLevel(path, storage.getConf(), config);
     Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
-        HoodieParquetConfigInjector.applyConfigInjector(path, storageConf, config);
+        ParquetUtils.prepareParquetWriterConfigs(path, storage.getConf(), config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
     HoodieConfig hoodieConfig = injectedConfigs.getRight();
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
@@ -102,7 +102,7 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
     MetaFieldsMode metaFieldsMode = MetaFieldsMode.resolve(config);
 
     Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
-        ParquetUtils.prepareParquetWriterConfigs(path, storage.getConf(), config);
+        ParquetUtils.injectParquetWriterConfigs(path, storage.getConf(), config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
     HoodieConfig hoodieConfig = injectedConfigs.getRight();
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -218,9 +218,9 @@ public class HoodieStorageConfig extends HoodieConfig {
       .defaultValue("gzip")
       .withDocumentation("Compression Codec for parquet files");
 
-  public static final ConfigProperty<String> LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL = ConfigProperty
+  public static final ConfigProperty<Integer> LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL = ConfigProperty
       .key("hoodie.logfile.parquet.compression.codec.zstd.level")
-      .defaultValue("1")
+      .defaultValue(1)
       .markAdvanced()
       .sinceVersion("1.3.0")
       .withDocumentation("Zstandard compression level for native Parquet log files. This setting overrides "

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -218,6 +218,14 @@ public class HoodieStorageConfig extends HoodieConfig {
       .defaultValue("gzip")
       .withDocumentation("Compression Codec for parquet files");
 
+  public static final ConfigProperty<String> LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL = ConfigProperty
+      .key("hoodie.logfile.parquet.compression.codec.zstd.level")
+      .defaultValue("1")
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("Zstandard compression level for native Parquet log files. This setting overrides "
+          + "parquet.compression.codec.zstd.level from the storage configuration for native log files.");
+
   public static final ConfigProperty<Boolean> PARQUET_DICTIONARY_ENABLED = ConfigProperty
       .key("hoodie.parquet.dictionary.enabled")
       .defaultValue(true)
@@ -629,6 +637,11 @@ public class HoodieStorageConfig extends HoodieConfig {
 
     public Builder parquetCompressionCodec(String parquetCompressionCodec) {
       storageConfig.setValue(PARQUET_COMPRESSION_CODEC_NAME, parquetCompressionCodec);
+      return this;
+    }
+
+    public Builder logFileParquetCompressionCodecZstdLevel(int zstdLevel) {
+      storageConfig.setValue(LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, String.valueOf(zstdLevel));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/core/io/HoodieParquetConfigInjector.java
+++ b/hudi-common/src/main/java/org/apache/hudi/core/io/HoodieParquetConfigInjector.java
@@ -28,12 +28,13 @@ import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
 
 /**
- * A pluggable interface that all parquet-based writers (Spark/Flink) will invoke before creating write support
- * or parquet file writer objects.
+ * An interface for built-in and user-defined Parquet configuration injectors that all parquet-based writers
+ * (Spark/Flink) invoke before creating write support or parquet file writer objects.
  * <p>
- * This allows users to inject custom configurations into the Parquet writer pipeline at runtime, enabling
- * fine-grained control over Parquet file properties such as bloom filters, compression settings, encoding
- * options, and other advanced Parquet configurations.
+ * Built-in injectors provide Hudi's default writer configuration, while users can inject custom configurations
+ * at runtime for fine-grained control over properties such as bloom filters, compression settings, encoding
+ * options, and other advanced Parquet configurations. Built-in injectors are applied before the user-defined
+ * injector so that custom configuration has the highest priority.
  * <p>
  * <strong>Important:</strong> Implementations must NOT mutate the input {@code storageConf} or
  * {@code hoodieConfig} objects directly. Instead, they should create copies, apply the desired
@@ -54,7 +55,7 @@ import org.apache.hudi.storage.StoragePath;
 public interface HoodieParquetConfigInjector {
 
   /**
-   * Injects custom configurations into the Parquet writer pipeline.
+   * Injects configurations into the Parquet writer pipeline.
    * <p>
    * This method is invoked before creating the Parquet write support and writer objects, allowing
    * implementations to modify both the storage-level and Hudi-level configurations.

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -31,8 +31,10 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.core.io.HoodieParquetConfigInjector;
 import org.apache.hudi.core.io.storage.HoodieFileWriter;
 import org.apache.hudi.core.io.storage.HoodieFileWriterFactory;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.MetadataNotFoundException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
@@ -90,6 +92,7 @@ import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToStoragePath;
 import static org.apache.parquet.avro.HoodieAvroParquetSchemaConverter.getAvroSchemaConverter;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_ROW_GROUPS;
+import static org.apache.parquet.hadoop.codec.ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL;
 
 /**
  * Utility functions involving with parquet.
@@ -97,7 +100,16 @@ import static org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_
 @Slf4j
 public class ParquetUtils extends FileFormatUtils {
 
-  private static final String PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL = "parquet.compression.codec.zstd.level";
+  /**
+   * Prepares the storage and Hudi configurations used by a Parquet writer. Built-in writer configuration
+   * overrides are applied first so that the user-provided config injector remains the highest-priority extension point.
+   */
+  public static Pair<StorageConfiguration, HoodieConfig> prepareParquetWriterConfigs(
+      StoragePath path, StorageConfiguration storageConf, HoodieConfig hoodieConfig) {
+    StorageConfiguration nativeLogStorageConf =
+        applyNativeLogZstdCompressionLevel(path, storageConf, hoodieConfig);
+    return HoodieParquetConfigInjector.applyConfigInjector(path, nativeLogStorageConf, hoodieConfig);
+  }
 
   /**
    * Returns a storage configuration with the native Parquet log ZSTD compression level applied.
@@ -112,14 +124,23 @@ public class ParquetUtils extends FileFormatUtils {
 
     int nativeLogZstdLevel =
         hoodieConfig.getIntOrDefault(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL);
-    Option<String> globalZstdLevel = storageConf.getString(PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL);
-    if (globalZstdLevel.isPresent() && nativeLogZstdLevel == Integer.parseInt(globalZstdLevel.get())) {
-      return storageConf;
+    Option<String> globalZstdLevel = storageConf.getString(PARQUET_COMPRESS_ZSTD_LEVEL);
+    if (globalZstdLevel.isPresent()) {
+      int parsedGlobalZstdLevel;
+      try {
+        parsedGlobalZstdLevel = Integer.parseInt(globalZstdLevel.get());
+      } catch (NumberFormatException e) {
+        throw new HoodieException("Invalid value for " + PARQUET_COMPRESS_ZSTD_LEVEL + ": "
+            + globalZstdLevel.get() + ". Expected an integer.", e);
+      }
+      if (nativeLogZstdLevel == parsedGlobalZstdLevel) {
+        return storageConf;
+      }
     }
 
     StorageConfiguration<T> nativeLogStorageConf = storageConf.newInstance();
     nativeLogStorageConf.set(
-        PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, String.valueOf(nativeLogZstdLevel));
+        PARQUET_COMPRESS_ZSTD_LEVEL, String.valueOf(nativeLogZstdLevel));
     return nativeLogStorageConf;
   }
 

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -21,8 +21,6 @@ package org.apache.hudi.common.util;
 
 import org.apache.hudi.avro.HoodieAvroWriteSupport;
 import org.apache.hudi.common.config.HoodieConfig;
-import org.apache.hudi.common.config.HoodieStorageConfig;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -32,9 +30,9 @@ import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.core.io.HoodieParquetConfigInjector;
+import org.apache.hudi.core.io.ParquetZstdCompressionLevelInjector;
 import org.apache.hudi.core.io.storage.HoodieFileWriter;
 import org.apache.hudi.core.io.storage.HoodieFileWriterFactory;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.MetadataNotFoundException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
@@ -92,7 +90,6 @@ import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToStoragePath;
 import static org.apache.parquet.avro.HoodieAvroParquetSchemaConverter.getAvroSchemaConverter;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_ROW_GROUPS;
-import static org.apache.parquet.hadoop.codec.ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL;
 
 /**
  * Utility functions involving with parquet.
@@ -101,47 +98,14 @@ import static org.apache.parquet.hadoop.codec.ZstandardCodec.PARQUET_COMPRESS_ZS
 public class ParquetUtils extends FileFormatUtils {
 
   /**
-   * Injects the storage and Hudi configurations used by a Parquet writer. Built-in writer configuration
-   * overrides are injected first so that the user-provided config injector remains the highest-priority extension point.
+   * Applies built-in injectors followed by the user-defined injector to the configurations used by a Parquet writer.
    */
   public static Pair<StorageConfiguration, HoodieConfig> injectParquetWriterConfigs(
       StoragePath path, StorageConfiguration storageConf, HoodieConfig hoodieConfig) {
-    StorageConfiguration nativeLogStorageConf =
-        injectDefaultZstdCompressionLevel(path, storageConf, hoodieConfig);
-    return HoodieParquetConfigInjector.applyConfigInjector(path, nativeLogStorageConf, hoodieConfig);
-  }
-
-  /**
-   * Injects the default ZSTD compression level into the storage configuration for native Parquet log files.
-   * The input configuration is copied only when its ZSTD level is absent or differs from the native log level,
-   * so base file writers and other users of the shared configuration are not affected.
-   */
-  public static <T> StorageConfiguration<T> injectDefaultZstdCompressionLevel(
-      StoragePath path, StorageConfiguration<T> storageConf, HoodieConfig hoodieConfig) {
-    if (!FSUtils.isNativeLogFile(path.getName())) {
-      return storageConf;
-    }
-
-    int nativeLogZstdLevel =
-        hoodieConfig.getIntOrDefault(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL);
-    Option<String> globalZstdLevel = storageConf.getString(PARQUET_COMPRESS_ZSTD_LEVEL);
-    if (globalZstdLevel.isPresent()) {
-      int parsedGlobalZstdLevel;
-      try {
-        parsedGlobalZstdLevel = Integer.parseInt(globalZstdLevel.get());
-      } catch (NumberFormatException e) {
-        throw new HoodieException("Invalid value for " + PARQUET_COMPRESS_ZSTD_LEVEL + ": "
-            + globalZstdLevel.get() + ". Expected an integer.", e);
-      }
-      if (nativeLogZstdLevel == parsedGlobalZstdLevel) {
-        return storageConf;
-      }
-    }
-
-    StorageConfiguration<T> nativeLogStorageConf = storageConf.newInstance();
-    nativeLogStorageConf.set(
-        PARQUET_COMPRESS_ZSTD_LEVEL, String.valueOf(nativeLogZstdLevel));
-    return nativeLogStorageConf;
+    Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
+        ParquetZstdCompressionLevelInjector.INSTANCE.injectConfig(path, storageConf, hoodieConfig);
+    return HoodieParquetConfigInjector.applyConfigInjector(
+        path, injectedConfigs.getLeft(), injectedConfigs.getRight());
   }
 
   /**

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -21,6 +21,8 @@ package org.apache.hudi.common.util;
 
 import org.apache.hudi.avro.HoodieAvroWriteSupport;
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -39,6 +41,7 @@ import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.metadata.stats.ValueMetadata;
 import org.apache.hudi.metadata.stats.ValueType;
 import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
 
 import lombok.extern.slf4j.Slf4j;
@@ -93,6 +96,32 @@ import static org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_
  */
 @Slf4j
 public class ParquetUtils extends FileFormatUtils {
+
+  private static final String PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL = "parquet.compression.codec.zstd.level";
+
+  /**
+   * Returns a storage configuration with the native Parquet log ZSTD compression level applied.
+   * The input configuration is copied only when its ZSTD level is absent or differs from the native log level,
+   * so base file writers and other users of the shared configuration are not affected.
+   */
+  public static <T> StorageConfiguration<T> applyNativeLogZstdCompressionLevel(
+      StoragePath path, StorageConfiguration<T> storageConf, HoodieConfig hoodieConfig) {
+    if (!FSUtils.isNativeLogFile(path.getName())) {
+      return storageConf;
+    }
+
+    int nativeLogZstdLevel =
+        hoodieConfig.getIntOrDefault(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL);
+    Option<String> globalZstdLevel = storageConf.getString(PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL);
+    if (globalZstdLevel.isPresent() && nativeLogZstdLevel == Integer.parseInt(globalZstdLevel.get())) {
+      return storageConf;
+    }
+
+    StorageConfiguration<T> nativeLogStorageConf = storageConf.newInstance();
+    nativeLogStorageConf.set(
+        PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, String.valueOf(nativeLogZstdLevel));
+    return nativeLogStorageConf;
+  }
 
   /**
    * Read the rowKey list matching the given filter, from the given parquet file. If the filter is empty, then this will

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -101,22 +101,22 @@ import static org.apache.parquet.hadoop.codec.ZstandardCodec.PARQUET_COMPRESS_ZS
 public class ParquetUtils extends FileFormatUtils {
 
   /**
-   * Prepares the storage and Hudi configurations used by a Parquet writer. Built-in writer configuration
-   * overrides are applied first so that the user-provided config injector remains the highest-priority extension point.
+   * Injects the storage and Hudi configurations used by a Parquet writer. Built-in writer configuration
+   * overrides are injected first so that the user-provided config injector remains the highest-priority extension point.
    */
-  public static Pair<StorageConfiguration, HoodieConfig> prepareParquetWriterConfigs(
+  public static Pair<StorageConfiguration, HoodieConfig> injectParquetWriterConfigs(
       StoragePath path, StorageConfiguration storageConf, HoodieConfig hoodieConfig) {
     StorageConfiguration nativeLogStorageConf =
-        applyNativeLogZstdCompressionLevel(path, storageConf, hoodieConfig);
+        injectDefaultZstdCompressionLevel(path, storageConf, hoodieConfig);
     return HoodieParquetConfigInjector.applyConfigInjector(path, nativeLogStorageConf, hoodieConfig);
   }
 
   /**
-   * Returns a storage configuration with the native Parquet log ZSTD compression level applied.
+   * Injects the default ZSTD compression level into the storage configuration for native Parquet log files.
    * The input configuration is copied only when its ZSTD level is absent or differs from the native log level,
    * so base file writers and other users of the shared configuration are not affected.
    */
-  public static <T> StorageConfiguration<T> applyNativeLogZstdCompressionLevel(
+  public static <T> StorageConfiguration<T> injectDefaultZstdCompressionLevel(
       StoragePath path, StorageConfiguration<T> storageConf, HoodieConfig hoodieConfig) {
     if (!FSUtils.isNativeLogFile(path.getName())) {
       return storageConf;

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/core/io/ParquetZstdCompressionLevelInjector.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/core/io/ParquetZstdCompressionLevelInjector.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.core.io;
+
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.storage.StoragePath;
+
+import static org.apache.parquet.hadoop.codec.ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL;
+
+/**
+ * Built-in injector that configures the ZSTD compression level for native Parquet log files.
+ */
+public class ParquetZstdCompressionLevelInjector implements HoodieParquetConfigInjector {
+
+  public static ParquetZstdCompressionLevelInjector INSTANCE = new ParquetZstdCompressionLevelInjector();
+
+  @Override
+  public Pair<StorageConfiguration, HoodieConfig> injectConfig(
+      StoragePath path, StorageConfiguration storageConf, HoodieConfig hoodieConfig) {
+    // Keep the global Parquet writer configuration unchanged for base files and non-native log files.
+    if (!FSUtils.isNativeLogFile(path.getName())) {
+      return Pair.of(storageConf, hoodieConfig);
+    }
+
+    int nativeLogZstdLevel =
+        hoodieConfig.getIntOrDefault(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL);
+    Option<String> globalZstdLevel = storageConf.getString(PARQUET_COMPRESS_ZSTD_LEVEL);
+    if (globalZstdLevel.isPresent()) {
+      // Parse an explicitly configured global level before overriding it so that malformed user
+      // configuration is not silently hidden by the native-log-specific value.
+      int parsedGlobalZstdLevel;
+      try {
+        parsedGlobalZstdLevel = Integer.parseInt(globalZstdLevel.get());
+      } catch (NumberFormatException e) {
+        throw new HoodieException("Invalid value for " + PARQUET_COMPRESS_ZSTD_LEVEL + ": "
+            + globalZstdLevel.get() + ". Expected an integer.", e);
+      }
+      // Reuse the original configuration when the desired level is already effective.
+      if (nativeLogZstdLevel == parsedGlobalZstdLevel) {
+        return Pair.of(storageConf, hoodieConfig);
+      }
+    }
+
+    // Isolate the native log override from other Parquet writers sharing the storage configuration.
+    StorageConfiguration nativeLogStorageConf = storageConf.newInstance();
+    nativeLogStorageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, String.valueOf(nativeLogZstdLevel));
+    return Pair.of(nativeLogStorageConf, hoodieConfig);
+  }
+}

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileWriterFactory.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileWriterFactory.java
@@ -34,6 +34,7 @@ import org.apache.hudi.common.model.MetaFieldsMode;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -111,7 +112,10 @@ public class HoodieAvroFileWriterFactory extends HoodieFileWriterFactory {
       TaskContextSupplier taskContextSupplier) throws IOException {
     MetaFieldsMode metaFieldsMode = MetaFieldsMode.resolve(config);
 
-    Pair<StorageConfiguration, HoodieConfig> injectedConfigs = HoodieParquetConfigInjector.applyConfigInjector(path, storage.getConf(), config);
+    StorageConfiguration storageConf =
+        ParquetUtils.applyNativeLogZstdCompressionLevel(path, storage.getConf(), config);
+    Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
+        HoodieParquetConfigInjector.applyConfigInjector(path, storageConf, config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
     HoodieConfig hoodieConfig = injectedConfigs.getRight();
 

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileWriterFactory.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileWriterFactory.java
@@ -38,7 +38,6 @@ import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
-import org.apache.hudi.core.io.HoodieParquetConfigInjector;
 import org.apache.hudi.core.io.storage.HoodieAvroHFileReaderImplBase;
 import org.apache.hudi.core.io.storage.HoodieFileWriter;
 import org.apache.hudi.core.io.storage.HoodieFileWriterFactory;
@@ -112,10 +111,8 @@ public class HoodieAvroFileWriterFactory extends HoodieFileWriterFactory {
       TaskContextSupplier taskContextSupplier) throws IOException {
     MetaFieldsMode metaFieldsMode = MetaFieldsMode.resolve(config);
 
-    StorageConfiguration storageConf =
-        ParquetUtils.applyNativeLogZstdCompressionLevel(path, storage.getConf(), config);
     Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
-        HoodieParquetConfigInjector.applyConfigInjector(path, storageConf, config);
+        ParquetUtils.prepareParquetWriterConfigs(path, storage.getConf(), config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
     HoodieConfig hoodieConfig = injectedConfigs.getRight();
 

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileWriterFactory.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileWriterFactory.java
@@ -112,7 +112,7 @@ public class HoodieAvroFileWriterFactory extends HoodieFileWriterFactory {
     MetaFieldsMode metaFieldsMode = MetaFieldsMode.resolve(config);
 
     Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
-        ParquetUtils.prepareParquetWriterConfigs(path, storage.getConf(), config);
+        ParquetUtils.injectParquetWriterConfigs(path, storage.getConf(), config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
     HoodieConfig hoodieConfig = injectedConfigs.getRight();
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -102,12 +102,12 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testApplyNativeLogZstdCompressionLevel() {
+  void testInjectDefaultZstdCompressionLevel() {
     HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
     storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "7");
 
     StorageConfiguration<Configuration> nativeLogStorageConf =
-        ParquetUtils.applyNativeLogZstdCompressionLevel(
+        ParquetUtils.injectDefaultZstdCompressionLevel(
             new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, new HoodieConfig());
 
     assertNotSame(storageConf, nativeLogStorageConf);
@@ -115,20 +115,20 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
     assertEquals(1, nativeLogStorageConf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
 
     StorageConfiguration<Configuration> baseFileStorageConf =
-        ParquetUtils.applyNativeLogZstdCompressionLevel(
+        ParquetUtils.injectDefaultZstdCompressionLevel(
             new StoragePath("/tmp/file-id_001.parquet"), storageConf, new HoodieConfig());
     assertSame(storageConf, baseFileStorageConf);
 
     HoodieConfig configuredZstdLevel = new HoodieConfig();
     configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "3");
     StorageConfiguration<Configuration> configuredNativeLogStorageConf =
-        ParquetUtils.applyNativeLogZstdCompressionLevel(
+        ParquetUtils.injectDefaultZstdCompressionLevel(
             new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, configuredZstdLevel);
     assertEquals(3, configuredNativeLogStorageConf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
 
     configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "7");
     StorageConfiguration<Configuration> sameLevelNativeLogStorageConf =
-        ParquetUtils.applyNativeLogZstdCompressionLevel(
+        ParquetUtils.injectDefaultZstdCompressionLevel(
             new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, configuredZstdLevel);
     assertSame(storageConf, sameLevelNativeLogStorageConf);
 
@@ -136,7 +136,7 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
         new HadoopStorageConfiguration(new Configuration(false));
     configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "3");
     StorageConfiguration<Configuration> storageConfWithExplicitNativeLevel =
-        ParquetUtils.applyNativeLogZstdCompressionLevel(
+        ParquetUtils.injectDefaultZstdCompressionLevel(
             new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"),
             storageConfWithoutGlobalLevel, configuredZstdLevel);
     assertNotSame(storageConfWithoutGlobalLevel, storageConfWithExplicitNativeLevel);
@@ -145,20 +145,20 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
   }
 
   @Test
-  void testApplyNativeLogZstdCompressionLevelFailsForInvalidGlobalLevel() {
+  void testInjectDefaultZstdCompressionLevelFailsForInvalidGlobalLevel() {
     HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
     storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "invalid");
 
     HoodieException exception = assertThrows(
         HoodieException.class,
-        () -> ParquetUtils.applyNativeLogZstdCompressionLevel(
+        () -> ParquetUtils.injectDefaultZstdCompressionLevel(
             new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"),
             storageConf, new HoodieConfig()));
     assertTrue(exception.getMessage().contains(PARQUET_COMPRESS_ZSTD_LEVEL));
   }
 
   @Test
-  void testPrepareParquetWriterConfigsAppliesCustomInjectorLast() {
+  void testInjectParquetWriterConfigsAppliesCustomInjectorLast() {
     HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
     storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "7");
     HoodieConfig hoodieConfig = new HoodieConfig();
@@ -166,11 +166,11 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
         HoodieStorageConfig.HOODIE_PARQUET_CONFIG_INJECTOR_CLASS,
         OverrideNativeLogZstdLevelInjector.class.getName());
 
-    Pair<StorageConfiguration, HoodieConfig> preparedConfigs =
-        ParquetUtils.prepareParquetWriterConfigs(
+    Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
+        ParquetUtils.injectParquetWriterConfigs(
             new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, hoodieConfig);
 
-    assertEquals(9, preparedConfigs.getLeft().getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+    assertEquals(9, injectedConfigs.getLeft().getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
   }
 
   public static class OverrideNativeLogZstdLevelInjector implements HoodieParquetConfigInjector {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -22,6 +22,8 @@ import org.apache.hudi.avro.HoodieAvroWriteSupport;
 import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.bloom.BloomFilterFactory;
 import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -35,10 +37,13 @@ import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
+import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.avro.AvroSchemaConverter;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -68,6 +73,8 @@ import static org.apache.hudi.common.schema.HoodieSchemaUtils.METADATA_FIELD_SCH
 import static org.apache.hudi.metadata.HoodieIndexVersion.V1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -88,6 +95,49 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
   public void setup() {
     initPath();
     parquetUtils = new ParquetUtils();
+  }
+
+  @Test
+  void testApplyNativeLogZstdCompressionLevel() {
+    String parquetZstdLevel = "parquet.compression.codec.zstd.level";
+    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
+    storageConf.set(parquetZstdLevel, "7");
+
+    StorageConfiguration<Configuration> nativeLogStorageConf =
+        ParquetUtils.applyNativeLogZstdCompressionLevel(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, new HoodieConfig());
+
+    assertNotSame(storageConf, nativeLogStorageConf);
+    assertEquals(7, storageConf.getInt(parquetZstdLevel, -1));
+    assertEquals(1, nativeLogStorageConf.getInt(parquetZstdLevel, -1));
+
+    StorageConfiguration<Configuration> baseFileStorageConf =
+        ParquetUtils.applyNativeLogZstdCompressionLevel(
+            new StoragePath("/tmp/file-id_001.parquet"), storageConf, new HoodieConfig());
+    assertSame(storageConf, baseFileStorageConf);
+
+    HoodieConfig configuredZstdLevel = new HoodieConfig();
+    configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "3");
+    StorageConfiguration<Configuration> configuredNativeLogStorageConf =
+        ParquetUtils.applyNativeLogZstdCompressionLevel(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, configuredZstdLevel);
+    assertEquals(3, configuredNativeLogStorageConf.getInt(parquetZstdLevel, -1));
+
+    configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "7");
+    StorageConfiguration<Configuration> sameLevelNativeLogStorageConf =
+        ParquetUtils.applyNativeLogZstdCompressionLevel(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, configuredZstdLevel);
+    assertSame(storageConf, sameLevelNativeLogStorageConf);
+
+    HadoopStorageConfiguration storageConfWithoutGlobalLevel =
+        new HadoopStorageConfiguration(new Configuration(false));
+    configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "3");
+    StorageConfiguration<Configuration> storageConfWithExplicitNativeLevel =
+        ParquetUtils.applyNativeLogZstdCompressionLevel(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"),
+            storageConfWithoutGlobalLevel, configuredZstdLevel);
+    assertNotSame(storageConfWithoutGlobalLevel, storageConfWithExplicitNativeLevel);
+    assertEquals(3, storageConfWithExplicitNativeLevel.getInt(parquetZstdLevel, -1));
   }
 
   @ParameterizedTest

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -22,8 +22,6 @@ import org.apache.hudi.avro.HoodieAvroWriteSupport;
 import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.bloom.BloomFilterFactory;
 import org.apache.hudi.common.bloom.BloomFilterTypeCode;
-import org.apache.hudi.common.config.HoodieConfig;
-import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -35,17 +33,12 @@ import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
-import org.apache.hudi.core.io.HoodieParquetConfigInjector;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
-import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
-import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.avro.AvroSchemaConverter;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -73,12 +66,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.schema.HoodieSchemaUtils.METADATA_FIELD_SCHEMA;
 import static org.apache.hudi.metadata.HoodieIndexVersion.V1;
-import static org.apache.parquet.hadoop.codec.ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -99,89 +88,6 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
   public void setup() {
     initPath();
     parquetUtils = new ParquetUtils();
-  }
-
-  @Test
-  void testInjectDefaultZstdCompressionLevel() {
-    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
-    storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "7");
-
-    StorageConfiguration<Configuration> nativeLogStorageConf =
-        ParquetUtils.injectDefaultZstdCompressionLevel(
-            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, new HoodieConfig());
-
-    assertNotSame(storageConf, nativeLogStorageConf);
-    assertEquals(7, storageConf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
-    assertEquals(1, nativeLogStorageConf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
-
-    StorageConfiguration<Configuration> baseFileStorageConf =
-        ParquetUtils.injectDefaultZstdCompressionLevel(
-            new StoragePath("/tmp/file-id_001.parquet"), storageConf, new HoodieConfig());
-    assertSame(storageConf, baseFileStorageConf);
-
-    HoodieConfig configuredZstdLevel = new HoodieConfig();
-    configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "3");
-    StorageConfiguration<Configuration> configuredNativeLogStorageConf =
-        ParquetUtils.injectDefaultZstdCompressionLevel(
-            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, configuredZstdLevel);
-    assertEquals(3, configuredNativeLogStorageConf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
-
-    configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "7");
-    StorageConfiguration<Configuration> sameLevelNativeLogStorageConf =
-        ParquetUtils.injectDefaultZstdCompressionLevel(
-            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, configuredZstdLevel);
-    assertSame(storageConf, sameLevelNativeLogStorageConf);
-
-    HadoopStorageConfiguration storageConfWithoutGlobalLevel =
-        new HadoopStorageConfiguration(new Configuration(false));
-    configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "3");
-    StorageConfiguration<Configuration> storageConfWithExplicitNativeLevel =
-        ParquetUtils.injectDefaultZstdCompressionLevel(
-            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"),
-            storageConfWithoutGlobalLevel, configuredZstdLevel);
-    assertNotSame(storageConfWithoutGlobalLevel, storageConfWithExplicitNativeLevel);
-    assertEquals(3, storageConfWithExplicitNativeLevel.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
-
-  }
-
-  @Test
-  void testInjectDefaultZstdCompressionLevelFailsForInvalidGlobalLevel() {
-    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
-    storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "invalid");
-
-    HoodieException exception = assertThrows(
-        HoodieException.class,
-        () -> ParquetUtils.injectDefaultZstdCompressionLevel(
-            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"),
-            storageConf, new HoodieConfig()));
-    assertTrue(exception.getMessage().contains(PARQUET_COMPRESS_ZSTD_LEVEL));
-  }
-
-  @Test
-  void testInjectParquetWriterConfigsAppliesCustomInjectorLast() {
-    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
-    storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "7");
-    HoodieConfig hoodieConfig = new HoodieConfig();
-    hoodieConfig.setValue(
-        HoodieStorageConfig.HOODIE_PARQUET_CONFIG_INJECTOR_CLASS,
-        OverrideNativeLogZstdLevelInjector.class.getName());
-
-    Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
-        ParquetUtils.injectParquetWriterConfigs(
-            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, hoodieConfig);
-
-    assertEquals(9, injectedConfigs.getLeft().getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
-  }
-
-  public static class OverrideNativeLogZstdLevelInjector implements HoodieParquetConfigInjector {
-    @Override
-    public Pair<StorageConfiguration, HoodieConfig> injectConfig(
-        StoragePath path, StorageConfiguration storageConf, HoodieConfig hoodieConfig) {
-      StorageConfiguration storageConfCopy = storageConf.newInstance();
-      storageConfCopy.set(PARQUET_COMPRESS_ZSTD_LEVEL, "9");
-      HoodieConfig hoodieConfigCopy = new HoodieConfig(TypedProperties.copy(hoodieConfig.getProps()));
-      return Pair.of(storageConfCopy, hoodieConfigCopy);
-    }
   }
 
   @ParameterizedTest

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -35,6 +35,8 @@ import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.core.io.HoodieParquetConfigInjector;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.StorageConfiguration;
@@ -71,10 +73,12 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.schema.HoodieSchemaUtils.METADATA_FIELD_SCHEMA;
 import static org.apache.hudi.metadata.HoodieIndexVersion.V1;
+import static org.apache.parquet.hadoop.codec.ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -99,17 +103,16 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
 
   @Test
   void testApplyNativeLogZstdCompressionLevel() {
-    String parquetZstdLevel = "parquet.compression.codec.zstd.level";
     HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
-    storageConf.set(parquetZstdLevel, "7");
+    storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "7");
 
     StorageConfiguration<Configuration> nativeLogStorageConf =
         ParquetUtils.applyNativeLogZstdCompressionLevel(
             new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, new HoodieConfig());
 
     assertNotSame(storageConf, nativeLogStorageConf);
-    assertEquals(7, storageConf.getInt(parquetZstdLevel, -1));
-    assertEquals(1, nativeLogStorageConf.getInt(parquetZstdLevel, -1));
+    assertEquals(7, storageConf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+    assertEquals(1, nativeLogStorageConf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
 
     StorageConfiguration<Configuration> baseFileStorageConf =
         ParquetUtils.applyNativeLogZstdCompressionLevel(
@@ -121,7 +124,7 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
     StorageConfiguration<Configuration> configuredNativeLogStorageConf =
         ParquetUtils.applyNativeLogZstdCompressionLevel(
             new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, configuredZstdLevel);
-    assertEquals(3, configuredNativeLogStorageConf.getInt(parquetZstdLevel, -1));
+    assertEquals(3, configuredNativeLogStorageConf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
 
     configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "7");
     StorageConfiguration<Configuration> sameLevelNativeLogStorageConf =
@@ -137,7 +140,48 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
             new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"),
             storageConfWithoutGlobalLevel, configuredZstdLevel);
     assertNotSame(storageConfWithoutGlobalLevel, storageConfWithExplicitNativeLevel);
-    assertEquals(3, storageConfWithExplicitNativeLevel.getInt(parquetZstdLevel, -1));
+    assertEquals(3, storageConfWithExplicitNativeLevel.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+
+  }
+
+  @Test
+  void testApplyNativeLogZstdCompressionLevelFailsForInvalidGlobalLevel() {
+    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
+    storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "invalid");
+
+    HoodieException exception = assertThrows(
+        HoodieException.class,
+        () -> ParquetUtils.applyNativeLogZstdCompressionLevel(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"),
+            storageConf, new HoodieConfig()));
+    assertTrue(exception.getMessage().contains(PARQUET_COMPRESS_ZSTD_LEVEL));
+  }
+
+  @Test
+  void testPrepareParquetWriterConfigsAppliesCustomInjectorLast() {
+    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
+    storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "7");
+    HoodieConfig hoodieConfig = new HoodieConfig();
+    hoodieConfig.setValue(
+        HoodieStorageConfig.HOODIE_PARQUET_CONFIG_INJECTOR_CLASS,
+        OverrideNativeLogZstdLevelInjector.class.getName());
+
+    Pair<StorageConfiguration, HoodieConfig> preparedConfigs =
+        ParquetUtils.prepareParquetWriterConfigs(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, hoodieConfig);
+
+    assertEquals(9, preparedConfigs.getLeft().getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+  }
+
+  public static class OverrideNativeLogZstdLevelInjector implements HoodieParquetConfigInjector {
+    @Override
+    public Pair<StorageConfiguration, HoodieConfig> injectConfig(
+        StoragePath path, StorageConfiguration storageConf, HoodieConfig hoodieConfig) {
+      StorageConfiguration storageConfCopy = storageConf.newInstance();
+      storageConfCopy.set(PARQUET_COMPRESS_ZSTD_LEVEL, "9");
+      HoodieConfig hoodieConfigCopy = new HoodieConfig(TypedProperties.copy(hoodieConfig.getProps()));
+      return Pair.of(storageConfCopy, hoodieConfigCopy);
+    }
   }
 
   @ParameterizedTest

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/core/io/TestHoodieParquetConfigInjector.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/core/io/TestHoodieParquetConfigInjector.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.core.io;
+
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.ParquetUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.parquet.hadoop.codec.ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for built-in and user-defined {@link HoodieParquetConfigInjector} composition.
+ */
+class TestHoodieParquetConfigInjector {
+
+  @Test
+  void testApplyBuiltInZstdCompressionLevelInjector() {
+    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
+    storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "7");
+
+    Pair<StorageConfiguration, HoodieConfig> nativeLogConfigs =
+        ParquetUtils.injectParquetWriterConfigs(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, new HoodieConfig());
+
+    assertNotSame(storageConf, nativeLogConfigs.getLeft());
+    assertEquals(7, storageConf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+    assertEquals(1, nativeLogConfigs.getLeft().getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+
+    Pair<StorageConfiguration, HoodieConfig> baseFileConfigs =
+        ParquetUtils.injectParquetWriterConfigs(
+            new StoragePath("/tmp/file-id_001.parquet"), storageConf, new HoodieConfig());
+    assertSame(storageConf, baseFileConfigs.getLeft());
+
+    HoodieConfig configuredZstdLevel = new HoodieConfig();
+    configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "3");
+    Pair<StorageConfiguration, HoodieConfig> configuredNativeLogConfigs =
+        ParquetUtils.injectParquetWriterConfigs(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, configuredZstdLevel);
+    assertEquals(3, configuredNativeLogConfigs.getLeft().getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+
+    configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "7");
+    Pair<StorageConfiguration, HoodieConfig> sameLevelNativeLogConfigs =
+        ParquetUtils.injectParquetWriterConfigs(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, configuredZstdLevel);
+    assertSame(storageConf, sameLevelNativeLogConfigs.getLeft());
+
+    HadoopStorageConfiguration storageConfWithoutGlobalLevel =
+        new HadoopStorageConfiguration(new Configuration(false));
+    configuredZstdLevel.setValue(HoodieStorageConfig.LOGFILE_PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, "3");
+    Pair<StorageConfiguration, HoodieConfig> configsWithExplicitNativeLevel =
+        ParquetUtils.injectParquetWriterConfigs(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"),
+            storageConfWithoutGlobalLevel, configuredZstdLevel);
+    assertNotSame(storageConfWithoutGlobalLevel, configsWithExplicitNativeLevel.getLeft());
+    assertEquals(3, configsWithExplicitNativeLevel.getLeft().getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+  }
+
+  @Test
+  void testBuiltInInjectorFailsForInvalidGlobalLevel() {
+    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
+    storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "invalid");
+
+    HoodieException exception = assertThrows(
+        HoodieException.class,
+        () -> ParquetUtils.injectParquetWriterConfigs(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"),
+            storageConf, new HoodieConfig()));
+    assertTrue(exception.getMessage().contains(PARQUET_COMPRESS_ZSTD_LEVEL));
+  }
+
+  @Test
+  void testApplyUserDefinedInjectorAfterBuiltInInjector() {
+    HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration(false));
+    storageConf.set(PARQUET_COMPRESS_ZSTD_LEVEL, "7");
+    HoodieConfig hoodieConfig = new HoodieConfig();
+    hoodieConfig.setValue(
+        HoodieStorageConfig.HOODIE_PARQUET_CONFIG_INJECTOR_CLASS,
+        OverrideNativeLogZstdLevelInjector.class.getName());
+
+    Pair<StorageConfiguration, HoodieConfig> injectedConfigs =
+        ParquetUtils.injectParquetWriterConfigs(
+            new StoragePath("/tmp/file-id_1-0-1_001_1.log.parquet"), storageConf, hoodieConfig);
+
+    assertEquals(9, injectedConfigs.getLeft().getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+  }
+
+  public static class OverrideNativeLogZstdLevelInjector implements HoodieParquetConfigInjector {
+    @Override
+    public Pair<StorageConfiguration, HoodieConfig> injectConfig(
+        StoragePath path, StorageConfiguration storageConf, HoodieConfig hoodieConfig) {
+      assertEquals(1, storageConf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+      StorageConfiguration storageConfCopy = storageConf.newInstance();
+      storageConfCopy.set(PARQUET_COMPRESS_ZSTD_LEVEL, "9");
+      HoodieConfig hoodieConfigCopy = new HoodieConfig(TypedProperties.copy(hoodieConfig.getProps()));
+      return Pair.of(storageConfCopy, hoodieConfigCopy);
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19780.

The global Hadoop `parquet.compression.codec.zstd.level` setting currently applies to both Parquet base files and native Parquet log files. Native logs favor write latency and may not need the higher compression level selected for base files, but there is no independent native-log setting.

### Summary and Changelog

- Add the advanced `hoodie.logfile.parquet.compression.codec.zstd.level` configuration with a default value of `1`.
- Add a `ParquetUtils` helper that applies the native-log level only to native log paths, copying the storage configuration only when the global level is absent or different.
- Apply the built-in native-log override before `HoodieParquetConfigInjector` in Spark, Flink, and Avro/Java Parquet writer factories, preserving the custom injector as the highest-priority extension point.
- Add unit coverage for the default level, explicit override, equal-level configuration reuse, missing global configuration, and unaffected base-file paths.

### Impact

Users can tune native Parquet log Zstd compression independently from base files. Native logs default to level `1`, while base files retain the global Hadoop setting. This adds one optional advanced configuration and does not change Hudi's storage format or public APIs.

### Risk Level

Low. The override is limited to native log paths, base-file paths retain the original configuration instance, and custom Parquet config injectors still run last. The targeted `TestParquetUtils#testApplyNativeLogZstdCompressionLevel` and Flink Parquet writer factory test passed.

### Documentation Update

The new configuration and its default behavior are documented in `HoodieStorageConfig`. No storage-format documentation changes are required.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
