### PR TITLE
fix(flink): run mapGroupsByKey in dedicated fork join pool

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/common/HoodieFlinkEngineContext.java
@@ -245,11 +245,18 @@ public class HoodieFlinkEngineContext extends HoodieEngineContext {
                                                                                             boolean preservesPartitioning) {
     // Group values by key and apply the function to each group in parallel
     List<Iterable<V>> groupedValues = data.groupByKey().values().collectAsList();
+    if (groupedValues.isEmpty()) {
+      return HoodieListData.eager(Collections.emptyList());
+    }
+
     // Process each group in parallel using parallel stream
     List<R> results = executeParallelStream(
         groupedValues.parallelStream(),
-        stream -> stream.map(values -> throwingMapWrapper(processFunc).apply(new ClosableSortingIterator<>(values.iterator()))),
-        groupedValues.size()).flatMap(CollectionUtils::toStream).collect(Collectors.toList());
+        stream -> stream
+            .map(values -> throwingMapWrapper(processFunc).apply(new ClosableSortingIterator<>(values.iterator())))
+            .flatMap(CollectionUtils::toStream)
+            .collect(Collectors.toList()),
+        groupedValues.size());
     return HoodieListData.eager(results);
   }
 

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/common/TestHoodieFlinkEngineContext.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/common/TestHoodieFlinkEngineContext.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.data.HoodieListPairData;
 import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -107,13 +109,20 @@ public class TestHoodieFlinkEngineContext {
     AtomicBoolean executedOutsideForkJoinPool = new AtomicBoolean(false);
 
     HoodieData<Integer> result = context.mapGroupsByKey(input, values -> {
-      ForkJoinPool executingPool = ForkJoinTask.getPool();
-      if (executingPool == null) {
-        executedOutsideForkJoinPool.set(true);
-      } else {
-        executingPools.add(executingPool);
-      }
-      return values;
+      recordExecutingPool(executingPools, executedOutsideForkJoinPool);
+      return new Iterator<Integer>() {
+        @Override
+        public boolean hasNext() {
+          recordExecutingPool(executingPools, executedOutsideForkJoinPool);
+          return values.hasNext();
+        }
+
+        @Override
+        public Integer next() {
+          recordExecutingPool(executingPools, executedOutsideForkJoinPool);
+          return values.next();
+        }
+      };
     }, Arrays.asList(1, 2, 3), false);
 
     Assertions.assertFalse(executedOutsideForkJoinPool.get());
@@ -133,6 +142,35 @@ public class TestHoodieFlinkEngineContext {
         input, values -> values, Collections.emptyList(), false);
 
     Assertions.assertTrue(result.collectAsList().isEmpty());
+  }
+
+  @Test
+  public void testMapGroupsByKeyWrapsProcessFunctionFailure() {
+    HoodiePairData<Integer, Integer> input = HoodieListPairData.eager(
+        Collections.singletonList(Pair.of(1, 1)));
+    IllegalStateException originalFailure = new IllegalStateException("process function failure");
+
+    HoodieException failure = Assertions.assertThrows(HoodieException.class, () ->
+        context.mapGroupsByKey(input, values -> {
+          throw originalFailure;
+        }, Collections.singletonList(1), false));
+
+    Assertions.assertEquals("Failed to execute parallel stream with dedicated ForkJoinPool.", failure.getMessage());
+    Throwable rootCause = failure;
+    while (rootCause.getCause() != null) {
+      rootCause = rootCause.getCause();
+    }
+    Assertions.assertSame(originalFailure, rootCause);
+  }
+
+  private static void recordExecutingPool(Set<ForkJoinPool> executingPools,
+                                          AtomicBoolean executedOutsideForkJoinPool) {
+    ForkJoinPool executingPool = ForkJoinTask.getPool();
+    if (executingPool == null) {
+      executedOutsideForkJoinPool.set(true);
+    } else {
+      executingPools.add(executingPool);
+    }
   }
 
 }

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/common/TestHoodieFlinkEngineContext.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/common/TestHoodieFlinkEngineContext.java
@@ -18,7 +18,11 @@
 
 package org.apache.hudi.client.common;
 
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodieListPairData;
+import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.util.collection.ImmutablePair;
+import org.apache.hudi.common.util.collection.Pair;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,8 +31,14 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Unit test against HoodieFlinkEngineContext.
@@ -87,6 +97,42 @@ public class TestHoodieFlinkEngineContext {
     }, 2);
 
     Assertions.assertEquals(resultMap.get("spark"), resultMap.get("flink"));
+  }
+
+  @Test
+  public void testMapGroupsByKeyUsesDedicatedForkJoinPool() {
+    HoodiePairData<Integer, Integer> input = HoodieListPairData.eager(Arrays.asList(
+        Pair.of(1, 3), Pair.of(1, 1), Pair.of(2, 4), Pair.of(2, 2), Pair.of(3, 5)));
+    Set<ForkJoinPool> executingPools = ConcurrentHashMap.newKeySet();
+    AtomicBoolean executedOutsideForkJoinPool = new AtomicBoolean(false);
+
+    HoodieData<Integer> result = context.mapGroupsByKey(input, values -> {
+      ForkJoinPool executingPool = ForkJoinTask.getPool();
+      if (executingPool == null) {
+        executedOutsideForkJoinPool.set(true);
+      } else {
+        executingPools.add(executingPool);
+      }
+      return values;
+    }, Arrays.asList(1, 2, 3), false);
+
+    Assertions.assertFalse(executedOutsideForkJoinPool.get());
+    Assertions.assertEquals(1, executingPools.size());
+    Assertions.assertNotSame(ForkJoinPool.commonPool(), executingPools.iterator().next());
+    Assertions.assertEquals(3, executingPools.iterator().next().getParallelism());
+    List<Integer> actual = result.collectAsList();
+    Collections.sort(actual);
+    Assertions.assertEquals(Arrays.asList(1, 2, 3, 4, 5), actual);
+  }
+
+  @Test
+  public void testMapGroupsByKeyWithEmptyInput() {
+    HoodiePairData<Integer, Integer> input = HoodieListPairData.eager(Collections.emptyList());
+
+    HoodieData<Integer> result = context.mapGroupsByKey(
+        input, values -> values, Collections.emptyList(), false);
+
+    Assertions.assertTrue(result.collectAsList().isEmpty());
   }
 
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19818.

`HoodieFlinkEngineContext#mapGroupsByKey` submitted only a lazy stream transformation to its dedicated `ForkJoinPool`. The terminal operation ran after the submitted task returned and the pool was shut down, so `processFunc` normally executed in the common pool instead of honoring the dedicated parallelism. Empty input also attempted to construct a pool with zero parallelism.

### Summary and Changelog

- Execute the complete grouped-map stream pipeline, including flattening and collection, inside the dedicated `ForkJoinPool`.
- Return empty `HoodieListData` directly when there are no groups.
- Add regression coverage for dedicated-pool execution and empty input.

### Impact

Flink grouped-map processing now uses the intended isolated pool rather than contending with unrelated common-pool work. There are no public API or configuration changes.

### Risk Level

Low. The change only moves the existing terminal stream operations into the already-intended execution scope and adds an empty-input guard. Targeted unit tests verify the pool identity, configured parallelism, results, and empty-input behavior.

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
