### PR TITLE
fix(common): keep committed logs visible under an uncommitted base instant

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
@@ -32,6 +32,7 @@ import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
@@ -117,12 +118,32 @@ public class HoodieFileGroup implements Serializable {
    *
    * <p>CAUTION: the log file must be added in sequence of the delta commit time.
    */
-  public void addLogFile(CompletionTimeQueryView completionTimeQueryView, HoodieLogFile logFile) {
+  private void addLogFile(CompletionTimeQueryView completionTimeQueryView, HoodieLogFile logFile) {
     String baseInstantTime = getBaseInstantTime(completionTimeQueryView, logFile);
     if (!fileSlices.containsKey(baseInstantTime)) {
       fileSlices.put(baseInstantTime, new FileSlice(fileGroupId, baseInstantTime));
     }
     fileSlices.get(baseInstantTime).addLogFile(logFile);
+  }
+
+  /**
+   * Add a batch of log files into the group, sorted by the delta commit time.
+   *
+   * <p>When the group has no existing slice yet, the earliest completed log establishes the initial
+   * slice before any log is added. An earlier pending log then follows the normal pending-log rule
+   * and attaches to that slice, instead of creating its own uncommitted slice that would also hide
+   * every later committed log in the group.
+   */
+  public void addLogFiles(CompletionTimeQueryView completionTimeQueryView, List<HoodieLogFile> logFiles) {
+    List<HoodieLogFile> sortedLogFiles = logFiles.stream()
+        .sorted(HoodieLogFile.getLogFileComparator()).collect(Collectors.toList());
+    if (fileSlices.isEmpty()) {
+      sortedLogFiles.stream()
+          .filter(logFile -> completionTimeQueryView.isCompleted(logFile.getDeltaCommitTime()))
+          .findFirst()
+          .ifPresent(logFile -> addNewFileSliceAtInstant(logFile.getDeltaCommitTime()));
+    }
+    sortedLogFiles.forEach(logFile -> addLogFile(completionTimeQueryView, logFile));
   }
 
   @VisibleForTesting

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -256,8 +256,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
       }
       if (logFiles.containsKey(fileId)) {
         // this should work for both table versions >= 8 and lower.
-        logFiles.get(fileId).stream().sorted(HoodieLogFile.getLogFileComparator())
-            .forEach(logFile -> group.addLogFile(completionTimeQueryView, logFile));
+        group.addLogFiles(completionTimeQueryView, logFiles.get(fileId));
       }
       fileGroups.add(group);
     });

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
@@ -86,7 +86,8 @@ public class TestHoodieFileGroup {
     for (int i = 0; i < 3; i++) {
       HoodieBaseFile baseFile = new HoodieBaseFile("data_1_00" + i + ".parquet");
       fileGroup.addBaseFile(baseFile);
-      fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(preTableVersion8 ? "001" : "00" + i, "data", i))));
+      addLogFile(fileGroup, queryView,
+          new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(preTableVersion8 ? "001" : "00" + i, "data", i))));
     }
 
     assertEquals(2, fileGroup.getAllFileSlices().count());
@@ -125,16 +126,22 @@ public class TestHoodieFileGroup {
     // when: building a file group with file slices like table version 6.
     HoodieFileGroup fileGroup = new HoodieFileGroup("", "f1", activeTimeline);
 
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName("001", "f1", 0))));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "001" : "002", "f1", 1))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName("001", "f1", 0))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "001" : "002", "f1", 1))));
 
     fileGroup.addBaseFile(new HoodieBaseFile(FileCreateUtilsLegacy.baseFileName("003", "f1")));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "003" : "004", "f1", 0))));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "003" : "005", "f1", 1))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "003" : "004", "f1", 0))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "003" : "005", "f1", 1))));
 
     fileGroup.addBaseFile(new HoodieBaseFile(FileCreateUtilsLegacy.baseFileName("006", "f1")));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "006" : "007", "f1", 0))));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "006" : "008", "f1", 1))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "006" : "007", "f1", 0))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "006" : "008", "f1", 1))));
 
     // then: assert that the file slices are in-tact.
     assertEquals(3, fileGroup.getAllFileSlices().count());
@@ -162,6 +169,63 @@ public class TestHoodieFileGroup {
   }
 
   @Test
