### PR TITLE
fix(spark): honor plan-time OPTION_RETURNING_BATCH in legacy parquet …

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLegacyParquetReadPath.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLegacyParquetReadPath.scala
@@ -44,6 +44,11 @@ private case class LegacyTestRow(id: String,
                                  nested: LegacyNested,
                                  tags: Seq[Int])
 
+/** Flat, all-atomic-type row shape, used where a nested schema (see [[LegacyTestRow]]) is not
+ * needed. Must stay top-level: a case class local to a method has no TypeTag, and
+ * `spark.createDataFrame` needs one. */
+private case class FlatTestRow(id: String, name: String, partition: String)
+
 /**
  * Functional tests for the legacy (pre-file-group-reader) Spark read path:
  * [[BaseFileOnlyRelation]], [[IncrementalRelationV1]], [[IncrementalRelationV2]] and the
@@ -305,7 +310,6 @@ class TestLegacyParquetReadPath extends HoodieSparkClientTestBase with ScalaAsse
   def testBroadcastJoinHonorsPlanTimeBatchingDecision(): Unit = {
     // Regression test: broadcast joins used to crash with a ColumnarBatch/InternalRow cast error
     // once whole-stage codegen was off, because the reader ignored the plan's OPTION_RETURNING_BATCH.
-    case class FlatTestRow(id: String, name: String, partition: String)
     spark.createDataFrame(Seq(FlatTestRow("1", "a", "p0"), FlatTestRow("2", "b", "p0")))
       .write.format("hudi")
       .options(Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLegacyParquetReadPath.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLegacyParquetReadPath.scala
@@ -26,7 +26,7 @@ import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
 
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
-import org.apache.spark.sql.functions.{col, lit, struct}
+import org.apache.spark.sql.functions.{broadcast, col, lit, struct}
 import org.apache.spark.sql.types.{IntegerType, LongType}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
@@ -298,6 +298,40 @@ class TestLegacyParquetReadPath extends HoodieSparkClientTestBase with ScalaAsse
       assertSameRows(newReaderDf, legacyRelationDf())
     } finally {
       spark.conf.set(vectorizedKey, previous)
+    }
+  }
+
+  @Test
+  def testBroadcastJoinHonorsPlanTimeBatchingDecision(): Unit = {
+    // Regression test: broadcast joins used to crash with a ColumnarBatch/InternalRow cast error
+    // once whole-stage codegen was off, because the reader ignored the plan's OPTION_RETURNING_BATCH.
+    case class FlatTestRow(id: String, name: String, partition: String)
+    spark.createDataFrame(Seq(FlatTestRow("1", "a", "p0"), FlatTestRow("2", "b", "p0")))
+      .write.format("hudi")
+      .options(Map(
+        DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+        DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+        DataSourceWriteOptions.TABLE_TYPE.key -> DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL,
+        DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key -> "true",
+        HoodieWriteConfig.TBL_NAME.key -> "legacy_read_path_tbl"))
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    assertTrue(legacyFormatSupportsBatch,
+      "Flat all-atomic-type schema must support the vectorized reader on its own")
+
+    val wholeStageKey = "spark.sql.codegen.wholeStage"
+    val previous = spark.conf.get(wholeStageKey, "true")
+    spark.conf.set(wholeStageKey, "false")
+    try {
+      val small = legacyFileFormatDf()
+      val big = spark.range(2).toDF("n")
+      // Must not throw ClassCastException: ColumnarBatch cannot be cast to InternalRow.
+      val joined = big.join(broadcast(small), col("n") === col("id").cast("long"), "left")
+      assertEquals(2L, joined.count())
+    } finally {
+      spark.conf.set(wholeStageKey, previous)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark3LegacyHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark3LegacyHoodieParquetFileFormat.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, JoinedRow}
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.execution.datasources.{DataSourceUtils, PartitionedFile, RecordReaderIterator}
+import org.apache.spark.sql.execution.datasources.{DataSourceUtils, FileFormat, PartitionedFile, RecordReaderIterator}
 import org.apache.spark.sql.execution.datasources.parquet.Spark3LegacyHoodieParquetFileFormat._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources._
@@ -171,7 +171,11 @@ abstract class Spark3LegacyHoodieParquetFileFormat(shouldAppendPartitionValues: 
     val int96RebaseModeInRead = parquetOptions.int96RebaseModeInRead
     val timeZoneId = Option(sqlConf.sessionLocalTimeZone)
     // Whole stage codegen (PhysicalRDD) is able to deal with batches directly.
-    val returningBatch = getReturningBatch(sparkSession, resultSchema)
+    // Respect the plan-time OPTION_RETURNING_BATCH decision when present, instead of recomputing it here.
+    val returningBatch = enableVectorizedReader &&
+      options.get(FileFormat.OPTION_RETURNING_BATCH)
+        .map(_.equals("true"))
+        .getOrElse(getReturningBatch(sparkSession, resultSchema))
 
     (file: PartitionedFile) => {
       assert(!shouldAppendPartitionValues || file.partitionValues.numFields == partitionSchema.size)


### PR DESCRIPTION
### Describe the issue this Pull Request addresses                                                                                                                                                             
                                                                                                                                                                                                                 
  Hudi's legacy (pre-file-group-reader) Spark Parquet file format                                                                                                                                                
  (`Spark3LegacyHoodieParquetFileFormat` and its per-Spark-version subclasses)                                                                                                                                   
  decides whether to hand back `ColumnarBatch` or row-based `InternalRow`                                                                                                                                        
  objects by recomputing `supportBatch(schema)` itself, ignoring                                                                                                                                                 
  `FileFormat.OPTION_RETURNING_BATCH` — the option `FileSourceScanExec`                                                                                                                                          
  already threads down with the batching decision it made at plan time (and                                                                                                                                      
  which vanilla Spark's own `ParquetFileFormat` does honor).                                                                                                                                                     
                                                                                                                                                                                                                 
  The two answers disagree whenever `FileSourceScanExec.supportsColumnar`                                                                                                                                        
  depends on something `supportBatch` alone does not account for — most                                                                                                                                          
  commonly, `spark.sql.codegen.wholeStage` being disabled for the query (or                                                                                                                                      
  another operator's schema tripping `spark.sql.codegen.maxFields`). In that                                                                                                                                     
  case the planner marks the scan row-based ("Batched: false" in `explain`),                                                                                                                                     
  but the reader still returns `ColumnarBatch` objects. Any consumer that                                                                                                                                        
  reads the RDD as rows — most visibly `BroadcastExchangeExec`'s collection                                                                                                                                      
  path — then fails with:                                                                                                                                                                                        
                                                                                                                                                                                                                 
  java.lang.ClassCastException: class org.apache.spark.sql.vectorized.ColumnarBatch                                                                                                                              
  cannot be cast to class org.apache.spark.sql.catalyst.InternalRow                                                                                                                                              
                                                                                                                                                                                                                 
  Closes #19817   
  
### Summary and Changelog                                                                                                                                                                                      
                                                                                                                                                                                                                 
  Reading a Hudi table through the legacy Parquet read path inside a query                                                                                                                                       
  with whole-stage codegen disabled (e.g. because it exceeds                                                                                                                                                     
  `spark.sql.codegen.maxFields`, or has it turned off explicitly) could throw                                                                                                                                    
  a `ClassCastException` during execution, most commonly during a broadcast                                                                                                                                      
  join. This fixes it by making the reader honor                                                                                                                                                                 
  `FileFormat.OPTION_RETURNING_BATCH` when the plan supplies it, falling back                                                                                                                                    
  to the existing `supportBatch`-based computation only when the option is                                                                                                                                       
  absent.                                                                                                                                                                                                        
                                                                                                                                                                                                                 
  - `Spark3LegacyHoodieParquetFileFormat.buildReaderWithPartitionValues`: read                                                                                                                                   
    `options.get(FileFormat.OPTION_RETURNING_BATCH)` first, matching the                                                                                                                                         
    precedent already set by Spark's own `ParquetFileFormat`.                                                                                                                                                    
  - Added `TestLegacyParquetReadPath#testBroadcastJoinHonorsPlanTimeBatchingDecision`,                                                                                                                           
    a regression test that writes a flat, all-atomic-type COW table (so                                                                                                                                          
    `supportBatch` alone would trivially say yes), disables                                                                                                                                                      
    `spark.sql.codegen.wholeStage`, and broadcast-joins the legacy-format                                                                                                                                        
    DataFrame — reproducing the exact crash and asserting it no longer occurs.                                                                                                                                   
                                                                                                                                                                                                                 
  No code was copied from elsewhere; the fix mirrors the existing                                                                                                                                                
  `OPTION_RETURNING_BATCH` handling already present in Spark's own                                                                                                                                               
  `ParquetFileFormat`.

### Impact                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  None to any public API, config, or storage format. Behavior-only fix to the                                                                                                                                    
  legacy Parquet read path, and only in the previously-broken case (whole-stage                                                                                                                                  
  codegen disabled or a wide-schema query alongside this scan). No change to                                                                                                                                     
  the common case where whole-stage codegen is enabled.                                                                                                                                                          
                                                                                                                                                                                                                 
### Risk Level                                                                                                                                                                                                 
                                                                                                                                                                                                                 
  low — the change is a single, narrowly-scoped computation gated behind a                                                                                                                                       
  Spark-supplied option key that is already part of Spark's public                                                                                                                                               
  `FileFormat` API, follows the exact precedent of vanilla Spark's own                                                                                                                                           
  `ParquetFileFormat`, and is covered by a new regression test reproducing the                                                                                                                                   
  originally-reported crash.                                                                                                                                                                                     
                                                                                                                                                                                                                 
  ### Documentation Update                                                                                                                                                                                       
                                                                                                                                                                                                                 
  none — internal bug fix, no new config, feature, or user-facing behavior                                                                                                                                       
  change.                                                                                                                                                                                                        
                                                                                                                                                                                                                 
  ### Contributor's checklist                                                                                                                                                                                    
                                                                                                                                                                                                                 
  - [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)                                                                                                                 
  - [x] Enough context is provided in the sections above                                                                                                                                                         
  - [x] Adequate tests were added if applicable