### PR TITLE
chore(trino): advance trino master pin to 40b70400a8a6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
          pin-advance job refreshes all three, humans merge its bot/trino-pin branch. Keep each
          property on one line: the workflows and scripts/trino/bootstrap_trino.sh read them with sed. -->
     <trino.version>484-SNAPSHOT</trino.version>
-    <trino.sha>5b82ec9e7116ec1ed3a83f4cc2f8cf9aaa87b12f</trino.sha>
+    <trino.sha>40b70400a8a67dfcc12cd9192e9050ea09b7c995</trino.sha>
     <trino.e2e.version>483</trino.e2e.version>
     <hive.exec.classifier>core</hive.exec.classifier>
     <metrics.version>4.1.1</metrics.version>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`hudi-trino` builds against a pinned Trino master SHA. The pin drifts as Trino master moves, so the nightly pin-advance job proposes a new SHA once it has been verified against the current tree.

### Summary and Changelog

Advances the Trino master pin from [`5b82ec9e7116`](https://github.com/trinodb/trino/commit/5b82ec9e7116ec1ed3a83f4cc2f8cf9aaa87b12f) to [`40b70400a8a6`](https://github.com/trinodb/trino/commit/40b70400a8a67dfcc12cd9192e9050ea09b7c995) ([diff](https://github.com/trinodb/trino/compare/5b82ec9e7116ec1ed3a83f4cc2f8cf9aaa87b12f...40b70400a8a67dfcc12cd9192e9050ea09b7c995)), verified by the nightly [Hudi Trino SPI Compatibility run](https://github.com/apache/hudi/actions/runs/33470091714) (green, 2026-09-01).

- `pom.xml`: bump `trino.sha` to [`40b70400a8a67dfcc12cd9192e9050ea09b7c995`](https://github.com/trinodb/trino/commit/40b70400a8a67dfcc12cd9192e9050ea09b7c995).

No other property changes; `trino.version` (484-SNAPSHOT) and `trino.e2e.version` (483) are unchanged.

### Impact

None for users. The pin is build-time only and the `hudi-trino` module is profile-gated, so default builds and released artifacts are unaffected.

### Risk Level

none

Single build property change, guarded by the SPI compatibility and Trino E2E jobs on this PR.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
