### PR TITLE
fix: preserve committed logs after a failed leading write

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileGroup.java
@@ -32,6 +32,7 @@ import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
@@ -117,12 +118,34 @@ public class HoodieFileGroup implements Serializable {
    *
    * <p>CAUTION: the log file must be added in sequence of the delta commit time.
    */
-  public void addLogFile(CompletionTimeQueryView completionTimeQueryView, HoodieLogFile logFile) {
+  private void addLogFile(CompletionTimeQueryView completionTimeQueryView, HoodieLogFile logFile) {
     String baseInstantTime = getBaseInstantTime(completionTimeQueryView, logFile);
     if (!fileSlices.containsKey(baseInstantTime)) {
       fileSlices.put(baseInstantTime, new FileSlice(fileGroupId, baseInstantTime));
     }
     fileSlices.get(baseInstantTime).addLogFile(logFile);
+  }
+
+  /**
+   * Add log files into the group.
+   *
+   * <p>When the group has no existing slice, the first completed log establishes the initial slice before any logs
+   * are added. This allows an earlier pending log to follow the normal pending-log rule and attach to the latest slice,
+   * instead of creating an uncommitted slice that would also hide later committed logs.
+   */
+  public void addLogFiles(CompletionTimeQueryView completionTimeQueryView, List<HoodieLogFile> logFiles) {
+    if (fileSlices.isEmpty()) {
+      List<HoodieLogFile> sortedLogFiles = logFiles.stream()
+          .sorted(HoodieLogFile.getLogFileComparator()).collect(Collectors.toList());
+      sortedLogFiles.stream()
+          .filter(logFile -> completionTimeQueryView.isCompleted(logFile.getDeltaCommitTime()))
+          .findFirst()
+          .ifPresent(logFile -> addNewFileSliceAtInstant(logFile.getDeltaCommitTime()));
+      sortedLogFiles.forEach(logFile -> addLogFile(completionTimeQueryView, logFile));
+    } else {
+      logFiles.stream().sorted(HoodieLogFile.getLogFileComparator())
+          .forEach(logFile -> addLogFile(completionTimeQueryView, logFile));
+    }
   }
 
   @VisibleForTesting

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -256,8 +256,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
       }
       if (logFiles.containsKey(fileId)) {
         // this should work for both table versions >= 8 and lower.
-        logFiles.get(fileId).stream().sorted(HoodieLogFile.getLogFileComparator())
-            .forEach(logFile -> group.addLogFile(completionTimeQueryView, logFile));
+        group.addLogFiles(completionTimeQueryView, logFiles.get(fileId));
       }
       fileGroups.add(group);
     });

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileGroup.java
@@ -86,7 +86,8 @@ public class TestHoodieFileGroup {
     for (int i = 0; i < 3; i++) {
       HoodieBaseFile baseFile = new HoodieBaseFile("data_1_00" + i + ".parquet");
       fileGroup.addBaseFile(baseFile);
-      fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(preTableVersion8 ? "001" : "00" + i, "data", i))));
+      addLogFile(fileGroup, queryView,
+          new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(preTableVersion8 ? "001" : "00" + i, "data", i))));
     }
 
     assertEquals(2, fileGroup.getAllFileSlices().count());
@@ -125,16 +126,22 @@ public class TestHoodieFileGroup {
     // when: building a file group with file slices like table version 6.
     HoodieFileGroup fileGroup = new HoodieFileGroup("", "f1", activeTimeline);
 
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName("001", "f1", 0))));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "001" : "002", "f1", 1))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName("001", "f1", 0))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "001" : "002", "f1", 1))));
 
     fileGroup.addBaseFile(new HoodieBaseFile(FileCreateUtilsLegacy.baseFileName("003", "f1")));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "003" : "004", "f1", 0))));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "003" : "005", "f1", 1))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "003" : "004", "f1", 0))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "003" : "005", "f1", 1))));
 
     fileGroup.addBaseFile(new HoodieBaseFile(FileCreateUtilsLegacy.baseFileName("006", "f1")));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "006" : "007", "f1", 0))));
-    fileGroup.addLogFile(queryView, new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "006" : "008", "f1", 1))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "006" : "007", "f1", 0))));
+    addLogFile(fileGroup, queryView,
+        new HoodieLogFile(new StoragePath(FileCreateUtilsLegacy.logFileName(useBaseInstantTime ? "006" : "008", "f1", 1))));
 
     // then: assert that the file slices are in-tact.
     assertEquals(3, fileGroup.getAllFileSlices().count());
@@ -162,6 +169,31 @@ public class TestHoodieFileGroup {
   }
 
   @Test
