### PR TITLE
fix(tests): reach TFramedTransport at the package libthrift 0.14 moved it to

### DIFF
--- a/hudi-sync/hudi-hive-sync/pom.xml
+++ b/hudi-sync/hudi-hive-sync/pom.xml
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-      <version>${thrift.version}</version>
+      <version>${hive.libthrift.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestService.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestService.java
@@ -40,13 +40,13 @@ import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TServer;
 import org.apache.thrift.server.TThreadPoolServer;
-import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TServerTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.TTransportFactory;
+import org.apache.thrift.transport.layered.TFramedTransport;
 
 import java.io.File;
 import java.io.IOException;

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -601,7 +601,7 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-      <version>${thrift.version}</version>
+      <version>${hive.libthrift.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19829

### Summary and Changelog

`HiveTestService` imports `TFramedTransport` from the package libthrift moved it out of in 0.14, while its `TServerSocketKeepAlive` overrides `TServerTransport.accept()`, which is `final` below 0.14. No single libthrift version satisfies both, and no method is overridable across both generations.

Points the import at `org.apache.thrift.transport.layered.TFramedTransport`, and moves the `libthrift` test dependency in `hudi-hive-sync` and `hudi-utilities` from `${thrift.version}` (0.13.0, which the metaserver needs) to the existing `${hive.libthrift.version}` (0.14.1), which already models the thrift the Hive client is compiled against.

### Impact

No production code changes; `libthrift` stays test scope so no bundle changes. `hudi-hive-sync` and `hudi-utilities` carry the full `hive-exec`, which already resolves a 0.14-era transport package, so behaviour there is unchanged (CI ran `TestHiveSyncTool` and `TestHoodieDeltaStreamer`, both start `HiveTestService`).

The in-repo consumer this fixes is `hudi-integ-test`: its main class `HiveServiceProvider` instantiates `HiveTestService` on a classpath with `hive-exec:core` and libthrift 0.14.1 as the only thrift provider, so on master the class cannot link there at all (no old-path `TFramedTransport` exists anywhere on that classpath). This is masked today only because `TestHoodieTestSuiteJob` is `@Disabled` (HUDI-3668) and `TestExpressionIndex`'s hive-sync branch is guarded to Java 8. `hudi-spark`'s test classpath is in the same situation.

### Risk Level

low

`ChainedTTransportFactory.getTransport` already declares the `TTransportException` that 0.14 adds to `TTransportFactory.getTransport`, so no call site changes. `hudi-hive-sync` and `hudi-utilities` both `test-compile` cleanly on JDK 11.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable

