### PR TITLE
[BUG] Fix delete_partition followed by re-insert silently loses data under NBCC

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/BucketIdentifier.java
@@ -100,6 +100,16 @@ public class BucketIdentifier implements Serializable {
    * Generate a new file id for NBCC mode, file id is fixed for each bucket with format: "{bucket_id}-0000-0000-0000-000000000000-0"
    */
   public static String newBucketFileIdForNBCC(String bucketIdStr) {
-    return FSUtils.createNewFileId(bucketIdStr + CONSTANT_FILE_ID_SUFFIX, 0);
+    return newBucketFileIdForNBCC(bucketIdStr, 0);
+  }
+
+  /**
+   * Generate a new file id for NBCC mode with a specific generation.
+   * Format: "{bucket_id}-0000-0000-0000-000000000000-{generation}"
+   * Used when the default generation (0) has been retired by a replacecommit,
+   * so subsequent writes land on a fresh file id.
+   */
+  public static String newBucketFileIdForNBCC(String bucketIdStr, int generation) {
+    return FSUtils.createNewFileId(bucketIdStr + CONSTANT_FILE_ID_SUFFIX, generation);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkBucketIndexBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/BaseSparkBucketIndexBucketInfoGetter.java
@@ -32,10 +32,18 @@ public abstract class BaseSparkBucketIndexBucketInfoGetter implements SparkBucke
   private final Map<String, Set<String>> updatePartitionPathFileIds;
   private final boolean isOverwrite;
   private final boolean isNonBlockingConcurrencyControl;
+  private final Map<String, Set<String>> replacedPartitionFileIds;
 
   public BaseSparkBucketIndexBucketInfoGetter(Map<String, Set<String>> updatePartitionPathFileIds,
                                               boolean isOverwrite,
                                               boolean isNonBlockingConcurrencyControl) {
+    this(updatePartitionPathFileIds, isOverwrite, isNonBlockingConcurrencyControl, Collections.emptyMap());
+  }
+
+  public BaseSparkBucketIndexBucketInfoGetter(Map<String, Set<String>> updatePartitionPathFileIds,
+                                              boolean isOverwrite,
+                                              boolean isNonBlockingConcurrencyControl,
+                                              Map<String, Set<String>> replacedPartitionFileIds) {
     if (isOverwrite) {
       ValidationUtils.checkArgument(!isNonBlockingConcurrencyControl,
           "Insert overwrite is not supported with non-blocking concurrency control");
@@ -43,6 +51,7 @@ public abstract class BaseSparkBucketIndexBucketInfoGetter implements SparkBucke
     this.updatePartitionPathFileIds = updatePartitionPathFileIds;
     this.isOverwrite = isOverwrite;
     this.isNonBlockingConcurrencyControl = isNonBlockingConcurrencyControl;
+    this.replacedPartitionFileIds = replacedPartitionFileIds;
   }
 
   protected BucketInfo getBucketInfo(int bucketId, String partitionPath) {
@@ -60,9 +69,21 @@ public abstract class BaseSparkBucketIndexBucketInfoGetter implements SparkBucke
     } else {
       // Always write into log file instead of base file if using NB-CC
       if (isNonBlockingConcurrencyControl) {
-        return new BucketInfo(BucketType.UPDATE, BucketIdentifier.newBucketFileIdForNBCC(bucketIdStr), partitionPath);
+        String fileId = BucketIdentifier.newBucketFileIdForNBCC(bucketIdStr);
+        // When the default generation file group has been retired by a replacecommit
+        // (e.g. delete_partition), bump the generation so the new file group id
+        // no longer matches the retired one, avoiding silent data loss.
+        if (isFileGroupReplaced(partitionPath, fileId)) {
+          fileId = BucketIdentifier.newBucketFileIdForNBCC(bucketIdStr, 1);
+        }
+        return new BucketInfo(BucketType.UPDATE, fileId, partitionPath);
       }
       return new BucketInfo(BucketType.INSERT, BucketIdentifier.newBucketFileIdPrefix(bucketIdStr), partitionPath);
     }
+  }
+
+  private boolean isFileGroupReplaced(String partitionPath, String fileId) {
+    Set<String> replacedFileIds = replacedPartitionFileIds.getOrDefault(partitionPath, Collections.emptySet());
+    return replacedFileIds.contains(fileId);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBucketIndexBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBucketIndexBucketInfoGetter.java
@@ -40,6 +40,17 @@ public class SparkBucketIndexBucketInfoGetter extends BaseSparkBucketIndexBucket
     this.partitionPaths = partitionPaths;
   }
 
+  public SparkBucketIndexBucketInfoGetter(int numBucketsPerPartition,
+                                          List<String> partitionPaths,
+                                          Map<String, Set<String>> updatePartitionPathFileIds,
+                                          boolean isOverwrite,
+                                          boolean isNonBlockingConcurrencyControl,
+                                          Map<String, Set<String>> replacedPartitionFileIds) {
+    super(updatePartitionPathFileIds, isOverwrite, isNonBlockingConcurrencyControl, replacedPartitionFileIds);
+    this.numBucketsPerPartition = numBucketsPerPartition;
+    this.partitionPaths = partitionPaths;
+  }
+
   @Override
   public BucketInfo getBucketInfo(int bucketNumber) {
     return getBucketInfo(bucketNumber % numBucketsPerPartition, partitionPaths.get(bucketNumber / numBucketsPerPartition));

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBucketIndexPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkBucketIndexPartitioner.java
@@ -34,12 +34,14 @@ import org.apache.hudi.table.WorkloadProfile;
 import org.apache.hudi.table.WorkloadStat;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import scala.Tuple2;
 
@@ -71,6 +73,7 @@ public class SparkBucketIndexPartitioner<T> extends
   private Map<String, Set<String>> updatePartitionPathFileIds;
 
   private final boolean isNonBlockingConcurrencyControl;
+  private final Map<String, Set<String>> replacedPartitionFileIds;
 
   public SparkBucketIndexPartitioner(WorkloadProfile profile,
                                      HoodieEngineContext context,
@@ -96,6 +99,8 @@ public class SparkBucketIndexPartitioner<T> extends
     WriteOperationType operationType = profile.getOperationType();
     this.isOverwrite = INSERT_OVERWRITE.equals(operationType) || INSERT_OVERWRITE_TABLE.equals(operationType);
     this.isNonBlockingConcurrencyControl = config.isNonBlockingConcurrencyControl();
+    this.replacedPartitionFileIds = isNonBlockingConcurrencyControl
+        ? computeReplacedFileIds(table) : Collections.emptyMap();
   }
 
   private void assignUpdates(WorkloadProfile profile) {
@@ -117,7 +122,21 @@ public class SparkBucketIndexPartitioner<T> extends
   @Override
   public SparkBucketInfoGetter getSparkBucketInfoGetter() {
     return new SparkBucketIndexBucketInfoGetter(numBuckets, partitionPaths,
-        updatePartitionPathFileIds, isOverwrite, isNonBlockingConcurrencyControl);
+        updatePartitionPathFileIds, isOverwrite, isNonBlockingConcurrencyControl, replacedPartitionFileIds);
+  }
+
+  private Map<String, Set<String>> computeReplacedFileIds(HoodieTable table) {
+    Map<String, Set<String>> result = new HashMap<>();
+    for (String partitionPath : partitionPaths) {
+      Set<String> replacedFileIds = table.getFileSystemView()
+          .getAllReplacedFileGroups(partitionPath)
+          .map(fg -> fg.getFileGroupId().getFileId())
+          .collect(Collectors.toSet());
+      if (!replacedFileIds.isEmpty()) {
+        result.put(partitionPath, replacedFileIds);
+      }
+    }
+    return result;
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkPartitionBucketIndexBucketInfoGetter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkPartitionBucketIndexBucketInfoGetter.java
@@ -40,6 +40,17 @@ public class SparkPartitionBucketIndexBucketInfoGetter extends BaseSparkBucketIn
     this.partitionNumberToPath = partitionNumberToPath;
   }
 
+  public SparkPartitionBucketIndexBucketInfoGetter(Integer[] partitionNumberToLocalBucketId,
+                                                   String[] partitionNumberToPath,
+                                                   Map<String, Set<String>> updatePartitionPathFileIds,
+                                                   boolean isOverwrite,
+                                                   boolean isNonBlockingConcurrencyControl,
+                                                   Map<String, Set<String>> replacedPartitionFileIds) {
+    super(updatePartitionPathFileIds, isOverwrite, isNonBlockingConcurrencyControl, replacedPartitionFileIds);
+    this.partitionNumberToLocalBucketId = partitionNumberToLocalBucketId;
+    this.partitionNumberToPath = partitionNumberToPath;
+  }
+
   @Override
   public BucketInfo getBucketInfo(int bucketNumber) {
     return getBucketInfo(partitionNumberToLocalBucketId[bucketNumber], partitionNumberToPath[bucketNumber]);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkPartitionBucketIndexPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkPartitionBucketIndexPartitioner.java
@@ -35,12 +35,14 @@ import org.apache.hudi.table.WorkloadProfile;
 import org.apache.hudi.table.WorkloadStat;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import scala.Tuple2;
 
@@ -86,6 +88,8 @@ public class SparkPartitionBucketIndexPartitioner<T> extends SparkHoodiePartitio
    */
   private final Integer[] partitionNumberToLocalBucketId;
 
+  private final Map<String, Set<String>> replacedPartitionFileIds;
+
   public SparkPartitionBucketIndexPartitioner(WorkloadProfile profile,
                                               HoodieEngineContext context,
                                               HoodieTable table,
@@ -113,6 +117,8 @@ public class SparkPartitionBucketIndexPartitioner<T> extends SparkHoodiePartitio
     WriteOperationType operationType = profile.getOperationType();
     this.isOverwrite = INSERT_OVERWRITE.equals(operationType) || INSERT_OVERWRITE_TABLE.equals(operationType);
     this.isNonBlockingConcurrencyControl = config.isNonBlockingConcurrencyControl();
+    this.replacedPartitionFileIds = isNonBlockingConcurrencyControl
+        ? computeReplacedFileIds(table) : Collections.emptyMap();
 
     this.partitionNumberToPath = new String[totalPartitions];
     this.partitionNumberToLocalBucketId = new Integer[totalPartitions];
@@ -148,7 +154,21 @@ public class SparkPartitionBucketIndexPartitioner<T> extends SparkHoodiePartitio
   @Override
   public SparkBucketInfoGetter getSparkBucketInfoGetter() {
     return new SparkPartitionBucketIndexBucketInfoGetter(partitionNumberToLocalBucketId, partitionNumberToPath,
-        updatePartitionPathFileIds, isOverwrite, isNonBlockingConcurrencyControl);
+        updatePartitionPathFileIds, isOverwrite, isNonBlockingConcurrencyControl, replacedPartitionFileIds);
+  }
+
+  private Map<String, Set<String>> computeReplacedFileIds(HoodieTable table) {
+    Map<String, Set<String>> result = new HashMap<>();
+    for (String partitionPath : partitionPaths) {
+      Set<String> replacedFileIds = table.getFileSystemView()
+          .getAllReplacedFileGroups(partitionPath)
+          .map(fg -> fg.getFileGroupId().getFileId())
+          .collect(Collectors.toSet());
+      if (!replacedFileIds.isEmpty()) {
+        result.put(partitionPath, replacedFileIds);
+      }
+    }
+    return result;
   }
 
   @Override


### PR DESCRIPTION
Fixes #19793: Under Non-Blocking Concurrency Control, delete_partition followed by re-insert results in silent data loss.

### Root Cause

NBCC uses fixed file IDs per bucket. After delete_partition retires the file group, re-inserts use the same fixed file ID, but FileSystemView filters out the retired file group, causing data to be written but invisible.

### Fix

When the fixed file ID has been retired by a replacecommit, bump the generation to create a new file ID that no longer matches the retired file group.