### PR TITLE
fix(hive-sync): close the SessionState HiveQL sync starts

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -164,12 +164,15 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
   private List<CommandProcessorResponse> updateHiveSQLs(List<String> sqls) {
     List<CommandProcessorResponse> responses = new ArrayList<>();
     HoodieTimer timer = HoodieTimer.start();
+    // Driver.compile() resolves its session from a thread local that every executor on this
+    // thread writes: the one constructed most recently wins, and one that is closed clears it.
+    // Bind ours, as Hive documents a thread running several sessions must, so these statements
+    // run under the session that owns hiveDriver. The thread is not ours to keep, though -- it
+    // may be another executor's or belong to an application that embeds this sync and holds its
+    // own session -- so hand it back in the state we found it.
+    SessionState previousSession = SessionState.get();
+    SessionState.setCurrentSessionState(sessionState);
     try {
-      // Driver.compile() resolves its session from a thread local that every executor on this
-      // thread writes: the one constructed most recently wins, and one that is closed clears it.
-      // Re-assert ours, as Hive documents a thread running several sessions must, so these
-      // statements run under the session that owns hiveDriver.
-      SessionState.setCurrentSessionState(sessionState);
       for (String sql : sqls) {
         if (hiveDriver != null) {
           responses.add(hiveDriver.run(sql));
@@ -177,6 +180,12 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       }
     } catch (Exception e) {
       throw new HoodieHiveSyncException("Failed in executing SQL", e);
+    } finally {
+      if (previousSession != null) {
+        SessionState.setCurrentSessionState(previousSession);
+      } else {
+        SessionState.detachSession();
+      }
     }
     log.info("Executed {} SQL statements sequentially in {} ms", sqls.size(), timer.endTimer());
     return responses;

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -28,6 +28,7 @@ import org.apache.hudi.hive.util.HiveMetaStoreClientPool;
 import org.apache.hudi.hive.util.HivePartitionUtil;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -84,11 +85,19 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     SessionState previousSession = SessionState.get();
     ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
     try {
-      this.sessionState = new SessionState(config.getHiveConf(),
+      // The session gets a conf of its own because it does not just read one: its constructor
+      // writes hive.session.id into it and swaps in a UDFClassLoader, and close() then deletes the
+      // scratch directories that id names and closes that loader. Given config's HiveConf, which
+      // outlives this executor, close() would leave the caller holding a closed loader, and every
+      // later copy of that conf -- the driver and metastore client pools each take one -- would
+      // inherit our session id and, with it, scratch directories we delete. HiveDriverPool's
+      // workers own their conf for the same reason.
+      HiveConf sessionConf = new HiveConf(config.getHiveConf());
+      this.sessionState = new SessionState(sessionConf,
           UserGroupInformation.getCurrentUser().getShortUserName());
       SessionState.start(this.sessionState);
       this.sessionState.setCurrentDatabase(databaseName);
-      this.hiveDriver = new org.apache.hadoop.hive.ql.Driver(config.getHiveConf());
+      this.hiveDriver = new org.apache.hadoop.hive.ql.Driver(sessionConf);
     } catch (Exception e) {
       try {
         closeDriverAndSession();

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -333,10 +333,21 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
         log.warn("Error closing HiveDriverPool", e);
       }
     });
-    if (metaStoreClient != null) {
-      Hive.closeCurrent();
+    // The session goes before this thread's Hive is cleared. SessionState.close() reaches for that
+    // Hive to uncache DataNucleus class loaders, and finds it gone if we clear it first, so it
+    // opens a metastore connection of its own to do the lookup -- a connect, and retries against a
+    // metastore that is down, in the middle of a teardown. Left in place, the session reuses the
+    // client the Driver has been using and closes it on the way out, since SessionState.close()
+    // ends in Hive.closeCurrent() itself. That leaves the call below as the one that clears this
+    // thread when there was no session to do it, and in a finally so a failed teardown cannot
+    // strand the client here either.
+    try {
+      closeDriverAndSession();
+    } finally {
+      if (metaStoreClient != null) {
+        Hive.closeCurrent();
+      }
     }
-    closeDriverAndSession();
   }
 
   /**

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -87,6 +87,8 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       // UDFClassLoader onto the conf it is handed, and close() deletes the directories that id
       // names and closes that loader. config's HiveConf outlives us and both pools copy it.
       HiveConf sessionConf = new HiveConf(config.getHiveConf());
+      // An inherited ID would make close() delete the caller's session directories.
+      sessionConf.setVar(HiveConf.ConfVars.HIVESESSIONID, "");
       this.sessionState = new SessionState(sessionConf,
           UserGroupInformation.getCurrentUser().getShortUserName());
       SessionState.start(this.sessionState);

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -357,10 +357,11 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     SessionState previousSession = SessionState.get();
     ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
     try {
-      // Inside the try so that a bind that fails still reaches the finally, which closes the
-      // session and gives the thread back. The Driver calls below are skipped in that case, by
-      // design: they act on the session the thread holds, so without ours bound they would clear
-      // another session's lineage and release our locks through its transaction manager. A null
+      // Inside the try so that a failed bind still reaches the finally, which is what repairs it:
+      // Hive attaches the session before the conf and class loader swap that can throw, so even a
+      // bind that fails leaves the thread holding ours, and only the close and restore below take
+      // it back off. The Driver calls are skipped in that case because they read their session
+      // from the thread, and a half-applied bind promises nothing about what is there. A null
       // session comes from the constructor's error path, where the session is what failed.
       if (sessionState != null) {
         SessionState.setCurrentSessionState(sessionState);

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -356,8 +356,15 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
   private void closeDriverAndSession() {
     SessionState previousSession = SessionState.get();
     ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
-    bindQuietly(sessionState);
     try {
+      // Inside the try so that a bind that fails still reaches the finally, which closes the
+      // session and gives the thread back. The Driver calls below are skipped in that case, by
+      // design: they act on the session the thread holds, so without ours bound they would clear
+      // another session's lineage and release our locks through its transaction manager. A null
+      // session comes from the constructor's error path, where the session is what failed.
+      if (sessionState != null) {
+        SessionState.setCurrentSessionState(sessionState);
+      }
       if (hiveDriver != null) {
         try {
           hiveDriver.close();
@@ -372,24 +379,6 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       if (previousSession != sessionState) {
         restoreThread(previousSession, previousLoader);
       }
-    }
-  }
-
-  /**
-   * Binds this executor's session for a teardown that has to run either way: a bind failure must
-   * not cost us the Driver's shutdown hook and the session's scratch directories, which are what
-   * the teardown is for. The statement path reports a failed bind instead, since running SQL under
-   * someone else's session is worse than not running it. A null session comes from the
-   * constructor's error path, where the session is what failed.
-   */
-  private static void bindQuietly(SessionState state) {
-    if (state == null) {
-      return;
-    }
-    try {
-      SessionState.setCurrentSessionState(state);
-    } catch (Exception e) {
-      log.error("Error while binding SessionState for teardown", e);
     }
   }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -77,21 +77,15 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     this.metaStoreClient = metaStoreClient;
     this.driverPool = driverPool;
     this.metaStoreClientPool = metaStoreClientPool;
-    // SessionState.start() attaches the session it starts to this thread, displacing whatever the
-    // caller had there -- another executor's session, or that of an application embedding this
-    // sync. Ours is not the thread's to keep: every statement and the teardown bind it
-    // explicitly, so give the thread back once the Driver, whose constructor reads
-    // SessionState.get(), has been built.
+    // SessionState.start() binds the session it starts to this thread, displacing the caller's.
+    // Statements and the teardown bind ours themselves, so the thread is handed back once the
+    // Driver is built -- its constructor is what reads SessionState.get().
     SessionState previousSession = SessionState.get();
     ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
     try {
-      // The session gets a conf of its own because it does not just read one: its constructor
-      // writes hive.session.id into it and swaps in a UDFClassLoader, and close() then deletes the
-      // scratch directories that id names and closes that loader. Given config's HiveConf, which
-      // outlives this executor, close() would leave the caller holding a closed loader, and every
-      // later copy of that conf -- the driver and metastore client pools each take one -- would
-      // inherit our session id and, with it, scratch directories we delete. HiveDriverPool's
-      // workers own their conf for the same reason.
+      // Its own conf copy, as HiveDriverPool's workers get: a session stamps hive.session.id and a
+      // UDFClassLoader onto the conf it is handed, and close() deletes the directories that id
+      // names and closes that loader. config's HiveConf outlives us and both pools copy it.
       HiveConf sessionConf = new HiveConf(config.getHiveConf());
       this.sessionState = new SessionState(sessionConf,
           UserGroupInformation.getCurrentUser().getShortUserName());
@@ -179,15 +173,15 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     return sql != null && sql.regionMatches(true, 0, "USE ", 0, 4);
   }
 
+  /**
+   * Runs the statements under the session that owns {@code hiveDriver}. {@code Driver.compile()}
+   * resolves its session from a thread local that every executor on the thread writes, so ours is
+   * bound for the duration, and the thread handed back as found: it may belong to another executor
+   * or to an application that embeds this sync and holds a session of its own.
+   */
   private List<CommandProcessorResponse> updateHiveSQLs(List<String> sqls) {
     List<CommandProcessorResponse> responses = new ArrayList<>();
     HoodieTimer timer = HoodieTimer.start();
-    // Driver.compile() resolves its session from a thread local that every executor on this
-    // thread writes: the one constructed most recently wins, and one that is closed clears it.
-    // Bind ours, as Hive documents a thread running several sessions must, so these statements
-    // run under the session that owns hiveDriver. The thread is not ours to keep, though -- it
-    // may be another executor's or belong to an application that embeds this sync and holds its
-    // own session -- so hand it back in the state we found it.
     SessionState previousSession = SessionState.get();
     ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
     try {
@@ -333,14 +327,9 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
         log.warn("Error closing HiveDriverPool", e);
       }
     });
-    // The session goes before this thread's Hive is cleared. SessionState.close() reaches for that
-    // Hive to uncache DataNucleus class loaders, and finds it gone if we clear it first, so it
-    // opens a metastore connection of its own to do the lookup -- a connect, and retries against a
-    // metastore that is down, in the middle of a teardown. Left in place, the session reuses the
-    // client the Driver has been using and closes it on the way out, since SessionState.close()
-    // ends in Hive.closeCurrent() itself. That leaves the call below as the one that clears this
-    // thread when there was no session to do it, and in a finally so a failed teardown cannot
-    // strand the client here either.
+    // The session goes first: SessionState.close() reaches for this thread's Hive to uncache
+    // DataNucleus class loaders, and opens a metastore connection of its own if that is already
+    // gone. It clears the thread local itself, leaving the call below for when it did not run.
     try {
       closeDriverAndSession();
     } finally {
@@ -352,28 +341,23 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
 
   /**
    * Tears down the Driver and the SessionState this executor owns, with that session bound for the
-   * duration. Both Driver methods act on whichever session the thread currently holds:
-   * {@code close()} clears its lineage state and {@code destroy()} takes its transaction manager to
-   * release locks. {@code SessionState.close()} then detaches, again regardless of whose session is
-   * attached. So an executor constructed later on this thread would have its session damaged and
-   * then unattached by this teardown unless ours is bound first and its own put back afterwards.
+   * duration and the thread handed back afterwards. Everything here acts on whichever session the
+   * thread holds: {@code Driver.close()} clears its lineage, {@code destroy()} reaches through it
+   * for the transaction manager, and {@code SessionState.close()} detaches it. Unbound, this
+   * teardown would damage and then unattach the session of another executor on the thread.
    *
-   * <p>The session goes last for the same reason. Closing it first detaches it, which leaves
-   * {@code close()} to skip the lineage clear it null-checks for, and leaves {@code destroy()}
-   * dereferencing a null session to reach the transaction manager -- before it has removed the
-   * Driver's shutdown hook, so a query holding locks would leak the hook this teardown is here to
-   * remove.
+   * <p>Hence also the order. Closing our session first would detach it, leaving {@code destroy()}
+   * to dereference a null session before it removes the Driver's shutdown hook -- leaking the hook
+   * this teardown exists to remove, for any query holding locks.
    */
   private void closeDriverAndSession() {
     SessionState previousSession = SessionState.get();
     ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
     try {
-      // Inside the try so that a failed bind still reaches the finally, which is what repairs it:
-      // Hive attaches the session before the conf and class loader swap that can throw, so even a
-      // bind that fails leaves the thread holding ours, and only the close and restore below take
-      // it back off. The Driver calls are skipped in that case because they read their session
-      // from the thread, and a half-applied bind promises nothing about what is there. A null
-      // session comes from the constructor's error path, where the session is what failed.
+      // Inside the try, because Hive attaches before the swap that can throw: a failed bind still
+      // leaves the thread holding ours, and only the finally takes it off. The Driver is then left
+      // alone, reading its session from a thread the bind no longer vouches for. Null session:
+      // the constructor's error path, where the session is what failed.
       if (sessionState != null) {
         SessionState.setCurrentSessionState(sessionState);
       }
@@ -395,13 +379,11 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
   }
 
   /**
-   * Puts the thread back the way an operation found it, so that binding this executor's session is
-   * scoped to the operation that needs it. Hive has no notion of an empty session slot to assign,
-   * hence the detach. The class loader has to be restored separately because
-   * {@code setCurrentSessionState()} swaps in the session conf's loader -- a UDFClassLoader that
-   * belongs to that one session -- while {@code detachSession()} only clears the session, and
-   * {@code SessionState.close()} closes that loader on the way out. Left alone, the thread keeps a
-   * loader it does not own, or a closed one, and class loading breaks for whoever owns the thread.
+   * Puts the thread back the way an operation found it, so binding our session stays scoped to the
+   * operation that needs it. Hive has no empty session to assign, hence the detach. The class
+   * loader needs restoring separately: binding a session swaps in its own UDFClassLoader, which
+   * {@code detachSession()} leaves behind and {@code SessionState.close()} closes, so the thread
+   * would keep a loader belonging to another session, or a closed one.
    */
   private static void restoreThread(SessionState previousSession, ClassLoader previousLoader) {
     if (previousSession != null) {
@@ -414,9 +396,8 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
 
   /**
    * Closes the SessionState this executor started. Hive derives the session's four scratch
-   * directory roots from hive.session.id and only reclaims them in close(), so a HiveSyncTool that
-   * runs per commit leaves a directory set behind on every sync. Called only from
-   * {@link #closeDriverAndSession()}, which documents why the session goes last.
+   * directory roots from hive.session.id and reclaims them only here, so a HiveSyncTool running
+   * per commit leaves a directory set behind on every sync.
    */
   private static void closeQuietly(SessionState state) {
     if (state == null) {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -346,6 +346,12 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
    * release locks. {@code SessionState.close()} then detaches, again regardless of whose session is
    * attached. So an executor constructed later on this thread would have its session damaged and
    * then unattached by this teardown unless ours is bound first and its own put back afterwards.
+   *
+   * <p>The session goes last for the same reason. Closing it first detaches it, which leaves
+   * {@code close()} to skip the lineage clear it null-checks for, and leaves {@code destroy()}
+   * dereferencing a null session to reach the transaction manager -- before it has removed the
+   * Driver's shutdown hook, so a query holding locks would leak the hook this teardown is here to
+   * remove.
    */
   private void closeDriverAndSession() {
     SessionState previousSession = SessionState.get();

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -181,8 +181,8 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     // own session -- so hand it back in the state we found it.
     SessionState previousSession = SessionState.get();
     ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
-    SessionState.setCurrentSessionState(sessionState);
     try {
+      SessionState.setCurrentSessionState(sessionState);
       for (String sql : sqls) {
         if (hiveDriver != null) {
           responses.add(hiveDriver.run(sql));
@@ -341,9 +341,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
   private void closeDriverAndSession() {
     SessionState previousSession = SessionState.get();
     ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
-    if (sessionState != null) {
-      SessionState.setCurrentSessionState(sessionState);
-    }
+    bindQuietly(sessionState);
     try {
       if (hiveDriver != null) {
         try {
@@ -359,6 +357,24 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       if (previousSession != sessionState) {
         restoreThread(previousSession, previousLoader);
       }
+    }
+  }
+
+  /**
+   * Binds this executor's session for a teardown that has to run either way: a bind failure must
+   * not cost us the Driver's shutdown hook and the session's scratch directories, which are what
+   * the teardown is for. The statement path reports a failed bind instead, since running SQL under
+   * someone else's session is worse than not running it. A null session comes from the
+   * constructor's error path, where the session is what failed.
+   */
+  private static void bindQuietly(SessionState state) {
+    if (state == null) {
+      return;
+    }
+    try {
+      SessionState.setCurrentSessionState(state);
+    } catch (Exception e) {
+      log.error("Error while binding SessionState for teardown", e);
     }
   }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -336,12 +336,12 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
    * above, because close() detaches the session from this thread and {@code Driver.destroy()} can
    * reach {@code SessionState.get()} while releasing locks.
    */
-  private static void closeQuietly(SessionState sessionState) {
-    if (sessionState == null) {
+  private static void closeQuietly(SessionState state) {
+    if (state == null) {
       return;
     }
     try {
-      sessionState.close();
+      state.close();
     } catch (Exception e) {
       log.error("Error while closing SessionState", e);
     }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -83,15 +83,11 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       this.sessionState.setCurrentDatabase(databaseName);
       this.hiveDriver = new org.apache.hadoop.hive.ql.Driver(config.getHiveConf());
     } catch (Exception e) {
-      if (this.hiveDriver != null) {
-        try {
-          this.hiveDriver.close();
-        } catch (Exception driverCloseException) {
-          log.error("Error while closing Hive Driver", driverCloseException);
-        }
-        destroyQuietly(this.hiveDriver);
+      try {
+        closeDriverAndSession();
+      } catch (Exception teardownException) {
+        log.error("Error while closing Hive Driver and SessionState", teardownException);
       }
-      closeQuietly(this.sessionState);
       // driverPool (if present) was already constructed by the caller before this
       // ctor ran; since we're about to throw, no one else will call close() on it.
       driverPool.ifPresent(pool -> {
@@ -316,6 +312,22 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     if (metaStoreClient != null) {
       Hive.closeCurrent();
     }
+    closeDriverAndSession();
+  }
+
+  /**
+   * Tears down the Driver and the SessionState this executor owns, with that session bound for the
+   * duration. Both Driver methods act on whichever session the thread currently holds:
+   * {@code close()} clears its lineage state and {@code destroy()} takes its transaction manager to
+   * release locks. {@code SessionState.close()} then detaches, again regardless of whose session is
+   * attached. So an executor constructed later on this thread would have its session damaged and
+   * then unattached by this teardown unless ours is bound first and its own put back afterwards.
+   */
+  private void closeDriverAndSession() {
+    SessionState previousSession = SessionState.get();
+    if (sessionState != null) {
+      SessionState.setCurrentSessionState(sessionState);
+    }
     try {
       if (hiveDriver != null) {
         try {
@@ -326,15 +338,17 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       }
     } finally {
       closeQuietly(sessionState);
+      if (previousSession != null && previousSession != sessionState) {
+        SessionState.setCurrentSessionState(previousSession);
+      }
     }
   }
 
   /**
    * Closes the SessionState this executor started. Hive derives the session's four scratch
    * directory roots from hive.session.id and only reclaims them in close(), so a HiveSyncTool that
-   * runs per commit leaves a directory set behind on every sync. Runs after the Driver teardown
-   * above, because close() detaches the session from this thread and {@code Driver.destroy()} can
-   * reach {@code SessionState.get()} while releasing locks.
+   * runs per commit leaves a directory set behind on every sync. Called only from
+   * {@link #closeDriverAndSession()}, which documents why the session goes last.
    */
   private static void closeQuietly(SessionState state) {
     if (state == null) {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -76,6 +76,12 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     this.metaStoreClient = metaStoreClient;
     this.driverPool = driverPool;
     this.metaStoreClientPool = metaStoreClientPool;
+    // SessionState.start() attaches the session it starts to this thread, displacing whatever the
+    // caller had there -- another executor's session, or that of an application embedding this
+    // sync. Ours is not the thread's to keep: every statement and the teardown bind it
+    // explicitly, so give the thread back once the Driver, whose constructor reads
+    // SessionState.get(), has been built.
+    SessionState previousSession = SessionState.get();
     try {
       this.sessionState = new SessionState(config.getHiveConf(),
           UserGroupInformation.getCurrentUser().getShortUserName());
@@ -98,6 +104,8 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
         }
       });
       throw new HoodieHiveSyncException("Failed to create HiveQueryDDL object", e);
+    } finally {
+      restoreSession(previousSession);
     }
   }
 
@@ -181,11 +189,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     } catch (Exception e) {
       throw new HoodieHiveSyncException("Failed in executing SQL", e);
     } finally {
-      if (previousSession != null) {
-        SessionState.setCurrentSessionState(previousSession);
-      } else {
-        SessionState.detachSession();
-      }
+      restoreSession(previousSession);
     }
     log.info("Executed {} SQL statements sequentially in {} ms", sqls.size(), timer.endTimer());
     return responses;
@@ -347,9 +351,24 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       }
     } finally {
       closeQuietly(sessionState);
-      if (previousSession != null && previousSession != sessionState) {
-        SessionState.setCurrentSessionState(previousSession);
+      // Unless the thread was holding ours, in which case closeQuietly has just detached the
+      // session it would restore.
+      if (previousSession != sessionState) {
+        restoreSession(previousSession);
       }
+    }
+  }
+
+  /**
+   * Puts the thread's session back to what an operation found there, so that binding this
+   * executor's session is scoped to the operation that needs it. Hive has no notion of an empty
+   * slot to assign, hence the detach.
+   */
+  private static void restoreSession(SessionState previousSession) {
+    if (previousSession != null) {
+      SessionState.setCurrentSessionState(previousSession);
+    } else {
+      SessionState.detachSession();
     }
   }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -82,6 +82,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     // explicitly, so give the thread back once the Driver, whose constructor reads
     // SessionState.get(), has been built.
     SessionState previousSession = SessionState.get();
+    ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
     try {
       this.sessionState = new SessionState(config.getHiveConf(),
           UserGroupInformation.getCurrentUser().getShortUserName());
@@ -105,7 +106,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       });
       throw new HoodieHiveSyncException("Failed to create HiveQueryDDL object", e);
     } finally {
-      restoreSession(previousSession);
+      restoreThread(previousSession, previousLoader);
     }
   }
 
@@ -179,6 +180,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     // may be another executor's or belong to an application that embeds this sync and holds its
     // own session -- so hand it back in the state we found it.
     SessionState previousSession = SessionState.get();
+    ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
     SessionState.setCurrentSessionState(sessionState);
     try {
       for (String sql : sqls) {
@@ -189,7 +191,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     } catch (Exception e) {
       throw new HoodieHiveSyncException("Failed in executing SQL", e);
     } finally {
-      restoreSession(previousSession);
+      restoreThread(previousSession, previousLoader);
     }
     log.info("Executed {} SQL statements sequentially in {} ms", sqls.size(), timer.endTimer());
     return responses;
@@ -338,6 +340,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
    */
   private void closeDriverAndSession() {
     SessionState previousSession = SessionState.get();
+    ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
     if (sessionState != null) {
       SessionState.setCurrentSessionState(sessionState);
     }
@@ -351,25 +354,30 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       }
     } finally {
       closeQuietly(sessionState);
-      // Unless the thread was holding ours, in which case closeQuietly has just detached the
-      // session it would restore.
+      // Unless the thread was holding ours, in which case there is nothing left to put back:
+      // closeQuietly has detached that session and closed the loader that came with it.
       if (previousSession != sessionState) {
-        restoreSession(previousSession);
+        restoreThread(previousSession, previousLoader);
       }
     }
   }
 
   /**
-   * Puts the thread's session back to what an operation found there, so that binding this
-   * executor's session is scoped to the operation that needs it. Hive has no notion of an empty
-   * slot to assign, hence the detach.
+   * Puts the thread back the way an operation found it, so that binding this executor's session is
+   * scoped to the operation that needs it. Hive has no notion of an empty session slot to assign,
+   * hence the detach. The class loader has to be restored separately because
+   * {@code setCurrentSessionState()} swaps in the session conf's loader -- a UDFClassLoader that
+   * belongs to that one session -- while {@code detachSession()} only clears the session, and
+   * {@code SessionState.close()} closes that loader on the way out. Left alone, the thread keeps a
+   * loader it does not own, or a closed one, and class loading breaks for whoever owns the thread.
    */
-  private static void restoreSession(SessionState previousSession) {
+  private static void restoreThread(SessionState previousSession, ClassLoader previousLoader) {
     if (previousSession != null) {
       SessionState.setCurrentSessionState(previousSession);
     } else {
       SessionState.detachSession();
     }
+    Thread.currentThread().setContextClassLoader(previousLoader);
   }
 
   /**

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.security.UserGroupInformation;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -84,13 +83,6 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       this.sessionState.setCurrentDatabase(databaseName);
       this.hiveDriver = new org.apache.hadoop.hive.ql.Driver(config.getHiveConf());
     } catch (Exception e) {
-      if (sessionState != null) {
-        try {
-          this.sessionState.close();
-        } catch (IOException ioException) {
-          log.error("Error while closing SessionState", ioException);
-        }
-      }
       if (this.hiveDriver != null) {
         try {
           this.hiveDriver.close();
@@ -99,6 +91,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
         }
         destroyQuietly(this.hiveDriver);
       }
+      closeQuietly(this.sessionState);
       // driverPool (if present) was already constructed by the caller before this
       // ctor ran; since we're about to throw, no one else will call close() on it.
       driverPool.ifPresent(pool -> {
@@ -176,6 +169,11 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     List<CommandProcessorResponse> responses = new ArrayList<>();
     HoodieTimer timer = HoodieTimer.start();
     try {
+      // Driver.compile() resolves its session from a thread local that every executor on this
+      // thread writes: the one constructed most recently wins, and one that is closed clears it.
+      // Re-assert ours, as Hive documents a thread running several sessions must, so these
+      // statements run under the session that owns hiveDriver.
+      SessionState.setCurrentSessionState(sessionState);
       for (String sql : sqls) {
         if (hiveDriver != null) {
           responses.add(hiveDriver.run(sql));
@@ -318,12 +316,34 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
     if (metaStoreClient != null) {
       Hive.closeCurrent();
     }
-    if (hiveDriver != null) {
-      try {
-        hiveDriver.close();
-      } finally {
-        destroyQuietly(hiveDriver);
+    try {
+      if (hiveDriver != null) {
+        try {
+          hiveDriver.close();
+        } finally {
+          destroyQuietly(hiveDriver);
+        }
       }
+    } finally {
+      closeQuietly(sessionState);
+    }
+  }
+
+  /**
+   * Closes the SessionState this executor started. Hive derives the session's four scratch
+   * directory roots from hive.session.id and only reclaims them in close(), so a HiveSyncTool that
+   * runs per commit leaves a directory set behind on every sync. Runs after the Driver teardown
+   * above, because close() detaches the session from this thread and {@code Driver.destroy()} can
+   * reach {@code SessionState.get()} while releasing locks.
+   */
+  private static void closeQuietly(SessionState sessionState) {
+    if (sessionState == null) {
+      return;
+    }
+    try {
+      sessionState.close();
+    } catch (Exception e) {
+      log.error("Error while closing SessionState", e);
     }
   }
 

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hive.ddl;
+
+import org.apache.hudi.common.util.Option;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.Driver;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for how {@link HiveQueryDDLExecutor} handles the SessionState it starts. A
+ * HiveSyncTool, and therefore an executor and its session, is built per sync, so anything close()
+ * skips accumulates for the life of the JVM.
+ */
+class TestHiveQueryDDLExecutorSession {
+
+  @AfterEach
+  void detachTestSession() {
+    SessionState.detachSession();
+  }
+
+  /**
+   * Hive reclaims a session's four scratch directory roots only in SessionState.close(), and the
+   * session is the executor's to close: nothing else holds a reference to it.
+   */
+  @Test
+  void closeClosesTheSessionAfterTheDriver() throws Exception {
+    Driver driver = mock(Driver.class);
+    SessionState sessionState = mock(SessionState.class);
+    HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
+
+    executor.close();
+
+    // Driver.destroy() releases locks through SessionState.get(), which SessionState.close()
+    // detaches, so the session has to go last.
+    InOrder inOrder = inOrder(driver, sessionState);
+    inOrder.verify(driver).close();
+    inOrder.verify(driver).destroy();
+    inOrder.verify(sessionState).close();
+  }
+
+  /**
+   * The Driver close is allowed to propagate, so without a finally the session -- and its scratch
+   * directories -- would leak exactly when teardown is already going wrong.
+   */
+  @Test
+  void closeClosesTheSessionEvenWhenTheDriverCloseThrows() throws Exception {
+    Driver driver = mock(Driver.class);
+    when(driver.close()).thenThrow(new RuntimeException("close failed"));
+    SessionState sessionState = mock(SessionState.class);
+    HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
+
+    assertThrows(RuntimeException.class, executor::close);
+
+    verify(driver, times(1)).destroy();
+    verify(sessionState, times(1)).close();
+  }
+
+  /**
+   * close() is reached from HoodieHiveSyncClient.close() while other resources still need
+   * releasing, so a session that fails to close must not become the caller's problem.
+   */
+  @Test
+  void closeSwallowsSessionCloseFailure() throws Exception {
+    Driver driver = mock(Driver.class);
+    SessionState sessionState = mock(SessionState.class);
+    doThrow(new RuntimeException("session close failed")).when(sessionState).close();
+    HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
+
+    executor.close();
+
+    verify(sessionState, times(1)).close();
+  }
+
+  /**
+   * Hive resolves the session from a thread local, so an executor cannot assume the session it
+   * started is still the current one: another executor on the same thread may have started its own
+   * or closed one, and Driver.compile() dereferences SessionState.get() unconditionally.
+   */
+  @Test
+  void sqlRunsUnderTheSessionThisExecutorStarted() throws Exception {
+    Driver driver = mock(Driver.class);
+    SessionState sessionState = mock(SessionState.class);
+    when(sessionState.getConf()).thenReturn(new HiveConf());
+    HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
+    SessionState.detachSession();
+
+    executor.runSQL("SHOW TABLES");
+
+    assertSame(sessionState, SessionState.get(), "The executor must run under its own session");
+    verify(driver, times(1)).run("SHOW TABLES");
+  }
+
+  /**
+   * Builds an executor without running its constructor, which would need a live metastore. A null
+   * metaStoreClient keeps close() away from Hive.closeCurrent() and its static thread-local state.
+   */
+  private static HiveQueryDDLExecutor executorWith(Driver driver, SessionState sessionState) throws Exception {
+    HiveQueryDDLExecutor executor = mock(HiveQueryDDLExecutor.class, CALLS_REAL_METHODS);
+    setField(executor, "driverPool", Option.empty());
+    setField(executor, "metaStoreClientPool", Option.empty());
+    setField(executor, "metaStoreClient", null);
+    setField(executor, "hiveDriver", driver);
+    setField(executor, "sessionState", sessionState);
+    return executor;
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Class<?> type = target.getClass();
+    while (type != null) {
+      try {
+        Field field = type.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+        return;
+      } catch (NoSuchFieldException e) {
+        type = type.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(name);
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -29,13 +29,19 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -114,7 +120,6 @@ class TestHiveQueryDDLExecutorSession {
   void sqlRunsUnderTheSessionThisExecutorStarted() throws Exception {
     Driver driver = mock(Driver.class);
     SessionState sessionState = mock(SessionState.class);
-    when(sessionState.getConf()).thenReturn(new HiveConf());
     HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
     SessionState.detachSession();
 
@@ -125,10 +130,45 @@ class TestHiveQueryDDLExecutorSession {
   }
 
   /**
+   * Driver.close() clears the current session's lineage state and Driver.destroy() takes its
+   * transaction manager to release locks, so both have to see the session that owns the Driver.
+   * SessionState.close() then detaches whatever is attached, which would leave an executor
+   * constructed later on this thread with no session at all.
+   */
+  @Test
+  void closeTearsDownUnderItsOwnSessionAndLeavesTheOtherAttached() throws Exception {
+    SessionState otherSession = mock(SessionState.class);
+    when(otherSession.getConf()).thenReturn(new HiveConf());
+    SessionState sessionState = mock(SessionState.class);
+    Driver driver = mock(Driver.class);
+    List<SessionState> sessionsSeenByDriver = new ArrayList<>();
+    when(driver.close()).thenAnswer(invocation -> {
+      sessionsSeenByDriver.add(SessionState.get());
+      return 0;
+    });
+    doAnswer(invocation -> {
+      sessionsSeenByDriver.add(SessionState.get());
+      return null;
+    }).when(driver).destroy();
+    HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
+    SessionState.setCurrentSessionState(otherSession);
+
+    executor.close();
+
+    assertEquals(Arrays.asList(sessionState, sessionState), sessionsSeenByDriver,
+        "Driver teardown must run under the session that owns the Driver");
+    assertSame(otherSession, SessionState.get(), "The session attached before close() must be put back");
+    verify(otherSession, never()).close();
+  }
+
+  /**
    * Builds an executor without running its constructor, which would need a live metastore. A null
    * metaStoreClient keeps close() away from Hive.closeCurrent() and its static thread-local state.
    */
   private static HiveQueryDDLExecutor executorWith(Driver driver, SessionState sessionState) throws Exception {
+    // SessionState.setCurrentSessionState() reads the session's conf to swap the thread's
+    // context classloader.
+    when(sessionState.getConf()).thenReturn(new HiveConf());
     HiveQueryDDLExecutor executor = mock(HiveQueryDDLExecutor.class, CALLS_REAL_METHODS);
     setField(executor, "driverPool", Option.empty());
     setField(executor, "metaStoreClientPool", Option.empty());

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -29,12 +29,15 @@ import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InOrder;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -65,9 +68,21 @@ import static org.mockito.Mockito.when;
  */
 class TestHiveQueryDDLExecutorSession {
 
+  private ClassLoader testLoader;
+
+  @BeforeEach
+  void rememberTestLoader() {
+    testLoader = Thread.currentThread().getContextClassLoader();
+  }
+
+  /**
+   * These tests attach sessions, and attaching one swaps the thread's class loader, so a test that
+   * fails mid-way would otherwise hand the next one a thread it does not expect.
+   */
   @AfterEach
   void detachTestSession() {
     SessionState.detachSession();
+    Thread.currentThread().setContextClassLoader(testLoader);
   }
 
   /**
@@ -133,18 +148,25 @@ class TestHiveQueryDDLExecutorSession {
     SessionState sessionState = mock(SessionState.class);
     Driver driver = mock(Driver.class);
     List<SessionState> sessionsSeenByDriver = new ArrayList<>();
+    List<ClassLoader> loadersSeenByDriver = new ArrayList<>();
     when(driver.run(anyString())).thenAnswer(invocation -> {
       sessionsSeenByDriver.add(SessionState.get());
+      loadersSeenByDriver.add(Thread.currentThread().getContextClassLoader());
       return null;
     });
     HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
     SessionState.detachSession();
+    ClassLoader callerLoader = Thread.currentThread().getContextClassLoader();
 
     executor.runSQL("SHOW TABLES");
 
     assertEquals(Collections.singletonList(sessionState), sessionsSeenByDriver,
         "The executor must run under its own session");
+    assertEquals(Collections.singletonList(sessionState.getConf().getClassLoader()), loadersSeenByDriver,
+        "Binding the session swaps the thread's class loader for the session's, which is what has to be undone");
     assertNull(SessionState.get(), "A thread that held no session must be left holding none");
+    assertSame(callerLoader, Thread.currentThread().getContextClassLoader(),
+        "detachSession() leaves the session's class loader on the thread, so the operation must take it off");
   }
 
   /**
@@ -160,10 +182,13 @@ class TestHiveQueryDDLExecutorSession {
     Driver driver = mock(Driver.class);
     HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
     SessionState.setCurrentSessionState(otherSession);
+    ClassLoader callerLoader = Thread.currentThread().getContextClassLoader();
 
     executor.runSQL("SHOW TABLES");
 
     assertSame(otherSession, SessionState.get(), "The session held before the statements must be put back");
+    assertSame(callerLoader, Thread.currentThread().getContextClassLoader(),
+        "The class loader held before the statements must be put back");
     verify(driver, times(1)).run("SHOW TABLES");
   }
 
@@ -208,16 +233,23 @@ class TestHiveQueryDDLExecutorSession {
   void constructionGivesTheThreadBackToTheCallersSession(@TempDir Path tempDir) throws Exception {
     SessionState callerSession = new SessionState(new HiveConf());
     SessionState.setCurrentSessionState(callerSession);
+    ClassLoader callerLoader = Thread.currentThread().getContextClassLoader();
 
     HiveQueryDDLExecutor executor =
         new HiveQueryDDLExecutor(hiveSyncConfig(tempDir), mock(IMetaStoreClient.class));
     try {
       assertSame(callerSession, SessionState.get(), "Construction must not keep the caller's thread");
+      assertSame(callerLoader, Thread.currentThread().getContextClassLoader(),
+          "Construction must not leave its session's class loader on the caller's thread");
     } finally {
       executor.close();
     }
 
     assertSame(callerSession, SessionState.get(), "close() must not take the caller's session with it");
+    // SessionState.close() closes the loader its session carries, so a thread left pointing at it
+    // could no longer load classes.
+    assertSame(callerLoader, Thread.currentThread().getContextClassLoader(),
+        "close() must not leave the closed loader of its session on the caller's thread");
   }
 
   /**
@@ -233,11 +265,14 @@ class TestHiveQueryDDLExecutorSession {
         Files.createFile(tempDir.resolve("not-a-directory")).toUri().toString() + "/scratch");
     SessionState callerSession = new SessionState(new HiveConf());
     SessionState.setCurrentSessionState(callerSession);
+    ClassLoader callerLoader = Thread.currentThread().getContextClassLoader();
 
     assertThrows(HoodieHiveSyncException.class,
         () -> new HiveQueryDDLExecutor(config, mock(IMetaStoreClient.class)));
 
     assertSame(callerSession, SessionState.get(), "A failed construction must not take the caller's session");
+    assertSame(callerLoader, Thread.currentThread().getContextClassLoader(),
+        "A failed construction must not take the caller's class loader");
   }
 
   /**
@@ -261,9 +296,13 @@ class TestHiveQueryDDLExecutorSession {
    * metaStoreClient keeps close() away from Hive.closeCurrent() and its static thread-local state.
    */
   private static HiveQueryDDLExecutor executorWith(Driver driver, SessionState sessionState) throws Exception {
-    // SessionState.setCurrentSessionState() reads the session's conf to swap the thread's
-    // context classloader.
-    when(sessionState.getConf()).thenReturn(new HiveConf());
+    // SessionState.setCurrentSessionState() swaps the thread's context class loader for the one on
+    // the session's conf. A real SessionState puts its own UDFClassLoader there, so give the stub a
+    // loader of its own too, otherwise the conf would carry this thread's loader and the swap would
+    // be invisible.
+    HiveConf sessionConf = new HiveConf();
+    sessionConf.setClassLoader(new URLClassLoader(new URL[0], sessionConf.getClassLoader()));
+    when(sessionState.getConf()).thenReturn(sessionConf);
     HiveQueryDDLExecutor executor = mock(HiveQueryDDLExecutor.class, CALLS_REAL_METHODS);
     setField(executor, "driverPool", Option.empty());
     setField(executor, "metaStoreClientPool", Option.empty());

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -226,10 +226,11 @@ class TestHiveQueryDDLExecutorSession {
   }
 
   /**
-   * A session that cannot be bound is still closed and the thread still handed back, but the
-   * Driver is left alone: it reads its session from the thread, so tearing it down here would
-   * clear another session's lineage and release our locks through its transaction manager. The
-   * caller hears about it, as it does for any other failure to close.
+   * A session that cannot be bound is still closed and the thread still handed back: Hive attaches
+   * the session before the part of the bind that can throw, so a failed bind leaves the thread
+   * holding it until the close and the restore take it off. The Driver is left alone, since it
+   * reads its session from the thread and a half-applied bind promises nothing about what is
+   * there. The caller hears about it, as it does for any other failure to close.
    */
   @Test
   void sessionThatCannotBeBoundIsStillClosedAndNothingElseIsTouched() throws Exception {

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -31,11 +31,14 @@ import org.mockito.InOrder;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -118,14 +121,40 @@ class TestHiveQueryDDLExecutorSession {
    */
   @Test
   void sqlRunsUnderTheSessionThisExecutorStarted() throws Exception {
-    Driver driver = mock(Driver.class);
     SessionState sessionState = mock(SessionState.class);
+    Driver driver = mock(Driver.class);
+    List<SessionState> sessionsSeenByDriver = new ArrayList<>();
+    when(driver.run(anyString())).thenAnswer(invocation -> {
+      sessionsSeenByDriver.add(SessionState.get());
+      return null;
+    });
     HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
     SessionState.detachSession();
 
     executor.runSQL("SHOW TABLES");
 
-    assertSame(sessionState, SessionState.get(), "The executor must run under its own session");
+    assertEquals(Collections.singletonList(sessionState), sessionsSeenByDriver,
+        "The executor must run under its own session");
+    assertNull(SessionState.get(), "A thread that held no session must be left holding none");
+  }
+
+  /**
+   * The thread belongs to the caller, which may be another executor or an application that embeds
+   * the sync and holds a session of its own. Leaving this executor's session behind would silently
+   * run the caller's later Hive work under our database, configuration and transaction state.
+   */
+  @Test
+  void sqlHandsTheThreadBackToTheSessionItFound() throws Exception {
+    SessionState otherSession = mock(SessionState.class);
+    when(otherSession.getConf()).thenReturn(new HiveConf());
+    SessionState sessionState = mock(SessionState.class);
+    Driver driver = mock(Driver.class);
+    HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
+    SessionState.setCurrentSessionState(otherSession);
+
+    executor.runSQL("SHOW TABLES");
+
+    assertSame(otherSession, SessionState.get(), "The session held before the statements must be put back");
     verify(driver, times(1)).run("SHOW TABLES");
   }
 

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -225,6 +225,26 @@ class TestHiveQueryDDLExecutorSession {
   }
 
   /**
+   * The teardown binds the owned session first, but a session that cannot be bound still has to be
+   * closed and its Driver still destroyed: those are the shutdown hook and the scratch directories
+   * this teardown exists to reclaim.
+   */
+  @Test
+  void closeTearsDownEvenWhenTheSessionCannotBeBound() throws Exception {
+    Driver driver = mock(Driver.class);
+    SessionState sessionState = mock(SessionState.class);
+    HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
+    when(sessionState.getConf()).thenThrow(new RuntimeException("conf unavailable"));
+
+    executor.close();
+
+    InOrder inOrder = inOrder(driver, sessionState);
+    inOrder.verify(driver).close();
+    inOrder.verify(driver).destroy();
+    inOrder.verify(sessionState).close();
+  }
+
+  /**
    * SessionState.start() displaces the session the calling thread already holds, so construction
    * has to put it back: the tests above bind explicitly for every statement and for the teardown,
    * which is only a complete story if the thread is the caller's between those operations.

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -20,19 +20,28 @@
 package org.apache.hudi.hive.ddl;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.hive.HiveSyncConfig;
+import org.apache.hudi.hive.HoodieHiveSyncException;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InOrder;
 
+import java.io.File;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -188,6 +197,63 @@ class TestHiveQueryDDLExecutorSession {
         "Driver teardown must run under the session that owns the Driver");
     assertSame(otherSession, SessionState.get(), "The session attached before close() must be put back");
     verify(otherSession, never()).close();
+  }
+
+  /**
+   * SessionState.start() displaces the session the calling thread already holds, so construction
+   * has to put it back: the tests above bind explicitly for every statement and for the teardown,
+   * which is only a complete story if the thread is the caller's between those operations.
+   */
+  @Test
+  void constructionGivesTheThreadBackToTheCallersSession(@TempDir Path tempDir) throws Exception {
+    SessionState callerSession = new SessionState(new HiveConf());
+    SessionState.setCurrentSessionState(callerSession);
+
+    HiveQueryDDLExecutor executor =
+        new HiveQueryDDLExecutor(hiveSyncConfig(tempDir), mock(IMetaStoreClient.class));
+    try {
+      assertSame(callerSession, SessionState.get(), "Construction must not keep the caller's thread");
+    } finally {
+      executor.close();
+    }
+
+    assertSame(callerSession, SessionState.get(), "close() must not take the caller's session with it");
+  }
+
+  /**
+   * The failed constructor closes the session it started, and SessionState.close() detaches
+   * whatever is attached, so the caller would lose its session to a failure it did not cause.
+   */
+  @Test
+  void failedConstructionGivesTheThreadBackToTheCallersSession(@TempDir Path tempDir) throws Exception {
+    // SessionState.start() attaches before it creates the session directories, so a scratch dir
+    // that cannot be created fails construction with our session attached.
+    HiveSyncConfig config = hiveSyncConfig(tempDir);
+    config.getHiveConf().setVar(HiveConf.ConfVars.SCRATCHDIR,
+        Files.createFile(tempDir.resolve("not-a-directory")).toUri().toString() + "/scratch");
+    SessionState callerSession = new SessionState(new HiveConf());
+    SessionState.setCurrentSessionState(callerSession);
+
+    assertThrows(HoodieHiveSyncException.class,
+        () -> new HiveQueryDDLExecutor(config, mock(IMetaStoreClient.class)));
+
+    assertSame(callerSession, SessionState.get(), "A failed construction must not take the caller's session");
+  }
+
+  /**
+   * A config whose Hive session directories all land under the test's temp dir, so starting a real
+   * SessionState needs neither a metastore nor a writable /tmp/hive.
+   */
+  private static HiveSyncConfig hiveSyncConfig(Path tempDir) {
+    Configuration hadoopConf = new Configuration();
+    hadoopConf.set("fs.defaultFS", "file:///");
+    HiveSyncConfig config = new HiveSyncConfig(new Properties(), hadoopConf);
+    HiveConf hiveConf = config.getHiveConf();
+    hiveConf.setVar(HiveConf.ConfVars.SCRATCHDIR, new File(tempDir.toFile(), "scratch").toURI().toString());
+    hiveConf.setVar(HiveConf.ConfVars.LOCALSCRATCHDIR, new File(tempDir.toFile(), "local").getAbsolutePath());
+    hiveConf.setVar(HiveConf.ConfVars.DOWNLOADED_RESOURCES_DIR,
+        new File(tempDir.toFile(), "resources").getAbsolutePath());
+    return config;
   }
 
   /**

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -27,12 +27,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.ql.Driver;
+import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InOrder;
+import org.mockito.MockedStatic;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -45,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -57,6 +60,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -223,6 +227,39 @@ class TestHiveQueryDDLExecutorSession {
         "Driver teardown must run under the session that owns the Driver");
     assertSame(otherSession, SessionState.get(), "The session attached before close() must be put back");
     verify(otherSession, never()).close();
+  }
+
+  /**
+   * SessionState.close() reaches for this thread's Hive to uncache DataNucleus class loaders, and
+   * ends by clearing that thread local itself. Clearing it first therefore costs a metastore
+   * connection: the session opens one of its own just to do that lookup, in the middle of a
+   * teardown, where a metastore that is down turns the lookup into a retry loop.
+   */
+  @Test
+  void theThreadLocalHiveOutlastsTheSessionThatReachesForIt() throws Exception {
+    Driver driver = mock(Driver.class);
+    SessionState sessionState = mock(SessionState.class);
+    HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
+    setField(executor, "metaStoreClient", mock(IMetaStoreClient.class));
+    AtomicBoolean sessionClosed = new AtomicBoolean();
+    doAnswer(invocation -> {
+      sessionClosed.set(true);
+      return null;
+    }).when(sessionState).close();
+
+    try (MockedStatic<Hive> hive = mockStatic(Hive.class)) {
+      AtomicBoolean sessionWasClosedFirst = new AtomicBoolean();
+      hive.when(Hive::closeCurrent)
+          .thenAnswer(invocation -> {
+            sessionWasClosedFirst.set(sessionClosed.get());
+            return null;
+          });
+
+      executor.close();
+
+      assertTrue(sessionWasClosedFirst.get(),
+          "The session must be closed while the Hive it reaches for is still on the thread");
+    }
   }
 
   /**

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -226,23 +226,27 @@ class TestHiveQueryDDLExecutorSession {
   }
 
   /**
-   * The teardown binds the owned session first, but a session that cannot be bound still has to be
-   * closed and its Driver still destroyed: those are the shutdown hook and the scratch directories
-   * this teardown exists to reclaim.
+   * A session that cannot be bound is still closed and the thread still handed back, but the
+   * Driver is left alone: it reads its session from the thread, so tearing it down here would
+   * clear another session's lineage and release our locks through its transaction manager. The
+   * caller hears about it, as it does for any other failure to close.
    */
   @Test
-  void closeTearsDownEvenWhenTheSessionCannotBeBound() throws Exception {
+  void sessionThatCannotBeBoundIsStillClosedAndNothingElseIsTouched() throws Exception {
     Driver driver = mock(Driver.class);
     SessionState sessionState = mock(SessionState.class);
     HiveQueryDDLExecutor executor = executorWith(driver, sessionState);
+    SessionState otherSession = mock(SessionState.class);
+    when(otherSession.getConf()).thenReturn(new HiveConf());
+    SessionState.setCurrentSessionState(otherSession);
     when(sessionState.getConf()).thenThrow(new RuntimeException("conf unavailable"));
 
-    executor.close();
+    assertThrows(RuntimeException.class, executor::close);
 
-    InOrder inOrder = inOrder(driver, sessionState);
-    inOrder.verify(driver).close();
-    inOrder.verify(driver).destroy();
-    inOrder.verify(sessionState).close();
+    verify(sessionState, times(1)).close();
+    verify(driver, never()).close();
+    verify(driver, never()).destroy();
+    assertSame(otherSession, SessionState.get(), "The session the thread came in with must be put back");
   }
 
   /**

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -42,6 +42,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -334,6 +335,34 @@ class TestHiveQueryDDLExecutorSession {
             + "and those sessions would share the scratch directories this one deletes");
     assertSame(callerConfLoader, config.getHiveConf().getClassLoader(),
         "close() closes the loader its session's conf carries, so that conf cannot be the caller's");
+  }
+
+  @Test
+  void closePreservesCallerScratchWhenConfigHasSessionId(@TempDir Path tempDir) throws Exception {
+    SessionState callerSession = SessionState.start(hiveSyncConfig(tempDir).getHiveConf());
+    HiveConf callerConf = callerSession.getConf();
+    String callerSessionId = callerSession.getSessionId();
+    // Only metastore access is stubbed; real sessions create and delete the scratch directories.
+    try (MockedStatic<Hive> ignored = mockStatic(Hive.class)) {
+      try {
+        Path localMarker = Files.write(Paths.get(SessionState.getLocalSessionPath(callerConf).toUri().getPath())
+            .resolve("caller-query-data"), new byte[] {1});
+        Path hdfsMarker = Files.write(Paths.get(SessionState.getHDFSSessionPath(callerConf).toUri().getPath())
+            .resolve("caller-query-data"), new byte[] {1});
+        HiveSyncConfig config = new HiveSyncConfig(new Properties(), callerConf);
+        try (HiveQueryDDLExecutor executor = new HiveQueryDDLExecutor(config, mock(IMetaStoreClient.class))) {
+          assertSame(callerSession, SessionState.get());
+          assertEquals(callerSessionId, config.getHiveConf().getVar(HiveConf.ConfVars.HIVESESSIONID),
+              "The caller's configuration must retain its session ID");
+        }
+
+        assertSame(callerSession, SessionState.get());
+        assertTrue(Files.exists(localMarker), "Closing the executor must preserve the caller's local scratch files");
+        assertTrue(Files.exists(hdfsMarker), "Closing the executor must preserve the caller's HDFS scratch files");
+      } finally {
+        callerSession.close();
+      }
+    }
   }
 
   /**

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHiveQueryDDLExecutorSession.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
@@ -270,6 +271,27 @@ class TestHiveQueryDDLExecutorSession {
     // could no longer load classes.
     assertSame(callerLoader, Thread.currentThread().getContextClassLoader(),
         "close() must not leave the closed loader of its session on the caller's thread");
+  }
+
+  /**
+   * The config outlives this executor and is copied by the driver and metastore client pools, so
+   * the session must not leave its id or its class loader on that config: close() deletes the
+   * scratch directories the id names and closes the loader.
+   */
+  @Test
+  void theSessionKeepsItsIdAndLoaderOffTheCallersConfig(@TempDir Path tempDir) throws Exception {
+    HiveSyncConfig config = hiveSyncConfig(tempDir);
+    ClassLoader callerConfLoader = config.getHiveConf().getClassLoader();
+
+    HiveQueryDDLExecutor executor = new HiveQueryDDLExecutor(config, mock(IMetaStoreClient.class));
+    executor.close();
+
+    String sessionId = config.getHiveConf().getVar(HiveConf.ConfVars.HIVESESSIONID);
+    assertTrue(sessionId == null || sessionId.isEmpty(),
+        "A session id on the caller's config is inherited by every session built from a copy of it, "
+            + "and those sessions would share the scratch directories this one deletes");
+    assertSame(callerConfLoader, config.getHiveConf().getClassLoader(),
+        "close() closes the loader its session's conf carries, so that conf cannot be the caller's");
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`HiveQueryDDLExecutor` starts a `SessionState` in its constructor and never closes it. Hive derives
a session's four scratch directory roots from `hive.session.id` and reclaims them only in
`SessionState.close()`, so every sync leaves a directory set behind, along with the session's
function registry and the class loaders it created. A `HiveSyncTool`, and therefore an executor and
its session, is built per sync, so on a long-running streaming job this accumulates for the life of
the JVM: `close()` released the metastore client and the Driver, never the session.

Observed on a Flink job syncing a 5,000-partition table in HiveQL mode: one unclosed session per
sync cycle, 63 of 63 and 76 of 76 across two runs, each leaving its scratch directory set on local
disk.

### Summary and Changelog

Users running `hive_sync.mode=hiveql` on a long-lived job stop accumulating scratch directories and
per-session objects; the session is now released with the rest of the executor's resources.

- `close()` closes the `SessionState`. It runs after the Driver teardown, because
  `SessionState.close()` detaches the session from the calling thread and `Driver.destroy()` can
  reach `SessionState.get()` while releasing locks, and it runs in a `finally` so a Driver `close()`
  that throws cannot skip it.
- The constructor's error path now uses the same `closeQuietly` helper instead of its own inline
  block. Besides removing the duplication, it widens the caught type from `IOException` to
  `Exception`, so a `RuntimeException` during teardown can no longer mask the construction failure
  that is about to be thrown.
- `updateHiveSQLs` re-asserts its own session before running statements. This is required by the
  change above: `SessionState.close()` calls `detachSession()`, which clears the thread local for
  whichever session is attached, so an executor can no longer assume the session it started in its
  constructor is still current when a second executor on the same thread is constructed or closed.
  `Driver.compile()` dereferences `SessionState.get()` unconditionally, and Hive documents that a
  thread running several sessions must set the current session when switching between them.
- New `TestHiveQueryDDLExecutorSession` covers the session lifecycle: closed after the Driver and in
  that order, closed even when the Driver `close()` throws, a failing session close swallowed so it
  does not become the caller's problem, and SQL running under the session the executor started.

### Impact

No public API or config change. Behaviour change is that the HiveQL sync path now releases its Hive
session when the sync tool is closed, so its scratch directories are reclaimed instead of being left
until the JVM exits.

### Risk Level

low

Verification: `TestHiveSyncTool` passes in full, 275 tests, which exercises the HiveQL path
end-to-end against the embedded metastore, plus `TestHiveDriverPool`,
`TestHiveQueryDDLExecutorFailures`, `TestHoodieHiveSyncClientClose` and the new tests. The session
re-assert was checked by removing it and confirming the new test fails with `SessionState.get()`
returning null, which is the same NPE in `Driver.compile()` that the full suite surfaced in teardown
before the re-assert was added.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