+  public void testUncommittedFirstLogDoesNotAnchorCommittedLogs() {
+    // The earliest log "001" is still pending while "002"/"003" are committed. The group must not
+    // create an uncommitted slice anchored at "001" (which would hide the committed logs); the
+    // earliest completed log "002" establishes the slice and "001" attaches to it as a pending log.
+    MockHoodieTimeline activeTimeline = new MockHoodieTimeline(Stream.of(
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "000", "000"),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "001"),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "004"),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "003", "005")
+    ).collect(Collectors.toList()));
+    CompletionTimeQueryView queryView = getMockCompletionTimeQueryView(activeTimeline);
+    HoodieFileGroup fileGroup = new HoodieFileGroup("", "data", activeTimeline.filterCompletedAndCompactionInstants());
+
+    // logs are supplied out of order on purpose: sorting is owned by addLogFiles.
+    fileGroup.addLogFiles(queryView, Stream.of("003", "001", "002")
+        .map(instant -> new HoodieLogFile(new StoragePath(getLogFileName(instant))))
+        .collect(Collectors.toList()));
+
+    assertEquals(CollectionUtils.createImmutableList("002"),
+        fileGroup.getAllFileSlicesIncludingInflight().map(FileSlice::getBaseInstantTime).collect(Collectors.toList()));
+    assertEquals(CollectionUtils.createImmutableList("002"),
+        fileGroup.getAllFileSlices().map(FileSlice::getBaseInstantTime).collect(Collectors.toList()));
+    FileSlice committedSlice = fileGroup.getLatestFileSlice().get();
+    assertEquals(CollectionUtils.createImmutableList("001", "002", "003"),
+        committedSlice.getLogFiles().map(HoodieLogFile::getDeltaCommitTime).sorted().collect(Collectors.toList()));
+  }
+
+  @Test
+  public void testUncommittedBaseFileSliceStaysHiddenDespiteCommittedLogs() {
+    // An uncommitted base file at "001" (e.g. a failed compaction/bulk_insert under LAZY) shares the
+    // file group with later committed logs "002"/"003". The slice must stay hidden - the committed
+    // logs cannot revive it, otherwise the uncommitted base file would be read in full.
+    MockHoodieTimeline activeTimeline = new MockHoodieTimeline(Stream.of(
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "000", "000"),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "001"),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "004"),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "003", "005")
+    ).collect(Collectors.toList()));
+    CompletionTimeQueryView queryView = getMockCompletionTimeQueryView(activeTimeline);
+    HoodieFileGroup fileGroup = new HoodieFileGroup("", "data", activeTimeline.filterCompletedAndCompactionInstants());
+
+    // uncommitted base file at "001"
+    fileGroup.addBaseFile(new HoodieBaseFile(getBaseFileName("001")));
+    // later committed logs land in the same file group
+    fileGroup.addLogFiles(queryView, Stream.of("002", "003")
+        .map(instant -> new HoodieLogFile(new StoragePath(getLogFileName(instant))))
+        .collect(Collectors.toList()));
+
+    // the slice exists on disk but stays hidden because its base file is uncommitted
+    assertEquals(CollectionUtils.createImmutableList("001"),
+        fileGroup.getAllFileSlicesIncludingInflight().map(FileSlice::getBaseInstantTime).collect(Collectors.toList()));
+    assertEquals(0, fileGroup.getAllFileSlices().count());
+    assertTrue(fileGroup.getLatestFileSlice().isEmpty());
+    assertTrue(fileGroup.getLatestDataFile().isEmpty());
+  }
+
+  @Test
   public void testGetBaseInstantTime() {
     MockHoodieTimeline activeTimeline = new MockHoodieTimeline(Stream.of(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "001", "001"),
@@ -176,13 +240,13 @@ public class TestHoodieFileGroup {
     HoodieFileGroup fileGroup = new HoodieFileGroup("", "data", activeTimeline.filterCompletedAndCompactionInstants());
 
     HoodieLogFile logFile1 = new HoodieLogFile(new StoragePath(getLogFileName("001")));
-    fileGroup.addLogFile(queryView, logFile1);
+    addLogFile(fileGroup, queryView, logFile1);
     assertThat("no base file in the file group, returns the delta commit instant itself",
         fileGroup.getBaseInstantTime(queryView, logFile1), is("001"));
     assertThat(collectFileSlices(fileGroup), is("001"));
 
     HoodieLogFile logFile2 = new HoodieLogFile(new StoragePath(getLogFileName("002")));
-    fileGroup.addLogFile(queryView, logFile2);
+    addLogFile(fileGroup, queryView, logFile2);
     assertThat("no base file in the file group, returns the earliest delta commit instant",
         fileGroup.getBaseInstantTime(queryView, logFile2), is("001"));
     assertThat(collectFileSlices(fileGroup), is("001"));
@@ -192,7 +256,7 @@ public class TestHoodieFileGroup {
         collectFileSlices(fileGroup), is("001,003"));
 
     HoodieLogFile logFile3 = new HoodieLogFile(new StoragePath(getLogFileName("004")));
-    fileGroup.addLogFile(queryView, logFile3);
+    addLogFile(fileGroup, queryView, logFile3);
     assertThat("Assign the log file to maximum base instant time that less than or equals its completion time",
         fileGroup.getBaseInstantTime(queryView, logFile2), is("003"));
     assertThat(collectFileSlices(fileGroup), is("001,003"));
@@ -217,7 +281,15 @@ public class TestHoodieFileGroup {
           String instantTime = invocationOnMock.getArgument(1);
           return Option.ofNullable(completionTimeMap.get(instantTime));
         });
+    when(queryView.isCompleted(any(String.class)))
+        .thenAnswer((InvocationOnMock invocationOnMock) -> completionTimeMap.containsKey(invocationOnMock.getArgument(0)));
     return queryView;
+  }
+
+  private static void addLogFile(HoodieFileGroup fileGroup,
+                                 CompletionTimeQueryView completionTimeQueryView,
+                                 HoodieLogFile logFile) {
+    fileGroup.addLogFiles(completionTimeQueryView, CollectionUtils.createImmutableList(logFile));
   }
 
   private static String collectFileSlices(HoodieFileGroup fileGroup) {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -325,6 +325,50 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
         "Total number of file-groups in view matches expected");
   }
 
