### PR TITLE
fix(utilities): cache StreamSync input records to avoid double-embedding

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -185,6 +185,8 @@ public class StreamSync implements Serializable, Closeable {
   private static final long serialVersionUID = 1L;
   private static final String NULL_PLACEHOLDER = "[null]";
   public static final String CHECKPOINT_IGNORE_KEY = "deltastreamer.checkpoint.ignore_key";
+  // Prefix for the per-write name tagged on the cached input records RDD; see inputRecordsCacheName.
+  private static final String INPUT_RECORDS_CACHE_NAME_PREFIX = "hoodie-input-records-";
 
   /**
    * Delta Sync Config.
@@ -1027,6 +1029,10 @@ public class StreamSync implements Serializable, Closeable {
       metrics.updateStreamerMetrics(overallTimeNanos);
       return Pair.of(scheduledCompactionInstant, writeStatusRDD);
     } finally {
+      // The write has consumed the input records (the index tag lookup and the write both materialize above), so
+      // release the RDD cached for this write. Looked up by its per-write tag; a no-op when nothing was cached. Runs
+      // on both the success and failure paths.
+      unpersistCachedInputRecords(hoodieSparkContext.jsc(), inputRecordsCacheName(cfg.targetBasePath, instantTime));
       if (!releaseResourcesInvoked) {
         releaseResources(instantTime);
       }
@@ -1104,6 +1110,20 @@ public class StreamSync implements Serializable, Closeable {
         records = DataSourceUtils.handleDuplicates(hoodieSparkContext, records, writeClient.getConfig(), false);
       }
 
+      // For index-based operations the input records RDD is read more than once inside the write (the index tag
+      // lookup and the write itself), so the whole upstream DAG is recomputed on each read. When a transformer chain
+      // such as EmbeddingTransformer - which calls a remote embedding service per record - is in play, that recompute
+      // re-embeds every record, doubling cost and latency. Cache the records once here (mirroring how writeStatusRDD
+      // is always cached) so both reads reuse the materialized records. instantTime is generated at startCommit above,
+      // before the first action, so the cache is in place before the first read. The RDD is named with a per-write
+      // tag (base path + instant) so it can be released by tag after the write without retaining a reference - see
+      // unpersistCachedInputRecords in the finally of writeToSinkAndDoMetaSync. Gated on a transformer being
+      // configured, since that is when the recompute is expensive.
+      if (transformer.isPresent()) {
+        records.rdd().setName(inputRecordsCacheName(cfg.targetBasePath, instantTime));
+        records.persist(StorageLevel.MEMORY_AND_DISK_SER());
+      }
+
       HoodieWriteResult writeResult = null;
       switch (cfg.operation) {
         case INSERT:
@@ -1140,6 +1160,30 @@ public class StreamSync implements Serializable, Closeable {
       }
     }
     return writeClientWriteResult;
+  }
+
+  /**
+   * Builds the unique-per-write name used to tag the cached input records RDD. Composed of the target table's
+   * base path and this write's instant time so it never collides with another table, or with a retried instant,
+   * that shares the same SparkContext (the persistent-RDD registry is context-wide).
+   */
+  @VisibleForTesting
+  static String inputRecordsCacheName(String basePath, String instantTime) {
+    return INPUT_RECORDS_CACHE_NAME_PREFIX + basePath + "-" + instantTime;
+  }
+
+  /**
+   * Releases the input records RDD cached under the given name, if present. The RDD is found by name through the
+   * context-wide persistent-RDD registry, so no reference to it needs to be retained across the write. A no-op
+   * when nothing is cached under that name.
+   */
+  @VisibleForTesting
+  static void unpersistCachedInputRecords(JavaSparkContext jsc, String cacheName) {
+    for (JavaRDD<?> rdd : jsc.getPersistentRDDs().values()) {
+      if (cacheName.equals(rdd.name())) {
+        rdd.unpersist(false);
+      }
+    }
   }
 
   private String getSyncClassShortName(String syncClassName) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamSyncInputRecordsCache.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamSyncInputRecordsCache.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.streamer;
+
+import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.storage.StorageLevel;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the per-write tagging and tag-based release of the cached input records RDD in StreamSync: the tag is
+ * unique per (base path, instant), the tagged RDD is found and released by tag without retaining a reference, and
+ * releasing one write's tag leaves another write's cache intact.
+ */
+public class TestStreamSyncInputRecordsCache extends UtilitiesTestBase {
+
+  @BeforeAll
+  public static void setupAll() throws Exception {
+    initTestServices();
+  }
+
+  @AfterAll
+  public static void tearDownAll() {
+    cleanUpUtilitiesTestServices();
+  }
+
+  private static boolean isPersistedByName(String name) {
+    return jsc.getPersistentRDDs().values().stream().anyMatch(rdd -> name.equals(rdd.name()));
+  }
+
+  @Test
+  public void testCacheNameIsUniquePerBasePathAndInstant() {
+    String name = StreamSync.inputRecordsCacheName("/base/path/tbl", "20240102030405006");
+    assertEquals("hoodie-input-records-/base/path/tbl-20240102030405006", name);
+    // a different instant or base path yields a different tag
+    assertNotEquals(name, StreamSync.inputRecordsCacheName("/base/path/tbl", "20240102030405007"));
+    assertNotEquals(name, StreamSync.inputRecordsCacheName("/base/path/other", "20240102030405006"));
+  }
+
+  @Test
+  public void testUnpersistCachedInputRecordsFindsAndReleasesByTag() {
+    String nameA = StreamSync.inputRecordsCacheName("/base/path/tbl", "20240102030405001");
+    String nameB = StreamSync.inputRecordsCacheName("/base/path/tbl", "20240102030405002");
+
+    JavaRDD<Integer> rddA = jsc.parallelize(Arrays.asList(1, 2, 3), 1);
+    rddA.rdd().setName(nameA);
+    rddA.persist(StorageLevel.MEMORY_AND_DISK_SER());
+    JavaRDD<Integer> rddB = jsc.parallelize(Arrays.asList(4, 5, 6), 1);
+    rddB.rdd().setName(nameB);
+    rddB.persist(StorageLevel.MEMORY_AND_DISK_SER());
+    try {
+      // both writes' caches are registered and findable by their tags
+      assertTrue(isPersistedByName(nameA));
+      assertTrue(isPersistedByName(nameB));
+
+      // releasing write A's tag releases only A (no reference retained), leaving write B intact - proving the
+      // per-write tag prevents one write from evicting another's cache in the shared SparkContext
+      StreamSync.unpersistCachedInputRecords(jsc, nameA);
+      assertFalse(isPersistedByName(nameA));
+      assertTrue(isPersistedByName(nameB));
+
+      // an unknown tag is a no-op
+      StreamSync.unpersistCachedInputRecords(jsc, StreamSync.inputRecordsCacheName("/base/path/tbl", "no-such-instant"));
+      assertTrue(isPersistedByName(nameB));
+
+      StreamSync.unpersistCachedInputRecords(jsc, nameB);
+      assertFalse(isPersistedByName(nameB));
+    } finally {
+      rddA.unpersist(false);
+      rddB.unpersist(false);
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/embedding/TestEmbeddingTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/embedding/TestEmbeddingTransformer.java
@@ -25,12 +25,14 @@ import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
 import com.sun.net.httpserver.HttpServer;
 import org.apache.spark.SparkException;
+import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.storage.StorageLevel;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -62,6 +64,9 @@ public class TestEmbeddingTransformer extends UtilitiesTestBase {
 
   private static HttpServer server;
   private static final AtomicInteger REQUEST_COUNT = new AtomicInteger();
+  // Total number of inputs (texts) the server was asked to embed across all requests; used to prove the
+  // upstream DAG (and therefore the per-input embedding call) is computed once when the records RDD is cached.
+  private static final AtomicInteger EMBEDDED_INPUT_COUNT = new AtomicInteger();
   private static final AtomicInteger REMAINING_FAILURES = new AtomicInteger();
   private static volatile int failureStatus = 500;
 
@@ -83,6 +88,7 @@ public class TestEmbeddingTransformer extends UtilitiesTestBase {
       Matcher matcher = INPUT_PATTERN.matcher(body);
       assertTrue(matcher.find());
       String[] inputs = matcher.group(1).split("\",\"");
+      EMBEDDED_INPUT_COUNT.addAndGet(inputs.length);
       for (int i = 0; i < inputs.length; i++) {
         String text = inputs[i].replaceAll("^\"|\"$", "");
         data.append(i > 0 ? "," : "")
@@ -197,5 +203,44 @@ public class TestEmbeddingTransformer extends UtilitiesTestBase {
         .apply(jsc, sparkSession, sourceDataset("doomed").coalesce(1), props(16));
     assertThrows(SparkException.class, failing::collectAsList);
     REMAINING_FAILURES.set(0);
+  }
+
+  @Test
+  public void testCachedRecordsRddEmbedsEachInputOnceAcrossTwoActions() {
+    REQUEST_COUNT.set(0);
+    EMBEDDED_INPUT_COUNT.set(0);
+    // 6 rows, all with text; a single partition keeps batching deterministic.
+    Dataset<Row> input = sourceDataset("a1", "b2", "c3", "d4", "e5", "f6").coalesce(1);
+    Dataset<Row> output = new EmbeddingTransformer().apply(jsc, sparkSession, input, props(2));
+
+    // Cache the records RDD the way StreamSync caches the input-to-write records, then trigger two actions - the
+    // index-tag lookup and the write both consume the RDD. The embedding backend must see each input exactly once.
+    JavaRDD<Row> records = output.toJavaRDD();
+    records.persist(StorageLevel.MEMORY_AND_DISK_SER());
+    try {
+      assertEquals(6L, records.count());
+      assertEquals(6, records.collect().size());
+      assertEquals(6, EMBEDDED_INPUT_COUNT.get(),
+          "with the records RDD cached, each of the 6 inputs must be embedded exactly once across the two actions");
+    } finally {
+      records.unpersist(false);
+    }
+  }
+
+  @Test
+  public void testUncachedRecordsRddEmbedsEachInputTwiceAcrossTwoActions() {
+    REQUEST_COUNT.set(0);
+    EMBEDDED_INPUT_COUNT.set(0);
+    Dataset<Row> input = sourceDataset("a1", "b2", "c3", "d4", "e5", "f6").coalesce(1);
+    Dataset<Row> output = new EmbeddingTransformer().apply(jsc, sparkSession, input, props(2));
+
+    // Control: without caching, each action recomputes the whole DAG, so every input is embedded again on the
+    // second action (2N). This is the double-embedding the cache fixes, and it proves the N assertion above is not
+    // vacuous.
+    JavaRDD<Row> records = output.toJavaRDD();
+    assertEquals(6L, records.count());
+    assertEquals(6, records.collect().size());
+    assertEquals(12, EMBEDDED_INPUT_COUNT.get(),
+        "without caching, the 6 inputs are embedded again on the second action (2N)");
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

In the `StreamSync` write path only the `writeStatusRDD` is cached; the **input records RDD** that feeds the write is not. For index-based operations (`UPSERT`/`INSERT`) that records RDD is read more than once *inside* the write:

1. the index tag lookup (eager inside `writeClient.upsert`/`insert`), and
2. the write itself (materialization of the tagged records).

Because only the tagged records are persisted, the whole upstream DAG is recomputed on each read. When the transformer chain contains `EmbeddingTransformer` (RFC-102, already on `master`) — which POSTs each chunk to a remote embedding service — every chunk is **re-embedded on each read**, doubling embedding cost and latency. `BULK_INSERT` avoids this (no index tag) and is the current workaround, but `UPSERT`/incremental still double-embed.

### Summary and Changelog

Cache the input records RDD once in `StreamSync.writeToSink`, before the write, so both reads reuse the materialized records — mirroring how `writeStatusRDD` is already cached.

- **No user config.** Caching is automatic, gated only on a transformer being configured (`transformer.isPresent()`) — that is when recomputing the input is expensive.
- **Storage level** `MEMORY_AND_DISK_SER`, so it spills to disk under memory pressure rather than forcing an OOM. Overhead is negligible relative to executor memory (~150 MB for a 1 GB input batch).
- **Timing.** `instantTime` is generated at `startCommit` (before the write, before the first action), so the cache is in place before the first read.
- **Release by tag (no retained reference).** The RDD is named `hoodie-input-records-<targetBasePath>-<instantTime>` via `rdd().setName(...)`; the tag is unique per `(table, instant)` so it cannot collide with another table or a retried instant in the context-wide persistent-RDD registry. In the `finally` of `writeToSinkAndDoMetaSync` it is released by looking it up by tag through `SparkContext.getPersistentRDDs()` and unpersisting the match — no reference retained, runs on both the success and failure paths, unknown tag is a no-op.
- **Why RDD-level, not `Dataset.persist()`.** `Dataset.persist()` registers in the SQL CacheManager keyed by the logical plan, and `df.rdd()` returns a fresh RDD each call, so a name set there would never appear in `getPersistentRDDs()`. We cache and name the `JavaRDD` that actually feeds `writeClient.upsert`/`insert`.

Changes:
- `hudi-utilities/.../streamer/StreamSync.java` — cache+name the input records RDD before the write (gated on `transformer.isPresent()`); release-by-tag in the `finally` of `writeToSinkAndDoMetaSync`; two `@VisibleForTesting static` helpers `inputRecordsCacheName(basePath, instantTime)` and `unpersistCachedInputRecords(jsc, name)`.
- `hudi-utilities/.../transform/embedding/TestEmbeddingTransformer.java` — count the total number of inputs the stub embedding server is asked to embed; two new tests.
- `hudi-utilities/.../streamer/TestStreamSyncInputRecordsCache.java` (new) — tag uniqueness and release-by-tag.

Tests (all offline, deterministic):
- `testCachedRecordsRddEmbedsEachInputOnceAcrossTwoActions` — cache the records RDD, then run `count()` then `collect()` (simulating the index-tag lookup + the write). The backend embeds each of the 6 inputs exactly once (N=6).
- `testUncachedRecordsRddEmbedsEachInputTwiceAcrossTwoActions` — control: the same two actions on the un-cached dataset embed every input again on the second action (2N=12), reproducing the double-embedding this fixes and proving the N assertion is not vacuous.
- `TestStreamSyncInputRecordsCache` — the tag is unique per `(base path, instant)`; the tagged RDD is found and released by tag via `getPersistentRDDs()` with no retained reference; releasing one write's tag leaves another write's cache intact; an unknown tag is a no-op.

Build / checkstyle / test (JDK 11, `-Dscala-2.12 -Dspark3.5`):
- `mvn install -pl hudi-utilities -am -DskipTests` — passes.
- `mvn checkstyle:check -pl hudi-utilities` — passes.
- `mvn test -pl hudi-utilities -Punit-tests -Dtest=TestEmbeddingTransformer,TestStreamSyncInputRecordsCache` — 7 tests, 0 failures.

### Impact

A performance / cost fix; correctness is preserved. When a transformer is configured, the input records RDD is cached (`MEMORY_AND_DISK_SER`) for the duration of one write and released immediately after, eliminating the second embedding pass on `UPSERT`/`INSERT`. No new config and no public API change. When no transformer is configured the path is unchanged (no caching is added).

### Risk Level

low — scoped to `StreamSync.writeToSink` / `writeToSinkAndDoMetaSync`, gated on `transformer.isPresent()`, uses a storage level that spills rather than OOMs, and releases the cache by tag on both the success and failure paths. Verified with the red/green test pair above (2N control vs. N cached).

### Documentation Update

none — no new config or user-facing surface; caching is automatic and internal.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

---

**Base / stacking note:** this fix depends only on the unstructured-ingestion feature (`EmbeddingTransformer` and the `StreamSync` transformer path), which is **already merged to `master`** (RFC-102). It therefore targets `master` directly as a clean, self-contained increment rather than stacking on an open feature PR. The remaining open unstructured PRs (e.g. #19677, #19678) only *harden* `EmbeddingTransformer` and this change does not depend on them.

Ported from internal onehouseinc/hudi-internal#2322 (adapted to upstream: the release-by-tag `finally` sits alongside `master`'s existing `writeStatusRDD` caching in the reworked pre-commit orchestration of `writeToSinkAndDoMetaSync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
