### PR TITLE
fix(hadoop-mr): return catalog class names as literals so sync never loads Hive

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -61,11 +61,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
-import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
-import org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat;
-import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
-import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
-import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
@@ -151,6 +146,27 @@ public class HoodieInputFormatUtils {
     }
   }
 
+  // Class names are returned as literals rather than via Class#getName so that resolving them never
+  // loads the class. HiveSyncTool and the other catalog syncs only ever hand these to a metastore as
+  // strings, and loading them would pull in Hive: HoodieParquetInputFormat extends Hive's
+  // MapredParquetInputFormat, and the output-format and SerDe names are Hive classes outright. On a
+  // deployment without Hive on the classpath (for example the utilities bundle) that resolution is a
+  // ClassNotFoundException at sync time (HUDI-7321). TestHoodieInputFormatUtils pins each constant
+  // against the class it names, so a rename cannot silently break these.
+  static final String HOODIE_PARQUET_INPUT_FORMAT = "org.apache.hudi.hadoop.HoodieParquetInputFormat";
+  static final String HOODIE_PARQUET_REALTIME_INPUT_FORMAT = "org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat";
+  static final String HOODIE_HFILE_INPUT_FORMAT = "org.apache.hudi.hadoop.HoodieHFileInputFormat";
+  static final String HOODIE_HFILE_REALTIME_INPUT_FORMAT = "org.apache.hudi.hadoop.realtime.HoodieHFileRealtimeInputFormat";
+  static final String HOODIE_LANCE_INPUT_FORMAT = "org.apache.hudi.hadoop.HoodieLanceInputFormat";
+  static final String HOODIE_LANCE_REALTIME_INPUT_FORMAT = "org.apache.hudi.hadoop.realtime.HoodieLanceRealtimeInputFormat";
+  static final String HOODIE_VORTEX_INPUT_FORMAT = "org.apache.hudi.hadoop.HoodieVortexInputFormat";
+  static final String HOODIE_VORTEX_REALTIME_INPUT_FORMAT = "org.apache.hudi.hadoop.realtime.HoodieVortexRealtimeInputFormat";
+  static final String ORC_INPUT_FORMAT = "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat";
+  static final String MAPRED_PARQUET_OUTPUT_FORMAT = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat";
+  static final String ORC_OUTPUT_FORMAT = "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat";
+  static final String PARQUET_HIVE_SERDE = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe";
+  static final String ORC_SERDE = "org.apache.hadoop.hive.ql.io.orc.OrcSerde";
+
   public static String getInputFormatClassName(HoodieFileFormat baseFileFormat, boolean realtime, boolean usePreApacheFormat) {
     return getInputFormatClassName(baseFileFormat, realtime);
   }