+  @Test
+  public void testUncommittedFirstLogUsesFirstCommittedLogAsBaseInstant() throws Exception {
+    String partitionPath = "2016/05/01";
+    Paths.get(basePath, partitionPath).toFile().mkdirs();
+    String fileId = UUID.randomUUID().toString();
+
+    String failedInstant = "2";
+    String firstCommittedInstant = "3";
+    String secondCommittedInstant = "4";
+    for (String instant : Arrays.asList(failedInstant, firstCommittedInstant, secondCommittedInstant)) {
+      String fileName = FSUtils.makeInlineLogFileName(
+          fileId, HoodieLogFile.DELTA_EXTENSION, instant, Integer.parseInt(instant), TEST_WRITE_TOKEN);
+      Paths.get(basePath, partitionPath, fileName).toFile().createNewFile();
+    }
+
+    HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
+    saveAsComplete(commitTimeline,
+        INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "1"),
+        new HoodieCommitMetadata());
+    HoodieInstant failedRequested =
+        INSTANT_GENERATOR.createNewInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, failedInstant);
+    commitTimeline.createNewInstant(failedRequested);
+    commitTimeline.transitionRequestedToInflight(failedRequested, Option.empty());
+    saveAsComplete(commitTimeline,
+        INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, firstCommittedInstant),
+        new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline,
+        INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, secondCommittedInstant),
+        new HoodieCommitMetadata());
+
+    refreshFsView();
+
+    HoodieFileGroup fileGroup = fsView.getAllFileGroups(partitionPath).findFirst().get();
+    List<FileSlice> rawSlices = fileGroup.getAllFileSlicesIncludingInflight().collect(Collectors.toList());
+    assertEquals(1, rawSlices.size());
+    assertEquals(firstCommittedInstant, rawSlices.get(0).getBaseInstantTime());
+    assertEquals(3, rawSlices.get(0).getLogFileCnt());
+
+    FileSlice visibleSlice = rtView.getLatestFileSlices(partitionPath).findFirst().get();
+    assertEquals(firstCommittedInstant, visibleSlice.getBaseInstantTime());
+    assertEquals(Arrays.asList(firstCommittedInstant, secondCommittedInstant),
+        visibleSlice.getLogFiles().map(HoodieLogFile::getDeltaCommitTime).sorted().collect(Collectors.toList()));
+  }
+
   @ParameterizedTest(name = TEST_NAME_WITH_PARAMS_2)
   @MethodSource("configParams2x2")
   public void testViewForFileSlicesWithNoBaseFileAndRequestedCompaction(boolean testBootstrap, boolean preTableVersion8) throws Exception {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

In a Merge-on-Read file group with no base file, the earliest log can belong to an uncommitted delta commit while later logs are committed. This can occur with non-blocking concurrency control and the bucket index after a failed write. Building the file group in log order anchors the initial slice at the uncommitted instant, causing the reader view to hide the entire slice and omit committed data from query results.

### Summary and Changelog

Keep committed logs visible by establishing the initial slice from the earliest completed log when the file group has no existing slices.

- Add `HoodieFileGroup.addLogFiles` to sort a batch of logs and initialize an empty file group using the earliest completed log's delta commit time. Earlier pending logs then attach through the existing log-assignment logic.
- Update `AbstractTableFileSystemView` to use the batch method, and make the single-log helper private.
- Preserve the existing visibility rules for slices with uncommitted base files and the read-side filtering of uncommitted logs.
- Add regression tests for an uncommitted first log followed by committed logs, for keeping an uncommitted base-file slice hidden despite later committed logs, and for exposing only committed logs through the filesystem view. Adapt existing file-group tests to the batch method.

### Impact

Restores committed data visibility for affected MOR file groups. The change affects file-group construction in the shared filesystem view. No configuration or storage-format changes are introduced. At the Java method level, callers of `HoodieFileGroup.addLogFile` must use the new `addLogFiles` batch method.

Log sorting moves into the batch method; initializing an empty group adds a scan for the first completed log. No performance benchmark was run for this description update.

### Risk Level

low

The change is limited to initializing file groups without existing slices, but it affects shared read-path logic. Regression coverage includes:

- `TestHoodieFileGroup.testUncommittedFirstLogDoesNotAnchorCommittedLogs`
- `TestHoodieFileGroup.testUncommittedBaseFileSliceStaysHiddenDespiteCommittedLogs`
- `TestHoodieTableFileSystemView.testUncommittedFirstLogUsesFirstCommittedLogAsBaseInstant`

The existing pre-v8 and v8+ file-slicing tests are retained and adapted to the batch method. The current PR's code CI checks passed, including the Spark client/Hadoop common and common-module test jobs. No local code tests were rerun for this description-only update.

### Documentation Update

none — this is a correctness fix restoring expected MOR read behavior, with no new feature, configuration, or storage format to document.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
