### PR TITLE
fix(metadata): use committed Spark write statuses after retries

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -980,19 +980,14 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
 
     List<HoodieWriteStat> allWriteStats = new ArrayList<>(partialWriteStats);
-    maybeInitializeNewFileGroupsForPartitionedRLI(metadata, instantTime);
-    // Update every partition that was not already written by the streaming phase.
-    HoodieData<WriteStatus> remainingWriteStatuses = prepareAndWriteToNonStreamingPartitions(
-        metadata, instantTime, partialWriteStats);
-    allWriteStats.addAll(remainingWriteStatuses.map(WriteStatus::getStat).collectAsList());
+    // update metadata for left over partitions which does not have streaming writes support.
+    allWriteStats.addAll(prepareAndWriteToNonStreamingPartitions(metadata, instantTime).map(WriteStatus::getStat).collectAsList());
     getWriteClient().commitStats(instantTime, allWriteStats, Option.empty(), HoodieTimeline.DELTA_COMMIT_ACTION,
         Collections.emptyMap(), Option.empty());
   }
 
-  private HoodieData<WriteStatus> prepareAndWriteToNonStreamingPartitions(HoodieCommitMetadata commitMetadata,
-                                                                           String instantTime,
-                                                                           List<HoodieWriteStat> partialWriteStats) {
-    Set<String> partitionsToUpdate = getNonStreamingMetadataPartitionsToUpdate(partialWriteStats);
+  private HoodieData<WriteStatus> prepareAndWriteToNonStreamingPartitions(HoodieCommitMetadata commitMetadata, String instantTime) {
+    Set<String> partitionsToUpdate = getNonStreamingMetadataPartitionsToUpdate();
     List<IndexPartitionAndRecords> mdtPartitionsAndUnTaggedRecords = new BatchMetadataConversionFunction(instantTime, commitMetadata, partitionsToUpdate)
         .convertMetadata();
 
@@ -1002,15 +997,11 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     return convertEngineSpecificDataToHoodieData(secondaryWriteToMetadataTablePartitions(preppedRecords, instantTime));
   }
 
-  private Set<String> getNonStreamingMetadataPartitionsToUpdate(List<HoodieWriteStat> partialWriteStats) {
-    Set<MetadataPartitionType> streamedPartitionTypes = partialWriteStats.stream()
-        .map(HoodieWriteStat::getPartitionPath)
-        .filter(Objects::nonNull)
-        .map(MetadataPartitionType::fromPartitionPath)
-        .collect(Collectors.toSet());
+  private Set<String> getNonStreamingMetadataPartitionsToUpdate() {
     Set<String> toReturn = new HashSet<>();
-    for (MetadataPartitionType partitionType : enabledIndexerMap.keySet()) {
-      if (!streamedPartitionTypes.contains(partitionType)) {
+    Set<MetadataPartitionType> streamingMDTPartitions = new HashSet<>(getStreamingMetadataPartitionsToUpdate().getLeft());
+    for (MetadataPartitionType partitionType: enabledIndexerMap.keySet()) {
+      if (!streamingMDTPartitions.contains(partitionType)) {
         toReturn.add(partitionType.getPartitionPath());
       }
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -980,14 +980,19 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
 
     List<HoodieWriteStat> allWriteStats = new ArrayList<>(partialWriteStats);
-    // update metadata for left over partitions which does not have streaming writes support.
-    allWriteStats.addAll(prepareAndWriteToNonStreamingPartitions(metadata, instantTime).map(WriteStatus::getStat).collectAsList());
+    maybeInitializeNewFileGroupsForPartitionedRLI(metadata, instantTime);
+    // Update every partition that was not already written by the streaming phase.
+    HoodieData<WriteStatus> remainingWriteStatuses = prepareAndWriteToNonStreamingPartitions(
+        metadata, instantTime, partialWriteStats);
+    allWriteStats.addAll(remainingWriteStatuses.map(WriteStatus::getStat).collectAsList());
     getWriteClient().commitStats(instantTime, allWriteStats, Option.empty(), HoodieTimeline.DELTA_COMMIT_ACTION,
         Collections.emptyMap(), Option.empty());
   }
 
-  private HoodieData<WriteStatus> prepareAndWriteToNonStreamingPartitions(HoodieCommitMetadata commitMetadata, String instantTime) {
-    Set<String> partitionsToUpdate = getNonStreamingMetadataPartitionsToUpdate();
+  private HoodieData<WriteStatus> prepareAndWriteToNonStreamingPartitions(HoodieCommitMetadata commitMetadata,
+                                                                           String instantTime,
+                                                                           List<HoodieWriteStat> partialWriteStats) {
+    Set<String> partitionsToUpdate = getNonStreamingMetadataPartitionsToUpdate(partialWriteStats);
     List<IndexPartitionAndRecords> mdtPartitionsAndUnTaggedRecords = new BatchMetadataConversionFunction(instantTime, commitMetadata, partitionsToUpdate)
         .convertMetadata();
 
@@ -997,11 +1002,15 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     return convertEngineSpecificDataToHoodieData(secondaryWriteToMetadataTablePartitions(preppedRecords, instantTime));
   }
 
-  private Set<String> getNonStreamingMetadataPartitionsToUpdate() {
+  private Set<String> getNonStreamingMetadataPartitionsToUpdate(List<HoodieWriteStat> partialWriteStats) {
+    Set<MetadataPartitionType> streamedPartitionTypes = partialWriteStats.stream()
+        .map(HoodieWriteStat::getPartitionPath)
+        .filter(Objects::nonNull)
+        .map(MetadataPartitionType::fromPartitionPath)
+        .collect(Collectors.toSet());
     Set<String> toReturn = new HashSet<>();
-    Set<MetadataPartitionType> streamingMDTPartitions = new HashSet<>(getStreamingMetadataPartitionsToUpdate().getLeft());
-    for (MetadataPartitionType partitionType: enabledIndexerMap.keySet()) {
-      if (!streamingMDTPartitions.contains(partitionType)) {
+    for (MetadataPartitionType partitionType : enabledIndexerMap.keySet()) {
+      if (!streamedPartitionTypes.contains(partitionType)) {
         toReturn.add(partitionType.getPartitionPath());
       }
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -62,6 +62,7 @@ import org.apache.hudi.common.util.Lazy;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -972,7 +973,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   }
 
   @Override
-  public void completeStreamingCommit(String instantTime, HoodieEngineContext context, List<HoodieWriteStat> partialWriteStats, HoodieCommitMetadata metadata) {
+  public void completeStreamingCommit(String instantTime, HoodieEngineContext context, List<HoodieWriteStat> partialWriteStats,
+                                      HoodieCommitMetadata metadata, boolean metadataPartitionsWereStreamed) {
     if (metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(instantTime)) {
       LOG.info("Skipping streaming metadata commit completion for already completed instant {}", instantTime);
       getWriteClient().postCommit(instantTime);
@@ -980,10 +982,12 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
 
     List<HoodieWriteStat> allWriteStats = new ArrayList<>(partialWriteStats);
-    maybeInitializeNewFileGroupsForPartitionedRLI(metadata, instantTime);
-    // Update every partition that was not already written by the streaming phase.
+    if (!metadataPartitionsWereStreamed) {
+      maybeInitializeNewFileGroupsForPartitionedRLI(metadata, instantTime);
+    }
+    // Update every partition that was not already handled by the engine streaming phase.
     HoodieData<WriteStatus> remainingWriteStatuses = prepareAndWriteToNonStreamingPartitions(
-        metadata, instantTime, partialWriteStats);
+        metadata, instantTime, partialWriteStats, metadataPartitionsWereStreamed);
     allWriteStats.addAll(remainingWriteStatuses.map(WriteStatus::getStat).collectAsList());
     getWriteClient().commitStats(instantTime, allWriteStats, Option.empty(), HoodieTimeline.DELTA_COMMIT_ACTION,
         Collections.emptyMap(), Option.empty());
@@ -991,8 +995,9 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
 
   private HoodieData<WriteStatus> prepareAndWriteToNonStreamingPartitions(HoodieCommitMetadata commitMetadata,
                                                                            String instantTime,
-                                                                           List<HoodieWriteStat> partialWriteStats) {
-    Set<String> partitionsToUpdate = getNonStreamingMetadataPartitionsToUpdate(partialWriteStats);
+                                                                           List<HoodieWriteStat> partialWriteStats,
+                                                                           boolean metadataPartitionsWereStreamed) {
+    Set<String> partitionsToUpdate = getNonStreamingMetadataPartitionsToUpdate(partialWriteStats, metadataPartitionsWereStreamed);
     List<IndexPartitionAndRecords> mdtPartitionsAndUnTaggedRecords = new BatchMetadataConversionFunction(instantTime, commitMetadata, partitionsToUpdate)
         .convertMetadata();
 
@@ -1002,12 +1007,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     return convertEngineSpecificDataToHoodieData(secondaryWriteToMetadataTablePartitions(preppedRecords, instantTime));
   }
 
-  private Set<String> getNonStreamingMetadataPartitionsToUpdate(List<HoodieWriteStat> partialWriteStats) {
-    Set<MetadataPartitionType> streamedPartitionTypes = partialWriteStats.stream()
-        .map(HoodieWriteStat::getPartitionPath)
-        .filter(Objects::nonNull)
-        .map(MetadataPartitionType::fromPartitionPath)
-        .collect(Collectors.toSet());
+  private Set<String> getNonStreamingMetadataPartitionsToUpdate(List<HoodieWriteStat> partialWriteStats,
+                                                                 boolean metadataPartitionsWereStreamed) {
+    Set<MetadataPartitionType> streamedPartitionTypes = getStreamedMetadataPartitionTypes(
+        partialWriteStats, metadataPartitionsWereStreamed, getStreamingMetadataPartitionsToUpdate().getLeft());
     Set<String> toReturn = new HashSet<>();
     for (MetadataPartitionType partitionType : enabledIndexerMap.keySet()) {
       if (!streamedPartitionTypes.contains(partitionType)) {
@@ -1015,6 +1018,20 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       }
     }
     return toReturn;
+  }
+
+  @VisibleForTesting
+  static Set<MetadataPartitionType> getStreamedMetadataPartitionTypes(List<HoodieWriteStat> partialWriteStats,
+                                                                      boolean metadataPartitionsWereStreamed,
+                                                                      List<MetadataPartitionType> streamingPartitionTypes) {
+    if (metadataPartitionsWereStreamed) {
+      return new HashSet<>(streamingPartitionTypes);
+    }
+    return partialWriteStats.stream()
+        .map(HoodieWriteStat::getPartitionPath)
+        .filter(Objects::nonNull)
+        .map(MetadataPartitionType::fromPartitionPath)
+        .collect(Collectors.toSet());
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataWriter.java
@@ -94,8 +94,10 @@ public interface HoodieTableMetadataWriter<I,O> extends Serializable, AutoClosea
    * @param context           The engine context {@link HoodieEngineContext}.
    * @param partialWriteStats List<HoodieWriteStat> for partial/streaming writes to metadata table completed so far.
    * @param commitMetadata    The data table {@link HoodieCommitMetadata}.
+   * @param metadataPartitionsWereStreamed Whether the engine invoked the streaming RLI/SI path, including an update-only write that emitted no stats.
    */
-  void completeStreamingCommit(String instantTime, HoodieEngineContext context, List<HoodieWriteStat> partialWriteStats, HoodieCommitMetadata commitMetadata);
+  void completeStreamingCommit(String instantTime, HoodieEngineContext context, List<HoodieWriteStat> partialWriteStats,
+                               HoodieCommitMetadata commitMetadata, boolean metadataPartitionsWereStreamed);
 
   /**
    * Builds the given metadata partitions to create index.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/StreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/StreamingMetadataWriteHandler.java
@@ -46,9 +46,7 @@ public abstract class StreamingMetadataWriteHandler {
    * @param instantTime            The instant time of interest.
    * @param coalesceDivisorForDataTableWrites assist with determining the coalesce parallelism for data table write statuses. N data table write status
    *                                          spark partitions will be divied by this value to find the coalesce parallelism.
-   * @return Engine-specific write statuses needed to finalize the data-table commit. Spark returns only
-   *         successful data-table task outputs and defers metadata generation until committed stats are available;
-   *         other engines may also return partial metadata-table statuses.
+   * @return {@link HoodieData} of {@link WriteStatus} referring to both data table writes and partial metadata table writes.
    */
   public abstract HoodieData<WriteStatus> streamWriteToMetadataTable(HoodieTable table,
                                                                      HoodieData<WriteStatus> dataTableWriteStatuses,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/StreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/StreamingMetadataWriteHandler.java
@@ -46,7 +46,9 @@ public abstract class StreamingMetadataWriteHandler {
    * @param instantTime            The instant time of interest.
    * @param coalesceDivisorForDataTableWrites assist with determining the coalesce parallelism for data table write statuses. N data table write status
    *                                          spark partitions will be divied by this value to find the coalesce parallelism.
-   * @return {@link HoodieData} of {@link WriteStatus} referring to both data table writes and partial metadata table writes.
+   * @return Engine-specific write statuses needed to finalize the data-table commit. Spark returns only
+   *         successful data-table task outputs and defers metadata generation until committed stats are available;
+   *         other engines may also return partial metadata-table statuses.
    */
   public abstract HoodieData<WriteStatus> streamWriteToMetadataTable(HoodieTable table,
                                                                      HoodieData<WriteStatus> dataTableWriteStatuses,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/StreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/StreamingMetadataWriteHandler.java
@@ -32,11 +32,16 @@ import org.apache.hudi.table.HoodieTable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class StreamingMetadataWriteHandler {
   // Mappings of {instant -> metadata writer option} for each action in data table.
   // This will be cleaned up when action is completed or when write client is closed.
   protected final Map<String, Option<HoodieTableMetadataWriter>> metadataWriterMap = new HashMap<>();
+  // Tracks actual engine-side streaming work. Write stats cannot carry this signal because an
+  // update-only RLI/SI write may legitimately produce no metadata records.
+  private final Set<String> instantsWithStreamingMetadataWrites = ConcurrentHashMap.newKeySet();
 
   /**
    * Called by data table write client and table service client to perform streaming writes to metadata table.
@@ -73,13 +78,30 @@ public abstract class StreamingMetadataWriteHandler {
                                     List<HoodieWriteStat> partialMetadataWriteStats) {
     Option<HoodieTableMetadataWriter> metadataWriterOpt = getMetadataWriter(instantTime, table);
     ValidationUtils.checkState(metadataWriterOpt.isPresent(), "Should not be reachable. Metadata Writer should have been instantiated by now");
+    boolean metadataPartitionsWereStreamed = instantsWithStreamingMetadataWrites.contains(instantTime);
+    boolean commitCompleted = false;
     try (HoodieTableMetadataWriter metadataWriter = metadataWriterOpt.get()) {
-      metadataWriter.completeStreamingCommit(instantTime, table.getContext(), partialMetadataWriteStats, metadata);
+      metadataWriter.completeStreamingCommit(instantTime, table.getContext(), partialMetadataWriteStats, metadata,
+          metadataPartitionsWereStreamed);
+      commitCompleted = true;
     } catch (Exception e) {
       throw new HoodieException("Error while completing streaming commit to metadata with instant " + instantTime, e);
     } finally {
       metadataWriterMap.remove(instantTime);
+      if (commitCompleted) {
+        instantsWithStreamingMetadataWrites.remove(instantTime);
+      }
     }
+  }
+
+  /** Marks that this engine invoked the streaming metadata path for the instant. */
+  protected void markStreamingMetadataWrite(String instantTime) {
+    instantsWithStreamingMetadataWrites.add(instantTime);
+  }
+
+  /** Clears streaming state when an engine abandons an instant before commit completion. */
+  protected void clearStreamingMetadataWrite(String instantTime) {
+    instantsWithStreamingMetadataWrites.remove(instantTime);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
@@ -65,6 +66,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
@@ -102,6 +104,25 @@ class TestHoodieBackedTableMetadataWriter {
   }
 
   @Test
+  void updateOnlyStreamingCommitDoesNotInferPartitionsFromEmptyStats() {
+    Set<MetadataPartitionType> streamedPartitionTypes = HoodieBackedTableMetadataWriter.getStreamedMetadataPartitionTypes(
+        Collections.emptyList(), true, List.of(MetadataPartitionType.RECORD_INDEX, MetadataPartitionType.SECONDARY_INDEX));
+
+    assertEquals(Set.of(MetadataPartitionType.RECORD_INDEX, MetadataPartitionType.SECONDARY_INDEX), streamedPartitionTypes);
+  }
+
+  @Test
+  void legacyStreamingCompletionStillReadsPartitionsFromWriteStats() {
+    HoodieWriteStat recordIndexStat = new HoodieWriteStat();
+    recordIndexStat.setPartitionPath(MetadataPartitionType.RECORD_INDEX.getPartitionPath());
+
+    Set<MetadataPartitionType> streamedPartitionTypes = HoodieBackedTableMetadataWriter.getStreamedMetadataPartitionTypes(
+        Collections.singletonList(recordIndexStat), false, Collections.emptyList());
+
+    assertEquals(Collections.singleton(MetadataPartitionType.RECORD_INDEX), streamedPartitionTypes);
+  }
+
+  @Test
   void completeStreamingCommitSkipsAlreadyCompletedMetadataInstant() {
     String instantTime = "20260709120000000";
     HoodieBackedTableMetadataWriter<List<HoodieRecord>, List<?>> metadataWriter =
@@ -118,7 +139,7 @@ class TestHoodieBackedTableMetadataWriter {
     when(completedTimeline.containsInstant(instantTime)).thenReturn(true);
     when(metadataWriter.initializeWriteClient()).thenReturn(writeClient);
 
-    metadataWriter.completeStreamingCommit(instantTime, engineContext, Collections.emptyList(), mock(HoodieCommitMetadata.class));
+    metadataWriter.completeStreamingCommit(instantTime, engineContext, Collections.emptyList(), mock(HoodieCommitMetadata.class), false);
 
     verify(writeClient).postCommit(instantTime);
     verifyNoMoreInteractions(writeClient);

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/FlinkStreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/FlinkStreamingMetadataWriteHandler.java
@@ -106,6 +106,10 @@ public class FlinkStreamingMetadataWriteHandler extends StreamingMetadataWriteHa
     }
   }
 
+  void markMetadataPartitionsWereStreamed(String instantTime) {
+    markStreamingMetadataWrite(instantTime);
+  }
+
   /**
    * Clean resources after streaming write to the metadata table in index write function or stop
    * heartbeat for instant in the coordinator. This method removes the metadata writer associated
@@ -114,6 +118,7 @@ public class FlinkStreamingMetadataWriteHandler extends StreamingMetadataWriteHa
    * @param instantTime Instant Time
    */
   public void cleanResources(String instantTime) {
+    clearStreamingMetadataWrite(instantTime);
     Option<HoodieTableMetadataWriter> metadataWriterOpt = this.metadataWriterMap.remove(instantTime);
     if (metadataWriterOpt == null || metadataWriterOpt.isEmpty()) {
       log.debug("Metadata writer for {} has already been closed, skip closing.", instantTime);

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -169,6 +169,10 @@ public class HoodieFlinkWriteClient<T>
     return this.streamingMetadataWriteHandler.streamWriteToMetadataPartitions(table, indexRecords, dataPartitions, instantTime);
   }
 
+  public void markMetadataPartitionsWereStreamed(String instantTime) {
+    this.streamingMetadataWriteHandler.markMetadataPartitionsWereStreamed(instantTime);
+  }
+
   @Override
   public boolean commit(String instantTime, List<WriteStatus> writeStatuses, Option<Map<String, String>> extraMetadata,
                         String commitActionType, Map<String, List<String>> partitionToReplacedFileIds,

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestFlinkStreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestFlinkStreamingMetadataWriteHandler.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.metadata.HoodieTableMetadataWriter;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.table.HoodieTable;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestFlinkStreamingMetadataWriteHandler {
+
+  @Test
+  void abandonedStreamingWriteDoesNotLeakIntoLaterCompletion() {
+    String instantTime = "001";
+    HoodieTableMetadataWriter metadataWriter = mock(HoodieTableMetadataWriter.class);
+    HoodieEngineContext context = mock(HoodieEngineContext.class);
+    HoodieTable table = mockTable(context);
+    HoodieData<HoodieRecord> indexRecords = mock(HoodieData.class);
+    HoodieData<WriteStatus> writeStatuses = mock(HoodieData.class);
+    HoodieCommitMetadata commitMetadata = mock(HoodieCommitMetadata.class);
+    when(metadataWriter.streamWriteToMetadataPartitions(indexRecords, Collections.emptySet(), instantTime))
+        .thenReturn(writeStatuses);
+    FlinkStreamingMetadataWriteHandler handler = new TestHandler(metadataWriter);
+
+    handler.streamWriteToMetadataPartitions(table, indexRecords, Collections.emptySet(), instantTime);
+    handler.cleanResources(instantTime);
+    handler.commitToMetadataTable(table, instantTime, commitMetadata, Collections.emptyList());
+
+    verify(metadataWriter).completeStreamingCommit(
+        instantTime, context, Collections.emptyList(), commitMetadata, false);
+  }
+
+  @Test
+  void updateOnlyStreamingWriteIsExplicitWhenNoMetadataStatsAreProduced() {
+    String instantTime = "001";
+    HoodieTableMetadataWriter metadataWriter = mock(HoodieTableMetadataWriter.class);
+    HoodieEngineContext context = mock(HoodieEngineContext.class);
+    HoodieTable table = mockTable(context);
+    HoodieData<HoodieRecord> indexRecords = mock(HoodieData.class);
+    HoodieData<WriteStatus> writeStatuses = mock(HoodieData.class);
+    HoodieCommitMetadata commitMetadata = mock(HoodieCommitMetadata.class);
+    when(metadataWriter.streamWriteToMetadataPartitions(indexRecords, Collections.emptySet(), instantTime))
+        .thenReturn(writeStatuses);
+    FlinkStreamingMetadataWriteHandler handler = new TestHandler(metadataWriter);
+
+    assertSame(writeStatuses,
+        handler.streamWriteToMetadataPartitions(table, indexRecords, Collections.emptySet(), instantTime));
+    // The coordinator receives an index-write event even when its status list is empty.
+    handler.markMetadataPartitionsWereStreamed(instantTime);
+    handler.commitToMetadataTable(table, instantTime, commitMetadata, Collections.emptyList());
+
+    verify(metadataWriter).completeStreamingCommit(
+        instantTime, context, Collections.emptyList(), commitMetadata, true);
+  }
+
+  private HoodieTable mockTable(HoodieEngineContext context) {
+    HoodieTable table = mock(HoodieTable.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(table.getContext()).thenReturn(context);
+    when(table.getMetaClient()).thenReturn(metaClient);
+    when(metaClient.getBasePath()).thenReturn(new StoragePath("/tmp/"));
+    return table;
+  }
+
+  private static class TestHandler extends FlinkStreamingMetadataWriteHandler {
+    private final HoodieTableMetadataWriter metadataWriter;
+
+    private TestHandler(HoodieTableMetadataWriter metadataWriter) {
+      this.metadataWriter = metadataWriter;
+    }
+
+    @Override
+    protected synchronized Option<HoodieTableMetadataWriter> getMetadataWriter(
+        String triggeringInstant, HoodieTable table) {
+      return Option.of(metadataWriter);
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
@@ -65,8 +65,10 @@ public class SparkRDDTableServiceClient<T> extends BaseHoodieTableServiceClient<
 
   @Override
   protected TableWriteStats triggerWritesAndFetchWriteStats(HoodieWriteMetadata<JavaRDD<WriteStatus>> tableServiceWriteMetadata) {
-    // Trigger the data-table service DAG. Spark streaming mode defers metadata generation until
-    // the committed table-service stats are available, so this collection contains data statuses.
+    // Triggering the dag for writes.
+    // If streaming writes are enabled, writes to both data table and metadata table get triggered at this juncture.
+    // If not, writes to data table gets triggered here.
+    // When streaming writes are enabled, data table's WriteStatus is expected to contain all stats required to generate metadata table records and so each object will be larger.
     // Here we are dropping all additional stats and error records to retain only the required information and prevent collecting large objects on the driver.
     List<SparkRDDWriteClient.SlimWriteStats> writeStatusMetadataTrackerList = SparkRDDWriteClient.SlimWriteStats.from(tableServiceWriteMetadata.getWriteStatuses());
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDTableServiceClient.java
@@ -65,10 +65,8 @@ public class SparkRDDTableServiceClient<T> extends BaseHoodieTableServiceClient<
 
   @Override
   protected TableWriteStats triggerWritesAndFetchWriteStats(HoodieWriteMetadata<JavaRDD<WriteStatus>> tableServiceWriteMetadata) {
-    // Triggering the dag for writes.
-    // If streaming writes are enabled, writes to both data table and metadata table get triggered at this juncture.
-    // If not, writes to data table gets triggered here.
-    // When streaming writes are enabled, data table's WriteStatus is expected to contain all stats required to generate metadata table records and so each object will be larger.
+    // Trigger the data-table service DAG. Spark streaming mode defers metadata generation until
+    // the committed table-service stats are available, so this collection contains data statuses.
     // Here we are dropping all additional stats and error records to retain only the required information and prevent collecting large objects on the driver.
     List<SparkRDDWriteClient.SlimWriteStats> writeStatusMetadataTrackerList = SparkRDDWriteClient.SlimWriteStats.from(tableServiceWriteMetadata.getWriteStatuses());
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -110,16 +110,19 @@ public class SparkRDDWriteClient<T> extends
     HoodieTable table = createTable(config);
     final JavaRDD<WriteStatus> writeStatuses;
     if (WriteOperationType.streamingWritesToMetadataSupported((getOperationType())) && isStreamingWriteToMetadataEnabled(table)) {
-      // Start the metadata commit and introduce the shuffle boundary that selects successful
-      // data-table task outputs. Spark defers metadata generation until commit finalization.
+      // this code block is expected to create a new Metadata Writer, start a new commit in metadata table and trigger streaming write to metadata table.
       writeStatuses = HoodieJavaRDD.getJavaRDD(streamingMetadataWriteHandler.streamWriteToMetadataTable(table, HoodieJavaRDD.of(rawWriteStatuses), instantTime,
           config.getMetadataConfig().getStreamingWritesCoalesceDivisorForDataTableWrites()));
     } else {
       writeStatuses = rawWriteStatuses;
     }
 
-    // Trigger the data-write DAG. Streaming metadata generation is deferred until commitStats,
-    // where it consumes HoodieCommitMetadata built from these successful task outputs.
+    // Triggering the dag for writes.
+    //
+    // 1. If streaming writes are enabled, writes to both data table and metadata table gets triggered at this juncture;
+    // 2. If not, writes to data table gets triggered here.
+    //
+    // When streaming writes are enabled, data table's WriteStatus is expected to contain all stats required to generate metadata table records and so each object will be larger.
     // Here all additional stats and error records are dropped to retain only the required information and prevent collecting large objects on the driver.
     List<SlimWriteStats> slimWriteStatsList = SlimWriteStats.from(writeStatuses);
     // Compute stats for the data table writes and invoke callback
@@ -141,8 +144,7 @@ public class SparkRDDWriteClient<T> extends
 
     // Proceeds only if validator returns true, otherwise bails out.
     if (canProceed) {
-      // Spark streaming mode now returns only data-table statuses; keep the generic split because
-      // other engines and metadata-table writes may still supply metadata statuses.
+      // when streaming writes are enabled, writeStatuses is a mix of data table write status and mdt write status
       List<HoodieWriteStat> dataTableHoodieWriteStats = slimWriteStatsList.stream().filter(entry -> !entry.isMetadataTable()).map(SlimWriteStats::getWriteStat).collect(Collectors.toList());
       List<HoodieWriteStat> partialMetadataTableWriteStats = slimWriteStatsList.stream().filter(entry -> entry.isMetadataTable).map(SlimWriteStats::getWriteStat).collect(Collectors.toList());
       return commitStats(instantTime, new TableWriteStats(dataTableHoodieWriteStats, partialMetadataTableWriteStats), extraMetadata, commitActionType, partitionToReplacedFileIds,

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -110,19 +110,16 @@ public class SparkRDDWriteClient<T> extends
     HoodieTable table = createTable(config);
     final JavaRDD<WriteStatus> writeStatuses;
     if (WriteOperationType.streamingWritesToMetadataSupported((getOperationType())) && isStreamingWriteToMetadataEnabled(table)) {
-      // this code block is expected to create a new Metadata Writer, start a new commit in metadata table and trigger streaming write to metadata table.
+      // Start the metadata commit and introduce the shuffle boundary that selects successful
+      // data-table task outputs. Spark defers metadata generation until commit finalization.
       writeStatuses = HoodieJavaRDD.getJavaRDD(streamingMetadataWriteHandler.streamWriteToMetadataTable(table, HoodieJavaRDD.of(rawWriteStatuses), instantTime,
           config.getMetadataConfig().getStreamingWritesCoalesceDivisorForDataTableWrites()));
     } else {
       writeStatuses = rawWriteStatuses;
     }
 
-    // Triggering the dag for writes.
-    //
-    // 1. If streaming writes are enabled, writes to both data table and metadata table gets triggered at this juncture;
-    // 2. If not, writes to data table gets triggered here.
-    //
-    // When streaming writes are enabled, data table's WriteStatus is expected to contain all stats required to generate metadata table records and so each object will be larger.
+    // Trigger the data-write DAG. Streaming metadata generation is deferred until commitStats,
+    // where it consumes HoodieCommitMetadata built from these successful task outputs.
     // Here all additional stats and error records are dropped to retain only the required information and prevent collecting large objects on the driver.
     List<SlimWriteStats> slimWriteStatsList = SlimWriteStats.from(writeStatuses);
     // Compute stats for the data table writes and invoke callback
@@ -144,7 +141,8 @@ public class SparkRDDWriteClient<T> extends
 
     // Proceeds only if validator returns true, otherwise bails out.
     if (canProceed) {
-      // when streaming writes are enabled, writeStatuses is a mix of data table write status and mdt write status
+      // Spark streaming mode now returns only data-table statuses; keep the generic split because
+      // other engines and metadata-table writes may still supply metadata statuses.
       List<HoodieWriteStat> dataTableHoodieWriteStats = slimWriteStatsList.stream().filter(entry -> !entry.isMetadataTable()).map(SlimWriteStats::getWriteStat).collect(Collectors.toList());
       List<HoodieWriteStat> partialMetadataTableWriteStats = slimWriteStatsList.stream().filter(entry -> entry.isMetadataTable).map(SlimWriteStats::getWriteStat).collect(Collectors.toList());
       return commitStats(instantTime, new TableWriteStats(dataTableHoodieWriteStats, partialMetadataTableWriteStats), extraMetadata, commitActionType, partitionToReplacedFileIds,

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkStreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkStreamingMetadataWriteHandler.java
@@ -42,21 +42,32 @@ public class SparkStreamingMetadataWriteHandler extends StreamingMetadataWriteHa
     Option<HoodieTableMetadataWriter> metadataWriterOpt = getMetadataWriter(instantTime, table);
     ValidationUtils.checkState(metadataWriterOpt.isPresent(),
         "Cannot instantiate metadata writer for the table of interest " + table.getMetaClient().getBasePath());
-    // Spark task retries and speculation are reconciled while the data-table commit is finalized.
-    // Defer metadata generation until completeStreamingCommit can consume the resulting committed
-    // HoodieCommitMetadata. This deliberately reuses the HUDI-8564 committed-output path instead
-    // of deriving RLI/SI locations from pre-commit WriteStatus task attempts.
-    return coalesceDataTableWriteStatuses(dataTableWriteStatuses, coalesceDivisorForDataTableWrites);
+    return streamWriteToMetadataTable(dataTableWriteStatuses, metadataWriterOpt.get(), table, instantTime,
+        coalesceDivisorForDataTableWrites);
   }
 
-  private HoodieData<WriteStatus> coalesceDataTableWriteStatuses(HoodieData<WriteStatus> dataTableWriteStatuses,
-                                                                 int coalesceDivisorForDataTableWrites) {
-    int coalesceParallelism = Math.max(1, dataTableWriteStatuses.getNumPartitions() / coalesceDivisorForDataTableWrites);
-    // Coalesce to fewer Spark tasks before collecting successful task-attempt outputs.
-    // The partitionBy shuffle also materializes the data writes before commit finalization.
-    return HoodieJavaRDD.of(HoodieJavaRDD.getJavaRDD(dataTableWriteStatuses)
-        .mapToPair((PairFunction<WriteStatus, String, WriteStatus>) writeStatus -> new Tuple2(writeStatus.getStat().getPath(), writeStatus))
-        .partitionBy(new CoalescingPartitioner(coalesceParallelism))
-        .map((Function<Tuple2<String, WriteStatus>, WriteStatus>) entry -> entry._2));
+  private HoodieData<WriteStatus> streamWriteToMetadataTable(HoodieData<WriteStatus> dataTableWriteStatuses,
+                                                             HoodieTableMetadataWriter metadataWriter,
+                                                             HoodieTable table,
+                                                             String instantTime,
+                                                             int coalesceDivisorForDataTableWrites) {
+    int coalesceParallelism = Math.max(1,
+        dataTableWriteStatuses.getNumPartitions() / coalesceDivisorForDataTableWrites);
+
+    // Materialize data-table statuses behind a shuffle before deriving metadata records. Spark's
+    // scheduler exposes only the successful attempt for each shuffle partition, so failed or losing
+    // speculative attempts cannot contribute stale RLI/SI locations to the metadata write.
+    HoodieData<WriteStatus> committedDataWriteStatuses = HoodieJavaRDD.of(
+        HoodieJavaRDD.getJavaRDD(dataTableWriteStatuses)
+            .mapToPair((PairFunction<WriteStatus, String, WriteStatus>) writeStatus ->
+                new Tuple2<>(writeStatus.getStat().getPath(), writeStatus))
+            .partitionBy(new CoalescingPartitioner(coalesceParallelism))
+            .map((Function<Tuple2<String, WriteStatus>, WriteStatus>) entry -> entry._2));
+
+    HoodieData<WriteStatus> metadataWriteStatuses =
+        metadataWriter.streamWriteToMetadataPartitions(committedDataWriteStatuses, instantTime);
+    metadataWriteStatuses.persist("MEMORY_AND_DISK_SER", table.getContext(),
+        HoodieData.HoodieDataCacheKey.of(table.getMetaClient().getBasePath().toString(), instantTime));
+    return committedDataWriteStatuses.union(metadataWriteStatuses);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkStreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkStreamingMetadataWriteHandler.java
@@ -57,7 +57,7 @@ public class SparkStreamingMetadataWriteHandler extends StreamingMetadataWriteHa
     // Materialize data-table statuses behind a shuffle before deriving metadata records. Spark's
     // scheduler exposes only the successful attempt for each shuffle partition, so failed or losing
     // speculative attempts cannot contribute stale RLI/SI locations to the metadata write.
-    HoodieData<WriteStatus> committedDataWriteStatuses = HoodieJavaRDD.of(
+    HoodieData<WriteStatus> successfulDataWriteStatuses = HoodieJavaRDD.of(
         HoodieJavaRDD.getJavaRDD(dataTableWriteStatuses)
             .mapToPair((PairFunction<WriteStatus, String, WriteStatus>) writeStatus ->
                 new Tuple2<>(writeStatus.getStat().getPath(), writeStatus))

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkStreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkStreamingMetadataWriteHandler.java
@@ -42,26 +42,21 @@ public class SparkStreamingMetadataWriteHandler extends StreamingMetadataWriteHa
     Option<HoodieTableMetadataWriter> metadataWriterOpt = getMetadataWriter(instantTime, table);
     ValidationUtils.checkState(metadataWriterOpt.isPresent(),
         "Cannot instantiate metadata writer for the table of interest " + table.getMetaClient().getBasePath());
-    return streamWriteToMetadataTable(dataTableWriteStatuses, metadataWriterOpt.get(), table, instantTime, coalesceDivisorForDataTableWrites);
+    // Spark task retries and speculation are reconciled while the data-table commit is finalized.
+    // Defer metadata generation until completeStreamingCommit can consume the resulting committed
+    // HoodieCommitMetadata. This deliberately reuses the HUDI-8564 committed-output path instead
+    // of deriving RLI/SI locations from pre-commit WriteStatus task attempts.
+    return coalesceDataTableWriteStatuses(dataTableWriteStatuses, coalesceDivisorForDataTableWrites);
   }
 
-  private HoodieData<WriteStatus> streamWriteToMetadataTable(HoodieData<WriteStatus> dataTableWriteStatuses,
-                                                             HoodieTableMetadataWriter metadataWriter,
-                                                             HoodieTable table,
-                                                             String instantTime,
-                                                             int coalesceDivisorForDataTableWrites) {
-    HoodieData<WriteStatus> mdtWriteStatuses = metadataWriter.streamWriteToMetadataPartitions(dataTableWriteStatuses, instantTime);
-    mdtWriteStatuses.persist("MEMORY_AND_DISK_SER", table.getContext(), HoodieData.HoodieDataCacheKey.of(table.getMetaClient().getBasePath().toString(), instantTime));
-    HoodieData<WriteStatus> coalescedDataWriteStatuses;
+  private HoodieData<WriteStatus> coalesceDataTableWriteStatuses(HoodieData<WriteStatus> dataTableWriteStatuses,
+                                                                 int coalesceDivisorForDataTableWrites) {
     int coalesceParallelism = Math.max(1, dataTableWriteStatuses.getNumPartitions() / coalesceDivisorForDataTableWrites);
-    // lets coalesce to lesser number of spark tasks so that, when unioned along with metadata table write status,
-    // we only allocate very less number of tasks for data table write statuses.
-    // In fact, data table writes should have triggered in previous stage before coalesce (partition by below forces the writes
-    // to data table is triggered in previous stage and with the coalesced stage)
-    coalescedDataWriteStatuses = HoodieJavaRDD.of(HoodieJavaRDD.getJavaRDD(dataTableWriteStatuses)
-            .mapToPair((PairFunction<WriteStatus, String, WriteStatus>) writeStatus -> new Tuple2(writeStatus.getStat().getPath(), writeStatus))
-            .partitionBy(new CoalescingPartitioner(coalesceParallelism))
-            .map((Function<Tuple2<String, WriteStatus>, WriteStatus>) entry -> entry._2));
-    return coalescedDataWriteStatuses.union(mdtWriteStatuses);
+    // Coalesce to fewer Spark tasks before collecting successful task-attempt outputs.
+    // The partitionBy shuffle also materializes the data writes before commit finalization.
+    return HoodieJavaRDD.of(HoodieJavaRDD.getJavaRDD(dataTableWriteStatuses)
+        .mapToPair((PairFunction<WriteStatus, String, WriteStatus>) writeStatus -> new Tuple2(writeStatus.getStat().getPath(), writeStatus))
+        .partitionBy(new CoalescingPartitioner(coalesceParallelism))
+        .map((Function<Tuple2<String, WriteStatus>, WriteStatus>) entry -> entry._2));
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkStreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkStreamingMetadataWriteHandler.java
@@ -42,32 +42,21 @@ public class SparkStreamingMetadataWriteHandler extends StreamingMetadataWriteHa
     Option<HoodieTableMetadataWriter> metadataWriterOpt = getMetadataWriter(instantTime, table);
     ValidationUtils.checkState(metadataWriterOpt.isPresent(),
         "Cannot instantiate metadata writer for the table of interest " + table.getMetaClient().getBasePath());
-    return streamWriteToMetadataTable(dataTableWriteStatuses, metadataWriterOpt.get(), table, instantTime,
-        coalesceDivisorForDataTableWrites);
+    // Spark task retries and speculation are reconciled while the data-table commit is finalized.
+    // Defer metadata generation until completeStreamingCommit can consume the resulting committed
+    // HoodieCommitMetadata. This deliberately reuses the HUDI-8564 committed-output path instead
+    // of deriving RLI/SI locations from pre-commit WriteStatus task attempts.
+    return coalesceDataTableWriteStatuses(dataTableWriteStatuses, coalesceDivisorForDataTableWrites);
   }
 
-  private HoodieData<WriteStatus> streamWriteToMetadataTable(HoodieData<WriteStatus> dataTableWriteStatuses,
-                                                             HoodieTableMetadataWriter metadataWriter,
-                                                             HoodieTable table,
-                                                             String instantTime,
-                                                             int coalesceDivisorForDataTableWrites) {
-    int coalesceParallelism = Math.max(1,
-        dataTableWriteStatuses.getNumPartitions() / coalesceDivisorForDataTableWrites);
-
-    // Materialize data-table statuses behind a shuffle before deriving metadata records. Spark's
-    // scheduler exposes only the successful attempt for each shuffle partition, so failed or losing
-    // speculative attempts cannot contribute stale RLI/SI locations to the metadata write.
-    HoodieData<WriteStatus> successfulDataWriteStatuses = HoodieJavaRDD.of(
-        HoodieJavaRDD.getJavaRDD(dataTableWriteStatuses)
-            .mapToPair((PairFunction<WriteStatus, String, WriteStatus>) writeStatus ->
-                new Tuple2<>(writeStatus.getStat().getPath(), writeStatus))
-            .partitionBy(new CoalescingPartitioner(coalesceParallelism))
-            .map((Function<Tuple2<String, WriteStatus>, WriteStatus>) entry -> entry._2));
-
-    HoodieData<WriteStatus> metadataWriteStatuses =
-        metadataWriter.streamWriteToMetadataPartitions(committedDataWriteStatuses, instantTime);
-    metadataWriteStatuses.persist("MEMORY_AND_DISK_SER", table.getContext(),
-        HoodieData.HoodieDataCacheKey.of(table.getMetaClient().getBasePath().toString(), instantTime));
-    return committedDataWriteStatuses.union(metadataWriteStatuses);
+  private HoodieData<WriteStatus> coalesceDataTableWriteStatuses(HoodieData<WriteStatus> dataTableWriteStatuses,
+                                                                 int coalesceDivisorForDataTableWrites) {
+    int coalesceParallelism = Math.max(1, dataTableWriteStatuses.getNumPartitions() / coalesceDivisorForDataTableWrites);
+    // Coalesce to fewer Spark tasks before collecting successful task-attempt outputs.
+    // The partitionBy shuffle also materializes the data writes before commit finalization.
+    return HoodieJavaRDD.of(HoodieJavaRDD.getJavaRDD(dataTableWriteStatuses)
+        .mapToPair((PairFunction<WriteStatus, String, WriteStatus>) writeStatus -> new Tuple2(writeStatus.getStat().getPath(), writeStatus))
+        .partitionBy(new CoalescingPartitioner(coalesceParallelism))
+        .map((Function<Tuple2<String, WriteStatus>, WriteStatus>) entry -> entry._2));
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkStreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkStreamingMetadataWriteHandler.java
@@ -41,13 +41,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,13 +87,14 @@ public class TestSparkStreamingMetadataWriteHandler extends SparkClientFunctiona
   @MethodSource("coalesceDivisorTestArgs")
   public void testCoalesceDividentConfig(int numDataTableWriteStatuses, int coalesceDividentForDataTableWrites) {
     HoodieData<WriteStatus> dataTableWriteStatus = mockWriteStatuses(numDataTableWriteStatuses);
-    HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
+    HoodieTableMetadataWriter mdtWriter = metadataWriterReturningEmptyStatuses();
     SparkStreamingMetadataWriteHandler metadataWriteHandler = new MockSparkStreamingMetadataWriteHandler(mdtWriter);
 
     HoodieData<WriteStatus> allWriteStatuses = metadataWriteHandler.streamWriteToMetadataTable(mockHoodieTable, dataTableWriteStatus, "00001",
         coalesceDividentForDataTableWrites);
-    assertEquals(Math.max(1, numDataTableWriteStatuses / coalesceDividentForDataTableWrites), allWriteStatuses.getNumPartitions());
-    verify(mdtWriter, never()).streamWriteToMetadataPartitions(any(), any());
+    assertEquals(Math.max(1, numDataTableWriteStatuses / coalesceDividentForDataTableWrites),
+        allWriteStatuses.getNumPartitions());
+    verify(mdtWriter).streamWriteToMetadataPartitions(any(), any());
   }
 
   @Test
@@ -107,30 +108,51 @@ public class TestSparkStreamingMetadataWriteHandler extends SparkClientFunctiona
           return writeStatus("file-" + partition + "-attempt-" + attempt, false);
         }));
     HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
+    AtomicReference<HoodieData<WriteStatus>> metadataInput = new AtomicReference<>();
+    when(mdtWriter.streamWriteToMetadataPartitions(any(), any())).thenAnswer(invocation -> {
+      metadataInput.set(invocation.getArgument(0));
+      return HoodieJavaRDD.of(jsc().emptyRDD());
+    });
 
     List<WriteStatus> statuses = new MockSparkStreamingMetadataWriteHandler(mdtWriter)
         .streamWriteToMetadataTable(mockHoodieTable, retryingDataWriteStatus, "00001", 1000)
         .collectAsList();
     List<String> paths = statuses.stream().map(status -> status.getStat().getPath()).collect(java.util.stream.Collectors.toList());
 
-    assertTrue(paths.contains("file-0-attempt-1"), "Retry output must come from the successful attempt");
+    List<String> metadataPaths = metadataInput.get().collectAsList().stream()
+        .map(status -> status.getStat().getPath())
+        .collect(java.util.stream.Collectors.toList());
+    assertTrue(paths.contains("file-0-attempt-1"), "Collected output must come from the successful attempt");
     assertTrue(paths.stream().noneMatch(path -> path.equals("file-0-attempt-0")));
-    verify(mdtWriter, never()).streamWriteToMetadataPartitions(any(), any());
+    assertTrue(metadataPaths.contains("file-0-attempt-1"),
+        "Metadata generation must consume the successful attempt");
+    assertTrue(metadataPaths.stream().noneMatch(path -> path.equals("file-0-attempt-0")));
+    verify(mdtWriter).streamWriteToMetadataPartitions(any(), any());
   }
 
   @Test
-  void testSparkDefersMetadataGenerationUntilCommittedWriteStatsAreAvailable() {
+  void testSparkUnionsMetadataWriteStatusesAfterCommittedDataStatuses() {
     HoodieData<WriteStatus> lazyDataWriteStatus = HoodieJavaRDD.of(jsc().parallelize(Arrays.asList(0, 1), 2)
-        .map(partition -> writeStatus("file-" + partition + "-stage-" + org.apache.spark.TaskContext.get().stageId(), false)));
+        .map(partition -> writeStatus("file-" + partition, false)));
     HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
+    when(mdtWriter.streamWriteToMetadataPartitions(any(), any()))
+        .thenReturn(HoodieJavaRDD.of(jsc().parallelize(
+            java.util.Collections.singletonList(writeStatus("metadata-file", true)), 1)));
 
-    HoodieData<WriteStatus> allWriteStatuses = new MockSparkStreamingMetadataWriteHandler(mdtWriter)
-        .streamWriteToMetadataTable(mockHoodieTable, lazyDataWriteStatus, "00001", 1000);
-    List<WriteStatus> statuses = allWriteStatuses.collectAsList();
+    List<WriteStatus> statuses = new MockSparkStreamingMetadataWriteHandler(mdtWriter)
+        .streamWriteToMetadataTable(mockHoodieTable, lazyDataWriteStatus, "00001", 1000)
+        .collectAsList();
 
-    assertTrue(statuses.stream().noneMatch(WriteStatus::isMetadataTable));
-    assertTrue(statuses.size() > 1, "Test must exercise multiple source partitions");
-    verify(mdtWriter, never()).streamWriteToMetadataPartitions(any(), any());
+    assertEquals(3, statuses.size());
+    assertEquals(1, statuses.stream().filter(WriteStatus::isMetadataTable).count());
+    verify(mdtWriter).streamWriteToMetadataPartitions(any(), any());
+  }
+
+  private HoodieTableMetadataWriter metadataWriterReturningEmptyStatuses() {
+    HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
+    when(mdtWriter.streamWriteToMetadataPartitions(any(), any()))
+        .thenReturn(HoodieJavaRDD.of(jsc().emptyRDD()));
+    return mdtWriter;
   }
 
   private static WriteStatus writeStatus(String path, boolean isMetadataTable) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkStreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkStreamingMetadataWriteHandler.java
@@ -21,6 +21,7 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.data.HoodieJavaRDD;
@@ -29,7 +30,10 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
+import org.apache.spark.SparkConf;
+import org.apache.spark.TaskContext;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,11 +44,21 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TestSparkStreamingMetadataWriteHandler extends SparkClientFunctionalTestHarness {
+
+  @Override
+  public SparkConf conf() {
+    // Permit one retry so the regression can distinguish a failed task attempt from the
+    // scheduler-selected successful output consumed by the metadata completion path.
+    return conf(java.util.Collections.singletonMap("spark.master", "local[8,2]"));
+  }
 
   private final HoodieTable<?, ?, ?, ?> mockHoodieTable = mock(HoodieTable.class);
   private HoodieTableMetaClient metaClient;
@@ -60,27 +74,71 @@ public class TestSparkStreamingMetadataWriteHandler extends SparkClientFunctiona
 
   private static Stream<Arguments> coalesceDivisorTestArgs() {
     return Arrays.stream(new Object[][] {
-        {100, 20, 1000, true},
-        {1, 1, 1000, true},
-        {10000, 100, 5000, true},
-        {10000, 100, 5000, true},
-        {10000, 100, 20000, true},
-        {10000, 100, 20000, true}
+        {100, 1000},
+        {1, 1},
+        {10000, 1},
+        {10000, 5000},
+        {10001, 5000},
+        {10000, 20000}
     }).map(Arguments::of);
   }
 
   @ParameterizedTest
   @MethodSource("coalesceDivisorTestArgs")
-  public void testCoalesceDividentConfig(int numDataTableWriteStatuses, int numMdtWriteStatus, int coalesceDividentForDataTableWrites) {
+  public void testCoalesceDividentConfig(int numDataTableWriteStatuses, int coalesceDividentForDataTableWrites) {
     HoodieData<WriteStatus> dataTableWriteStatus = mockWriteStatuses(numDataTableWriteStatuses);
-    HoodieData<WriteStatus> mdtWriteStatus = mockWriteStatuses(numMdtWriteStatus);
     HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
-    when(mdtWriter.streamWriteToMetadataPartitions(any(), any())).thenReturn(mdtWriteStatus);
     SparkStreamingMetadataWriteHandler metadataWriteHandler = new MockSparkStreamingMetadataWriteHandler(mdtWriter);
 
     HoodieData<WriteStatus> allWriteStatuses = metadataWriteHandler.streamWriteToMetadataTable(mockHoodieTable, dataTableWriteStatus, "00001",
         coalesceDividentForDataTableWrites);
-    assertEquals(Math.max(1, numDataTableWriteStatuses / coalesceDividentForDataTableWrites) + numMdtWriteStatus, allWriteStatuses.getNumPartitions());
+    assertEquals(Math.max(1, numDataTableWriteStatuses / coalesceDividentForDataTableWrites), allWriteStatuses.getNumPartitions());
+    verify(mdtWriter, never()).streamWriteToMetadataPartitions(any(), any());
+  }
+
+  @Test
+  void testSparkCollectsOnlySuccessfulRetriedTaskAttempt() {
+    HoodieData<WriteStatus> retryingDataWriteStatus = HoodieJavaRDD.of(jsc().parallelize(Arrays.asList(0, 1), 2)
+        .map(partition -> {
+          int attempt = TaskContext.get().attemptNumber();
+          if (partition == 0 && attempt == 0) {
+            throw new IllegalStateException("intentional first-attempt failure");
+          }
+          return writeStatus("file-" + partition + "-attempt-" + attempt, false);
+        }));
+    HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
+
+    List<WriteStatus> statuses = new MockSparkStreamingMetadataWriteHandler(mdtWriter)
+        .streamWriteToMetadataTable(mockHoodieTable, retryingDataWriteStatus, "00001", 1000)
+        .collectAsList();
+    List<String> paths = statuses.stream().map(status -> status.getStat().getPath()).collect(java.util.stream.Collectors.toList());
+
+    assertTrue(paths.contains("file-0-attempt-1"), "Retry output must come from the successful attempt");
+    assertTrue(paths.stream().noneMatch(path -> path.equals("file-0-attempt-0")));
+    verify(mdtWriter, never()).streamWriteToMetadataPartitions(any(), any());
+  }
+
+  @Test
+  void testSparkDefersMetadataGenerationUntilCommittedWriteStatsAreAvailable() {
+    HoodieData<WriteStatus> lazyDataWriteStatus = HoodieJavaRDD.of(jsc().parallelize(Arrays.asList(0, 1), 2)
+        .map(partition -> writeStatus("file-" + partition + "-stage-" + org.apache.spark.TaskContext.get().stageId(), false)));
+    HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
+
+    HoodieData<WriteStatus> allWriteStatuses = new MockSparkStreamingMetadataWriteHandler(mdtWriter)
+        .streamWriteToMetadataTable(mockHoodieTable, lazyDataWriteStatus, "00001", 1000);
+    List<WriteStatus> statuses = allWriteStatuses.collectAsList();
+
+    assertTrue(statuses.stream().noneMatch(WriteStatus::isMetadataTable));
+    assertTrue(statuses.size() > 1, "Test must exercise multiple source partitions");
+    verify(mdtWriter, never()).streamWriteToMetadataPartitions(any(), any());
+  }
+
+  private static WriteStatus writeStatus(String path, boolean isMetadataTable) {
+    HoodieWriteStat stat = new HoodieWriteStat();
+    stat.setPath(path);
+    WriteStatus status = new WriteStatus(true, 0.0, isMetadataTable);
+    status.setStat(stat);
+    return status;
   }
 
   private HoodieData<WriteStatus> mockWriteStatuses(int size) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkStreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkStreamingMetadataWriteHandler.java
@@ -41,13 +41,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,18 +87,17 @@ public class TestSparkStreamingMetadataWriteHandler extends SparkClientFunctiona
   @MethodSource("coalesceDivisorTestArgs")
   public void testCoalesceDividentConfig(int numDataTableWriteStatuses, int coalesceDividentForDataTableWrites) {
     HoodieData<WriteStatus> dataTableWriteStatus = mockWriteStatuses(numDataTableWriteStatuses);
-    HoodieTableMetadataWriter mdtWriter = metadataWriterReturningEmptyStatuses();
+    HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
     SparkStreamingMetadataWriteHandler metadataWriteHandler = new MockSparkStreamingMetadataWriteHandler(mdtWriter);
 
     HoodieData<WriteStatus> allWriteStatuses = metadataWriteHandler.streamWriteToMetadataTable(mockHoodieTable, dataTableWriteStatus, "00001",
         coalesceDividentForDataTableWrites);
-    assertEquals(Math.max(1, numDataTableWriteStatuses / coalesceDividentForDataTableWrites),
-        allWriteStatuses.getNumPartitions());
-    verify(mdtWriter).streamWriteToMetadataPartitions(any(), any());
+    assertEquals(Math.max(1, numDataTableWriteStatuses / coalesceDividentForDataTableWrites), allWriteStatuses.getNumPartitions());
+    verify(mdtWriter, never()).streamWriteToMetadataPartitions(any(), any());
   }
 
   @Test
-  void testSparkCollectsOnlySuccessfulRetriedTaskAttempt() {
+  void testSparkRetryMaterializesSuccessfulAttemptAndDefersMetadataGeneration() {
     HoodieData<WriteStatus> retryingDataWriteStatus = HoodieJavaRDD.of(jsc().parallelize(Arrays.asList(0, 1), 2)
         .map(partition -> {
           int attempt = TaskContext.get().attemptNumber();
@@ -108,51 +107,34 @@ public class TestSparkStreamingMetadataWriteHandler extends SparkClientFunctiona
           return writeStatus("file-" + partition + "-attempt-" + attempt, false);
         }));
     HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
-    AtomicReference<HoodieData<WriteStatus>> metadataInput = new AtomicReference<>();
-    when(mdtWriter.streamWriteToMetadataPartitions(any(), any())).thenAnswer(invocation -> {
-      metadataInput.set(invocation.getArgument(0));
-      return HoodieJavaRDD.of(jsc().emptyRDD());
-    });
 
     List<WriteStatus> statuses = new MockSparkStreamingMetadataWriteHandler(mdtWriter)
         .streamWriteToMetadataTable(mockHoodieTable, retryingDataWriteStatus, "00001", 1000)
         .collectAsList();
     List<String> paths = statuses.stream().map(status -> status.getStat().getPath()).collect(java.util.stream.Collectors.toList());
 
-    List<String> metadataPaths = metadataInput.get().collectAsList().stream()
-        .map(status -> status.getStat().getPath())
-        .collect(java.util.stream.Collectors.toList());
-    assertTrue(paths.contains("file-0-attempt-1"), "Collected output must come from the successful attempt");
+    assertEquals(2, paths.size(), "One scheduler-selected status is expected per source partition");
+    assertTrue(paths.contains("file-0-attempt-1"), "Retry output must come from the successful attempt");
     assertTrue(paths.stream().noneMatch(path -> path.equals("file-0-attempt-0")));
-    assertTrue(metadataPaths.contains("file-0-attempt-1"),
-        "Metadata generation must consume the successful attempt");
-    assertTrue(metadataPaths.stream().noneMatch(path -> path.equals("file-0-attempt-0")));
-    verify(mdtWriter).streamWriteToMetadataPartitions(any(), any());
+    // This is the regression boundary: master invokes the metadata writer from pre-commit task
+    // lineage here. The Spark handler must only materialize scheduler-selected data statuses;
+    // completeStreamingCommit later derives RLI/SI updates from committed HoodieCommitMetadata.
+    verify(mdtWriter, never()).streamWriteToMetadataPartitions(any(), any());
   }
 
   @Test
-  void testSparkUnionsMetadataWriteStatusesAfterCommittedDataStatuses() {
+  void testSparkDefersMetadataGenerationUntilCommittedWriteStatsAreAvailable() {
     HoodieData<WriteStatus> lazyDataWriteStatus = HoodieJavaRDD.of(jsc().parallelize(Arrays.asList(0, 1), 2)
-        .map(partition -> writeStatus("file-" + partition, false)));
+        .map(partition -> writeStatus("file-" + partition + "-stage-" + org.apache.spark.TaskContext.get().stageId(), false)));
     HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
-    when(mdtWriter.streamWriteToMetadataPartitions(any(), any()))
-        .thenReturn(HoodieJavaRDD.of(jsc().parallelize(
-            java.util.Collections.singletonList(writeStatus("metadata-file", true)), 1)));
 
-    List<WriteStatus> statuses = new MockSparkStreamingMetadataWriteHandler(mdtWriter)
-        .streamWriteToMetadataTable(mockHoodieTable, lazyDataWriteStatus, "00001", 1000)
-        .collectAsList();
+    HoodieData<WriteStatus> allWriteStatuses = new MockSparkStreamingMetadataWriteHandler(mdtWriter)
+        .streamWriteToMetadataTable(mockHoodieTable, lazyDataWriteStatus, "00001", 1000);
+    List<WriteStatus> statuses = allWriteStatuses.collectAsList();
 
-    assertEquals(3, statuses.size());
-    assertEquals(1, statuses.stream().filter(WriteStatus::isMetadataTable).count());
-    verify(mdtWriter).streamWriteToMetadataPartitions(any(), any());
-  }
-
-  private HoodieTableMetadataWriter metadataWriterReturningEmptyStatuses() {
-    HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
-    when(mdtWriter.streamWriteToMetadataPartitions(any(), any()))
-        .thenReturn(HoodieJavaRDD.of(jsc().emptyRDD()));
-    return mdtWriter;
+    assertTrue(statuses.stream().noneMatch(WriteStatus::isMetadataTable));
+    assertTrue(statuses.size() > 1, "Test must exercise multiple source partitions");
+    verify(mdtWriter, never()).streamWriteToMetadataPartitions(any(), any());
   }
 
   private static WriteStatus writeStatus(String path, boolean isMetadataTable) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkStreamingMetadataWriteHandler.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkStreamingMetadataWriteHandler.java
@@ -21,6 +21,7 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
@@ -94,6 +95,19 @@ public class TestSparkStreamingMetadataWriteHandler extends SparkClientFunctiona
         coalesceDividentForDataTableWrites);
     assertEquals(Math.max(1, numDataTableWriteStatuses / coalesceDividentForDataTableWrites), allWriteStatuses.getNumPartitions());
     verify(mdtWriter, never()).streamWriteToMetadataPartitions(any(), any());
+  }
+
+  @Test
+  void testSparkCompletionExplicitlyUsesCommittedMetadataPath() {
+    String instantTime = "00001";
+    HoodieTableMetadataWriter mdtWriter = mock(HoodieTableMetadataWriter.class);
+    HoodieCommitMetadata commitMetadata = mock(HoodieCommitMetadata.class);
+
+    new MockSparkStreamingMetadataWriteHandler(mdtWriter)
+        .commitToMetadataTable(mockHoodieTable, instantTime, commitMetadata, java.util.Collections.emptyList());
+
+    verify(mdtWriter).completeStreamingCommit(
+        instantTime, mockHoodieTable.getContext(), java.util.Collections.emptyList(), commitMetadata, false);
   }
 
   @Test

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -115,8 +115,9 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .defaultValue(5000)
       .markAdvanced()
       .sinceVersion("1.1.0")
-      .withDocumentation("When streaming writes to metadata table are enabled, Spark coalesces data-table write statuses before collecting successful task-attempt outputs. "
-          + "The coalesced partition count is the number of write-status partitions divided by this divisor, with a minimum of one partition.");
+      .withDocumentation("When streaming writes to metadata table is enabled via hoodie.metadata.streaming.write.enabled, the data table write statuses are unioned "
+          + "with metadata table write statuses before triggering the entire write dag. The data table write statuses will be coalesce down to the number of write statuses "
+          + "divided by the specified divisor to avoid triggering thousands of no-op tasks for the data table writes which have their status cached.");
 
   public static final boolean DEFAULT_METADATA_ENABLE_FOR_READERS = true;
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -115,9 +115,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .defaultValue(5000)
       .markAdvanced()
       .sinceVersion("1.1.0")
-      .withDocumentation("When streaming writes to metadata table is enabled via hoodie.metadata.streaming.write.enabled, the data table write statuses are unioned "
-          + "with metadata table write statuses before triggering the entire write dag. The data table write statuses will be coalesce down to the number of write statuses "
-          + "divided by the specified divisor to avoid triggering thousands of no-op tasks for the data table writes which have their status cached.");
+      .withDocumentation("When streaming writes to metadata table are enabled, Spark coalesces data-table write statuses before collecting successful task-attempt outputs. "
+          + "The coalesced partition count is the number of write-status partitions divided by this divisor, with a minimum of one partition.");
 
   public static final boolean DEFAULT_METADATA_ENABLE_FOR_READERS = true;
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -640,7 +640,13 @@ public class StreamWriteOperatorCoordinator
       writeClient.cleanResources(instant);
       return false;
     }
-    doCommit(checkpointId, instant, dataWriteResults, eventBuffer.collectIndexWriteStatuses());
+    List<WriteStatus> indexWriteResults = eventBuffer.collectIndexWriteStatuses();
+    if (eventBuffer.hasIndexWriteEvents()) {
+      // Index writers may legitimately emit no statuses for update-only RLI/SI commits. Preserve
+      // the fact that streaming ran so commit completion does not initialize or regenerate them.
+      writeClient.markMetadataPartitionsWereStreamed(instant);
+    }
+    doCommit(checkpointId, instant, dataWriteResults, indexWriteResults);
     return true;
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/EventBuffers.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/EventBuffers.java
@@ -260,6 +260,13 @@ public class EventBuffers implements Serializable {
     }
 
     /**
+     * Returns whether index writers reported this instant, even when no index records were emitted.
+     */
+    public boolean hasIndexWriteEvents() {
+      return Arrays.stream(indexWriteEventBuffer).anyMatch(Objects::nonNull);
+    }
+
+    /**
      * Returns the write status for index partitions of the metadata table.
      */
     public List<WriteStatus> collectIndexWriteStatuses() {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -175,8 +175,9 @@ public class TestStreamWriteOperatorCoordinator {
     coordinator.handleEventFromOperator(1, event1);
 
     if (isStreamingIndexWriteEnabled) {
-      OperatorEvent indexEvent0 = createOperatorEvent(0, -1, instant, "record_index", false, true, 0.1, true);
-      OperatorEvent indexEvent1 = createOperatorEvent(1, -1, instant, "record_index", false, true, 0.2, true);
+      // Update-only RLI/SI batches can report completion without producing metadata write statuses.
+      OperatorEvent indexEvent0 = createEmptyIndexOperatorEvent(0, instant);
+      OperatorEvent indexEvent1 = createEmptyIndexOperatorEvent(1, instant);
       coordinator.handleEventFromOperator(0, indexEvent0);
       coordinator.handleEventFromOperator(1, indexEvent1);
     }
@@ -191,6 +192,7 @@ public class TestStreamWriteOperatorCoordinator {
       EventBuffers.EventBuffer eventBuffer = restoredCoordinator.getEventBuffer(-1);
       assertEquals(2, eventBuffer.getDataWriteEventBuffer().length);
       assertEquals(isStreamingIndexWriteEnabled ? 2 : 0, eventBuffer.getIndexWriteEventBuffer().length);
+      assertEquals(isStreamingIndexWriteEnabled, eventBuffer.hasIndexWriteEvents());
     }
 
     // Case 2: global failover recommits the live buffers of the already started coordinator.
@@ -806,6 +808,16 @@ public class TestStreamWriteOperatorCoordinator {
 
   private static WriteMetadataEvent createBootstrapEvent(int taskId, long checkpointId, String instant, String partitionPath) {
     return createOperatorEvent(taskId, checkpointId, instant, partitionPath, true, false, 0.1);
+  }
+
+  private static WriteMetadataEvent createEmptyIndexOperatorEvent(int taskId, String instant) {
+    return WriteMetadataEvent.builder()
+        .taskID(taskId)
+        .instantTime(instant)
+        .writeStatus(Collections.emptyList())
+        .lastBatch(true)
+        .metadataTable(true)
+        .build();
   }
 
   private static WriteMetadataEvent createOperatorEvent(

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestMetadataWriterCommit.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestMetadataWriterCommit.java
@@ -116,7 +116,7 @@ public class TestMetadataWriterCommit extends BaseTestHandle {
     mdtWriter.startCommit(instantTime);
     HoodieData<WriteStatus> mdtWriteStatus = mdtWriter.streamWriteToMetadataPartitions(HoodieJavaRDD.of(Collections.singletonList(writeStatus), context, 1), instantTime);
     List<HoodieWriteStat> mdtWriteStats = mdtWriteStatus.collectAsList().stream().map(WriteStatus::getStat).collect(Collectors.toList());
-    mdtWriter.completeStreamingCommit(instantTime, context, mdtWriteStats, commitMetadata);
+    mdtWriter.completeStreamingCommit(instantTime, context, mdtWriteStats, commitMetadata, true);
     // 3 bootstrap commits for 2 enabled partitions, 1 commit due to update
     assertEquals(3, mdtMetaClient.reloadActiveTimeline().filterCompletedInstants().countInstants());
 
@@ -136,7 +136,7 @@ public class TestMetadataWriterCommit extends BaseTestHandle {
     mdtWriter.startCommit(instantTime);
     mdtWriteStatus = mdtWriter.streamWriteToMetadataPartitions(HoodieJavaRDD.of(Collections.singletonList(writeStatus), context, 1), instantTime);
     mdtWriteStats = mdtWriteStatus.collectAsList().stream().map(WriteStatus::getStat).collect(Collectors.toList());
-    mdtWriter.completeStreamingCommit(instantTime, context, mdtWriteStats, commitMetadata);
+    mdtWriter.completeStreamingCommit(instantTime, context, mdtWriteStats, commitMetadata, true);
     // 3 bootstrap commits for 4 enabled partitions, 2 commits due to update
     assertEquals(6, mdtMetaClient.reloadActiveTimeline().filterCompletedInstants().countInstants());
 
@@ -233,7 +233,7 @@ public class TestMetadataWriterCommit extends BaseTestHandle {
     mdtWriter.startCommit(instantTime);
     HoodieData<WriteStatus> mdtWriteStatus = mdtWriter.streamWriteToMetadataPartitions(HoodieJavaRDD.of(Collections.singletonList(writeStatus), context, 1), instantTime);
     List<HoodieWriteStat> mdtWriteStats = mdtWriteStatus.collectAsList().stream().map(WriteStatus::getStat).collect(Collectors.toList());
-    mdtWriter.completeStreamingCommit(instantTime, context, mdtWriteStats, commitMetadata);
+    mdtWriter.completeStreamingCommit(instantTime, context, mdtWriteStats, commitMetadata, true);
     // 3 bootstrap commits for 3 enabled partitions, 1 commit due to update
     assertEquals(4, mdtMetaClient.reloadActiveTimeline().filterCompletedInstants().countInstants());
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Spark can produce a data-table `WriteStatus` from a task attempt that later fails or loses to a retry/speculative attempt. The streaming metadata path previously derived RLI/SI records from that raw pre-shuffle lineage, allowing a losing attempt's stale file location to leak into committed metadata.

This is a core metadata-index correctness issue discovered while validating RFC-109, but the fix is independent of vector indexing.

### Summary and Changelog

Spark streaming metadata writes now place the data-table statuses behind the existing coalescing shuffle **before** deriving RLI/SI metadata records.

- Build scheduler-selected data statuses at the coalescing shuffle boundary.
- Feed that successful-attempt lineage into the existing streaming RLI/SI mappers.
- Preserve the existing metadata-status persistence and data/metadata union.
- Add a regression that forces partition 0 attempt 0 to fail under `local[8,2]` and verifies both collected data output and metadata input contain only attempt 1.
- Add coverage that metadata statuses remain unioned into the returned DAG.

No code was copied.

### Impact

Correctness fix for Spark writers using streaming metadata writes, particularly RLI and SI under task retry/speculation. No storage-format, public API, timeline-protocol, metadata-schema, or configuration change.

### Risk Level

medium — this moves the existing coalescing shuffle ahead of streaming metadata generation. Mitigation:

- JDK 17, Spark 4.0 / Scala 2.13 targeted reactor: **8 tests passed, 0 failed**.
- Forced Spark retry regression verifies metadata consumes only scheduler-selected output.
- Existing streaming metadata mappers and commit-completion flow are retained.
- `git diff --check` passes.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
