### PR TITLE
fix(build): exclude bundled Avro from the DataHub sync bundle

### DIFF
--- a/packaging/hudi-datahub-sync-bundle/pom.xml
+++ b/packaging/hudi-datahub-sync-bundle/pom.xml
@@ -106,6 +106,15 @@
                     <exclude>**/*.proto</exclude>
                   </excludes>
                 </filter>
+                <filter>
+                  <artifact>io.acryl:datahub-client-java8</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                  <excludes>
+                    <exclude>org/apache/avro/**</exclude>
+                  </excludes>
+                </filter>
               </filters>
               <finalName>${project.artifactId}-${project.version}</finalName>
             </configuration>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19813

### Summary and Changelog

`io.acryl:datahub-client-java8` bundles its own copy of Avro. The DataHub sync bundle shades that artifact in without filtering those classes, so `hudi-datahub-sync-bundle` ships ~450 unrelocated `org/apache/avro/*.class` entries alongside Hudi's own.

Adds a shade filter excluding `org/apache/avro/**` from the DataHub client, matching how the other bundles keep third-party copies of shared libraries out.

### Impact

Consumers that place the bundle ahead of their own Avro on the classpath no longer bind against DataHub's copy. DataHub sync itself is unaffected: it uses the Avro already on the Hudi classpath.

### Risk Level

low

The change is confined to shade filtering in one packaging module. The filter's effect is directly observable in built artifacts: a bundle built with it carries zero `org/apache/avro` entries, one built without it carries the DataHub client's copy.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