+  public void testUncommittedFirstLogDoesNotAnchorCommittedLogs() {
+    MockHoodieTimeline activeTimeline = new MockHoodieTimeline(Stream.of(
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "000", "000"),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "001"),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "002", "004"),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, "003", "005")
+    ).collect(Collectors.toList()));
+    CompletionTimeQueryView queryView = getMockCompletionTimeQueryView(activeTimeline);
+    HoodieFileGroup fileGroup = new HoodieFileGroup("", "data", activeTimeline.filterCompletedAndCompactionInstants());
+
+    fileGroup.addLogFiles(queryView, Stream.of("003", "001", "002")
+        .map(instant -> new HoodieLogFile(new StoragePath(getLogFileName(instant))))
+        .collect(Collectors.toList()));
+
+    assertEquals(
+        CollectionUtils.createImmutableList("002"),
+        fileGroup.getAllFileSlicesIncludingInflight().map(FileSlice::getBaseInstantTime).collect(Collectors.toList()));
+    assertEquals(CollectionUtils.createImmutableList("002"),
+        fileGroup.getAllFileSlices().map(FileSlice::getBaseInstantTime).collect(Collectors.toList()));
+    FileSlice committedSlice = fileGroup.getLatestFileSlice().get();
+    assertEquals(CollectionUtils.createImmutableList("001", "002", "003"),
+        committedSlice.getLogFiles().map(HoodieLogFile::getDeltaCommitTime).sorted().collect(Collectors.toList()));
+  }
+
+  @Test
   public void testGetBaseInstantTime() {
     MockHoodieTimeline activeTimeline = new MockHoodieTimeline(Stream.of(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, "001", "001"),
@@ -176,13 +208,13 @@ public class TestHoodieFileGroup {
     HoodieFileGroup fileGroup = new HoodieFileGroup("", "data", activeTimeline.filterCompletedAndCompactionInstants());
 
     HoodieLogFile logFile1 = new HoodieLogFile(new StoragePath(getLogFileName("001")));
-    fileGroup.addLogFile(queryView, logFile1);
+    addLogFile(fileGroup, queryView, logFile1);
     assertThat("no base file in the file group, returns the delta commit instant itself",
         fileGroup.getBaseInstantTime(queryView, logFile1), is("001"));
     assertThat(collectFileSlices(fileGroup), is("001"));
 
     HoodieLogFile logFile2 = new HoodieLogFile(new StoragePath(getLogFileName("002")));
-    fileGroup.addLogFile(queryView, logFile2);
+    addLogFile(fileGroup, queryView, logFile2);
     assertThat("no base file in the file group, returns the earliest delta commit instant",
         fileGroup.getBaseInstantTime(queryView, logFile2), is("001"));
     assertThat(collectFileSlices(fileGroup), is("001"));
@@ -192,7 +224,7 @@ public class TestHoodieFileGroup {
         collectFileSlices(fileGroup), is("001,003"));
 
     HoodieLogFile logFile3 = new HoodieLogFile(new StoragePath(getLogFileName("004")));
-    fileGroup.addLogFile(queryView, logFile3);
+    addLogFile(fileGroup, queryView, logFile3);
     assertThat("Assign the log file to maximum base instant time that less than or equals its completion time",
         fileGroup.getBaseInstantTime(queryView, logFile2), is("003"));
     assertThat(collectFileSlices(fileGroup), is("001,003"));
@@ -217,11 +249,19 @@ public class TestHoodieFileGroup {
           String instantTime = invocationOnMock.getArgument(1);
           return Option.ofNullable(completionTimeMap.get(instantTime));
         });
+    when(queryView.isCompleted(any(String.class)))
+        .thenAnswer((InvocationOnMock invocationOnMock) -> completionTimeMap.containsKey(invocationOnMock.getArgument(0)));
     return queryView;
   }
 
   private static String collectFileSlices(HoodieFileGroup fileGroup) {
     return fileGroup.getAllFileSlices().map(FileSlice::getBaseInstantTime).sorted().collect(Collectors.joining(","));
+  }
+
+  private static void addLogFile(HoodieFileGroup fileGroup,
+                                 CompletionTimeQueryView completionTimeQueryView,
+                                 HoodieLogFile logFile) {
+    fileGroup.addLogFiles(completionTimeQueryView, CollectionUtils.createImmutableList(logFile));
   }
 
   private static String getLogFileName(String instantTime) {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -325,6 +325,50 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
         "Total number of file-groups in view matches expected");
   }
 
