### PR TITLE
fix(spark): handle empty projections with internal schema

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -750,6 +750,12 @@ object HoodieBaseRelation extends SparkAdapterSupport {
     tableSchema match {
       case Right(internalSchema) =>
         checkState(!internalSchema.isEmptySchema)
+        // An empty projection (count(*), select 1) reads no column data, so there is nothing to
+        // evolve, and pruning to zero columns builds an InternalSchema around a null record instead
+        // (NPE in buildIdToName, #19734). The empty sentinel is deliberate: it serializes to "" in
+        // SerDeHelper.toJson, so embedInternalSchema leaves HOODIE_QUERY_SCHEMA unset and the reader
+        // stays on zero columns. Hive takes the same carve-out in
+        // SchemaEvolutionContext#doEvolutionForParquetFormat.
         val prunedInternalSchema = if (requiredColumns.isEmpty) {
           InternalSchema.getEmptyInternalSchema
         } else {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
@@ -750,7 +750,11 @@ object HoodieBaseRelation extends SparkAdapterSupport {
     tableSchema match {
       case Right(internalSchema) =>
         checkState(!internalSchema.isEmptySchema)
-        val prunedInternalSchema = InternalSchemaUtils.pruneInternalSchema(internalSchema, requiredColumns.toList.asJava)
+        val prunedInternalSchema = if (requiredColumns.isEmpty) {
+          InternalSchema.getEmptyInternalSchema
+        } else {
+          InternalSchemaUtils.pruneInternalSchema(internalSchema, requiredColumns.toList.asJava)
+        }
         val requiredSchema = InternalSchemaConverter.convert(prunedInternalSchema, "schema")
         val requiredStructSchema = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(requiredSchema)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieRelations.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieRelations.scala
@@ -67,5 +67,15 @@ class TestHoodieRelations {
     assertEquals(0, requiredAvroSchema.getFields.size)
     assertEquals(0, requiredStructSchema.fields.length)
     assertTrue(requiredInternalSchema.isEmptySchema)
+
+    // The schema-on-read arm must land on the same projection as the plain arm, which has always
+    // handled an empty projection by building a zero-field record. The record names differ ("schema"
+    // vs the table's own), so compare the struct schema and the field count rather than the records.
+    val (plainAvroSchema, plainStructSchema, plainInternalSchema) =
+      HoodieBaseRelation.projectSchema(Left(tableSchema), Array.empty)
+
+    assertEquals(plainStructSchema, requiredStructSchema)
+    assertEquals(plainAvroSchema.getFields.size, requiredAvroSchema.getFields.size)
+    assertTrue(plainInternalSchema.isEmptySchema)
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieRelations.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieRelations.scala
@@ -18,8 +18,10 @@
 package org.apache.hudi
 
 import org.apache.hudi.common.schema.HoodieSchema
+import org.apache.hudi.common.schema.internal.convert.InternalSchemaConverter
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 import scala.collection.JavaConverters.asScalaBufferConverter
@@ -50,5 +52,20 @@ class TestHoodieRelations {
       Seq(tableStructSchema.fields.apply(tableStructSchema.fieldIndex("ts"))),
       requiredStructSchema.fields.toSeq
     )
+  }
+
+  @Test
+  def testPruningInternalSchemaToEmptyProjection(): Unit = {
+    val tableSchema = HoodieSchema.parse(
+      "{\"type\":\"record\",\"name\":\"record\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"}]}"
+    )
+    val internalSchema = InternalSchemaConverter.convert(tableSchema)
+
+    val (requiredAvroSchema, requiredStructSchema, requiredInternalSchema) =
+      HoodieBaseRelation.projectSchema(Right(internalSchema), Array.empty)
+
+    assertEquals(0, requiredAvroSchema.getFields.size)
+    assertEquals(0, requiredStructSchema.fields.length)
+    assertTrue(requiredInternalSchema.isEmptySchema)
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLegacyParquetReadPath.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLegacyParquetReadPath.scala
@@ -509,6 +509,11 @@ class TestLegacyParquetReadPath extends HoodieSparkClientTestBase with ScalaAsse
       assertWidenedValues(legacyDf)
       assertSameRows(newReaderDf, legacyDf)
     }
+
+    // An empty projection prunes the internal schema to zero columns, which used to build an
+    // InternalSchema around a null record and NPE in buildIdToName (#19734). The shredded-variant
+    // test pins this too, but only from Spark 4.1 up; this leg is the one that runs on every profile.
+    assertEquals(30L, legacyRelationDf(readOpts).count())
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLegacyParquetReadPath.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLegacyParquetReadPath.scala
@@ -561,15 +561,7 @@ class TestLegacyParquetReadPath extends HoodieSparkClientTestBase with ScalaAsse
       && String.valueOf(c.getMessage).contains("shredded variant")),
       s"Expected the shredded-variant rejection but got: $thrown")
 