@@ -159,30 +175,30 @@ public class HoodieInputFormatUtils {
     switch (baseFileFormat) {
       case PARQUET:
         if (realtime) {
-          return HoodieParquetRealtimeInputFormat.class.getName();
+          return HOODIE_PARQUET_REALTIME_INPUT_FORMAT;
         } else {
-          return HoodieParquetInputFormat.class.getName();
+          return HOODIE_PARQUET_INPUT_FORMAT;
         }
       case HFILE:
         if (realtime) {
-          return HoodieHFileRealtimeInputFormat.class.getName();
+          return HOODIE_HFILE_REALTIME_INPUT_FORMAT;
         } else {
-          return HoodieHFileInputFormat.class.getName();
+          return HOODIE_HFILE_INPUT_FORMAT;
         }
       case LANCE:
         if (realtime) {
-          return HoodieLanceRealtimeInputFormat.class.getName();
+          return HOODIE_LANCE_REALTIME_INPUT_FORMAT;
         } else {
-          return HoodieLanceInputFormat.class.getName();
+          return HOODIE_LANCE_INPUT_FORMAT;
         }
       case VORTEX:
         if (realtime) {
-          return HoodieVortexRealtimeInputFormat.class.getName();
+          return HOODIE_VORTEX_REALTIME_INPUT_FORMAT;
         } else {
-          return HoodieVortexInputFormat.class.getName();
+          return HOODIE_VORTEX_INPUT_FORMAT;
         }
       case ORC:
-        return OrcInputFormat.class.getName();
+        return ORC_INPUT_FORMAT;
       default:
         throw new HoodieIOException("Hoodie InputFormat not implemented for base file format " + baseFileFormat);
     }
@@ -194,9 +210,9 @@ public class HoodieInputFormatUtils {
       case HFILE:
       case LANCE:
       case VORTEX:
-        return MapredParquetOutputFormat.class.getName();
+        return MAPRED_PARQUET_OUTPUT_FORMAT;
       case ORC:
-        return OrcOutputFormat.class.getName();
+        return ORC_OUTPUT_FORMAT;
       default:
         throw new HoodieIOException("No OutputFormat for base file format " + baseFileFormat);
     }
@@ -208,9 +224,9 @@ public class HoodieInputFormatUtils {
       case HFILE:
       case LANCE:
       case VORTEX:
-        return ParquetHiveSerDe.class.getName();
+        return PARQUET_HIVE_SERDE;
       case ORC:
-        return OrcSerde.class.getName();
+        return ORC_SERDE;
       default:
         throw new HoodieIOException("No SerDe for base file format " + baseFileFormat);
     }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieInputFormatUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop.utils;
+
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.hadoop.HoodieHFileInputFormat;
+import org.apache.hudi.hadoop.HoodieLanceInputFormat;
+import org.apache.hudi.hadoop.HoodieParquetInputFormat;
+import org.apache.hudi.hadoop.HoodieVortexInputFormat;
+import org.apache.hudi.hadoop.realtime.HoodieHFileRealtimeInputFormat;
+import org.apache.hudi.hadoop.realtime.HoodieLanceRealtimeInputFormat;
+import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
+import org.apache.hudi.hadoop.realtime.HoodieVortexRealtimeInputFormat;
+
+import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The input format, output format and SerDe names are returned as string literals so that a catalog
+ * sync never class-loads them (see the comment on the constants in {@link HoodieInputFormatUtils}).
+ * That trades compile-time safety for a runtime one, so these assertions put it back: Hive is on the
+ * test classpath here, and each constant is checked against the class it names. A rename that would
+ * otherwise ship a dangling name to a metastore fails here instead.
+ */
+class TestHoodieInputFormatUtils {
+
+  @Test
+  void testInputFormatConstantsMatchTheirClasses() {
+    assertEquals(HoodieParquetInputFormat.class.getName(), HoodieInputFormatUtils.HOODIE_PARQUET_INPUT_FORMAT);
+    assertEquals(HoodieParquetRealtimeInputFormat.class.getName(), HoodieInputFormatUtils.HOODIE_PARQUET_REALTIME_INPUT_FORMAT);
+    assertEquals(HoodieHFileInputFormat.class.getName(), HoodieInputFormatUtils.HOODIE_HFILE_INPUT_FORMAT);
+    assertEquals(HoodieHFileRealtimeInputFormat.class.getName(), HoodieInputFormatUtils.HOODIE_HFILE_REALTIME_INPUT_FORMAT);
+    assertEquals(HoodieLanceInputFormat.class.getName(), HoodieInputFormatUtils.HOODIE_LANCE_INPUT_FORMAT);
+    assertEquals(HoodieLanceRealtimeInputFormat.class.getName(), HoodieInputFormatUtils.HOODIE_LANCE_REALTIME_INPUT_FORMAT);
+    assertEquals(HoodieVortexInputFormat.class.getName(), HoodieInputFormatUtils.HOODIE_VORTEX_INPUT_FORMAT);
+    assertEquals(HoodieVortexRealtimeInputFormat.class.getName(), HoodieInputFormatUtils.HOODIE_VORTEX_REALTIME_INPUT_FORMAT);
+    assertEquals(OrcInputFormat.class.getName(), HoodieInputFormatUtils.ORC_INPUT_FORMAT);
+  }
+
+  @Test
+  void testOutputFormatAndSerDeConstantsMatchTheirClasses() {
+    assertEquals(MapredParquetOutputFormat.class.getName(), HoodieInputFormatUtils.MAPRED_PARQUET_OUTPUT_FORMAT);
+    assertEquals(OrcOutputFormat.class.getName(), HoodieInputFormatUtils.ORC_OUTPUT_FORMAT);
+    assertEquals(ParquetHiveSerDe.class.getName(), HoodieInputFormatUtils.PARQUET_HIVE_SERDE);
+    assertEquals(OrcSerde.class.getName(), HoodieInputFormatUtils.ORC_SERDE);
+  }
+
+  /** The names the catalog syncs actually ask for, so the switch wiring is covered too. */
+  @Test
+  void testClassNamesForParquetAndOrc() {
+    assertEquals(HoodieParquetInputFormat.class.getName(),
+        HoodieInputFormatUtils.getInputFormatClassName(HoodieFileFormat.PARQUET, false));
+    assertEquals(HoodieParquetRealtimeInputFormat.class.getName(),
+        HoodieInputFormatUtils.getInputFormatClassName(HoodieFileFormat.PARQUET, true));
+    assertEquals(MapredParquetOutputFormat.class.getName(),
+        HoodieInputFormatUtils.getOutputFormatClassName(HoodieFileFormat.PARQUET));
+    assertEquals(ParquetHiveSerDe.class.getName(),
+        HoodieInputFormatUtils.getSerDeClassName(HoodieFileFormat.PARQUET));
+    assertEquals(OrcInputFormat.class.getName(),
+        HoodieInputFormatUtils.getInputFormatClassName(HoodieFileFormat.ORC, false));
+    assertEquals(OrcOutputFormat.class.getName(),
+        HoodieInputFormatUtils.getOutputFormatClassName(HoodieFileFormat.ORC));
+    assertEquals(OrcSerde.class.getName(),
+        HoodieInputFormatUtils.getSerDeClassName(HoodieFileFormat.ORC));
+  }
+}

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -158,8 +158,6 @@
                   <include>org.apache.hive:hive-service-rpc</include>
                   <include>org.apache.hive:hive-metastore</include>
                   <include>org.apache.hive:hive-jdbc</include>
-                  <!-- MapredParquetInputFormat, superclass of the bundled hudi-hadoop-mr input formats -->
-                  <include>org.apache.hive:hive-exec</include>
 
                   <include>org.apache.curator:curator-framework</include>
                   <include>org.apache.curator:curator-client</include>
@@ -355,31 +353,6 @@
       <artifactId>hive-common</artifactId>
       <version>${hive.version}</version>
       <scope>${utilities.bundle.hive.scope}</scope>
-    </dependency>
-
-    <!--
-      Supplies org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat, which is the superclass of
-      HoodieParquetInputFormatBase in hudi-hadoop-mr, which is whitelisted in the shade artifactSet above. Without
-      this, the bundle ships those subclasses with their superclass missing and any use of the Hive input formats fails
-      with ClassNotFoundException on MapredParquetInputFormat (HUDI-7321).
-
-      The core classifier is what the rest of the build uses (hive.exec.classifier): it carries Hive's own
-      classes without Hive's shaded copies of third-party libraries, so it does not drag protobuf, guava and
-      friends into this bundle. Scope follows utilities.bundle.hive.scope like the hive artifacts above, so it
-      is provided by default and only packaged under -Putilities-bundle-shade-hive.
-    -->
-    <dependency>
-      <groupId>${hive.groupid}</groupId>
-      <artifactId>hive-exec</artifactId>
-      <version>${hive.version}</version>
-      <classifier>${hive.exec.classifier}</classifier>
-      <scope>${utilities.bundle.hive.scope}</scope>
-      <!--
-        Deliberately no <exclusions> here. The root pom's dependencyManagement entry for hive-exec already
-        excludes javax.mail, the jetty aggregate, pentaho, log4j 1.x, log4j2, slf4j-log4j12 and hbase, several
-        of which the enforcer bans outright. Declaring exclusions locally replaces that managed set rather
-        than adding to it, which would quietly let those back in.
-      -->
     </dependency>
 
     <dependency>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -158,6 +158,8 @@
                   <include>org.apache.hive:hive-service-rpc</include>
                   <include>org.apache.hive:hive-metastore</include>
                   <include>org.apache.hive:hive-jdbc</include>
+                  <!-- MapredParquetInputFormat, superclass of the bundled hudi-hadoop-mr input formats -->
+                  <include>org.apache.hive:hive-exec</include>
 
                   <include>org.apache.curator:curator-framework</include>
                   <include>org.apache.curator:curator-client</include>
@@ -353,6 +355,31 @@
       <artifactId>hive-common</artifactId>
       <version>${hive.version}</version>
       <scope>${utilities.bundle.hive.scope}</scope>
+    </dependency>
+
+    <!--
+      Supplies org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat, which is the superclass of
+      HoodieParquetInputFormatBase in hudi-hadoop-mr, which is whitelisted in the shade artifactSet above. Without
+      this, the bundle ships those subclasses with their superclass missing and any use of the Hive input formats fails
+      with ClassNotFoundException on MapredParquetInputFormat (HUDI-7321).
+
+      The core classifier is what the rest of the build uses (hive.exec.classifier): it carries Hive's own
+      classes without Hive's shaded copies of third-party libraries, so it does not drag protobuf, guava and
+      friends into this bundle. Scope follows utilities.bundle.hive.scope like the hive artifacts above, so it
+      is provided by default and only packaged under -Putilities-bundle-shade-hive.
+    -->
+    <dependency>
+      <groupId>${hive.groupid}</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>${hive.version}</version>
+      <classifier>${hive.exec.classifier}</classifier>
+      <scope>${utilities.bundle.hive.scope}</scope>
+      <!--
+        Deliberately no <exclusions> here. The root pom's dependencyManagement entry for hive-exec already
+        excludes javax.mail, the jetty aggregate, pentaho, log4j 1.x, log4j2, slf4j-log4j12 and hbase, several
+        of which the enforcer bans outright. Declaring exclusions locally replaces that managed set rather
+        than adding to it, which would quietly let those back in.
+      -->
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #16374.

Syncing a Hudi table to a catalog from a deployment without Hive on the classpath fails with `ClassNotFoundException` / `NoClassDefFoundError` before anything reaches the metastore.

`HoodieInputFormatUtils.get{InputFormat,OutputFormat,SerDe}ClassName` resolved each name through `Class#getName`, which loads the class. `HoodieParquetInputFormat` extends Hive's `MapredParquetInputFormat`, and the output-format and SerDe names are Hive classes outright, so merely asking for the *name* pulled Hive in. Every caller (`HiveSyncTool`, `HoodieHiveSyncClient`, `AdbSyncTool`, `DataHubTableProperties`, `CreateHoodieTableCommand`, `HoodieHiveCatalog`) consumes the result as a plain `String` and hands it to a metastore, so none of them needs the class object.

**An earlier revision of this PR bundled `hive-exec` into the utilities bundle instead. That approach was wrong and has been reverted in full**; review established two independent reasons, both of which I reproduced:

- It did not fix the reported failure. The `core` classifier carries **0** `serde2/` entries (the uber jar has 578), so `getSerDeClassName(PARQUET)` still threw `NoClassDefFoundError: AbstractSerDe` one call later.
- It regressed the jar CI actually builds. `hive-exec:core` at depth 1 made its transitive `commons-io:2.4` win nearest-wins mediation over 2.14.0, downgrading the **default** bundle and re-opening CVE-2024-47554 (HUDI-8805 / #12709).

Fixing it at the call site rather than in packaging also closes the `utilities-slim-bundle` and `hudi-spark-bundle` halves of #16374, which the bundling approach left open, and lines up with #15841.

### Summary and Changelog

A catalog sync from a Hive-less classpath now works, because it no longer loads a Hive class to learn a class name.

- `HoodieInputFormatUtils`: `get{InputFormat,OutputFormat,SerDe}ClassName` return string literals held in named constants instead of `SomeClass.class.getName()`. The five now-unused Hive imports are dropped. `getInputFormat` still constructs the classes, which is correct: a caller that wants the object genuinely does need Hive present.
- `TestHoodieInputFormatUtils` (new): asserts every constant equals `TheClass.class.getName()`, plus the switch wiring for parquet and orc.

No packaging change, no new dependency, no jar-size growth. No code was copied.

### Impact

Behavioural change is limited to *when* Hive classes load, not to the values returned. The returned strings are identical, which the new test pins against the classes themselves.

Trading `Class#getName` for a literal gives up compile-time safety: a rename or package move would leave a dangling name that only surfaces at the metastore. That is what `TestHoodieInputFormatUtils` is for. Hive is on the test classpath in `hudi-hadoop-mr`, so each constant is checked against the class it names and a rename fails the build there instead.

### Risk Level

low

Verified on Spark 3.5 / Scala 2.12:

- `mvn test -pl hudi-hadoop-mr -Dtest=TestHoodieInputFormatUtils` -> `Tests run: 3, Failures: 0, Errors: 0`
- `mvn test -Punit-tests -pl hudi-hadoop-mr` (full module) -> `BUILD SUCCESS`, no failures or errors
- `mvn compile checkstyle:check -pl hudi-hadoop-mr` -> clean

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