+  @Test
+  public void testUncommittedFirstLogUsesFirstCommittedLogAsBaseInstant() throws Exception {
+    String partitionPath = "2016/05/01";
+    Paths.get(basePath, partitionPath).toFile().mkdirs();
+    String fileId = UUID.randomUUID().toString();
+
+    String failedInstant = "2";
+    String firstCommittedInstant = "3";
+    String secondCommittedInstant = "4";
+    for (String instant : Arrays.asList(failedInstant, firstCommittedInstant, secondCommittedInstant)) {
+      String fileName = FSUtils.makeInlineLogFileName(
+          fileId, HoodieLogFile.DELTA_EXTENSION, instant, Integer.parseInt(instant), TEST_WRITE_TOKEN);
+      Paths.get(basePath, partitionPath, fileName).toFile().createNewFile();
+    }
+
+    HoodieActiveTimeline commitTimeline = metaClient.getActiveTimeline();
+    saveAsComplete(commitTimeline,
+        INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "1"),
+        new HoodieCommitMetadata());
+    HoodieInstant failedRequested =
+        INSTANT_GENERATOR.createNewInstant(State.REQUESTED, HoodieTimeline.DELTA_COMMIT_ACTION, failedInstant);
+    commitTimeline.createNewInstant(failedRequested);
+    commitTimeline.transitionRequestedToInflight(failedRequested, Option.empty());
+    saveAsComplete(commitTimeline,
+        INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, firstCommittedInstant),
+        new HoodieCommitMetadata());
+    saveAsComplete(commitTimeline,
+        INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, secondCommittedInstant),
+        new HoodieCommitMetadata());
+
+    refreshFsView();
+
+    HoodieFileGroup fileGroup = fsView.getAllFileGroups(partitionPath).findFirst().get();
+    List<FileSlice> rawSlices = fileGroup.getAllFileSlicesIncludingInflight().collect(Collectors.toList());
+    assertEquals(1, rawSlices.size());
+    assertEquals(firstCommittedInstant, rawSlices.get(0).getBaseInstantTime());
+    assertEquals(3, rawSlices.get(0).getLogFileCnt());
+
+    FileSlice visibleSlice = rtView.getLatestFileSlices(partitionPath).findFirst().get();
+    assertEquals(firstCommittedInstant, visibleSlice.getBaseInstantTime());
+    assertEquals(Arrays.asList(firstCommittedInstant, secondCommittedInstant),
+        visibleSlice.getLogFiles().map(HoodieLogFile::getDeltaCommitTime).sorted().collect(Collectors.toList()));
+  }
+
   @ParameterizedTest(name = TEST_NAME_WITH_PARAMS_2)
   @MethodSource("configParams2x2")
   public void testViewForFileSlicesWithNoBaseFileAndRequestedCompaction(boolean testBootstrap, boolean preTableVersion8) throws Exception {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

With MOR tables using the bucket index and non-blocking concurrency control, a failed first write can leave an uncommitted log file as the earliest physical file in a file group. The file group is then anchored at that uncommitted instant, causing the committed slice APIs to discard the entire slice, including later committed logs.

Closes #19774

### Summary and Changelog

This change constructs log-only file groups around the earliest completed log so that a failed leading log cannot hide later committed data.

- Add log files to `HoodieFileGroup` as a batch sorted by delta-commit time.
- When a file group has no existing base or compaction slice, establish the earliest completed log instant as the initial slice base.
- Route earlier pending logs through the existing pending-log rule while leaving `isFileSliceCommitted` unchanged.
- Update filesystem-view construction to use the batch API.
- Add model and filesystem-view regressions covering out-of-order input and the MOR/NBCC sequence with an inflight first log followed by two completed logs.
- No code was copied from another project.

### Impact

Snapshot readers retain later committed logs when the earliest physical log in a file group belongs to a failed, uncommitted write. Existing base-file and pending-compaction slices remain authoritative, pending-only groups retain their existing behavior, and V8+ file-level filtering continues to remove the uncommitted log itself.

The internal file-group construction API now batches log files through `HoodieFileGroup#addLogFiles`. There are no storage-format, configuration, or expected performance changes.

### Risk Level

medium

This changes file-slice construction in a shared filesystem-view path. The risk is mitigated by the existing pre-V8 and V8+ slicing coverage plus the new model and filesystem-view regressions. Validation completed with:

- `mvn -pl hudi-hadoop-common -am -DskipShade -DskipITs -Dcheckstyle.skip -Drat.skip -Dtest=TestHoodieFileGroup -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl hudi-hadoop-common -am -DskipShade -DskipITs -Dcheckstyle.skip -Drat.skip -Dtest=TestHoodieTableFileSystemView -Dsurefire.failIfNoSpecifiedTests=false test`

Together these ran 59 tests with no failures or errors.

### Documentation Update

none. This is a correctness fix with no new feature, configuration, default, or storage-format change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