-    // The guard's empty-projection carve-out (count(*) reads no column data and must keep working)
-    // is pinned on the file-group-reader path by the count(*) leg of "Schema-on-read reads of
-    // shredded variant files fail fast" in TestVariantShreddingMixedLayouts, not here: this relation
-    // cannot serve an empty projection under schema-on-read at all, with or
-    // without a variant. buildScan prunes the internal schema to the zero requested columns, and
-    // InternalSchemaUtils.pruneInternalSchema builds an InternalSchema around a null record (NPE in
-    // buildIdToName; pre-existing, tracked by #19734).
-    // TODO(voon): once #19734 is fixed, restore the carve-out here so the legacy relation pins it too:
-    //   assertEquals(2L, legacyRelationDf(readOpts).count())
+    assertEquals(2L, legacyRelationDf(readOpts).count())
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19734.

`HoodieBaseRelation.projectSchema` calls `InternalSchemaUtils.pruneInternalSchema(schema, [])` when a legacy relation is asked for zero columns (`count()`, `select 1`). `pruneType` keeps no field and returns `null`, `pruneInternalSchemaByID` wraps it in `new InternalSchema(null)`, and `InternalSchema.buildIdToName` throws `NullPointerException: Cannot invoke Types$RecordType.fields() because "record" is null`.

`BaseFileOnlyRelation` is the only relation that reaches this: it is the only one with empty `mandatoryFields`, so nothing pads the projection. Every other relation forces the record key plus commit time. The non-schema-on-read (`Left`) arm of the same method has always built a zero-field record instead of throwing.

### Summary and Changelog

Return the existing empty internal-schema sentinel when a legacy relation projects no columns, so `count()` under `hoodie.schema.on.read.enable` behaves as it already does without it.

- `HoodieBaseRelation.projectSchema`: return `InternalSchema.getEmptyInternalSchema` when `requiredColumns` is empty; non-empty projections still go through `InternalSchemaUtils.pruneInternalSchema` unchanged. The empty sentinel is deliberate -- it serializes to `""` in `SerDeHelper.toJson`, so `embedInternalSchema` leaves `HOODIE_QUERY_SCHEMA` unset and the reader stays on zero columns. Hive takes the same carve-out in `SchemaEvolutionContext#doEvolutionForParquetFormat`.
- `TestHoodieRelations`: new `testPruningInternalSchemaToEmptyProjection`, pinning the empty projection and that the schema-on-read arm agrees with the plain arm.
- `TestLegacyParquetReadPath`: restored the `count()` assertion in `testCowSnapshotReadWithSchemaOnReadRejectsShreddedVariant` that #19687 parked behind a `TODO` on this issue, and added an ungated `count()` leg to `testCowSnapshotReadWithSchemaOnRead` so the fix is pinned on every Spark profile rather than only 4.1+.

Known remaining gap, left for a follow-up: `SchemaEvolutionContext#doEvolutionForRealtimeInputFormat` (hudi-hadoop-mr) still calls `pruneInternalSchema` with no empty-projection carve-out, unlike its `doEvolutionForParquetFormat` sibling. It surfaces as `IllegalArgumentException: cannot prune col:` rather than the NPE, and is out of scope for a Spark-side fix.

### Impact

Zero-column projections (`count()`) on a schema-on-read table read through `BaseFileOnlyRelation` no longer throw. No public API, config or storage format change. Non-empty projections are unaffected, as is the default file-group-reader read path.

### Risk Level

low

A single branch on a path that previously always threw, guarded on `requiredColumns.isEmpty`; non-empty projections are untouched. Verified with `TestHoodieRelations` and `TestLegacyParquetReadPath` on `-Dscala-2.12 -Dspark3.5`.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
