### PR TITLE
fix(common): prevent multi-table commits failing with metrics enabled

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/common/metrics/LocalRegistry.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/metrics/LocalRegistry.java
@@ -72,9 +72,6 @@ public class LocalRegistry implements Registry {
   }
 
   private synchronized Counter getCounter(String name) {
-    if (!counters.containsKey(name)) {
-      counters.put(name, new Counter());
-    }
-    return counters.get(name);
+    return counters.computeIfAbsent(name, key -> new Counter());
   }
 }

--- a/hudi-io/src/test/java/org/apache/hudi/common/metrics/TestLocalRegistry.java
+++ b/hudi-io/src/test/java/org/apache/hudi/common/metrics/TestLocalRegistry.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestLocalRegistry {
+
+  @Test
+  public void testAddConcurrentWithClear() throws Exception {
+    LocalRegistry registry = new LocalRegistry("test");
+    registry.add("counter", 1);
+
+    CountDownLatch counterLookupStarted = new CountDownLatch(1);
+    CountDownLatch clearCompleted = new CountDownLatch(1);
+    registry.counters = new ClearBeforeLookupMap<>(
+        registry.counters, counterLookupStarted, clearCompleted);
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> addFuture = executor.submit(() -> registry.add("counter", 1));
+      assertTrue(counterLookupStarted.await(10, TimeUnit.SECONDS));
+      registry.clear();
+      clearCompleted.countDown();
+
+      assertDoesNotThrow(() -> addFuture.get(10, TimeUnit.SECONDS));
+      assertEquals(1L, registry.getAllCounts().get("counter"));
+    } finally {
+      clearCompleted.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  private static class ClearBeforeLookupMap<K, V> extends ConcurrentHashMap<K, V> {
+    private final CountDownLatch counterLookupStarted;
+    private final CountDownLatch clearCompleted;
+
+    private ClearBeforeLookupMap(
+        Map<K, V> entries,
+        CountDownLatch counterLookupStarted,
+        CountDownLatch clearCompleted) {
+      super(entries);
+      this.counterLookupStarted = counterLookupStarted;
+      this.clearCompleted = clearCompleted;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      return super.get(key) != null;
+    }
+
+    @Override
+    public V get(Object key) {
+      awaitClear();
+      return super.get(key);
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+      awaitClear();
+      return super.computeIfAbsent(key, mappingFunction);
+    }
+
+    private void awaitClear() {
+      counterLookupStarted.countDown();
+      try {
+        assertTrue(clearCompleted.await(10, TimeUnit.SECONDS));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When one Spark driver writes several Hudi tables with metrics enabled, clearing one table's local metrics can abort another table's commit. `LocalRegistry.clear()` can run between `containsKey()` and `get()`, causing a concurrent metric update to fail with:

```text
java.lang.NullPointerException: Cannot invoke "org.apache.hudi.common.metrics.Counter.add(long)" because the return value of "org.apache.hudi.common.metrics.LocalRegistry.getCounter(String)" is null
```

Closes https://github.com/apache/hudi/issues/19570.

### Summary and Changelog

Counter lookup now uses `ConcurrentHashMap.computeIfAbsent()`, so a concurrent clear cannot make it return null. The atomic lookup matches the fix proposed in https://github.com/apache/hudi/pull/19584. This PR adds a deterministic interleaving test that reproduces the failure.

### Impact

There is no public API change. Concurrent metric updates no longer fail when the local registry is cleared.

### Risk Level

Low. The change replaces a compound access to an existing `ConcurrentHashMap` with its atomic lookup operation.

### Testing

<details>
<summary>Raw failing and passing regression</summary>

```console
$ export JAVA_HOME=$(/usr/libexec/java_home -v 17)
$ git restore --source=upstream/master --worktree hudi-io/src/main/java/org/apache/hudi/common/metrics/LocalRegistry.java
$ mvn -pl hudi-io -am -Dtest=org.apache.hudi.common.metrics.TestLocalRegistry -Dsurefire.failIfNoSpecifiedTests=false test
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
org.opentest4j.AssertionFailedError: Unexpected exception thrown: java.util.concurrent.ExecutionException: java.lang.NullPointerException: Cannot invoke "org.apache.hudi.common.metrics.Counter.add(long)" because the return value of "org.apache.hudi.common.metrics.LocalRegistry.getCounter(String)" is null
[INFO] BUILD FAILURE

$ git restore --source=HEAD --worktree hudi-io/src/main/java/org/apache/hudi/common/metrics/LocalRegistry.java
$ mvn -pl hudi-io -am -Dtest=org.apache.hudi.common.metrics.TestLocalRegistry -Dsurefire.failIfNoSpecifiedTests=false test
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

</details>

<details>
<summary>Full hudi-io suite</summary>

```console
$ mvn -pl hudi-io -am test
[INFO] Tests run: 126, Failures: 0, Errors: 0, Skipped: 0
[INFO] hudi-io ............................................ SUCCESS
[INFO] BUILD SUCCESS
```

</details>

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute). Reviewed the contributor guide and repository PR template.
- [x] Enough context is provided in the sections above. The issue and prior implementation are linked.
- [x] Adequate tests were added if applicable. The deterministic regression fails on `upstream/master`, passes on this branch, and the full `hudi-io` suite passes.
