### PR TITLE
fix(spark): keep the embedded Derby metastore out of the RAT check

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hive/TestSparkCatalogMetaStoreClient.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hive/TestSparkCatalogMetaStoreClient.scala
@@ -46,14 +46,20 @@ import scala.collection.JavaConverters._
 class TestSparkCatalogMetaStoreClient extends FunSuite with BeforeAndAfterAll {
 
   private val warehouseDir = Files.createTempDirectory("spark-catalog-metastore-client").toFile
+  // Keep the embedded Derby metastore (and derby.log) out of the module directory, where the
+  // RAT check would otherwise flag the unlicensed database files.
+  private val metastoreDir = Files.createTempDirectory("spark-catalog-metastore-db").toFile
   private val nameId = new AtomicInteger(0)
 
   private lazy val spark: SparkSession = {
     val sparkConf = getSparkConfForTest("TestSparkCatalogMetaStoreClient")
       .remove("spark.sql.catalog.spark_catalog")
 
+    System.setProperty("derby.system.home", metastoreDir.getCanonicalPath)
     SparkSession.builder()
       .config("spark.sql.warehouse.dir", warehouseDir.getCanonicalPath)
+      .config("spark.hadoop.javax.jdo.option.ConnectionURL",
+        s"jdbc:derby:;databaseName=${new File(metastoreDir, "metastore_db").getCanonicalPath};create=true")
       .config("spark.sql.session.timeZone", "UTC")
       .config(sparkConf)
       .enableHiveSupport()
@@ -73,6 +79,7 @@ class TestSparkCatalogMetaStoreClient extends FunSuite with BeforeAndAfterAll {
       spark.stop()
     }
     Utils.deleteRecursively(warehouseDir)
+    Utils.deleteRecursively(metastoreDir)
     super.afterAll()
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -704,6 +704,8 @@
               <exclude>**/*.json</exclude>
               <exclude>**/*.hfile</exclude>
               <exclude>**/*.log</exclude>
+              <!-- embedded Derby metastore created by Hive-enabled Spark tests -->
+              <exclude>**/metastore_db/**</exclude>
               <exclude>**/*.sqltemplate</exclude>
               <exclude>**/compose_env</exclude>
               <exclude>**/main/resources/version.txt</exclude>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Master CI is red since #19162 (6fd80965): `test-spark-java17-scala-other-tests` fails in its "Scala FT - Spark" step with

```
[WARNING] Files with unapproved licenses:
    /home/runner/work/hudi/hudi/hudi-spark-datasource/hudi-spark/metastore_db/log/README_DO_NOT_TOUCH_FILES.txt
    /home/runner/work/hudi/hudi/hudi-spark-datasource/hudi-spark/metastore_db/db.lck
    /home/runner/work/hudi/hudi/hudi-spark-datasource/hudi-spark/metastore_db/service.properties
    /home/runner/work/hudi/hudi/hudi-spark-datasource/hudi-spark/metastore_db/README_DO_NOT_TOUCH_FILES.txt
    /home/runner/work/hudi/hudi/hudi-spark-datasource/hudi-spark/metastore_db/seg0/README_DO_NOT_TOUCH_FILES.txt
```

#19162 added `org.apache.spark.sql.hive` to the scalatest wildcard lists, so `TestSparkCatalogMetaStoreClient` (a `SparkSession.enableHiveSupport()` suite) now runs in that job's UT step. The embedded Derby metastore it boots writes `metastore_db/` into the module working directory, and the following maven invocation in the same job runs the RAT check over the tree and flags the unlicensed database files.

### Summary and Changelog

- Root pom: exclude `**/metastore_db/**` from the RAT check, so any Hive-enabled test in any module is safe (`derby.log` was already covered by `**/*.log`).
- `TestSparkCatalogMetaStoreClient`: point the embedded metastore at a temp directory (`spark.hadoop.javax.jdo.option.ConnectionURL` and `derby.system.home`) and delete it in `afterAll`, so nothing is left in the module directory in the first place.

Verified locally: with a planted `hudi-spark/metastore_db/db.lck`, `mvn apache-rat:check -pl hudi-spark-datasource/hudi-spark` fails on master's pom and passes with the exclude; after running the suite with the test change, no `metastore_db`/`derby.log` remains under the module.

### Impact

CI fix; no production code changed.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
