### PR TITLE
refactor(config): deprecate hoodie.parquet.outputtimestamptype, a no-op since 1.1.0

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2535,10 +2535,6 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED);
   }
 
-  public String parquetOutputTimestampType() {
-    return getString(HoodieStorageConfig.PARQUET_OUTPUT_TIMESTAMP_TYPE);
-  }
-
   public String parquetFieldIdWriteEnabled() {
     return getString(HoodieStorageConfig.PARQUET_FIELD_ID_WRITE_ENABLED);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2535,6 +2535,17 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED);
   }
 
+  /**
+   * @deprecated the underlying config has had no effect since 1.1.0. Both the Spark row writer and
+   *     the Avro Parquet writer take the Parquet timestamp unit from the writer schema's logical
+   *     type, so the value returned here does not describe what gets written. Declare the precision
+   *     in the writer schema instead. Scheduled for removal.
+   */
+  @Deprecated
+  public String parquetOutputTimestampType() {
+    return getString(HoodieStorageConfig.PARQUET_OUTPUT_TIMESTAMP_TYPE);
+  }
+
   public String parquetFieldIdWriteEnabled() {
     return getString(HoodieStorageConfig.PARQUET_FIELD_ID_WRITE_ENABLED);
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -151,7 +151,6 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     Configuration hadoopConf = new Configuration(conf);
     String writeLegacyFormatEnabled = config.getStringOrDefault(HoodieStorageConfig.PARQUET_WRITE_LEGACY_FORMAT_ENABLED, "false");
     hadoopConf.set("spark.sql.parquet.writeLegacyFormat", writeLegacyFormatEnabled);
-    hadoopConf.set("spark.sql.parquet.outputTimestampType", config.getStringOrDefault(HoodieStorageConfig.PARQUET_OUTPUT_TIMESTAMP_TYPE));
     hadoopConf.set("spark.sql.parquet.fieldId.write.enabled", config.getStringOrDefault(PARQUET_FIELD_ID_WRITE_ENABLED));
 
     // Variant shredding configs

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -662,6 +662,12 @@ public class HoodieStorageConfig extends HoodieConfig {
       return this;
     }
 
+    /**
+     * @deprecated since 1.1.0; the config has no effect. Both the Spark row writer and the Avro
+     *     Parquet writer take the Parquet timestamp unit from the writer schema's logical type, so
+     *     declare the precision in the writer schema instead.
+     */
+    @Deprecated
     public Builder parquetOutputTimestampType(String parquetOutputTimestampType) {
       storageConfig.setValue(PARQUET_OUTPUT_TIMESTAMP_TYPE, parquetOutputTimestampType);
       return this;

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -240,7 +240,9 @@ public class HoodieStorageConfig extends HoodieConfig {
       .key("hoodie.parquet.outputtimestamptype")
       .defaultValue("TIMESTAMP_MICROS")
       .markAdvanced()
-      .withDocumentation("Sets spark.sql.parquet.outputTimestampType. Parquet timestamp type to use when Spark writes data to Parquet files.");
+      .withDocumentation("Sets spark.sql.parquet.outputTimestampType for the Spark row-writer Parquet path (for example bulk insert). "
+          + "Writes that go through the Avro path, such as insert and upsert, derive the Parquet timestamp type from the table's "
+          + "Avro schema and are unaffected by this config.");
 
   // SPARK-38094 Spark 3.3 checks if this field is enabled. Hudi has to provide this or there would be NPE thrown
   // Would ONLY be effective with Spark 3.3+

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -236,13 +236,15 @@ public class HoodieStorageConfig extends HoodieConfig {
           + "For example, decimal values will be written in Parquet's fixed-length byte array format which other systems such as Apache Hive and Apache Impala use. "
           + "If false, the newer format in Parquet will be used. For example, decimals will be written in int-based format.");
 
+  @Deprecated
   public static final ConfigProperty<String> PARQUET_OUTPUT_TIMESTAMP_TYPE = ConfigProperty
       .key("hoodie.parquet.outputtimestamptype")
       .defaultValue("TIMESTAMP_MICROS")
       .markAdvanced()
-      .withDocumentation("Sets spark.sql.parquet.outputTimestampType for the Spark row-writer Parquet path (for example bulk insert). "
-          + "Writes that go through the Avro path, such as insert and upsert, derive the Parquet timestamp type from the table's "
-          + "Avro schema and are unaffected by this config.");
+      .deprecatedAfter("1.1.0")
+      .withDocumentation("No effect since 1.1.0. Both the Spark row writer and the Avro Parquet writer derive the "
+          + "Parquet timestamp unit from the writer schema's logical type (timestamp-micros or timestamp-millis), "
+          + "so declare the precision in the writer schema (for example via hoodie.write.schema) instead.");
 
   // SPARK-38094 Spark 3.3 checks if this field is enabled. Hudi has to provide this or there would be NPE thrown
   // Would ONLY be effective with Spark 3.3+

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieInternalRowParquetWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieInternalRowParquetWriter.java
@@ -36,6 +36,7 @@ import org.apache.hudi.testutils.SparkDatasetTestUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.spark.sql.Dataset;
@@ -141,6 +142,45 @@ public class TestHoodieInternalRowParquetWriter extends HoodieSparkClientTestHar
     assertEquals(9, decimalParquetTypeLength(decimalRecordSchema(
         "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":2}")),
         "bytes decimal keeps the precision-minimal FIXED_LEN width (9)");
+  }
+
+  /**
+   * hoodie.parquet.outputtimestamptype has had no effect since #13882: the Parquet timestamp
+   * unit comes from the writer schema's logical type, not from the config. Pin both directions
+   * so the config description cannot drift back to claiming otherwise.
+   */
+  @Test
+  public void testOutputTimestampTypeConfigDoesNotOverrideWriterSchema() {
+    // Config asks for MILLIS, writer schema says micros: the schema wins.
+    assertEquals(LogicalTypeAnnotation.TimeUnit.MICROS,
+        timestampUnitOf(timestampRecordSchema("timestamp-micros"), "TIMESTAMP_MILLIS"));
+    // Config left at its default of MICROS, writer schema says millis: the schema wins again.
+    assertEquals(LogicalTypeAnnotation.TimeUnit.MILLIS,
+        timestampUnitOf(timestampRecordSchema("timestamp-millis"), null));
+  }
+
+  private static String timestampRecordSchema(String logicalType) {
+    return "{\"type\":\"record\",\"name\":\"rec\",\"fields\":[{\"name\":\"ts\","
+        + "\"type\":{\"type\":\"long\",\"logicalType\":\"" + logicalType + "\"}}]}";
+  }
+
+  /** Builds the write support for the given writer schema and returns the Parquet timestamp unit it emits. */
+  private LogicalTypeAnnotation.TimeUnit timestampUnitOf(String avroSchemaJson, String outputTimestampType) {
+    StructType structType = new StructType().add("ts", DataTypes.TimestampType, false);
+    HoodieWriteConfig.Builder builder = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withSchema(avroSchemaJson);
+    if (outputTimestampType != null) {
+      builder.withStorageConfig(HoodieStorageConfig.newBuilder()
+          .parquetOutputTimestampType(outputTimestampType).build());
+    }
+    HoodieRowParquetWriteSupport writeSupport = HoodieRowParquetWriteSupport.getHoodieRowParquetWriteSupport(
+        storageConf.unwrap(), structType, Option.empty(), builder.build());
+    MessageType parquetSchema = writeSupport.init(writeSupport.getHadoopConf()).getSchema();
+    LogicalTypeAnnotation annotation = parquetSchema.getType("ts").asPrimitiveType().getLogicalTypeAnnotation();
+    assertTrue(annotation instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation,
+        "ts must carry a timestamp logical type, got: " + annotation);
+    return ((LogicalTypeAnnotation.TimestampLogicalTypeAnnotation) annotation).getUnit();
   }
 
   private static String decimalRecordSchema(String decType) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieInternalRowParquetWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieInternalRowParquetWriter.java
@@ -165,6 +165,7 @@ public class TestHoodieInternalRowParquetWriter extends HoodieSparkClientTestHar
   }
 
   /** Builds the write support for the given writer schema and returns the Parquet timestamp unit it emits. */
+  @SuppressWarnings("deprecation")
   private LogicalTypeAnnotation.TimeUnit timestampUnitOf(String avroSchemaJson, String outputTimestampType) {
     StructType structType = new StructType().add("ts", DataTypes.TimestampType, false);
     HoodieWriteConfig.Builder builder = HoodieWriteConfig.newBuilder()


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Relates to https://issues.apache.org/jira/browse/HUDI-8592 (#17302), which reports that `hoodie.parquet.outputtimestamptype=TIMESTAMP_MILLIS` is ignored and Parquet files are always written with `timestamp-micros`.

The config has had **no effect at all since 1.1.0**, and its description still promised otherwise:

> Sets spark.sql.parquet.outputTimestampType. Parquet timestamp type to use when Spark writes data to Parquet files.

Since #13882 (`4d95b2c2d165`) `HoodieRowParquetWriteSupport` builds the Parquet schema itself, and `convertField` takes the timestamp unit from the writer schema's logical type. The Avro Parquet writer has always derived it from the writer schema too. So neither write path consults this config; the value copied into the hadoop conf was simply never read by anything.

That dead assignment is also *why* the config kept looking live on a code read, and why the original HUDI-8592 triage (and an earlier revision of this PR, which narrowed the description to "the row-writer path") both landed on the wrong answer. Removing it closes that trap.

This PR does not make the config work. Making the timestamp unit configurable independently of the writer schema would be a storage-format decision and wants its own discussion, so HUDI-8592 should stay open for that.

### Summary and Changelog

`hoodie.parquet.outputtimestamptype` is now marked deprecated and documented as having no effect, so users stop setting it and expecting a different Parquet footer. The precision is declared in the writer schema instead.

- `HoodieStorageConfig.PARQUET_OUTPUT_TIMESTAMP_TYPE`: description rewritten to say it has no effect since 1.1.0 and to point at the writer schema; added `@Deprecated` and `deprecatedAfter("1.1.0")`. The key and its default are untouched.
- `HoodieRowParquetWriteSupport`: dropped the dead `hadoopConf.set("spark.sql.parquet.outputTimestampType", ...)`. Nothing has read that key from this Configuration since #13882; the only other reference in the tree, `SparkReaderContextFactory`, reads Spark's own `SQLConf` on the read path and is unaffected.
- `HoodieWriteConfig.parquetOutputTimestampType()`: marked `@Deprecated` with a javadoc explaining that the value does not describe what gets written. It has no callers in the tree, but it is public, so it is deprecated rather than deleted, matching how the other 76 deprecated members of that class are handled. An earlier revision of this PR deleted it; that would have been a source-incompatible change for downstream integrations for no benefit.
- `TestHoodieInternalRowParquetWriter`: new test pinning both directions, so the description cannot drift back.

No code was copied.

### Impact

No behaviour change: the same Parquet footers are written before and after. The new test demonstrates that, and the full `hudi-hadoop-mr`-adjacent modules build clean.

User-facing: the generated config table on the Hudi website will show the config as deprecated with the corrected description. No config key, default, or public method is removed, so nothing downstream fails to compile or resolve.

The test lives in `TestHoodieInternalRowParquetWriter` (`hudi-spark`) rather than `TestHoodieRowParquetWriteSupport` (`hudi-spark-client`), because the latter cannot construct the write support: it needs a Spark adapter that is not on that module's test classpath, as its own class javadoc records.

### Risk Level

low

Rebased onto current master (`7a3e2f3ad69b`) and verified on Spark 3.5 / Scala 2.12:

- `mvn test -pl hudi-spark-datasource/hudi-spark -Dtest=TestHoodieInternalRowParquetWriter` -> `Tests run: 4, Failures: 0, Errors: 0`, including the two new assertions
- `mvn install -DskipTests -am -pl hudi-spark-datasource/hudi-spark` -> `BUILD SUCCESS`
- `mvn checkstyle:check` across the four touched modules -> clean

### Documentation Update

The config description is the documentation update, corrected in place. That is what feeds the generated config tables on the Hudi website, so no separate website change is needed. The config now renders as deprecated.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
