### PR TITLE
fix(spark): restore the java.util.Map import in TestDataSourceUtils

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDataSourceUtils.java
@@ -66,6 +66,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19788

Test compilation of `hudi-spark_2.12` fails on current master: `TestDataSourceUtils` uses `Map<String, String>` but no longer imports `java.util.Map`.

### Summary and Changelog

Restores `import java.util.Map;`. The import was dropped alongside an unrelated cleanup that removed the file's other use of `Map`, leaving the one at line 136 uncovered.

Verified with `mvn test-compile -pl hudi-spark-datasource/hudi-spark -Dspark3.5 -Dscala-2.12`, which fails before the change and passes after; checkstyle on the module is clean.

### Impact

None. Test-only, and no test behavior changes.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
