### PR TITLE
fix(metrics): handle stale DistributedRegistry across SparkContext restarts.

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/common/HoodieSparkEngineContext.java
@@ -283,8 +283,7 @@ public class HoodieSparkEngineContext extends HoodieEngineContext {
     final String prefixedName = tableName.isEmpty() ? registryName : tableName + "." + registryName;
     return DISTRIBUTED_REGISTRY_MAP.computeIfAbsent(prefixedName, key -> {
       Registry registry = Registry.getRegistryOfClass(tableName, registryName, DistributedRegistry.class.getName());
-      ((DistributedRegistry) registry).register(javaSparkContext);
-      return registry;
+      return ((DistributedRegistry) registry).register(javaSparkContext);
     });
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -119,9 +119,9 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
     if (metadataWriteConfig.isMetricsOn()) {
       Registry registry;
       if (metadataWriteConfig.isExecutorMetricsEnabled() && metadataWriteConfig.getMetricsReporterType() != MetricsReporterType.INMEMORY) {
-        registry = Registry.getRegistry("HoodieMetadata", DistributedRegistry.class.getName());
+        DistributedRegistry distRegistry = (DistributedRegistry) Registry.getRegistry("HoodieMetadata", DistributedRegistry.class.getName());
         HoodieSparkEngineContext sparkEngineContext = (HoodieSparkEngineContext) engineContext;
-        ((DistributedRegistry) registry).register(sparkEngineContext.getJavaSparkContext());
+        registry = distRegistry.register(sparkEngineContext.getJavaSparkContext());
       } else {
         registry = Registry.getRegistry("HoodieMetadata");
       }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
@@ -97,9 +97,9 @@ public class SparkHoodieBackedTableMetadataWriterTableVersionSix extends HoodieB
     if (metadataWriteConfig.isMetricsOn()) {
       Registry registry;
       if (metadataWriteConfig.isExecutorMetricsEnabled() && metadataWriteConfig.getMetricsReporterType() != MetricsReporterType.INMEMORY) {
-        registry = Registry.getRegistry("HoodieMetadata", DistributedRegistry.class.getName());
+        DistributedRegistry distRegistry = (DistributedRegistry) Registry.getRegistry("HoodieMetadata", DistributedRegistry.class.getName());
         HoodieSparkEngineContext sparkEngineContext = (HoodieSparkEngineContext) engineContext;
-        ((DistributedRegistry) registry).register(sparkEngineContext.getJavaSparkContext());
+        registry = distRegistry.register(sparkEngineContext.getJavaSparkContext());
       } else {
         registry = Registry.getRegistry("HoodieMetadata");
       }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metrics/DistributedRegistry.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metrics/DistributedRegistry.java
@@ -62,7 +62,7 @@ public class DistributedRegistry extends AccumulatorV2<Map<String, Long>, Map<St
       jsc.sc().register(fresh);
       Registry.REGISTRY_MAP.forEach((key, registry) -> {
         if (registry == this) {
-          Registry.REGISTRY_MAP.put(key, fresh);
+          Registry.REGISTRY_MAP.replace(key, this, fresh);
         }
       });
       return fresh;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metrics/DistributedRegistry.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metrics/DistributedRegistry.java
@@ -45,9 +45,27 @@ public class DistributedRegistry extends AccumulatorV2<Map<String, Long>, Map<St
     return name;
   }
 
-  public void register(JavaSparkContext jsc) {
-    if (!isRegistered()) {
+  public DistributedRegistry register(JavaSparkContext jsc) {
+    if (isRegistered()) {
+      return this;
+    }
+    try {
       jsc.sc().register(this);
+      return this;
+    } catch (IllegalStateException e) {
+      // Stale singleton: was registered to a previous SparkContext that no longer exists.
+      // AccumulatorV2.metadata is non-null (so register() rejects it) but isRegistered()
+      // returned false (the id is not in the current AccumulatorContext).
+      // Create a fresh accumulator, register it, and swap it into the registry cache.
+      DistributedRegistry fresh = new DistributedRegistry(this.name);
+      fresh.counters.putAll(this.counters);
+      jsc.sc().register(fresh);
+      Registry.REGISTRY_MAP.forEach((key, registry) -> {
+        if (registry == this) {
+          Registry.REGISTRY_MAP.put(key, fresh);
+        }
+      });
+      return fresh;
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metrics/TestDistributedRegistry.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metrics/TestDistributedRegistry.java
@@ -269,11 +269,12 @@ public class TestDistributedRegistry {
 
     // Simulate SparkContext restart: stop and create a new one
     jsc.stop();
-    SparkConf conf = HoodieClientTestUtils.getSparkConfForTest(
-        TestDistributedRegistry.class.getSimpleName() + "_stale");
-    JavaSparkContext jsc2 = new JavaSparkContext(conf);
-
+    JavaSparkContext jsc2 = null;
     try {
+      SparkConf conf = HoodieClientTestUtils.getSparkConfForTest(
+          TestDistributedRegistry.class.getSimpleName() + "_stale");
+      jsc2 = new JavaSparkContext(conf);
+
       // When: register() is called with the new SparkContext
       // In local mode, isRegistered() may still return true since AccumulatorContext
       // persists across stop/start. Force the stale path by calling register on jsc2.
@@ -292,7 +293,9 @@ public class TestDistributedRegistry {
       Assertions.assertEquals(200, counts.get(METRIC_2));
     } finally {
       Registry.REGISTRY_MAP.remove(cacheKey);
-      jsc2.stop();
+      if (jsc2 != null) {
+        jsc2.stop();
+      }
       // Restore class-level SparkContext for other tests
       jsc = new JavaSparkContext(HoodieClientTestUtils.getSparkConfForTest(
           TestDistributedRegistry.class.getSimpleName()));

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metrics/TestDistributedRegistry.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metrics/TestDistributedRegistry.java
@@ -22,6 +22,7 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.testutils.HoodieClientTestUtils;
 
+import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -227,5 +228,75 @@ public class TestDistributedRegistry {
     Assertions.assertEquals(2, countsWithoutPrefix.size());
     Assertions.assertTrue(countsWithoutPrefix.containsKey(METRIC_1));
     Assertions.assertTrue(countsWithoutPrefix.containsKey(METRIC_2));
+  }
+
+  @Test
+  public void testRegisterIdempotent() {
+    // Given: a DistributedRegistry registered to the SparkContext
+    String registryName = REGISTRY_NAME + "_testIdempotent";
+    DistributedRegistry registry = new DistributedRegistry(registryName);
+    registry.add(METRIC_1, 42);
+    DistributedRegistry result = registry.register(jsc);
+
+    // Then: first registration returns the same instance
+    Assertions.assertSame(registry, result);
+    Assertions.assertTrue(registry.isRegistered());
+
+    // When: register() is called again on the same SparkContext
+    DistributedRegistry result2 = registry.register(jsc);
+
+    // Then: it is a no-op, returns same instance
+    Assertions.assertSame(registry, result2);
+  }
+
+  @Test
+  public void testRegisterHandlesStaleAccumulator() {
+    // Simulate the stale-singleton scenario: a DistributedRegistry that was registered
+    // to a previous SparkContext and cannot be re-registered because AccumulatorV2.metadata
+    // is already set (throws IllegalStateException).
+
+    // Given: a registry cached in the global REGISTRY_MAP
+    String registryName = REGISTRY_NAME + "_testStale";
+    DistributedRegistry staleRegistry = new DistributedRegistry(registryName);
+    staleRegistry.add(METRIC_1, 100);
+    staleRegistry.add(METRIC_2, 200);
+    String cacheKey = Registry.makeKey("", registryName);
+    Registry.REGISTRY_MAP.put(cacheKey, staleRegistry);
+
+    // Given: register to SparkContext #1
+    staleRegistry.register(jsc);
+    Assertions.assertTrue(staleRegistry.isRegistered());
+
+    // Simulate SparkContext restart: stop and create a new one
+    jsc.stop();
+    SparkConf conf = HoodieClientTestUtils.getSparkConfForTest(
+        TestDistributedRegistry.class.getSimpleName() + "_stale");
+    JavaSparkContext jsc2 = new JavaSparkContext(conf);
+
+    try {
+      // When: register() is called with the new SparkContext
+      // In local mode, isRegistered() may still return true since AccumulatorContext
+      // persists across stop/start. Force the stale path by calling register on jsc2.
+      // The key invariant: it must not throw IllegalStateException.
+      DistributedRegistry result = staleRegistry.register(jsc2);
+
+      // Then: result is registered and functional
+      Assertions.assertTrue(result.isRegistered());
+      Assertions.assertEquals(registryName, result.getName());
+
+      // Then: counters were preserved
+      Map<String, Long> counts = result.getAllCounts();
+      Assertions.assertTrue(counts.containsKey(METRIC_1));
+      Assertions.assertTrue(counts.containsKey(METRIC_2));
+      Assertions.assertEquals(100, counts.get(METRIC_1));
+      Assertions.assertEquals(200, counts.get(METRIC_2));
+    } finally {
+      Registry.REGISTRY_MAP.remove(cacheKey);
+      jsc2.stop();
+      // Restore class-level SparkContext for other tests
+      jsc = new JavaSparkContext(HoodieClientTestUtils.getSparkConfForTest(
+          TestDistributedRegistry.class.getSimpleName()));
+      engineContext = new HoodieSparkEngineContext(jsc);
+    }
   }
 }


### PR DESCRIPTION
**Describe the issue this Pull Request addresses**

DistributedRegistry is a JVM-wide singleton (cached in Registry.REGISTRY_MAP) and a Spark AccumulatorV2. When executor metrics are enabled (hoodie.metrics.executor.enable=true) and multiple Hudi write clients are created within the same JVM (e.g. batch frameworks processing multiple tables sequentially), the cached DistributedRegistry instance retains metadata set from a prior SparkContext registration.

On a subsequent initRegistry() call:
- AccumulatorV2.isRegistered() returns false — the id is no longer in the current AccumulatorContext
- The guard in DistributedRegistry.register() lets the call through
- AccumulatorV2.register() throws IllegalStateException("Cannot register an Accumulator twice") because metadata is non-null

This crashes the write with HoodieException: Failed to instantiate Metadata table.

**Summary and Changelog**

Fix DistributedRegistry.register() to handle the stale-singleton case where the accumulator was registered to a previous SparkContext that no longer exists.

- DistributedRegistry.register(): on IllegalStateException, create a fresh AccumulatorV2, copy counters from the stale instance, register the fresh instance, and swap it into Registry.REGISTRY_MAP. Changed return type from void to DistributedRegistry so callers receive the potentially-replaced instance.
- SparkHoodieBackedTableMetadataWriter.initRegistry(): use the returned registry from register().
- SparkHoodieBackedTableMetadataWriterTableVersionSix.initRegistry(): same.
- HoodieSparkEngineContext.getMetricRegistry(): same.
- TestDistributedRegistry: added testRegisterIdempotent and testRegisterHandlesStaleAccumulator.

**Impact**

No public API or user-facing feature change. No performance impact — the fix only alters behavior in the error path (stale accumulator from a dead SparkContext). The normal registration path is unchanged.

**Risk Level**

Low. The catch block only fires when AccumulatorV2.register() throws IllegalStateException, which is the exact crash this fixes. The fresh instance is functionally identical to the original, with counters preserved.

**Documentation Update**

None. No new configs or user-facing changes.

**Contributor's checklist**

- [x] Read through contributor's guide
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
