### PR TITLE
fix(lock): fix lock config derivation for Spark procedure

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -55,7 +55,6 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_EXPIRE_PROP_KEY;
 import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_PATH_PROP_KEY;
 import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_CLIENT_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY;
-import static org.apache.hudi.common.table.HoodieTableMetaClient.AUXILIARYFOLDER_NAME;
 
 /**
  * A FileSystem based lock. This {@link LockProvider} implementation allows to lock table operations
@@ -115,8 +114,9 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
     this.lockConfiguration = lockConfiguration;
     String lockDirectory = lockConfiguration.getConfig().getString(FILESYSTEM_LOCK_PATH_PROP_KEY, null);
     if (StringUtils.isNullOrEmpty(lockDirectory)) {
-      lockDirectory = lockConfiguration.getConfig().getString(HoodieWriteConfig.BASE_PATH.key())
-          + StoragePath.SEPARATOR + HoodieTableMetaClient.METAFOLDER_NAME;
+      // Reuse the shared default so this fallback can never diverge from getLockConfig()'s default,
+      // which would silently place the lock file at a different path and break cross-engine locking.
+      lockDirectory = defaultLockPath(lockConfiguration.getConfig().getString(HoodieWriteConfig.BASE_PATH.key()));
     }
     this.lockTimeoutMinutes = lockConfiguration.getConfig().getInteger(FILESYSTEM_LOCK_EXPIRE_PROP_KEY);
     this.lockFile = new StoragePath(lockDirectory + StoragePath.SEPARATOR + LOCK_FILE_NAME);
@@ -293,9 +293,12 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   /**
    * Returns the default lock file root path.
    *
-   * <p>IMPORTANT: this path should be shared especially when there is engine cooperation.
+   * <p>IMPORTANT: this path should be shared especially when there is engine cooperation. It lives
+   * under the table metadata folder ({@code .hoodie}) so every engine/task derives the same lock
+   * file location from the table base path. This is also the fallback used by the constructor when
+   * no explicit lock path is configured, so the two must stay in sync.
    */
   private static String defaultLockPath(String tablePath) {
-    return tablePath + StoragePath.SEPARATOR + AUXILIARYFOLDER_NAME;
+    return tablePath + StoragePath.SEPARATOR + HoodieTableMetaClient.METAFOLDER_NAME;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.config.LockConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.lock.LockProvider;
 import org.apache.hudi.common.lock.LockState;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.HoodieStorageUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -55,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_EXPIRE_PROP_KEY;
 import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_PATH_PROP_KEY;
 import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_CLIENT_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY;
+import static org.apache.hudi.common.table.HoodieTableMetaClient.AUXILIARYFOLDER_NAME;
 
 /**
  * A FileSystem based lock. This {@link LockProvider} implementation allows to lock table operations
@@ -114,8 +114,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
     this.lockConfiguration = lockConfiguration;
     String lockDirectory = lockConfiguration.getConfig().getString(FILESYSTEM_LOCK_PATH_PROP_KEY, null);
     if (StringUtils.isNullOrEmpty(lockDirectory)) {
-      // Reuse the shared default so this fallback can never diverge from getLockConfig()'s default,
-      // which would silently place the lock file at a different path and break cross-engine locking.
+      // Match getLockConfig() so writers using either default share the same lock.
       lockDirectory = defaultLockPath(lockConfiguration.getConfig().getString(HoodieWriteConfig.BASE_PATH.key()));
     }
     this.lockTimeoutMinutes = lockConfiguration.getConfig().getInteger(FILESYSTEM_LOCK_EXPIRE_PROP_KEY);
@@ -293,12 +292,9 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   /**
    * Returns the default lock file root path.
    *
-   * <p>IMPORTANT: this path should be shared especially when there is engine cooperation. It lives
-   * under the table metadata folder ({@code .hoodie}) so every engine/task derives the same lock
-   * file location from the table base path. This is also the fallback used by the constructor when
-   * no explicit lock path is configured, so the two must stay in sync.
+   * <p>IMPORTANT: this path should be shared especially when there is engine cooperation.
    */
   private static String defaultLockPath(String tablePath) {
-    return tablePath + StoragePath.SEPARATOR + HoodieTableMetaClient.METAFOLDER_NAME;
+    return tablePath + StoragePath.SEPARATOR + AUXILIARYFOLDER_NAME;
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
@@ -433,8 +433,11 @@ public class TestFileSystemBasedLockProvider {
   public void testGetLockConfigProducesUsableProperties() {
     String tablePath = tempDir.resolve("table").toString();
     TypedProperties props = FileSystemBasedLockProvider.getLockConfig(tablePath);
-    // The generated config points the lock provider at the table's auxiliary folder.
+    // The generated config points the lock provider at the table metadata folder, the shared
+    // location every engine/task derives so the lock is mutually exclusive across processes.
     assertTrue(props.getString(HoodieLockConfig.FILESYSTEM_LOCK_PATH.key()).startsWith(tablePath));
+    assertTrue(props.getString(HoodieLockConfig.FILESYSTEM_LOCK_PATH.key())
+        .endsWith(HoodieTableMetaClient.METAFOLDER_NAME));
     assertEquals(FileSystemBasedLockProvider.class.getName(),
         props.getString(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key()));
 
@@ -447,6 +450,34 @@ public class TestFileSystemBasedLockProvider {
       provider.unlock();
       provider.close();
     }
+  }
+
+  @Test
+  public void testExplicitLockConfigAndBasePathFallbackResolveToSamePath() {
+    // Regression guard for the cross-engine lock-path divergence: getLockConfig()'s explicit default
+    // and the constructor's BASE_PATH-derived fallback must point at the very same lock file, or a
+    // writer relying on one would not be mutually excluded from a writer relying on the other.
+    StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    String tablePath = tempDir.resolve("sharedtable").toString();
+
+    // 1) Provider built from getLockConfig() (explicit FILESYSTEM_LOCK_PATH).
+    FileSystemBasedLockProvider fromLockConfig =
+        new FileSystemBasedLockProvider(
+            new LockConfiguration(FileSystemBasedLockProvider.getLockConfig(tablePath)), storageConf);
+
+    // 2) Provider built with only BASE_PATH set, exercising the constructor fallback.
+    Properties fallbackProps = new Properties();
+    fallbackProps.setProperty(HoodieWriteConfig.BASE_PATH.key(), tablePath);
+    fallbackProps.setProperty(FILESYSTEM_LOCK_EXPIRE_PROP_KEY, "0");
+    FileSystemBasedLockProvider fromFallback =
+        new FileSystemBasedLockProvider(new LockConfiguration(fallbackProps), storageConf);
+
+    // getLock() is a pure accessor of the resolved lock-file path (no storage I/O), so comparing it
+    // is enough and needs no acquire/release.
+    assertEquals(fromLockConfig.getLock(), fromFallback.getLock(),
+        "explicit default and BASE_PATH fallback must resolve to the same lock file");
+    assertTrue(fromLockConfig.getLock()
+        .endsWith(HoodieTableMetaClient.METAFOLDER_NAME + StoragePath.SEPARATOR + "lock"));
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
@@ -433,11 +433,8 @@ public class TestFileSystemBasedLockProvider {
   public void testGetLockConfigProducesUsableProperties() {
     String tablePath = tempDir.resolve("table").toString();
     TypedProperties props = FileSystemBasedLockProvider.getLockConfig(tablePath);
-    // The generated config points the lock provider at the table metadata folder, the shared
-    // location every engine/task derives so the lock is mutually exclusive across processes.
-    assertTrue(props.getString(HoodieLockConfig.FILESYSTEM_LOCK_PATH.key()).startsWith(tablePath));
-    assertTrue(props.getString(HoodieLockConfig.FILESYSTEM_LOCK_PATH.key())
-        .endsWith(HoodieTableMetaClient.METAFOLDER_NAME));
+    assertEquals(tablePath + StoragePath.SEPARATOR + HoodieTableMetaClient.AUXILIARYFOLDER_NAME,
+        props.getString(HoodieLockConfig.FILESYSTEM_LOCK_PATH.key()));
     assertEquals(FileSystemBasedLockProvider.class.getName(),
         props.getString(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key()));
 
@@ -477,11 +474,11 @@ public class TestFileSystemBasedLockProvider {
     assertEquals(fromLockConfig.getLock(), fromFallback.getLock(),
         "explicit default and BASE_PATH fallback must resolve to the same lock file");
     assertTrue(fromLockConfig.getLock()
-        .endsWith(HoodieTableMetaClient.METAFOLDER_NAME + StoragePath.SEPARATOR + "lock"));
+        .endsWith(HoodieTableMetaClient.AUXILIARYFOLDER_NAME + StoragePath.SEPARATOR + "lock"));
   }
 
   @Test
-  public void testLockPathDefaultsToMetafolderFromBasePath() {
+  public void testLockPathDefaultsToAuxiliaryFolderFromBasePath() {
     StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
     Properties props = new Properties();
     props.setProperty(HoodieWriteConfig.BASE_PATH.key(), lockDir("defaultpath"));
@@ -491,9 +488,9 @@ public class TestFileSystemBasedLockProvider {
     try {
       assertTrue(provider.tryLock(1, TimeUnit.SECONDS),
           "lock acquisition must work without an explicit lock path");
-      // Without an explicit lock path the provider locks under the table metafolder.
+      // Without an explicit lock path the provider locks under the table auxiliary folder.
       assertTrue(provider.getLock().endsWith(
-          HoodieTableMetaClient.METAFOLDER_NAME + StoragePath.SEPARATOR + "lock"));
+          HoodieTableMetaClient.AUXILIARYFOLDER_NAME + StoragePath.SEPARATOR + "lock"));
     } finally {
       provider.unlock();
       provider.close();

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
@@ -22,9 +22,10 @@ package org.apache.hudi
 import org.apache.hudi.avro.model.HoodieClusteringGroup
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider
-import org.apache.hudi.common.config.{HoodieCommonConfig, TypedProperties}
+import org.apache.hudi.common.config.HoodieCommonConfig
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.StringUtils
+import org.apache.hudi.config.HoodieLockConfig
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.storage.StorageSchemes
 
@@ -36,8 +37,6 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
 import org.apache.spark.sql.hudi.HoodieOptionConfig
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.filterHoodieConfigs
-
-import java.util.ArrayList
 
 import scala.collection.JavaConverters.{collectionAsScalaIterableConverter, mapAsJavaMapConverter, propertiesAsScalaMapConverter}
 
@@ -60,12 +59,25 @@ object HoodieCLIUtils extends Logging {
     }
 
     // Priority: defaults < catalog props < table config < sparkSession conf < specified conf
-    val finalParameters = HoodieWriterUtils.parametersWithWriteDefaults(
+    val parameters = HoodieWriterUtils.parametersWithWriteDefaults(
       (catalogProps ++
         metaClient.getTableConfig.getProps.asScala.toMap ++
         filterHoodieConfigs(sparkSession.sqlContext.getAllConfs) ++
         conf).toMap
     )
+
+    // Auto-config a DFS-based lock for the metadata table when the table has an MDT and no lock
+    // provider is configured at any layer. Table-service writers created here (compaction,
+    // clustering, clean, TTL, restore, rollback, savepoint, ...) can update the metadata table, so
+    // they must be mutually exclusive with concurrent writers on the shared lock path. This must be
+    // applied before building the client so the lock config actually takes effect.
+    val finalParameters =
+      if (metaClient.getTableConfig.isMetadataTableAvailable
+        && !parameters.contains(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key)) {
+        parameters ++ getLockOptions(basePath, metaClient.getBasePath.toUri.getScheme, parameters)
+      } else {
+        parameters
+      }
 
     val jsc = new JavaSparkContext(sparkSession.sparkContext)
     DataSourceUtils.createHoodieClient(jsc, schemaStr, basePath,
@@ -166,9 +178,20 @@ object HoodieCLIUtils extends Logging {
     key -> value
   }
 
-  def getLockOptions(tablePath: String, schema: String, lockConfig: TypedProperties): Map[String, String] = {
-    val customSupportedFSs = lockConfig.getStringList(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key, ",", new ArrayList[String])
-    if (schema == null || customSupportedFSs.contains(schema) || StorageSchemes.isAtomicCreationSupported(schema)) {
+  /**
+   * Builds the filesystem-based lock configuration for the metadata table, or an empty map when the
+   * table's filesystem cannot support atomic file creation (a hard requirement for the FS lock).
+   *
+   * @param tablePath the table base path, used to derive the shared lock file location
+   * @param scheme    the table filesystem scheme; {@code null} is treated as supported
+   * @param params    the already-merged write parameters, read only for the custom
+   *                  atomic-creation-support list ({@code hoodie.fs.atomic_creation.support})
+   */
+  def getLockOptions(tablePath: String, scheme: String, params: Map[String, String]): Map[String, String] = {
+    val customSupportedFSs = params.get(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key)
+      .map(v => StringUtils.split(v, ",").asScala.map(_.trim).filter(_.nonEmpty).toList)
+      .getOrElse(List.empty)
+    if (scheme == null || customSupportedFSs.contains(scheme) || StorageSchemes.isAtomicCreationSupported(scheme)) {
       logInfo("Auto config filesystem lock provider for metadata table")
       val props = FileSystemBasedLockProvider.getLockConfig(tablePath)
       props.stringPropertyNames.asScala

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCLIUtils.scala
@@ -22,10 +22,9 @@ package org.apache.hudi
 import org.apache.hudi.avro.model.HoodieClusteringGroup
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider
-import org.apache.hudi.common.config.HoodieCommonConfig
+import org.apache.hudi.common.config.{HoodieCommonConfig, TypedProperties}
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.util.StringUtils
-import org.apache.hudi.config.HoodieLockConfig
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.storage.StorageSchemes
 
@@ -37,6 +36,8 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
 import org.apache.spark.sql.hudi.HoodieOptionConfig
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.filterHoodieConfigs
+
+import java.util.Collections
 
 import scala.collection.JavaConverters.{collectionAsScalaIterableConverter, mapAsJavaMapConverter, propertiesAsScalaMapConverter}
 
@@ -51,6 +52,16 @@ object HoodieCLIUtils extends Logging {
     val schemaUtil = new TableSchemaResolver(metaClient)
     val schemaStr = schemaUtil.getTableSchema(false).toString
 
+    val finalParameters = getWriteParameters(sparkSession, metaClient, conf, tableName)
+    val jsc = new JavaSparkContext(sparkSession.sparkContext)
+    DataSourceUtils.createHoodieClient(jsc, schemaStr, basePath,
+      metaClient.getTableConfig.getTableName, finalParameters.asJava)
+  }
+
+  def getWriteParameters(sparkSession: SparkSession,
+                         metaClient: HoodieTableMetaClient,
+                         conf: Map[String, String],
+                         tableName: Option[String]): Map[String, String] = {
     // If tableName is provided, we need to add catalog props
     val catalogProps = tableName match {
       case Some(value) => HoodieOptionConfig.mapSqlOptionsToDataSourceWriteConfigs(
@@ -59,29 +70,12 @@ object HoodieCLIUtils extends Logging {
     }
 
     // Priority: defaults < catalog props < table config < sparkSession conf < specified conf
-    val parameters = HoodieWriterUtils.parametersWithWriteDefaults(
+    HoodieWriterUtils.parametersWithWriteDefaults(
       (catalogProps ++
         metaClient.getTableConfig.getProps.asScala.toMap ++
         filterHoodieConfigs(sparkSession.sqlContext.getAllConfs) ++
         conf).toMap
     )
-
-    // Auto-config a DFS-based lock for the metadata table when the table has an MDT and no lock
-    // provider is configured at any layer. Table-service writers created here (compaction,
-    // clustering, clean, TTL, restore, rollback, savepoint, ...) can update the metadata table, so
-    // they must be mutually exclusive with concurrent writers on the shared lock path. This must be
-    // applied before building the client so the lock config actually takes effect.
-    val finalParameters =
-      if (metaClient.getTableConfig.isMetadataTableAvailable
-        && !parameters.contains(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key)) {
-        parameters ++ getLockOptions(basePath, metaClient.getBasePath.toUri.getScheme, parameters)
-      } else {
-        parameters
-      }
-
-    val jsc = new JavaSparkContext(sparkSession.sparkContext)
-    DataSourceUtils.createHoodieClient(jsc, schemaStr, basePath,
-      metaClient.getTableConfig.getTableName, finalParameters.asJava)
   }
 
   def extractPartitions(clusteringGroups: Seq[HoodieClusteringGroup]): String = {
@@ -188,9 +182,8 @@ object HoodieCLIUtils extends Logging {
    *                  atomic-creation-support list ({@code hoodie.fs.atomic_creation.support})
    */
   def getLockOptions(tablePath: String, scheme: String, params: Map[String, String]): Map[String, String] = {
-    val customSupportedFSs = params.get(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key)
-      .map(v => StringUtils.split(v, ",").asScala.map(_.trim).filter(_.nonEmpty).toList)
-      .getOrElse(List.empty)
+    val customSupportedFSs = TypedProperties.fromMap(params.asJava)
+      .getStringList(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key, ",", Collections.emptyList[String]())
     if (scheme == null || customSupportedFSs.contains(scheme) || StorageSchemes.isAtomicCreationSupported(scheme)) {
       logInfo("Auto config filesystem lock provider for metadata table")
       val props = FileSystemBasedLockProvider.getLockConfig(tablePath)

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestHoodieCLIUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestHoodieCLIUtils.scala
@@ -19,6 +19,11 @@
 
 package org.apache.hudi
 
+import org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider
+import org.apache.hudi.common.config.HoodieCommonConfig
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.config.HoodieLockConfig
+
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
 import org.junit.jupiter.api.Test
 
@@ -100,5 +105,34 @@ class TestHoodieCLIUtils {
     assertThrows(
       classOf[IllegalArgumentException],
       () => HoodieCLIUtils.extractOptions("   =v"))
+  }
+
+  @Test
+  def testGetLockOptionsSupportedSchemeReturnsFsLockConfig(): Unit = {
+    val tablePath = "/tmp/hudi/some_table"
+    // A null scheme is treated as supported; the FS lock provider must be auto-configured.
+    val opts = HoodieCLIUtils.getLockOptions(tablePath, null, Map.empty)
+    assertEquals(classOf[FileSystemBasedLockProvider].getName,
+      opts(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key))
+    // The lock path must live under the shared table metadata folder (not the .aux folder), so the
+    // lock is mutually exclusive across engines/tasks operating on the same table.
+    val lockPath = opts(HoodieLockConfig.FILESYSTEM_LOCK_PATH.key)
+    assertTrue(lockPath.startsWith(tablePath))
+    assertTrue(lockPath.endsWith(HoodieTableMetaClient.METAFOLDER_NAME))
+  }
+
+  @Test
+  def testGetLockOptionsUnsupportedSchemeReturnsEmpty(): Unit = {
+    // s3 is a known scheme without atomic-creation support, so no FS lock can be configured.
+    assertTrue(HoodieCLIUtils.getLockOptions("s3://bucket/table", "s3", Map.empty).isEmpty)
+  }
+
+  @Test
+  def testGetLockOptionsCustomAtomicSupportEnablesScheme(): Unit = {
+    // Opting s3 into hoodie.fs.atomic_creation.support makes the FS lock provider eligible again.
+    val params = Map(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key -> "s3")
+    val opts = HoodieCLIUtils.getLockOptions("s3://bucket/table", "s3", params)
+    assertEquals(classOf[FileSystemBasedLockProvider].getName,
+      opts(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key))
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestHoodieCLIUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestHoodieCLIUtils.scala
@@ -20,12 +20,14 @@
 package org.apache.hudi
 
 import org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider
-import org.apache.hudi.common.config.HoodieCommonConfig
-import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.config.{HoodieCommonConfig, TypedProperties}
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.config.HoodieLockConfig
 
+import org.apache.spark.sql.{SparkSession, SQLContext}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.{mock, when}
 
 class TestHoodieCLIUtils {
 
@@ -114,11 +116,8 @@ class TestHoodieCLIUtils {
     val opts = HoodieCLIUtils.getLockOptions(tablePath, null, Map.empty)
     assertEquals(classOf[FileSystemBasedLockProvider].getName,
       opts(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key))
-    // The lock path must live under the shared table metadata folder (not the .aux folder), so the
-    // lock is mutually exclusive across engines/tasks operating on the same table.
-    val lockPath = opts(HoodieLockConfig.FILESYSTEM_LOCK_PATH.key)
-    assertTrue(lockPath.startsWith(tablePath))
-    assertTrue(lockPath.endsWith(HoodieTableMetaClient.METAFOLDER_NAME))
+    assertEquals(s"$tablePath/${HoodieTableMetaClient.AUXILIARYFOLDER_NAME}",
+      opts(HoodieLockConfig.FILESYSTEM_LOCK_PATH.key))
   }
 
   @Test
@@ -130,9 +129,48 @@ class TestHoodieCLIUtils {
   @Test
   def testGetLockOptionsCustomAtomicSupportEnablesScheme(): Unit = {
     // Opting s3 into hoodie.fs.atomic_creation.support makes the FS lock provider eligible again.
-    val params = Map(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key -> "s3")
+    val params = Map(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key -> " hdfs, s3 ")
     val opts = HoodieCLIUtils.getLockOptions("s3://bucket/table", "s3", params)
     assertEquals(classOf[FileSystemBasedLockProvider].getName,
       opts(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key))
   }
+
+  @Test
+  def testWriteParametersPreserveLockConfigPrecedence(): Unit = {
+    val sparkSession = mock(classOf[SparkSession])
+    val sqlContext = mock(classOf[SQLContext])
+    val metaClient = mock(classOf[HoodieTableMetaClient])
+    val tableConfig = mock(classOf[HoodieTableConfig])
+    val tableProps = new TypedProperties()
+    val providerKey = HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key
+    val atomicSupportKey = HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key
+    tableProps.setProperty(providerKey, "table.provider")
+    tableProps.setProperty(atomicSupportKey, "hdfs")
+    when(sparkSession.sqlContext).thenReturn(sqlContext)
+    when(metaClient.getTableConfig).thenReturn(tableConfig)
+    when(tableConfig.getProps).thenReturn(tableProps)
+    when(sqlContext.getAllConfs).thenReturn(Map.empty[String, String])
+
+    val fromTable = HoodieCLIUtils.getWriteParameters(sparkSession, metaClient, Map.empty, None)
+    assertEquals("table.provider", fromTable(providerKey))
+    assertEquals("hdfs", fromTable(atomicSupportKey))
+
+    when(sqlContext.getAllConfs).thenReturn(Map(providerKey -> "session.provider", atomicSupportKey -> "s3"))
+    val fromSession = HoodieCLIUtils.getWriteParameters(sparkSession, metaClient, Map.empty, None)
+    assertEquals("session.provider", fromSession(providerKey))
+    assertEquals("s3", fromSession(atomicSupportKey))
+
+    val fromOptions = HoodieCLIUtils.getWriteParameters(sparkSession, metaClient,
+      Map(providerKey -> "options.provider", atomicSupportKey -> "file"), None)
+    assertEquals("options.provider", fromOptions(providerKey))
+    assertEquals("file", fromOptions(atomicSupportKey))
+    assertEquals(fromOptions,
+      HoodieCLIUtils.getWriteParameters(sparkSession, metaClient, fromOptions, None))
+
+    tableProps.clear()
+    when(sqlContext.getAllConfs).thenReturn(Map.empty[String, String])
+    val withoutLock = HoodieCLIUtils.getWriteParameters(sparkSession, metaClient, Map.empty, None)
+    assertTrue(!withoutLock.contains(providerKey))
+  }
+
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.table.timeline.HoodieTimeline
 import org.apache.hudi.common.util.{ClusteringUtils, HoodieTimer, Option => HOption, SortUtils}
 import org.apache.hudi.common.util.ValidationUtils.checkArgument
-import org.apache.hudi.config.{HoodieClusteringConfig, HoodieLockConfig}
+import org.apache.hudi.config.HoodieClusteringConfig
 import org.apache.hudi.exception.HoodieClusteringException
 import org.apache.hudi.execution.bulkinsert.SpatialCurveSortPartitionerBase
 
@@ -195,11 +195,6 @@ class RunClusteringProcedure extends BaseProcedure
         val strategy = client.getConfig.getLayoutOptimizationStrategy
         if (strategy != HoodieClusteringConfig.LayoutOptimizationStrategy.LINEAR) {
           SpatialCurveSortPartitionerBase.validateOrderByColumns(orderColumns, tableSchema, strategy)
-        }
-      }
-      if (metaClient.getTableConfig.isMetadataTableAvailable) {
-        if (!confs.contains(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key)) {
-          confs = confs ++ HoodieCLIUtils.getLockOptions(basePath, metaClient.getBasePath.toUri.getScheme, client.getConfig.getCommonConfig.getProps())
         }
       }
       if (operation.isSchedule) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunClusteringProcedure.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.table.timeline.HoodieTimeline
 import org.apache.hudi.common.util.{ClusteringUtils, HoodieTimer, Option => HOption, SortUtils}
 import org.apache.hudi.common.util.ValidationUtils.checkArgument
-import org.apache.hudi.config.HoodieClusteringConfig
+import org.apache.hudi.config.{HoodieClusteringConfig, HoodieLockConfig}
 import org.apache.hudi.exception.HoodieClusteringException
 import org.apache.hudi.execution.bulkinsert.SpatialCurveSortPartitionerBase
 
@@ -180,6 +180,14 @@ class RunClusteringProcedure extends BaseProcedure
 
     var (filteredPendingClusteringInstants, operation) = HoodieProcedureUtils.filterPendingInstantsAndGetOperation(
       pendingClusteringInstants, specificInstants.asInstanceOf[Option[String]], op.asInstanceOf[Option[String]], limit.asInstanceOf[Option[Int]])
+
+    confs = HoodieCLIUtils.getWriteParameters(sparkSession, metaClient, confs,
+      tableName.asInstanceOf[Option[String]])
+    // Apply the lock options before constructing the write client.
+    if (metaClient.getTableConfig.isMetadataTableAvailable
+      && !confs.contains(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key)) {
+      confs = HoodieCLIUtils.getLockOptions(basePath, metaClient.getBasePath.toUri.getScheme, confs) ++ confs
+    }
 
     var client: SparkRDDWriteClient[_] = null
     try {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
@@ -23,7 +23,6 @@ import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.common.model.HoodieCommitMetadata
 import org.apache.hudi.common.table.timeline.HoodieTimeline
 import org.apache.hudi.common.util.{CompactionUtils, HoodieTimer, Option => HOption}
-import org.apache.hudi.config.HoodieLockConfig
 import org.apache.hudi.exception.HoodieException
 
 import org.apache.spark.internal.Logging
@@ -98,12 +97,6 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
     try {
       client = HoodieCLIUtils.createHoodieWriteClient(sparkSession, basePath, confs,
         tableName.asInstanceOf[Option[String]])
-
-      if (metaClient.getTableConfig.isMetadataTableAvailable) {
-        if (!confs.contains(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key)) {
-          confs = confs ++ HoodieCLIUtils.getLockOptions(basePath, metaClient.getBasePath.toUri.getScheme, client.getConfig.getCommonConfig.getProps())
-        }
-      }
 
       if (operation.isSchedule) {
         val instantTime = client.scheduleCompaction(HOption.empty[java.util.Map[String, String]])

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCompactionProcedure.scala
@@ -23,6 +23,7 @@ import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.common.model.HoodieCommitMetadata
 import org.apache.hudi.common.table.timeline.HoodieTimeline
 import org.apache.hudi.common.util.{CompactionUtils, HoodieTimer, Option => HOption}
+import org.apache.hudi.config.HoodieLockConfig
 import org.apache.hudi.exception.HoodieException
 
 import org.apache.spark.internal.Logging
@@ -92,6 +93,14 @@ class RunCompactionProcedure extends BaseProcedure with ProcedureBuilder with Sp
 
     var (filteredPendingCompactionInstants, operation) = HoodieProcedureUtils.filterPendingInstantsAndGetOperation(
       pendingCompactionInstants, specificInstants.asInstanceOf[Option[String]], Option(op), limit)
+
+    confs = HoodieCLIUtils.getWriteParameters(sparkSession, metaClient, confs,
+      tableName.asInstanceOf[Option[String]])
+    // Apply the lock options before constructing the write client.
+    if (metaClient.getTableConfig.isMetadataTableAvailable
+      && !confs.contains(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key)) {
+      confs = HoodieCLIUtils.getLockOptions(basePath, metaClient.getBasePath.toUri.getScheme, confs) ++ confs
+    }
 
     var client: SparkRDDWriteClient[_] = null
     try {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestTableServiceLockConfig.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestTableServiceLockConfig.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.procedure
+
+import org.apache.hudi.HoodieCLIUtils
+import org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider
+import org.apache.hudi.common.config.LockConfiguration
+import org.apache.hudi.common.testutils.HoodieTestUtils
+import org.apache.hudi.config.HoodieLockConfig
+import org.apache.hudi.exception.HoodieLockException
+
+import java.util.concurrent.TimeUnit
+
+class TestTableServiceLockConfig extends HoodieSparkProcedureTestBase {
+  Seq("run_clustering" -> "cow", "run_compaction" -> "mor").foreach { case (procedure, tableType) =>
+    test(s"$procedure acquires the derived metadata table lock") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        val basePath = tmp.getCanonicalPath
+        spark.sql(
+          s"""create table $tableName (id int, ts long) using hudi
+             |location '$basePath'
+             |tblproperties (primaryKey = 'id', preCombineField = 'ts', type = '$tableType',
+             |  'hoodie.metadata.enable' = 'true')""".stripMargin)
+        spark.sql(s"insert into $tableName values (1, 1)")
+        assert(HoodieTestUtils.createMetaClient(basePath).getTableConfig.isMetadataTableAvailable)
+
+        val client = HoodieCLIUtils.createHoodieWriteClient(spark, basePath, Map.empty, Some(tableName))
+        try {
+          assert(client.getConfig.getLockProviderClass != classOf[FileSystemBasedLockProvider].getName)
+        } finally {
+          client.close()
+        }
+
+        val lock = new FileSystemBasedLockProvider(
+          new LockConfiguration(FileSystemBasedLockProvider.getLockConfig(basePath)),
+          HoodieTestUtils.getDefaultStorageConf)
+        try {
+          assert(lock.tryLock(1, TimeUnit.SECONDS))
+          val options = Seq(
+            HoodieLockConfig.LOCK_ACQUIRE_WAIT_TIMEOUT_MS.key -> "1",
+            HoodieLockConfig.LOCK_ACQUIRE_CLIENT_NUM_RETRIES.key -> "0"
+          ).map { case (key, value) => s"$key=$value" }.mkString(",")
+          val error = intercept[Exception] {
+            spark.sql(s"call $procedure(op => 'schedule', table => '$tableName', options => '$options')").collect()
+          }
+          assert(Iterator.iterate[Throwable](error)(_.getCause).takeWhile(_ != null)
+            .exists(_.isInstanceOf[HoodieLockException]))
+        } finally {
+          lock.unlock()
+          lock.close()
+        }
+        spark.sql(s"call $procedure(op => 'schedule', table => '$tableName')").collect()
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`run_clustering` and `run_compaction` append metadata-table lock options after constructing the write client, so the derived filesystem lock configuration never reaches the client.

### Summary and Changelog

- Use the shared `.hoodie/.aux` default for the filesystem lock provider constructor and generated lock configuration.
- Keep lock derivation inside `RunClusteringProcedure` and `RunCompactionProcedure`, and apply the options before creating the write client.
- Extract the existing configuration merge into `HoodieCLIUtils.getWriteParameters()` so both procedures check the effective catalog, table, session, global-default, and procedure options before deriving a lock. Preserve explicit providers and lock options.
- Derive the existing filesystem lock configuration only when the table has a metadata table, no provider is configured, and the filesystem supports atomic creation. Parse custom filesystem support with `TypedProperties.getStringList()`.
- Add unit coverage for filesystem eligibility and configuration precedence, plus SQL tests confirming that both procedures reject scheduling while the generated filesystem lock is held. Shared client creation does not automatically derive a filesystem lock for other callers.

### Impact

The clustering and compaction write clients now receive the intended lock options before construction. The generated filesystem lock configuration continues to use `.hoodie/.aux` through the existing `FileSystemBasedLockProvider.getLockConfig()` helper. The filesystem lock provider constructor fallback now also uses `.hoodie/.aux`, replacing its previous `.hoodie` fallback. Explicitly configured paths and generated defaults remain unchanged. Lock cleanup behavior and lock format are unchanged. Other SQL procedures retain their existing derivation behavior.

### Risk Level

medium

This enables a previously dropped lock configuration and changes the constructor fallback path. Old clients using `.hoodie/lock` do not contend with updated clients using `.hoodie/.aux/lock`; deployments must coordinate the change and configure the same explicit path across all clients before mixing versions. Tests cover configuration precedence, eligibility, and initial lock contention. The existing filesystem-provider cleanup/ownership bug and the `hoodie.auto.adjust.lock.configs=true` provider override remain outside this PR's scope; the SQL tests do not establish ownership preservation after a failed acquisition.

Validation: the focused Maven reactor run passed on Java 17 / Spark 3.5: `TestFileSystemBasedLockProvider` (17 tests), `TestHoodieCLIUtils` (14 tests), and `TestTableServiceLockConfig` (2 SQL tests). Checkstyle, Scalastyle, and license checks passed in the same build.

### Documentation Update

No new configuration keys. The constructor-fallback compatibility requirement is described above and should accompany release documentation.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
