### PR TITLE
refactor(reader): Use reader context API for legacy scanner delete re…

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestHoodieLogFileCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestHoodieLogFileCommand.java
@@ -25,9 +25,11 @@ import org.apache.hudi.cli.TableHeader;
 import org.apache.hudi.cli.functional.CLIFunctionalTestHarness;
 import org.apache.hudi.cli.testutils.HoodieTestCommitMetadataGenerator;
 import org.apache.hudi.cli.testutils.ShellEvaluationResultUtil;
+import org.apache.hudi.common.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieReaderConfig;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieLogFile;
@@ -35,6 +37,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.log.HoodieLogFormatWriter;
 import org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner;
@@ -236,6 +239,7 @@ public class TestHoodieLogFileCommand extends CLIFunctionalTestHarness {
         .withStorage(storage)
         .withBasePath(tablePath)
         .withLogFilePaths(logFilePaths)
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime(INSTANT_TIME)
         .withMaxMemorySizeInBytes(
@@ -265,5 +269,12 @@ public class TestHoodieLogFileCommand extends CLIFunctionalTestHarness {
     expected = removeNonWordAndStripSpace(expected);
     String got = removeNonWordAndStripSpace(result.toString());
     assertEquals(expected, got);
+  }
+
+  private HoodieAvroReaderContext createReaderContext() {
+    HoodieTableMetaClient metaClient = HoodieCLI.getTableMetaClient();
+    TypedProperties readerProps = TypedProperties.copy(metaClient.getTableConfig().getProps(true));
+    return new HoodieAvroReaderContext(
+        metaClient.getStorageConf(), metaClient.getTableConfig(), Option.empty(), Option.empty(), readerProps);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/avro/HoodieAvroReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/avro/HoodieAvroReaderContext.java
@@ -243,22 +243,25 @@ public class HoodieAvroReaderContext extends HoodieReaderContext<IndexedRecord> 
       HoodieSchema requiredSchema) throws IOException {
     HoodieSchema fileOutputSchema;
     Map<String, String> renamedColumns;
-    // Even when dataSchema equals requiredSchema, renamed columns still require schema rewriting
-    // to map old column names to new names during record reading. We only skip the lookup when
-    // both schemas match AND there are no renamed columns.
-    Pair<HoodieSchema, Map<String, String>> requiredSchemaForFileAndRenamedColumns = getSchemaHandler().getRequiredSchemaForFileAndRenamedColumns(filePath);
-    boolean hasNoRenamedColumns = requiredSchemaForFileAndRenamedColumns.getRight().isEmpty();
-    if (isLogFile || (dataSchema.equals(requiredSchema) && hasNoRenamedColumns)) {
-      // Skip per-file schema rewriting in these cases:
-      // 1. Log files: Schema evolution is handled during record merging (via rewriteRecordWithNewSchema),
-      //    not at the file reader level. Log records are read with their writer schema, then promoted later.
-      // 2. Bootstrap skeleton files (and other cases where dataSchema == requiredSchema with no renamed columns):
-      //    No schema rewriting is needed since schemas already match.
+    if (isLogFile) {
+      // Schema evolution for log files is handled during record merging (via rewriteRecordWithNewSchema),
+      // not at the file reader level. Log records are read with their writer schema, then promoted later.
       fileOutputSchema = requiredSchema;
       renamedColumns = Collections.emptyMap();
     } else {
-      fileOutputSchema = requiredSchemaForFileAndRenamedColumns.getLeft();
-      renamedColumns = requiredSchemaForFileAndRenamedColumns.getRight();
+      // Even when dataSchema equals requiredSchema, renamed columns still require schema rewriting
+      // to map old column names to new names during record reading. We only skip the lookup when
+      // both schemas match AND there are no renamed columns.
+      Pair<HoodieSchema, Map<String, String>> requiredSchemaForFileAndRenamedColumns =
+          getSchemaHandler().getRequiredSchemaForFileAndRenamedColumns(filePath);
+      boolean hasNoRenamedColumns = requiredSchemaForFileAndRenamedColumns.getRight().isEmpty();
+      if (dataSchema.equals(requiredSchema) && hasNoRenamedColumns) {
+        fileOutputSchema = requiredSchema;
+        renamedColumns = Collections.emptyMap();
+      } else {
+        fileOutputSchema = requiredSchemaForFileAndRenamedColumns.getLeft();
+        renamedColumns = requiredSchemaForFileAndRenamedColumns.getRight();
+      }
     }
     if (keyFilterOpt.isEmpty()) {
       return reader.getIndexedRecordIterator(dataSchema, fileOutputSchema, renamedColumns);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.common.table.log;
 
-import org.apache.hudi.common.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.HoodieLogFile;
@@ -40,7 +39,6 @@ import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.table.read.FileGroupReaderSchemaHandler;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.InternalSchemaCache;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
@@ -56,7 +54,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -165,8 +162,9 @@ public abstract class AbstractHoodieLogRecordScanner {
   private HoodieTimeline commitsTimeline = null;
   private HoodieTimeline completedInstantsTimeline = null;
   private HoodieTimeline inflightInstantsTimeline = null;
-  // Reader context used to materialize delete records through the engine-agnostic reader APIs.
-  private HoodieReaderContext<IndexedRecord> deleteReaderContext;
+  // Caller-owned reader context used to materialize delete records through the engine-agnostic reader APIs.
+  private final HoodieReaderContext<?> readerContext;
+  private boolean isReaderContextInitialized;
   // Physical partition path of the log files, used to restore HoodieKey for buffered deletes.
   private final Option<String> deletePartitionPathOpt;
 
@@ -178,6 +176,7 @@ public abstract class AbstractHoodieLogRecordScanner {
                                            InternalSchema internalSchema,
                                            Option<String> keyFieldOverride,
                                            HoodieRecordMerger recordMerger,
+                                           HoodieReaderContext<?> readerContext,
                                            Option<HoodieTableMetaClient> hoodieTableMetaClientOption) {
     this.readerSchema = readerSchema;
     this.latestInstantTime = latestInstantTime;
@@ -232,6 +231,7 @@ public abstract class AbstractHoodieLogRecordScanner {
     this.partitionNameOverrideOpt = partitionNameOverride;
     this.deletePartitionPathOpt = resolveDeletePartitionPath(basePath, logFilePaths, partitionNameOverride);
     this.recordType = recordMerger.getRecordType();
+    this.readerContext = readerContext;
   }
 
   private static Option<String> resolveDeletePartitionPath(String basePath, List<String> logFilePaths,
@@ -246,12 +246,10 @@ public abstract class AbstractHoodieLogRecordScanner {
         new StoragePath(basePath), new StoragePath(logFilePaths.get(0)).getParent()));
   }
 
-  private HoodieReaderContext<IndexedRecord> getOrCreateDeleteReaderContext() {
-    if (deleteReaderContext == null) {
-      HoodieTableConfig tableConfig = hoodieTableMetaClient.getTableConfig();
-      TypedProperties mergeProps = ConfigUtils.getMergeProps(payloadProps, tableConfig);
-      HoodieReaderContext<IndexedRecord> readerContext = new HoodieAvroReaderContext(
-          hoodieTableMetaClient.getStorageConf(), tableConfig, instantRange, Option.empty(), mergeProps);
+  private <T> void initializeReaderContext(HoodieReaderContext<T> readerContext) {
+    if (!isReaderContextInitialized) {
+      TypedProperties readerProps = TypedProperties.copy(readerContext.getHoodieReaderConfig().getProps());
+      TypedProperties mergeProps = readerContext.getMergeProps(readerProps);
       readerContext.setHasLogFiles(true);
       readerContext.setHasBootstrapBaseFile(false);
       readerContext.setShouldMergeUseRecordPosition(false);
@@ -263,9 +261,8 @@ public abstract class AbstractHoodieLogRecordScanner {
           ? Option.empty() : Option.of(internalSchema);
       readerContext.setSchemaHandler(new FileGroupReaderSchemaHandler<>(
           readerContext, readerSchema, readerSchema, internalSchemaOpt, mergeProps, hoodieTableMetaClient));
-      deleteReaderContext = readerContext;
+      isReaderContextInitialized = true;
     }
-    return deleteReaderContext;
   }
 
   private HoodieTimeline getOrCreateCompletedInstantsTimeline() {
@@ -554,10 +551,11 @@ public abstract class AbstractHoodieLogRecordScanner {
    */
   protected abstract void processNextDeletedRecord(BufferedRecord<?> deleteRecord, String partitionPath);
 
-  private void processDeleteBlock(HoodieDeleteBlock deleteBlock) {
+  private <T> void processDeleteBlock(HoodieDeleteBlock deleteBlock, HoodieReaderContext<T> readerContext) {
     checkState(deletePartitionPathOpt.isPresent(), "Partition path is required when processing delete records");
+    initializeReaderContext(readerContext);
     String partitionPath = deletePartitionPathOpt.get();
-    for (BufferedRecord<IndexedRecord> deleteRecord : deleteBlock.getRecordsToDelete(getOrCreateDeleteReaderContext())) {
+    for (BufferedRecord<T> deleteRecord : deleteBlock.getRecordsToDelete(readerContext)) {
       processNextDeletedRecord(deleteRecord, partitionPath);
     }
   }
@@ -578,7 +576,7 @@ public abstract class AbstractHoodieLogRecordScanner {
           processDataBlock((HoodieDataBlock) lastBlock, keySpecOpt);
           break;
         case DELETE_BLOCK:
-          processDeleteBlock((HoodieDeleteBlock) lastBlock);
+          processDeleteBlock((HoodieDeleteBlock) lastBlock, readerContext);
           break;
         case CORRUPT_BLOCK:
           log.warn("Found a corrupt block which was not rolled back");
@@ -782,6 +780,10 @@ public abstract class AbstractHoodieLogRecordScanner {
     }
 
     public Builder withTableMetaClient(HoodieTableMetaClient hoodieTableMetaClient) {
+      throw new UnsupportedOperationException();
+    }
+
+    public Builder withReaderContext(HoodieReaderContext<?> readerContext) {
       throw new UnsupportedOperationException();
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
@@ -37,7 +37,6 @@ import org.apache.hudi.common.table.log.block.HoodieDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.read.BufferedRecord;
-import org.apache.hudi.common.table.read.FileGroupReaderSchemaHandler;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.InternalSchemaCache;
 import org.apache.hudi.common.util.Option;
@@ -248,19 +247,12 @@ public abstract class AbstractHoodieLogRecordScanner {
 
   private <T> void initializeReaderContext(HoodieReaderContext<T> readerContext) {
     if (!isReaderContextInitialized) {
-      TypedProperties readerProps = TypedProperties.copy(readerContext.getHoodieReaderConfig().getProps());
-      TypedProperties mergeProps = readerContext.getMergeProps(readerProps);
       readerContext.setHasLogFiles(true);
       readerContext.setHasBootstrapBaseFile(false);
       readerContext.setShouldMergeUseRecordPosition(false);
       readerContext.setTablePath(hoodieTableMetaClient.getBasePath().toString());
       readerContext.setLatestCommitTime(latestInstantTime);
       readerContext.getRecordContext().setPartitionPath(deletePartitionPathOpt.orElse(null));
-      readerContext.initRecordMerger(mergeProps);
-      Option<InternalSchema> internalSchemaOpt = internalSchema.isEmptySchema()
-          ? Option.empty() : Option.of(internalSchema);
-      readerContext.setSchemaHandler(new FileGroupReaderSchemaHandler<>(
-          readerContext, readerSchema, readerSchema, internalSchemaOpt, mergeProps, hoodieTableMetaClient));
       isReaderContextInitialized = true;
     }
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
@@ -18,8 +18,9 @@
 
 package org.apache.hudi.common.table.log;
 
+import org.apache.hudi.common.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.model.DeleteRecord;
+import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -36,7 +37,10 @@ import org.apache.hudi.common.table.log.block.HoodieCommandBlock;
 import org.apache.hudi.common.table.log.block.HoodieDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.read.BufferedRecord;
+import org.apache.hudi.common.table.read.FileGroupReaderSchemaHandler;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.InternalSchemaCache;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
@@ -52,6 +56,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -68,6 +73,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.fs.FSUtils.getRelativePartitionPath;
 import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType.COMPACTED_BLOCK_TIMES;
 import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType.INSTANT_TIME;
 import static org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType.TARGET_INSTANT_TIME;
@@ -159,6 +165,10 @@ public abstract class AbstractHoodieLogRecordScanner {
   private HoodieTimeline commitsTimeline = null;
   private HoodieTimeline completedInstantsTimeline = null;
   private HoodieTimeline inflightInstantsTimeline = null;
+  // Reader context used to materialize delete records through the engine-agnostic reader APIs.
+  private HoodieReaderContext<IndexedRecord> deleteReaderContext;
+  // Physical partition path of the log files, used to restore HoodieKey for buffered deletes.
+  private final Option<String> deletePartitionPathOpt;
 
   protected AbstractHoodieLogRecordScanner(HoodieStorage storage, String basePath, List<String> logFilePaths,
                                            HoodieSchema readerSchema, String latestInstantTime,
@@ -220,7 +230,42 @@ public abstract class AbstractHoodieLogRecordScanner {
     }
 
     this.partitionNameOverrideOpt = partitionNameOverride;
+    this.deletePartitionPathOpt = resolveDeletePartitionPath(basePath, logFilePaths, partitionNameOverride);
     this.recordType = recordMerger.getRecordType();
+  }
+
+  private static Option<String> resolveDeletePartitionPath(String basePath, List<String> logFilePaths,
+                                                           Option<String> partitionNameOverride) {
+    if (partitionNameOverride.isPresent()) {
+      return partitionNameOverride;
+    }
+    if (logFilePaths.isEmpty()) {
+      return Option.empty();
+    }
+    return Option.of(getRelativePartitionPath(
+        new StoragePath(basePath), new StoragePath(logFilePaths.get(0)).getParent()));
+  }
+
+  private HoodieReaderContext<IndexedRecord> getOrCreateDeleteReaderContext() {
+    if (deleteReaderContext == null) {
+      HoodieTableConfig tableConfig = hoodieTableMetaClient.getTableConfig();
+      TypedProperties mergeProps = ConfigUtils.getMergeProps(payloadProps, tableConfig);
+      HoodieReaderContext<IndexedRecord> readerContext = new HoodieAvroReaderContext(
+          hoodieTableMetaClient.getStorageConf(), tableConfig, instantRange, Option.empty(), mergeProps);
+      readerContext.setHasLogFiles(true);
+      readerContext.setHasBootstrapBaseFile(false);
+      readerContext.setShouldMergeUseRecordPosition(false);
+      readerContext.setTablePath(hoodieTableMetaClient.getBasePath().toString());
+      readerContext.setLatestCommitTime(latestInstantTime);
+      readerContext.getRecordContext().setPartitionPath(deletePartitionPathOpt.orElse(null));
+      readerContext.initRecordMerger(mergeProps);
+      Option<InternalSchema> internalSchemaOpt = internalSchema.isEmptySchema()
+          ? Option.empty() : Option.of(internalSchema);
+      readerContext.setSchemaHandler(new FileGroupReaderSchemaHandler<>(
+          readerContext, readerSchema, readerSchema, internalSchemaOpt, mergeProps, hoodieTableMetaClient));
+      deleteReaderContext = readerContext;
+    }
+    return deleteReaderContext;
   }
 
   private HoodieTimeline getOrCreateCompletedInstantsTimeline() {
@@ -504,9 +549,18 @@ public abstract class AbstractHoodieLogRecordScanner {
   /**
    * Process next deleted record.
    *
-   * @param deleteRecord Deleted record(hoodie key and ordering value)
+   * @param deleteRecord Deleted record (record key and ordering value)
+   * @param partitionPath Partition containing the deleted record
    */
-  protected abstract void processNextDeletedRecord(DeleteRecord deleteRecord);
+  protected abstract void processNextDeletedRecord(BufferedRecord<?> deleteRecord, String partitionPath);
+
+  private void processDeleteBlock(HoodieDeleteBlock deleteBlock) {
+    checkState(deletePartitionPathOpt.isPresent(), "Partition path is required when processing delete records");
+    String partitionPath = deletePartitionPathOpt.get();
+    for (BufferedRecord<IndexedRecord> deleteRecord : deleteBlock.getRecordsToDelete(getOrCreateDeleteReaderContext())) {
+      processNextDeletedRecord(deleteRecord, partitionPath);
+    }
+  }
 
   /**
    * Process the set of log blocks belonging to the last instant which is read fully.
@@ -524,7 +578,7 @@ public abstract class AbstractHoodieLogRecordScanner {
           processDataBlock((HoodieDataBlock) lastBlock, keySpecOpt);
           break;
         case DELETE_BLOCK:
-          Arrays.stream(((HoodieDeleteBlock) lastBlock).getRecordsToDelete()).forEach(this::processNextDeletedRecord);
+          processDeleteBlock((HoodieDeleteBlock) lastBlock);
           break;
         case CORRUPT_BLOCK:
           log.warn("Found a corrupt block which was not rolled back");

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.table.log;
 
 import org.apache.hudi.common.avro.AvroRecordContext;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.model.HoodieEmptyRecord;
 import org.apache.hudi.common.model.HoodieKey;
@@ -112,11 +113,12 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
                                          InternalSchema internalSchema,
                                          Option<String> keyFieldOverride,
                                          HoodieRecordMerger recordMerger,
+                                         HoodieReaderContext<?> readerContext,
                                          Option<HoodieTableMetaClient> hoodieTableMetaClientOption,
                                          boolean allowInflightInstants) {
     super(storage, basePath, logFilePaths, readerSchema, latestInstantTime, reverseReader, bufferSize,
         instantRange, withOperationField, forceFullScan, partitionName, internalSchema, keyFieldOverride, recordMerger,
-        hoodieTableMetaClientOption);
+        readerContext, hoodieTableMetaClientOption);
     try {
       this.maxMemorySizeInBytes = maxMemorySizeInBytes;
       // Store merged records for all versions for this log file, set the in-memory footprint to maxInMemoryMapSize
@@ -354,6 +356,7 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
     private boolean forceFullScan = true;
     protected boolean allowInflightInstants = false;
     private HoodieRecordMerger recordMerger = new HoodiePreCombineAvroRecordMerger();
+    private HoodieReaderContext<?> readerContext;
     protected HoodieTableMetaClient hoodieTableMetaClient;
 
     @Override
@@ -471,6 +474,12 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
       return this;
     }
 
+    @Override
+    public Builder withReaderContext(HoodieReaderContext<?> readerContext) {
+      this.readerContext = readerContext;
+      return this;
+    }
+
     public Builder withAllowInflightInstants(boolean allowInflightInstants) {
       this.allowInflightInstants = allowInflightInstants;
       return this;
@@ -483,13 +492,14 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
             new StoragePath(basePath), new StoragePath(this.logFilePaths.get(0)).getParent());
       }
       checkArgument(recordMerger != null);
+      checkArgument(readerContext != null, "Reader context is required");
 
       return new HoodieMergedLogRecordScanner(storage, basePath, logFilePaths, readerSchema,
           latestInstantTime, maxMemorySizeInBytes, reverseReader,
           bufferSize, spillableMapBasePath, instantRange,
           diskMapType, isBitCaskDiskMapCompressionEnabled, withOperationField, forceFullScan,
           Option.ofNullable(partitionName), internalSchema, Option.ofNullable(keyFieldOverride), recordMerger,
-          Option.ofNullable(hoodieTableMetaClient), allowInflightInstants);
+          readerContext, Option.ofNullable(hoodieTableMetaClient), allowInflightInstants);
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -21,7 +21,6 @@ package org.apache.hudi.common.table.log;
 import org.apache.hudi.common.avro.AvroRecordContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.RecordContext;
-import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.HoodieEmptyRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodiePreCombineAvroRecordMerger;
@@ -281,7 +280,7 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
   }
 
   @Override
-  protected void processNextDeletedRecord(DeleteRecord deleteRecord) {
+  protected void processNextDeletedRecord(BufferedRecord<?> deleteRecord, String partitionPath) {
     String key = deleteRecord.getRecordKey();
     HoodieRecord oldRecord = records.get(key);
     if (oldRecord != null) {
@@ -304,9 +303,9 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
     // Put the DELETE record
     if (recordType == HoodieRecord.HoodieRecordType.AVRO) {
       records.put(key, HoodieRecordUtils.generateEmptyPayload(key,
-          deleteRecord.getPartitionPath(), deleteRecord.getOrderingValue(), getPayloadClassFQN()));
+          partitionPath, deleteRecord.getOrderingValue(), getPayloadClassFQN()));
     } else {
-      HoodieEmptyRecord record = new HoodieEmptyRecord<>(new HoodieKey(key, deleteRecord.getPartitionPath()), null, deleteRecord.getOrderingValue(), recordType);
+      HoodieEmptyRecord record = new HoodieEmptyRecord<>(new HoodieKey(key, partitionPath), null, deleteRecord.getOrderingValue(), recordType);
       records.put(key, record);
     }
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.common.table.log;
 
-import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodiePreCombineAvroRecordMerger;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -27,6 +26,7 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.internal.InternalSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.cdc.HoodieCDCUtils;
+import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.util.HoodieRecordUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -86,9 +86,9 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordScann
   }
 
   @Override
-  protected void processNextDeletedRecord(DeleteRecord deleteRecord) {
+  protected void processNextDeletedRecord(BufferedRecord<?> deleteRecord, String partitionPath) {
     if (recordDeletionCallback != null) {
-      recordDeletionCallback.apply(deleteRecord.getHoodieKey());
+      recordDeletionCallback.apply(new HoodieKey(deleteRecord.getRecordKey(), partitionPath));
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieUnMergedLogRecordScanner.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table.log;
 
+import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodiePreCombineAvroRecordMerger;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -48,10 +49,11 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordScann
                                          String latestInstantTime, boolean reverseReader, int bufferSize,
                                          LogRecordScannerCallback callback, RecordDeletionCallback recordDeletionCallback,
                                          Option<InstantRange> instantRange, InternalSchema internalSchema,
-                                         HoodieRecordMerger recordMerger, Option<HoodieTableMetaClient> hoodieTableMetaClientOption) {
+                                         HoodieRecordMerger recordMerger, HoodieReaderContext<?> readerContext,
+                                         Option<HoodieTableMetaClient> hoodieTableMetaClientOption) {
     super(storage, basePath, logFilePaths, readerSchema, latestInstantTime, reverseReader, bufferSize, instantRange,
         false, true, Option.empty(), internalSchema, Option.empty(), recordMerger,
-         hoodieTableMetaClientOption);
+        readerContext, hoodieTableMetaClientOption);
     this.callback = callback;
     this.recordDeletionCallback = recordDeletionCallback;
   }
@@ -126,6 +128,7 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordScann
     private LogRecordScannerCallback callback;
     private RecordDeletionCallback recordDeletionCallback;
     private HoodieRecordMerger recordMerger = new HoodiePreCombineAvroRecordMerger();
+    private HoodieReaderContext<?> readerContext;
     private HoodieTableMetaClient hoodieTableMetaClient;
 
     public Builder withStorage(HoodieStorage storage) {
@@ -206,12 +209,19 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordScann
     }
 
     @Override
+    public HoodieUnMergedLogRecordScanner.Builder withReaderContext(HoodieReaderContext<?> readerContext) {
+      this.readerContext = readerContext;
+      return this;
+    }
+
+    @Override
     public HoodieUnMergedLogRecordScanner build() {
       ValidationUtils.checkArgument(recordMerger != null);
+      ValidationUtils.checkArgument(readerContext != null, "Reader context is required");
 
       return new HoodieUnMergedLogRecordScanner(storage, basePath, logFilePaths, readerSchema,
           latestInstantTime, reverseReader, bufferSize, callback, recordDeletionCallback, instantRange,
-          internalSchema, recordMerger, Option.ofNullable(hoodieTableMetaClient));
+          internalSchema, recordMerger, readerContext, Option.ofNullable(hoodieTableMetaClient));
     }
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieDeleteBlock.java
@@ -112,6 +112,11 @@ public class HoodieDeleteBlock extends HoodieLogBlock {
     return baos;
   }
 
+  /**
+   * @deprecated Use {@link #getRecordsToDelete(HoodieReaderContext)} so delete records are
+   * materialized through the reader context.
+   */
+  @Deprecated
   public DeleteRecord[] getRecordsToDelete() {
     try {
       if (recordsToDelete == null) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieNativeLogDeleteBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieNativeLogDeleteBlock.java
@@ -80,6 +80,11 @@ public class HoodieNativeLogDeleteBlock extends HoodieDeleteBlock {
     return decodeOrderedRecordPositionList(getLogBlockHeader());
   }
 
+  /**
+   * @deprecated Use {@link #getRecordsToDelete(HoodieReaderContext)} so delete records are
+   * materialized through the reader context.
+   */
+  @Deprecated
   @Override
   public DeleteRecord[] getRecordsToDelete() {
     if (recordsToDelete == null) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/avro/TestHoodieAvroReaderContext.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/avro/TestHoodieAvroReaderContext.java
@@ -26,7 +26,9 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.core.io.storage.HoodieAvroFileReader;
 import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.storage.StoragePath;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -35,6 +37,7 @@ import org.apache.avro.generic.IndexedRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,6 +47,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -62,6 +66,21 @@ class TestHoodieAvroReaderContext {
   @BeforeEach
   void setup() {
     when(tableConfig.getPayloadClass()).thenReturn(DefaultHoodieRecordPayload.class.getName());
+  }
+
+  @Test
+  void getLogFileRecordIteratorDoesNotRequireSchemaHandler() throws IOException {
+    HoodieAvroReaderContext avroReaderContext = getReaderContextWithMetaFields();
+    HoodieAvroFileReader reader = mock(HoodieAvroFileReader.class);
+    ClosableIterator<IndexedRecord> expectedIterator = ClosableIterator.wrap(Collections.emptyIterator());
+    when(reader.getIndexedRecordIterator(BASE_SCHEMA, LIMITED_BASE_SCHEMA, Collections.emptyMap()))
+        .thenReturn(expectedIterator);
+
+    ClosableIterator<IndexedRecord> actualIterator = avroReaderContext.getFileRecordIterator(
+        reader, new StoragePath("file:///tmp/test-fileid_1-0-1_100_1.deletes.parquet"),
+        true, BASE_SCHEMA, LIMITED_BASE_SCHEMA);
+
+    assertSame(expectedIterator, actualIterator);
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -18,8 +18,11 @@
 
 package org.apache.hudi.common.functional;
 
+import org.apache.hudi.common.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.avro.HoodieAvroUtils;
 import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.HoodieArchivedLogFile;
@@ -783,6 +786,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withLogFilePaths(
             logFiles.stream()
                 .map(logFile -> logFile.getPath().toString()).collect(Collectors.toList()))
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("200")
         .withMaxMemorySizeInBytes(1024000L)
@@ -858,6 +862,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withBasePath(basePath)
         .withLogFilePaths(Arrays.asList(
             nativeDataLog.getPath().toString(), nativeDeleteLog.getPath().toString()))
+        .withReaderContext(createReaderContext())
         .withReaderSchema(HoodieTestDataGenerator.HOODIE_SCHEMA_WITH_METADATA_FIELDS)
         .withLatestInstantTime("100")
         .withMaxMemorySizeInBytes(1024000L)
@@ -915,6 +920,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withLogFilePaths(
             logFiles.stream()
                 .map(logFile -> logFile.getPath().toString()).collect(Collectors.toList()))
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("100")
         .withMaxMemorySizeInBytes(1024000L)
@@ -1001,6 +1007,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withLogFilePaths(
             logFiles.stream()
                 .map(logFile -> logFile.getPath().toString()).collect(Collectors.toList()))
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("100")
         .withMaxMemorySizeInBytes(1024000L)
@@ -1534,6 +1541,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(allLogFiles)
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("102")
         .withMaxMemorySizeInBytes(1024000L)
@@ -1580,6 +1588,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(allLogFiles)
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("103")
         .withMaxMemorySizeInBytes(1024000L)
@@ -1693,6 +1702,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(allLogFiles)
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("103")
         .withMaxMemorySizeInBytes(1024000L)
@@ -1821,6 +1831,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(allLogFiles)
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("104")
         .withMaxMemorySizeInBytes(1024000L)
@@ -2172,6 +2183,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(allLogFiles)
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("103")
         .withMaxMemorySizeInBytes(1024000L)
@@ -2545,6 +2557,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(allLogFiles)
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("108")
         .withMaxMemorySizeInBytes(1024000L)
@@ -2639,6 +2652,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
           .withStorage(storage)
           .withBasePath(basePath)
           .withLogFilePaths(allLogFiles)
+          .withReaderContext(createReaderContext())
           .withReaderSchema(schema)
           .withLatestInstantTime("100")
           .withMaxMemorySizeInBytes(10240L)
@@ -3089,6 +3103,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(Collections.singletonList(writer.getLogFile().getPath().toString()))
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("100")
         .withReverseReader(false)
@@ -3167,6 +3182,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withBasePath(basePath)
         .withLogFilePaths(Arrays.asList(
             legacyDataWriter.getLogFile().getPath().toString(), nativeDeleteLog.getPath().toString()))
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime("100")
         .withReverseReader(false)
@@ -3227,6 +3243,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(Collections.singletonList(writer.getLogFile().getPath().toString()))
+        .withReaderContext(createReaderContext(Option.of(instantRange)))
         .withReaderSchema(schema)
         .withLatestInstantTime("101")
         .withReverseReader(false)
@@ -3401,6 +3418,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(allLogFiles)
+        .withReaderContext(createReaderContext())
         .withReaderSchema(schema)
         .withLatestInstantTime(latestInstantTime)
         .withMaxMemorySizeInBytes(10240L)
@@ -3419,5 +3437,16 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         assertEquals(expectedKeys.get(), readKeys, "Keys read from log file should match written keys");
       }
     }
+  }
+
+  private HoodieReaderContext<IndexedRecord> createReaderContext() {
+    return createReaderContext(Option.empty());
+  }
+
+  private HoodieReaderContext<IndexedRecord> createReaderContext(Option<InstantRange> instantRange) {
+    HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(storage, basePath);
+    TypedProperties readerProps = TypedProperties.copy(metaClient.getTableConfig().getProps(true));
+    return new HoodieAvroReaderContext(
+        metaClient.getStorageConf(), metaClient.getTableConfig(), instantRange, Option.empty(), readerProps);
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -838,14 +838,16 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         HoodieTestDataGenerator.HOODIE_SCHEMA_WITH_METADATA_FIELDS,
         "100");
 
-    // Native delete log file removing key2 with a higher ordering value, so the delete wins.
-    IndexedRecord deleteRecord = HoodieFileSliceTestUtils.DATA_GEN.generatePayloadForTripSchema(
+    // A higher-ordering delete removes key2, while a lower-ordering delete must not remove key3.
+    IndexedRecord winningDeleteRecord = HoodieFileSliceTestUtils.DATA_GEN.generatePayloadForTripSchema(
         new HoodieKey("key2", "partition_path"), "100", 7L);
+    IndexedRecord losingDeleteRecord = HoodieFileSliceTestUtils.DATA_GEN.generatePayloadForTripSchema(
+        new HoodieKey("key3", "partition_path"), "100", 3L);
     HoodieLogFile nativeDeleteLog = HoodieFileSliceTestUtils.createNativeDeleteLogFile(
         storage,
         new StoragePath(partitionPath, String.format("%s_%s_%s_%d%s",
             "test-fileid1", "1-0-1", "100", 2, ".deletes.parquet")).toString(),
-        Collections.singletonList(deleteRecord),
+        Arrays.asList(winningDeleteRecord, losingDeleteRecord),
         HoodieTestDataGenerator.HOODIE_SCHEMA,
         "100");
 
@@ -868,6 +870,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
 
       // key1 and key3 survive as data records, key2 is retained as a delete.
       assertEquals(3, recordsByKey.size());
+      assertEquals(3, scanner.getTotalLogRecords(), "Delete records should not change the data record metric");
 
       for (String key : Arrays.asList("key1", "key3")) {
         HoodieRecord dataResult = recordsByKey.get(key);
@@ -881,7 +884,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         assertEquals(5L, scannedRecord.get("timestamp"));
       }
 
-      // key2 is removed by the delete log file and resolves to a delete.
+      // key2 is removed by the higher-ordering delete; the lower-ordering key3 delete was ignored.
       HoodieRecord deleteResult = recordsByKey.get("key2");
       assertEquals("partition_path", deleteResult.getPartitionPath());
       assertEquals(7L, deleteResult.getOrderingValue(
@@ -3081,7 +3084,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
 
     List<String> insertedKeys = new ArrayList<>();
-    List<String> deletedKeysSeen = new ArrayList<>();
+    List<HoodieKey> deletedKeysSeen = new ArrayList<>();
     HoodieUnMergedLogRecordScanner scanner = HoodieUnMergedLogRecordScanner.newBuilder()
         .withStorage(storage)
         .withBasePath(basePath)
@@ -3091,7 +3094,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
         .withReverseReader(false)
         .withBufferSize(BUFFER_SIZE)
         .withLogRecordScannerCallback(record -> insertedKeys.add(record.getRecordKey()))
-        .withRecordDeletionCallback(key -> deletedKeysSeen.add(key.getRecordKey()))
+        .withRecordDeletionCallback(deletedKeysSeen::add)
         .build();
     scanner.scan();
 
@@ -3101,8 +3104,83 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     assertEquals(new HashSet<>(allKeys), new HashSet<>(insertedKeys),
         "Callback keys should match every appended record key");
     assertEquals(20, deletedKeysSeen.size(), "Deletion callback should see every deleted key");
-    assertEquals(new HashSet<>(deletedKeys), new HashSet<>(deletedKeysSeen),
+    assertEquals(new HashSet<>(deletedKeys), deletedKeysSeen.stream()
+        .map(HoodieKey::getRecordKey).collect(Collectors.toSet()),
         "Deletion callback keys should match the delete block keys");
+    assertTrue(deletedKeysSeen.stream().allMatch(key -> "partition_path".equals(key.getPartitionPath())),
+        "Deletion callbacks should retain the physical partition path");
+  }
+
+  @Test
+  public void testUnMergedLogRecordScannerCallbacksWithNativeDeletes()
+      throws IOException, URISyntaxException, InterruptedException {
+    HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(basePath);
+    Properties updatedProps = new Properties();
+    updatedProps.setProperty(HoodieTableConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.EVENT_TIME_ORDERING.name());
+    updatedProps.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+    HoodieTableConfig.update(metaClient.getStorage(), metaClient.getMetaPath(), updatedProps);
+
+    HoodieSchema schema = HoodieTestDataGenerator.HOODIE_SCHEMA_WITH_METADATA_FIELDS;
+    List<IndexedRecord> dataRecords = new ArrayList<>();
+    for (String key : Arrays.asList("key1", "key2", "key3")) {
+      IndexedRecord dataRecordWithoutMetaFields = HoodieFileSliceTestUtils.DATA_GEN.generateGenericRecord(
+          key, "partition_path", "rider-100", "driver-100", 5L);
+      GenericRecord dataRecord = HoodieAvroUtils.rewriteRecordWithNewSchema(
+          dataRecordWithoutMetaFields, HoodieTestDataGenerator.AVRO_SCHEMA_WITH_METADATA_FIELDS);
+      HoodieAvroUtils.addHoodieKeyToRecord(dataRecord, key, "partition_path", "test-fileid1");
+      HoodieAvroUtils.addCommitMetadataToRecord(dataRecord, "100", "100_0_0");
+      dataRecords.add(dataRecord);
+    }
+
+    HoodieLogFormat.Writer legacyDataWriter = HoodieLogFormatWriter.builder()
+        .withParentPath(partitionPath)
+        .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
+        .withLogFileId("test-fileid1")
+        .withInstantTime("100")
+        .withStorage(storage)
+        .build();
+    Map<HeaderMetadataType, String> header = new HashMap<>();
+    header.put(HeaderMetadataType.INSTANT_TIME, "100");
+    header.put(HeaderMetadataType.SCHEMA, schema.toString());
+    legacyDataWriter.appendBlock(getDataBlock(DEFAULT_DATA_BLOCK_TYPE, dataRecords, header));
+    legacyDataWriter.close();
+
+    List<IndexedRecord> deleteRecords = Arrays.asList(
+        HoodieFileSliceTestUtils.DATA_GEN.generatePayloadForTripSchema(
+            new HoodieKey("key1", "partition_path"), "100", 7L),
+        HoodieFileSliceTestUtils.DATA_GEN.generatePayloadForTripSchema(
+            new HoodieKey("key2", "partition_path"), "100", 3L));
+    HoodieLogFile nativeDeleteLog = HoodieFileSliceTestUtils.createNativeDeleteLogFile(
+        storage,
+        new StoragePath(partitionPath, String.format("%s_%s_%s_%d%s",
+            "test-fileid1", "1-0-1", "100", 2, ".deletes.parquet")).toString(),
+        deleteRecords,
+        HoodieTestDataGenerator.HOODIE_SCHEMA,
+        "100");
+
+    FileCreateUtilsLegacy.createDeltaCommit(basePath, "100", storage);
+
+    List<String> insertedKeys = new ArrayList<>();
+    List<HoodieKey> deletedKeysSeen = new ArrayList<>();
+    HoodieUnMergedLogRecordScanner scanner = HoodieUnMergedLogRecordScanner.newBuilder()
+        .withStorage(storage)
+        .withBasePath(basePath)
+        .withLogFilePaths(Arrays.asList(
+            legacyDataWriter.getLogFile().getPath().toString(), nativeDeleteLog.getPath().toString()))
+        .withReaderSchema(schema)
+        .withLatestInstantTime("100")
+        .withReverseReader(false)
+        .withBufferSize(BUFFER_SIZE)
+        .withLogRecordScannerCallback(record -> insertedKeys.add(record.getRecordKey()))
+        .withRecordDeletionCallback(deletedKeysSeen::add)
+        .build();
+    scanner.scan();
+
+    assertEquals(new HashSet<>(Arrays.asList("key1", "key2", "key3")), new HashSet<>(insertedKeys));
+    assertEquals(new HashSet<>(Arrays.asList("key1", "key2")), deletedKeysSeen.stream()
+        .map(HoodieKey::getRecordKey).collect(Collectors.toSet()));
+    assertTrue(deletedKeysSeen.stream().allMatch(key -> "partition_path".equals(key.getPartitionPath())),
+        "Native delete callbacks should use the physical partition path");
   }
 
   @Test

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -18,8 +18,10 @@
 
 package org.apache.hudi.hadoop.realtime;
 
+import org.apache.hudi.common.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.schema.HoodieSchema;
@@ -38,6 +40,7 @@ import org.apache.hudi.hadoop.utils.HoodieRealtimeRecordReaderUtils;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ArrayWritableObjectInspector;
 import org.apache.hadoop.hive.serde.serdeConstants;
@@ -213,5 +216,15 @@ public abstract class AbstractRealtimeRecordReader {
 
   protected HoodieSchema getLogScannerReaderSchema() {
     return usesCustomPayload ? writerSchema : readerSchema;
+  }
+
+  /**
+   * Creates a reader context using the table configuration and the complete Hadoop runtime configuration.
+   */
+  protected HoodieReaderContext<IndexedRecord> createReaderContext() {
+    TypedProperties readerProps = TypedProperties.copy(metaClient.getTableConfig().getProps(true));
+    jobConf.forEach(entry -> readerProps.setProperty(entry.getKey(), entry.getValue()));
+    return new HoodieAvroReaderContext(
+        metaClient.getStorageConf(), metaClient.getTableConfig(), Option.empty(), Option.empty(), readerProps);
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java
@@ -103,6 +103,7 @@ public class RealtimeCompactedRecordReader extends AbstractRealtimeRecordReader
             split.getPath().toString(), HadoopFSUtils.getStorageConf(jobConf)))
         .withBasePath(split.getBasePath())
         .withLogFilePaths(split.getDeltaLogPaths())
+        .withReaderContext(createReaderContext())
         .withReaderSchema(getLogScannerReaderSchema())
         .withLatestInstantTime(split.getMaxCommitTime())
         .withMaxMemorySizeInBytes(HoodieRealtimeRecordReaderUtils.getMaxCompactionMemoryInBytes(jobConf))

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeUnmergedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeUnmergedRecordReader.java
@@ -81,6 +81,7 @@ class RealtimeUnmergedRecordReader extends AbstractRealtimeRecordReader
                 split.getPath().toString(), HadoopFSUtils.getStorageConf(this.jobConf)))
             .withBasePath(split.getBasePath())
             .withLogFilePaths(split.getDeltaLogPaths())
+            .withReaderContext(createReaderContext())
             .withReaderSchema(getReaderSchema())
             .withLatestInstantTime(split.getMaxCommitTime())
             .withReverseReader(false)

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/reader/DFSHoodieDatasetInputReader.java
@@ -19,10 +19,12 @@
 package org.apache.hudi.integ.testsuite.reader;
 
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
+import org.apache.hudi.common.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.avro.HoodieAvroUtils;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieAvroRecord;
@@ -286,6 +288,7 @@ public class DFSHoodieDatasetInputReader extends DFSDeltaInputReader {
           .withLogFilePaths(
               fileSlice.getLogFiles().map(l -> l.getPath().getName())
                   .collect(Collectors.toList()))
+          .withReaderContext(createReaderContext())
           .withReaderSchema(HoodieSchema.parse(schemaStr))
           .withLatestInstantTime(metaClient.getActiveTimeline().getCommitsTimeline()
               .filterCompletedInstants().lastInstant().get().requestedTime())
@@ -310,6 +313,15 @@ public class DFSHoodieDatasetInputReader extends DFSDeltaInputReader {
             }
           }).iterator();
     }
+  }
+
+  private HoodieAvroReaderContext createReaderContext() {
+    TypedProperties readerProps = TypedProperties.copy(metaClient.getTableConfig().getProps(true));
+    jsc.hadoopConfiguration().forEach(entry -> readerProps.setProperty(entry.getKey(), entry.getValue()));
+    Arrays.stream(jsc.getConf().getAll())
+        .forEach(entry -> readerProps.setProperty(entry._1(), entry._2()));
+    return new HoodieAvroReaderContext(
+        metaClient.getStorageConf(), metaClient.getTableConfig(), Option.empty(), Option.empty(), readerProps);
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowHoodieLogFileRecordsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ShowHoodieLogFileRecordsProcedure.scala
@@ -17,15 +17,17 @@
 
 package org.apache.spark.sql.hudi.command.procedures
 
-import org.apache.hudi.common.config.{HoodieCommonConfig, HoodieMemoryConfig, HoodieReaderConfig}
+import org.apache.hudi.common.avro.HoodieAvroReaderContext
+import org.apache.hudi.common.config.{HoodieCommonConfig, HoodieMemoryConfig, HoodieReaderConfig, TypedProperties}
+import org.apache.hudi.common.expression.Predicate
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieLogFile, HoodieRecordPayload}
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.TableSchemaResolver
-import org.apache.hudi.common.table.log.{HoodieLogFormat, HoodieMergedLogRecordScanner}
+import org.apache.hudi.common.table.log.{HoodieLogFormat, HoodieMergedLogRecordScanner, InstantRange}
 import org.apache.hudi.common.table.log.block.HoodieDataBlock
-import org.apache.hudi.common.util.ValidationUtils
+import org.apache.hudi.common.util.{Option => HOption, ValidationUtils}
 import org.apache.hudi.io.util.FileIOUtils
 import org.apache.hudi.storage.StoragePath
 
@@ -71,10 +73,16 @@ class ShowHoodieLogFileRecordsProcedure extends BaseProcedure with ProcedureBuil
     val allRecords: java.util.List[IndexedRecord] = new java.util.ArrayList[IndexedRecord]
     if (merge) {
       val schema = Objects.requireNonNull(TableSchemaResolver.readSchemaFromLogFile(client, new StoragePath(logFilePaths.last)))
+      val readerProps = TypedProperties.copy(client.getTableConfig.getProps(true))
+      jsc.hadoopConfiguration.iterator.asScala.foreach(entry => readerProps.setProperty(entry.getKey, entry.getValue))
+      TypedProperties.putAll(readerProps, spark.sessionState.conf.getAllConfs.asJava)
+      val readerContext = new HoodieAvroReaderContext(
+        client.getStorageConf, client.getTableConfig, HOption.empty[InstantRange](), HOption.empty[Predicate](), readerProps)
       val scanner = HoodieMergedLogRecordScanner.newBuilder
         .withStorage(storage)
         .withBasePath(basePath)
         .withLogFilePaths(logFilePaths.asJava)
+        .withReaderContext(readerContext)
         .withReaderSchema(schema)
         .withLatestInstantTime(client.getActiveTimeline.getCommitAndReplaceTimeline.lastInstant.get.requestedTime)
         .withReverseReader(java.lang.Boolean.parseBoolean(HoodieReaderConfig.COMPACTION_REVERSE_LOG_READ_ENABLE.defaultValue))


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

  Closes #19196.

  The legacy log record scanner reads delete blocks through the no-argument `HoodieDeleteBlock#getRecordsToDelete()` API. This bypasses `HoodieReaderContext` and prevents the scanner from correctly reading native delete log blocks, whose records must be materialized through the reader-context API.

### Summary and Changelog

  This PR refactors legacy log scanners to read delete records through `HoodieReaderContext`.

  - Lazily initializes an Avro `HoodieReaderContext` when the first delete block is processed.
  - Configures the reader context with table merge properties, instant range, schema handler, table path, and latest commit time.
  - Reads delete records through `HoodieDeleteBlock#getRecordsToDelete(HoodieReaderContext)`.
  - Passes the physical partition path separately when processing `BufferedRecord` delete records.
  - Updates merged log scanning while preserving delete ordering semantics:
    - A delete with a higher ordering value wins.
    - A delete with a lower ordering value does not overwrite a newer data record.
  - Updates unmerged log scanning so deletion callbacks retain the correct physical partition path.
  - Deprecates the no-argument `getRecordsToDelete()` APIs while retaining them for compatibility and block serialization.
  - Adds coverage for:
    - Merged native data and native delete log scanning.
    - Delete ordering semantics.
    - Data-record metric preservation.
    - Unmerged legacy delete callbacks.
    - Mixed legacy data and native delete log scanning.

### Impact

  There are no storage-format, configuration, or user-facing behavior changes.

  The existing no-argument delete-record APIs remain available but are now deprecated. Reader-context initialization is lazy and only occurs when a delete block is processed.

  The protected delete-processing hook used by the legacy scanner implementations now operates on `BufferedRecord` and receives the physical partition path explicitly.

### Risk Level

  Low.

  The change is scoped to delete-block processing in legacy merged and unmerged log scanners. Existing compatibility APIs and serialization paths are preserved.

  The merged, unmerged, and mixed-format delete paths are covered by regression tests. Module compilation and Checkstyle validation also pass.

### Documentation Update

  None. This is an internal refactoring without new configuration or user-facing behavior.

### Contributor's checklist

  - [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
  - [x] Enough context is provided in the sections above
  - [x] Adequate tests were added if applicable