### PR TITLE
fix(schema): stop union walks looping forever

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -199,8 +199,12 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
       case st: StructType =>
         val childNameSpace = if (nameSpace != "") s"$nameSpace.$recordName" else recordName
 
-        // Check if this might be a union (using heuristic like Avro converter)
-        if (canBeUnion(st)) {
+        // Check if this might be a union (using heuristic like Avro converter). The root struct is
+        // never one: it is the row, so a projection whose columns are all nullable and named
+        // member0..memberN would otherwise convert to a union, which pruneDataSchema keeps whole --
+        // handing the reader the entire table schema -- or which Avro rejects outright once two of
+        // those columns share a type ("Duplicate in union").
+        if (depth > 0 && canBeUnion(st)) {
           val nonNullUnionFieldTypes = st.map { f =>
             toHoodieTypeNested(f.dataType, nullable = false, f.name, childNameSpace, f.metadata, depth + 1)
           }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/SparkSchemaTransformUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/SparkSchemaTransformUtils.scala
@@ -22,7 +22,7 @@ package org.apache.spark.sql.execution.datasources
 import org.apache.hudi.HoodieSparkUtils
 import org.apache.spark.sql.HoodieSchemaUtils
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
-import org.apache.spark.sql.catalyst.expressions.{ArrayTransform, Attribute, AttributeReference, Cast, CreateNamedStruct, CreateStruct, Expression, GetStructField, LambdaFunction, Literal, MapEntries, MapFromEntries, NamedLambdaVariable, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.{ArrayTransform, Attribute, AttributeReference, Cast, CreateNamedStruct, CreateStruct, Expression, GetStructField, If, IsNull, LambdaFunction, Literal, MapEntries, MapFromEntries, NamedLambdaVariable, UnsafeProjection}
 import org.apache.spark.sql.types.{ArrayType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, StringType, StructField, StructType, TimestampNTZType}
 
 import scala.util.Try
@@ -33,6 +33,8 @@ import scala.util.Try
  *
  * These utilities are used by file format readers that need to:
  * - Pad missing columns with NULL literals (required for Lance)
+ * - Drop nested fields the reader returns but the scan did not ask for (unions, BLOB and VARIANT are
+ *   read whole)
  * - Handle nested struct/array/map type conversions
  * - Work around Spark unsafe cast issues (float->double, numeric->decimal)
  *
@@ -162,6 +164,92 @@ object SparkSchemaTransformUtils {
 
     case _ =>
       // No padding needed, return expression as-is
+      expr
+  }
+
+  /**
+   * Generate UnsafeProjection that narrows nested structs down to the fields the target names, matched
+   * by name at every depth. The counterpart of [[generateNullPaddingProjection]] for input that is wider
+   * than the target rather than narrower: the file group reader hands back a union (a member0..memberN
+   * struct on the Spark side), a BLOB and a VARIANT whole because pruneDataSchema cannot prune their
+   * inner fields, while Spark's nested schema pruning may have asked for only some of them.
+   *
+   * @param inputSchema Schema of the rows the reader emits
+   * @param targetSchema Schema the scan has to produce (a subset of inputSchema at every depth)
+   * @return UnsafeProjection that drops the nested fields the target does not name
+   */
+  def generateNestedPruningProjection(inputSchema: StructType, targetSchema: StructType): UnsafeProjection = {
+    val inputAttributes = inputSchema.fields.map(f => AttributeReference(f.name, f.dataType, f.nullable)())
+    val inputFieldMap = inputAttributes.map(a => a.name -> a).toMap
+    val expressions = targetSchema.fields.map { field =>
+      val attr = inputFieldMap(field.name)
+      recursivelyPruneExpression(attr, attr.dataType, field.dataType)
+    }
+    GenerateUnsafeProjection.generate(expressions, inputAttributes)
+  }
+
+  /**
+   * Used to determine if [[generateNestedPruningProjection]] has anything to drop.
+   *
+   * @param readType Type of the value the reader emits
+   * @param requestedType Type the scan has to produce
+   * @return true if readType names a struct field, at any depth, that requestedType does not
+   */
+  def needsNestedPruning(readType: DataType, requestedType: DataType): Boolean = (readType, requestedType) match {
+    case (readStruct: StructType, requestedStruct: StructType) =>
+      readStruct.fields.exists(f => requestedStruct.getFieldIndex(f.name).isEmpty) ||
+        requestedStruct.fields.exists { requestedField =>
+          readStruct.getFieldIndex(requestedField.name)
+            .exists(i => needsNestedPruning(readStruct.fields(i).dataType, requestedField.dataType))
+        }
+    case (ArrayType(readElem, _), ArrayType(requestedElem, _)) =>
+      needsNestedPruning(readElem, requestedElem)
+    case (MapType(readKey, readVal, _), MapType(requestedKey, requestedVal, _)) =>
+      needsNestedPruning(readKey, requestedKey) || needsNestedPruning(readVal, requestedVal)
+    case _ => false
+  }
+
+  /**
+   * Recursively rebuild nested struct/array/map values with only the fields the destination names.
+   *
+   * @param expr Source expression
+   * @param srcType Source data type (may have additional nested fields)
+   * @param dstType Destination data type
+   * @return Expression carrying only the nested fields the destination names
+   */
+  private def recursivelyPruneExpression(
+      expr: Expression,
+      srcType: DataType,
+      dstType: DataType
+  ): Expression = (srcType, dstType) match {
+    case (s: StructType, d: StructType) if needsNestedPruning(s, d) =>
+      val children = d.fields.toSeq.flatMap { dstField =>
+        val srcIndex = s.fieldIndex(dstField.name)
+        val child = GetStructField(expr, srcIndex, Some(dstField.name))
+        Seq(Literal(dstField.name), recursivelyPruneExpression(child, s.fields(srcIndex).dataType, dstField.dataType))
+      }
+      val pruned = CreateNamedStruct(children)
+      // CreateNamedStruct is never null, so without this guard a null struct comes back as a struct of nulls
+      If(IsNull(expr), Literal(null, pruned.dataType), pruned)
+
+    case (ArrayType(sElementType, containsNull), ArrayType(dElementType, _))
+        if needsNestedPruning(sElementType, dElementType) =>
+      val lambdaVar = NamedLambdaVariable("element", sElementType, containsNull)
+      val body = recursivelyPruneExpression(lambdaVar, sElementType, dElementType)
+      ArrayTransform(expr, LambdaFunction(body, Seq(lambdaVar)))
+
+    case (MapType(sKeyType, sValType, vnull), MapType(dKeyType, dValType, _))
+        if needsNestedPruning(sKeyType, dKeyType) || needsNestedPruning(sValType, dValType) =>
+      val kv = NamedLambdaVariable("kv", new StructType()
+        .add("key", sKeyType, nullable = false)
+        .add("value", sValType, nullable = vnull), nullable = false)
+      val newKey = recursivelyPruneExpression(GetStructField(kv, 0), sKeyType, dKeyType)
+      val newVal = recursivelyPruneExpression(GetStructField(kv, 1), sValType, dValType)
+      val entry = CreateStruct(Seq(newKey, newVal))
+      MapFromEntries(ArrayTransform(MapEntries(expr), LambdaFunction(entry, Seq(kv))))
+
+    case _ =>
+      // Nothing below this point is wider than requested
       expr
   }
 

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/SparkSchemaTransformUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/SparkSchemaTransformUtils.scala
@@ -238,11 +238,11 @@ object SparkSchemaTransformUtils {
       val body = recursivelyPruneExpression(lambdaVar, sElementType, dElementType)
       ArrayTransform(expr, LambdaFunction(body, Seq(lambdaVar)))
 
-    case (MapType(sKeyType, sValType, vnull), MapType(dKeyType, dValType, _))
+    case (MapType(sKeyType, sValType, valueContainsNull), MapType(dKeyType, dValType, _))
         if needsNestedPruning(sKeyType, dKeyType) || needsNestedPruning(sValType, dValType) =>
       val kv = NamedLambdaVariable("kv", new StructType()
         .add("key", sKeyType, nullable = false)
-        .add("value", sValType, nullable = vnull), nullable = false)
+        .add("value", sValType, nullable = valueContainsNull), nullable = false)
       val newKey = recursivelyPruneExpression(GetStructField(kv, 0), sKeyType, dKeyType)
       val newVal = recursivelyPruneExpression(GetStructField(kv, 1), sValType, dValType)
       val entry = CreateStruct(Seq(newKey, newVal))

--- a/hudi-client/hudi-spark-client/src/test/scala/org/apache/spark/sql/execution/datasources/TestSparkSchemaTransformUtils.scala
+++ b/hudi-client/hudi-spark-client/src/test/scala/org/apache/spark/sql/execution/datasources/TestSparkSchemaTransformUtils.scala
@@ -266,6 +266,92 @@ class TestSparkSchemaTransformUtils {
   }
 
   @Test
+  def testGenerateNestedPruningProjection_nestedStructNarrowedByName(): Unit = {
+    // Input: (id: int, choice: struct<member0: string, member1: int, member2: long>), the member struct a
+    // union comes back as from the reader
+    val inputSchema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("choice", StructType(Seq(
+        StructField("member0", StringType, nullable = true),
+        StructField("member1", IntegerType, nullable = true),
+        StructField("member2", LongType, nullable = true)
+      )), nullable = true)
+    ))
+
+    // Target keeps the last two members only, so a positional read of the struct would be off by one
+    val targetSchema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("choice", StructType(Seq(
+        StructField("member1", IntegerType, nullable = true),
+        StructField("member2", LongType, nullable = true)
+      )), nullable = true)
+    ))
+
+    assertTrue(SparkSchemaTransformUtils.needsNestedPruning(inputSchema, targetSchema))
+    // The other direction is padding, not pruning
+    assertFalse(SparkSchemaTransformUtils.needsNestedPruning(targetSchema, inputSchema))
+
+    val projection = SparkSchemaTransformUtils.generateNestedPruningProjection(inputSchema, targetSchema)
+
+    val outputRow = projection.apply(new GenericInternalRow(Array[Any](
+      1,
+      new GenericInternalRow(Array[Any](UTF8String.fromString("a1"), 7, 100L))
+    )))
+    assertEquals(2, outputRow.numFields)
+    assertEquals(1, outputRow.getInt(0))
+    val choice = outputRow.getStruct(1, 2)
+    assertEquals(7, choice.getInt(0))
+    assertEquals(100L, choice.getLong(1))
+
+    // A null struct stays null instead of coming back as a struct of nulls
+    val nullRow = projection.apply(new GenericInternalRow(Array[Any](2, null)))
+    assertTrue(nullRow.isNullAt(1), "choice should stay NULL")
+  }
+
+  @Test
+  def testGenerateNestedPruningProjection_arrayAndMapOfStructs(): Unit = {
+    val wideElement = StructType(Seq(
+      StructField("k", StringType, nullable = true),
+      StructField("v", StringType, nullable = true)
+    ))
+    val narrowElement = StructType(Seq(StructField("v", StringType, nullable = true)))
+    val inputSchema = StructType(Seq(
+      StructField("tags", ArrayType(wideElement, containsNull = true), nullable = true),
+      StructField("props", MapType(StringType, wideElement, valueContainsNull = true), nullable = true)
+    ))
+    val targetSchema = StructType(Seq(
+      StructField("tags", ArrayType(narrowElement, containsNull = true), nullable = true),
+      StructField("props", MapType(StringType, narrowElement, valueContainsNull = true), nullable = true)
+    ))
+
+    assertTrue(SparkSchemaTransformUtils.needsNestedPruning(inputSchema, targetSchema))
+    val projection = SparkSchemaTransformUtils.generateNestedPruningProjection(inputSchema, targetSchema)
+
+    val element = new GenericInternalRow(Array[Any](UTF8String.fromString("k0"), UTF8String.fromString("v0")))
+    val outputRow = projection.apply(new GenericInternalRow(Array[Any](
+      ArrayData.toArrayData(Array[Any](element)),
+      new ArrayBasedMapData(ArrayData.toArrayData(Array[Any](UTF8String.fromString("m0"))), ArrayData.toArrayData(Array[Any](element)))
+    )))
+
+    val tags = outputRow.getArray(0)
+    assertEquals(1, tags.numElements())
+    assertEquals(UTF8String.fromString("v0"), tags.getStruct(0, 1).getUTF8String(0))
+    val props = outputRow.getMap(1)
+    assertEquals(UTF8String.fromString("m0"), props.keyArray().getUTF8String(0))
+    assertEquals(UTF8String.fromString("v0"), props.valueArray().getStruct(0, 1).getUTF8String(0))
+  }
+
+  @Test
+  def testNeedsNestedPruning_ignoresNullabilityAndLeafTypes(): Unit = {
+    val readType = StructType(Seq(StructField("x", IntegerType, nullable = true)))
+    val requestedType = StructType(Seq(StructField("x", IntegerType, nullable = false)))
+    assertFalse(SparkSchemaTransformUtils.needsNestedPruning(readType, requestedType))
+    assertFalse(SparkSchemaTransformUtils.needsNestedPruning(ArrayType(readType), ArrayType(requestedType)))
+    assertFalse(SparkSchemaTransformUtils.needsNestedPruning(StringType, StringType))
+    assertFalse(SparkSchemaTransformUtils.needsNestedPruning(readType, StringType))
+  }
+
+  @Test
   def testFilterSchemaByFileSchema_allFieldsPresent(): Unit = {
     // Both schemas have (id, name, age)
     val requestedSchema = StructType(Seq(

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
@@ -1379,9 +1379,13 @@ public class HoodieSchema implements Serializable {
   }
 
   /**
-   * If this is a union schema, returns the non-null type. Otherwise, returns this schema.
+   * Strips the null branch from a nullable union. For {@code ["null", T]} (in either order) this returns
+   * {@code T}. For a union with two or more non-null branches it returns a union of just those branches,
+   * or this schema when there is no null branch to strip, so the result can itself be a UNION. Callers
+   * that recurse on the result must check for that, or they will recurse forever. Non-union schemas are
+   * returned as-is.
    *
-   * @return the non-null schema from a union or the current schema
+   * @return the non-null schema from a nullable union, a union of the non-null branches, or this schema
    */
   public HoodieSchema getNonNullType() {
     if (type != HoodieSchemaType.UNION) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
@@ -1379,13 +1379,28 @@ public class HoodieSchema implements Serializable {
   }
 
   /**
-   * Strips the null branch from a nullable union. For {@code ["null", T]} (in either order) this returns
-   * {@code T}. For a union with two or more non-null branches it returns a union of just those branches,
-   * or this schema when there is no null branch to strip, so the result can itself be a UNION. Callers
-   * that recurse on the result must check for that, or they will recurse forever. Non-union schemas are
-   * returned as-is.
+   * Whether this is a union other than the nullable wrapper of a single type: two or more non-null
+   * branches ({@code [A, B]}, {@code ["null", A, B]}), a lone branch with no null ({@code [T]}), or null
+   * alone ({@code ["null"]}). {@link #getNonNullType()} cannot reduce such a union to one non-null type,
+   * so walkers that need one check this before recursing on it.
+   *
+   * @return true if this is a union with anything other than exactly one null and one non-null branch
+   */
+  public boolean isComplexUnion() {
+    return type == HoodieSchemaType.UNION && !(avroSchema.getTypes().size() == 2 && isNullable());
+  }
+
+  /**
+   * Strips the null branch from a union. {@code ["null", T]} (in either order) yields {@code T}. A union
+   * with two or more non-null branches yields a union of just those branches (this schema itself when
+   * there was no null branch to strip), so the result can still be a UNION. A lone-branch union
+   * {@code [T]} is returned as-is, still a UNION. {@code ["null"]} has nothing left once the null is
+   * stripped and throws. Callers that need one non-null type out of a union check
+   * {@link #isComplexUnion()} first: recursing on this result without it never terminates. Non-union
+   * schemas are returned as-is.
    *
    * @return the non-null schema from a nullable union, a union of the non-null branches, or this schema
+   * @throws IllegalArgumentException if this is the union {@code ["null"]}
    */
   public HoodieSchema getNonNullType() {
     if (type != HoodieSchemaType.UNION) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaRepair.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaRepair.java
@@ -246,7 +246,7 @@ public class HoodieSchemaRepair {
         return hasTimestampMillisField(tableSchema.getValueType());
 
       case UNION:
-        return hasTimestampMillisField(tableSchema.getNonNullType());
+        return tableSchema.getTypes().stream().anyMatch(HoodieSchemaRepair::hasTimestampMillisField);
 
       case TIMESTAMP:
         HoodieSchema.Timestamp timestampType = (HoodieSchema.Timestamp) tableSchema;

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -662,7 +662,12 @@ public final class HoodieSchemaUtils {
 
   private static Option<HoodieSchemaField> findNestedField(HoodieSchema schema, String[] fieldParts, int index) {
     if (schema.getType() == HoodieSchemaType.UNION) {
-      Option<HoodieSchemaField> notUnion = findNestedField(schema.getNonNullType(), fieldParts, index);
+      HoodieSchema nonNullSchema = schema.getNonNullType();
+      if (nonNullSchema.getType() == HoodieSchemaType.UNION) {
+        // A union with two or more non-null branches has no single record to descend into
+        return Option.empty();
+      }
+      Option<HoodieSchemaField> notUnion = findNestedField(nonNullSchema, fieldParts, index);
       if (!notUnion.isPresent()) {
         return Option.empty();
       }
@@ -800,6 +805,13 @@ public final class HoodieSchemaUtils {
     return "hoodie." + sanitizedTableName + "." + sanitizedTableName + "_record";
   }
 
+  /**
+   * Checks whether the schema is, or nests, a DECIMAL at any depth, descending through records, arrays,
+   * maps and every branch of a union.
+   *
+   * @param schema the schema to search
+   * @return true if a decimal type is found anywhere in the schema
+   */
   public static boolean hasDecimalField(HoodieSchema schema) {
     switch (schema.getType()) {
       case RECORD:
@@ -814,7 +826,7 @@ public final class HoodieSchemaUtils {
       case MAP:
         return hasDecimalField(schema.getValueType());
       case UNION:
-        return hasDecimalField(schema.getNonNullType());
+        return schema.getTypes().stream().anyMatch(HoodieSchemaUtils::hasDecimalField);
       case DECIMAL:
         return true;
       default:

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -574,7 +574,12 @@ public final class HoodieSchemaUtils {
         return HoodieSchema.createMap(pruneDataSchema(dataSchema.getValueType(), requiredSchema.getValueType(), Collections.emptySet()));
 
       case UNION:
-        throw new IllegalArgumentException("Data schema is a union");
+        // A union is a leaf as far as pruning goes: Avro resolves a branch by its type, so dropping a
+        // branch changes the column's type instead of narrowing it. Hand back the data schema unpruned,
+        // which is what the default arm below already does when Spark projects a single member out of
+        // the member-struct encoding of a union. This also covers a plain record whose fields happen to
+        // be named member0..memberN, which HoodieSparkSchemaConverters reads back as a union.
+        return dataSchema;
 
       default:
         return dataSchema;

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -525,6 +525,18 @@ public final class HoodieSchemaUtils {
   }
 
   private static HoodieSchema pruneDataSchemaInternal(HoodieSchema dataSchema, HoodieSchema requiredSchema, Set<String> mandatoryFields) {
+    // A union is a leaf as far as pruning goes: Avro resolves a branch by its type, so dropping a branch
+    // changes the column's type instead of narrowing it. Hand the data schema back unpruned whichever
+    // side still holds a union once the null branch is stripped, and let the caller's projection drop
+    // what it did not ask for. Spark reads a union as a struct of nullable member0..memberN fields and
+    // its nested schema pruning can project a subset of those members, so the required schema comes back
+    // as a union when two or more members survive and as the surviving member's own type when one does:
+    // a record, array or map there belongs to a branch and must not be matched against the data union.
+    // The reverse pairing is a plain record whose fields happen to be named member0..memberN, which
+    // HoodieSparkSchemaConverters also reads back as a union.
+    if (dataSchema.getType() == HoodieSchemaType.UNION || requiredSchema.getType() == HoodieSchemaType.UNION) {
+      return dataSchema;
+    }
     switch (requiredSchema.getType()) {
       case RECORD:
         // BLOB and VARIANT are represented as Avro RECORDs but carry a logical type
@@ -572,14 +584,6 @@ public final class HoodieSchemaUtils {
           throw new IllegalArgumentException("Data schema is not a map");
         }
         return HoodieSchema.createMap(pruneDataSchema(dataSchema.getValueType(), requiredSchema.getValueType(), Collections.emptySet()));
-
-      case UNION:
-        // A union is a leaf as far as pruning goes: Avro resolves a branch by its type, so dropping a
-        // branch changes the column's type instead of narrowing it. Hand back the data schema unpruned,
-        // which is what the default arm below already does when Spark projects a single member out of
-        // the member-struct encoding of a union. This also covers a plain record whose fields happen to
-        // be named member0..memberN, which HoodieSparkSchemaConverters reads back as a union.
-        return dataSchema;
 
       default:
         return dataSchema;

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -667,12 +667,11 @@ public final class HoodieSchemaUtils {
 
   private static Option<HoodieSchemaField> findNestedField(HoodieSchema schema, String[] fieldParts, int index) {
     if (schema.getType() == HoodieSchemaType.UNION) {
-      HoodieSchema nonNullSchema = schema.getNonNullType();
-      if (nonNullSchema.getType() == HoodieSchemaType.UNION) {
-        // A union with two or more non-null branches has no single record to descend into
+      if (schema.isComplexUnion()) {
+        // No single record to descend into
         return Option.empty();
       }
-      Option<HoodieSchemaField> notUnion = findNestedField(nonNullSchema, fieldParts, index);
+      Option<HoodieSchemaField> notUnion = findNestedField(schema.getNonNullType(), fieldParts, index);
       if (!notUnion.isPresent()) {
         return Option.empty();
       }
@@ -860,13 +859,12 @@ public final class HoodieSchemaUtils {
       return schema;
     }
 
-    List<HoodieSchema> innerTypes = schema.getTypes();
-    if (innerTypes.size() == 2 && schema.isNullable()) {
+    if (!schema.isComplexUnion()) {
       // this is a basic nullable field so handle it more efficiently
       return schema.getNonNullType();
     }
 
-    HoodieSchema nonNullType = innerTypes.stream()
+    HoodieSchema nonNullType = schema.getTypes().stream()
         .filter(it -> it.getType() != HoodieSchemaType.NULL && Objects.equals(it.getFullName(), fieldSchemaFullName))
         .findFirst()
         .orElse(null);

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/convert/InternalSchemaConverter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/convert/InternalSchemaConverter.java
@@ -130,7 +130,7 @@ public class InternalSchemaConverter {
         return;
 
       case UNION:
-        collectColNamesFromSchema(schema.getNonNullType(), visited, resultSet);
+        schema.getTypes().forEach(branch -> collectColNamesFromSchema(branch, visited, resultSet));
         return;
 
       case ARRAY:

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/convert/InternalSchemaConverter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/convert/InternalSchemaConverter.java
@@ -130,7 +130,17 @@ public class InternalSchemaConverter {
         return;
 
       case UNION:
-        schema.getTypes().forEach(branch -> collectColNamesFromSchema(branch, visited, resultSet));
+        // visitSchemaToBuildType keeps a single branch of a union -- the first one unless that is the
+        // null branch -- and drops the rest, so the internal schema only carries ids for that branch's
+        // leaves. Walk the same branch: naming a leaf of any other one makes pruneInternalSchema fail
+        // with "cannot prune col: x.y which does not exist in hudi table". A union branch is never
+        // itself a union, so this terminates where recursing on getNonNullType() did not (#19825).
+        for (HoodieSchema branch : schema.getTypes()) {
+          if (branch.getType() != HoodieSchemaType.NULL) {
+            collectColNamesFromSchema(branch, visited, resultSet);
+            break;
+          }
+        }
         return;
 
       case ARRAY:

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1382,7 +1382,12 @@ public class HoodieTableMetadataUtil {
     switch (schemaType) {
       case UNION:
         // TODO we need to handle unions in general case as well
-        return coerceToComparable(schema.getNonNullType(), val);
+        HoodieSchema nonNullSchema = schema.getNonNullType();
+        if (nonNullSchema.getType() == HoodieSchemaType.UNION) {
+          throw new HoodieNotSupportedException("Unsupported union type " + schema
+              + ": only a union of null and one non-null type is supported");
+        }
+        return coerceToComparable(nonNullSchema, val);
 
       case FIXED:
       case BYTES:

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1509,6 +1509,8 @@ public class HoodieTableMetadataUtil {
   }
 
   public static boolean isColumnTypeSupported(HoodieSchema schema, Option<HoodieRecordType> recordType, HoodieIndexVersion indexVersion) {
+    // getNonNullType() strips the null branch of a nullable column, so a UNION still standing after this
+    // is one with two or more non-null branches, which has no single value type to collect stats for.
     HoodieSchema schemaToCheck = schema.getNonNullType();
     if (indexVersion.lowerThan(HoodieIndexVersion.V2)) {
       return isColumnTypeSupportedV1(schemaToCheck, recordType);
@@ -1528,11 +1530,12 @@ public class HoodieTableMetadataUtil {
     }
 
     HoodieSchemaType type = schema.getType();
-    // if record type is set and if its AVRO, MAP, ARRAY, RECORD and ENUM types are unsupported.
+    // if record type is set and if its AVRO, MAP, ARRAY, RECORD, ENUM and multi-branch UNION types are unsupported.
     if (recordType.isPresent() && recordType.get() == HoodieRecordType.AVRO) {
       return (type != HoodieSchemaType.RECORD && type != HoodieSchemaType.ARRAY && type != HoodieSchemaType.MAP
           && type != HoodieSchemaType.ENUM && type != HoodieSchemaType.VARIANT
-          && type != HoodieSchemaType.BLOB && type != HoodieSchemaType.VECTOR);
+          && type != HoodieSchemaType.BLOB && type != HoodieSchemaType.VECTOR
+          && type != HoodieSchemaType.UNION);
     }
     // if record Type is not set or if recordType is SPARK then we cannot support AVRO, MAP, ARRAY, RECORD, ENUM and FIXED and BYTES type as well.
     // HUDI-8585 will add support for BYTES and FIXED
@@ -1541,7 +1544,8 @@ public class HoodieTableMetadataUtil {
         && type != HoodieSchemaType.DECIMAL // DECIMAL's underlying type is BYTES
         && type != HoodieSchemaType.BLOB
         && type != HoodieSchemaType.VECTOR
-        && type != HoodieSchemaType.VARIANT;
+        && type != HoodieSchemaType.VARIANT
+        && type != HoodieSchemaType.UNION;
   }
 
   private static boolean isColumnTypeSupportedV2(HoodieSchema schema) {
@@ -1553,7 +1557,7 @@ public class HoodieTableMetadataUtil {
     return type != HoodieSchemaType.RECORD && type != HoodieSchemaType.MAP
         && type != HoodieSchemaType.ARRAY && type != HoodieSchemaType.ENUM
         && type != HoodieSchemaType.BLOB && type != HoodieSchemaType.VECTOR
-        && type != HoodieSchemaType.VARIANT;
+        && type != HoodieSchemaType.VARIANT && type != HoodieSchemaType.UNION;
   }
 
   public static Set<String> getInflightMetadataPartitions(HoodieTableConfig tableConfig) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1382,12 +1382,11 @@ public class HoodieTableMetadataUtil {
     switch (schemaType) {
       case UNION:
         // TODO we need to handle unions in general case as well
-        HoodieSchema nonNullSchema = schema.getNonNullType();
-        if (nonNullSchema.getType() == HoodieSchemaType.UNION) {
-          throw new HoodieNotSupportedException("Unsupported union type " + schema
-              + ": only a union of null and one non-null type is supported");
+        if (schema.isComplexUnion()) {
+          throw new HoodieNotSupportedException(String.format(
+              "Unsupported UNION type %s: Only UNION of a null type and a non-null type is supported", schema));
         }
-        return coerceToComparable(nonNullSchema, val);
+        return coerceToComparable(schema.getNonNullType(), val);
 
       case FIXED:
       case BYTES:
@@ -1510,7 +1509,7 @@ public class HoodieTableMetadataUtil {
 
   public static boolean isColumnTypeSupported(HoodieSchema schema, Option<HoodieRecordType> recordType, HoodieIndexVersion indexVersion) {
     // getNonNullType() strips the null branch of a nullable column, so a UNION still standing after this
-    // is one with two or more non-null branches, which has no single value type to collect stats for.
+    // is a complex one (HoodieSchema#isComplexUnion), which has no single value type to collect stats for.
     HoodieSchema schemaToCheck = schema.getNonNullType();
     if (indexVersion.lowerThan(HoodieIndexVersion.V2)) {
       return isColumnTypeSupportedV1(schemaToCheck, recordType);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/stats/ValueType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/stats/ValueType.java
@@ -294,7 +294,12 @@ public enum ValueType {
       case UUID:
         return ValueType.UUID;
       case UNION:
-        return fromSchema(schema.getNonNullType());
+        HoodieSchema nonNullSchema = schema.getNonNullType();
+        if (nonNullSchema.getType() == HoodieSchemaType.UNION) {
+          throw new IllegalArgumentException("Unsupported union type " + schema
+              + ": only a union of null and one non-null type is supported");
+        }
+        return fromSchema(nonNullSchema);
       default:
         throw new IllegalArgumentException("Unsupported type: " + type);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/stats/ValueType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/stats/ValueType.java
@@ -294,12 +294,11 @@ public enum ValueType {
       case UUID:
         return ValueType.UUID;
       case UNION:
-        HoodieSchema nonNullSchema = schema.getNonNullType();
-        if (nonNullSchema.getType() == HoodieSchemaType.UNION) {
-          throw new IllegalArgumentException("Unsupported union type " + schema
-              + ": only a union of null and one non-null type is supported");
+        if (schema.isComplexUnion()) {
+          throw new IllegalArgumentException(String.format(
+              "Unsupported UNION type %s: Only UNION of a null type and a non-null type is supported", schema));
         }
-        return fromSchema(nonNullSchema);
+        return fromSchema(schema.getNonNullType());
       default:
         throw new IllegalArgumentException("Unsupported type: " + type);
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchema.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchema.java
@@ -380,6 +380,22 @@ public class TestHoodieSchema {
     ), complexNonNullType.getTypes());
 
     assertSame(complexNonNullType, complexNonNullType.getNonNullType());
+
+    // isComplexUnion() is what a walker checks before recursing on getNonNullType()
+    assertTrue(union.isComplexUnion());
+    assertTrue(unionWithoutNull.isComplexUnion());
+    assertTrue(complexUnion.isComplexUnion());
+    assertFalse(HoodieSchema.createNullable(HoodieSchema.create(HoodieSchemaType.STRING)).isComplexUnion());
+    assertFalse(HoodieSchema.createUnion(HoodieSchema.create(HoodieSchemaType.STRING), HoodieSchema.create(HoodieSchemaType.NULL)).isComplexUnion());
+    assertFalse(HoodieSchema.create(HoodieSchemaType.STRING).isComplexUnion());
+
+    // A lone branch has no null to strip and comes back as-is, still a union; null alone has nothing left
+    HoodieSchema loneBranch = HoodieSchema.createUnion(HoodieSchema.create(HoodieSchemaType.STRING));
+    assertSame(loneBranch, loneBranch.getNonNullType());
+    assertTrue(loneBranch.isComplexUnion());
+    HoodieSchema nullOnly = HoodieSchema.createUnion(HoodieSchema.create(HoodieSchemaType.NULL));
+    assertThrows(IllegalArgumentException.class, nullOnly::getNonNullType);
+    assertTrue(nullOnly.isComplexUnion());
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaRepair.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaRepair.java
@@ -781,6 +781,26 @@ public class TestHoodieSchemaRepair {
   }
 
   @Test
+  public void testHasTimestampMillisFieldMultiBranchUnion() {
+    // Unions with two or more non-null branches used to recurse forever (#19825)
+    HoodieSchema withoutMillis = HoodieSchema.createUnion(
+        HoodieSchema.create(HoodieSchemaType.NULL),
+        HoodieSchema.create(HoodieSchemaType.STRING),
+        HoodieSchema.create(HoodieSchemaType.LONG)
+    );
+    assertFalse(HoodieSchemaRepair.hasTimestampMillisField(withoutMillis),
+        "Should return false for multi-branch union without timestamp-millis");
+
+    HoodieSchema withMillis = HoodieSchema.createUnion(
+        HoodieSchema.create(HoodieSchemaType.NULL),
+        HoodieSchema.create(HoodieSchemaType.STRING),
+        HoodieSchema.createTimestampMillis()
+    );
+    assertTrue(HoodieSchemaRepair.hasTimestampMillisField(withMillis),
+        "Should return true for multi-branch union containing timestamp-millis");
+  }
+
+  @Test
   public void testHasTimestampMillisFieldUnionWithRecordContainingTimestampMillis() {
     HoodieSchema recordSchema = HoodieSchema.createRecord("Record", null, null, Collections.singletonList(
         HoodieSchemaField.of("timestamp", HoodieSchema.createTimestampMillis(), null, null)

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
@@ -1124,6 +1124,20 @@ public class TestHoodieSchemaUtils {
   }
 
   @Test
+  public void testFindNestedFieldThroughMultiBranchUnion() {
+    // A field typed ["null", "string", "int"] has no record to descend into and used to recurse forever (#19825)
+    HoodieSchema schema = HoodieSchema.createRecord("record", null, null, false,
+        Collections.singletonList(
+            HoodieSchemaField.of("u", HoodieSchema.createUnion(
+                HoodieSchema.create(HoodieSchemaType.NULL),
+                HoodieSchema.create(HoodieSchemaType.STRING),
+                HoodieSchema.create(HoodieSchemaType.INT)), null, null)
+        ));
+    assertTrue(HoodieSchemaUtils.findNestedField(schema, "u").isPresent());
+    assertFalse(HoodieSchemaUtils.findNestedField(schema, "u.x").isPresent());
+  }
+
+  @Test
   public void testCreateNewSchemaFromFieldsWithReference_NullSchema() {
     // This test should throw an IllegalArgumentException
     assertThrows(IllegalArgumentException.class, () -> HoodieSchemaUtils.createNewSchemaFromFieldsWithReference(null, Collections.emptyList()));
@@ -1332,6 +1346,26 @@ public class TestHoodieSchemaUtils {
             HoodieSchemaField.of("arrayfield", HoodieSchema.createArray(HoodieSchema.createDecimal(10, 6)), null, null)
         ));
     assertTrue(HoodieSchemaUtils.hasDecimalField(recordWithMapAndDecArray));
+    // Unions with two or more non-null branches used to recurse forever (#19825)
+    HoodieSchema recordWithMultiBranchUnions = HoodieSchema.createRecord("recordWithMultiBranchUnions", null, null, false,
+        Arrays.asList(
+            HoodieSchemaField.of("nullableStringOrInt", HoodieSchema.createUnion(
+                HoodieSchema.create(HoodieSchemaType.NULL),
+                HoodieSchema.create(HoodieSchemaType.STRING),
+                HoodieSchema.create(HoodieSchemaType.INT)), null, null),
+            HoodieSchemaField.of("stringOrInt", HoodieSchema.createUnion(
+                HoodieSchema.create(HoodieSchemaType.STRING),
+                HoodieSchema.create(HoodieSchemaType.INT)), null, null)
+        ));
+    assertFalse(HoodieSchemaUtils.hasDecimalField(recordWithMultiBranchUnions));
+    HoodieSchema recordWithDecimalInLastBranch = HoodieSchema.createRecord("recordWithDecimalInLastBranch", null, null, false,
+        Collections.singletonList(
+            HoodieSchemaField.of("nullableStringOrDecimal", HoodieSchema.createUnion(
+                HoodieSchema.create(HoodieSchemaType.NULL),
+                HoodieSchema.create(HoodieSchemaType.STRING),
+                HoodieSchema.createDecimal(10, 6)), null, null)
+        ));
+    assertTrue(HoodieSchemaUtils.hasDecimalField(recordWithDecimalInLastBranch));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
@@ -877,6 +877,52 @@ public class TestHoodieSchemaUtils {
   }
 
   @Test
+  void testPruningPreservesMultiBranchUnion() {
+    // A field typed ["null", "string", "int"] reaches the pruner as a union even after the null branch
+    // is stripped. A union branch is picked by type, so there is nothing to narrow: the pruner must pass
+    // the data schema through rather than reject it (#19825).
+    HoodieSchema unionSchema = HoodieSchema.createUnion(
+        HoodieSchema.create(HoodieSchemaType.NULL),
+        HoodieSchema.create(HoodieSchemaType.STRING),
+        HoodieSchema.create(HoodieSchemaType.INT));
+    HoodieSchema dataSchema = HoodieSchema.createRecord("test_record", null, null, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.LONG)),
+        HoodieSchemaField.of("choice", unionSchema)
+    ));
+    HoodieSchema requiredSchema = HoodieSchema.createRecord("test_record", null, null, Collections.singletonList(
+        HoodieSchemaField.of("choice", unionSchema)
+    ));
+
+    HoodieSchema pruned = HoodieSchemaUtils.pruneDataSchema(dataSchema, requiredSchema, Collections.emptySet());
+
+    assertEquals(1, pruned.getFields().size());
+    assertEquals(unionSchema, pruned.getFields().get(0).schema());
+  }
+
+  @Test
+  void testPruningPreservesRecordWhenRequiredIsMemberUnion() {
+    // HoodieSparkSchemaConverters reads a struct of nullable member0..memberN fields back as a union, so
+    // the Spark-side required schema can be a union where the data schema still holds the record it was
+    // written from. The pruner must pass the record through instead of rejecting the mismatch (#19825).
+    HoodieSchema memberRecord = HoodieSchema.createRecord("choice", null, null, Arrays.asList(
+        HoodieSchemaField.of("member0", HoodieSchema.createNullable(HoodieSchemaType.STRING), null, null),
+        HoodieSchemaField.of("member1", HoodieSchema.createNullable(HoodieSchemaType.INT), null, null)
+    ));
+    HoodieSchema dataSchema = HoodieSchema.createRecord("test_record", null, null, Collections.singletonList(
+        HoodieSchemaField.of("choice", memberRecord)
+    ));
+    HoodieSchema requiredSchema = HoodieSchema.createRecord("test_record", null, null, Collections.singletonList(
+        HoodieSchemaField.of("choice", HoodieSchema.createUnion(
+            HoodieSchema.create(HoodieSchemaType.STRING),
+            HoodieSchema.create(HoodieSchemaType.INT)))
+    ));
+
+    HoodieSchema pruned = HoodieSchemaUtils.pruneDataSchema(dataSchema, requiredSchema, Collections.emptySet());
+
+    assertEquals(memberRecord, pruned.getFields().get(0).schema());
+  }
+
+  @Test
   void testPruningPreserveNullable() {
     String dataSchemaStr = "{"
         + "\"type\": \"record\","
@@ -1358,14 +1404,14 @@ public class TestHoodieSchemaUtils {
                 HoodieSchema.create(HoodieSchemaType.INT)), null, null)
         ));
     assertFalse(HoodieSchemaUtils.hasDecimalField(recordWithMultiBranchUnions));
-    HoodieSchema recordWithDecimalInLastBranch = HoodieSchema.createRecord("recordWithDecimalInLastBranch", null, null, false,
+    HoodieSchema recordWithDecimalInMultiBranchUnion = HoodieSchema.createRecord("recordWithDecimalInMultiBranchUnion", null, null, false,
         Collections.singletonList(
             HoodieSchemaField.of("nullableStringOrDecimal", HoodieSchema.createUnion(
                 HoodieSchema.create(HoodieSchemaType.NULL),
                 HoodieSchema.create(HoodieSchemaType.STRING),
                 HoodieSchema.createDecimal(10, 6)), null, null)
         ));
-    assertTrue(HoodieSchemaUtils.hasDecimalField(recordWithDecimalInLastBranch));
+    assertTrue(HoodieSchemaUtils.hasDecimalField(recordWithDecimalInMultiBranchUnion));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
@@ -923,6 +923,41 @@ public class TestHoodieSchemaUtils {
   }
 
   @Test
+  void testPruningPreservesMultiBranchUnionWhenRequiredIsOneMember() {
+    // Spark's nested schema pruning can cut the member0..memberN struct a union is read as down to a
+    // single member, and HoodieSparkSchemaConverters converts that one-member struct back to a union
+    // over the member's own type. The required schema then presents as a record, array or map while the
+    // data schema still holds the whole union, which used to be rejected as a type mismatch (#19825).
+    HoodieSchema branchRecord = HoodieSchema.createRecord("branch_record", null, null, Arrays.asList(
+        HoodieSchemaField.of("x", HoodieSchema.create(HoodieSchemaType.STRING), null, null),
+        HoodieSchemaField.of("y", HoodieSchema.create(HoodieSchemaType.STRING), null, null)
+    ));
+    HoodieSchema prunedBranchRecord = HoodieSchema.createRecord("branch_record", null, null, Collections.singletonList(
+        HoodieSchemaField.of("x", HoodieSchema.create(HoodieSchemaType.STRING), null, null)
+    ));
+    HoodieSchema branchArray = HoodieSchema.createArray(HoodieSchema.create(HoodieSchemaType.STRING));
+    HoodieSchema branchMap = HoodieSchema.createMap(HoodieSchema.create(HoodieSchemaType.STRING));
+
+    for (Pair<HoodieSchema, HoodieSchema> branchAndRequired : Arrays.asList(
+        Pair.of(branchRecord, prunedBranchRecord), Pair.of(branchArray, branchArray), Pair.of(branchMap, branchMap))) {
+      HoodieSchema dataUnion = HoodieSchema.createUnion(
+          HoodieSchema.create(HoodieSchemaType.NULL),
+          HoodieSchema.create(HoodieSchemaType.INT),
+          branchAndRequired.getLeft());
+      HoodieSchema dataSchema = HoodieSchema.createRecord("test_record", null, null, Collections.singletonList(
+          HoodieSchemaField.of("choice", dataUnion, null, null)
+      ));
+      HoodieSchema requiredSchema = HoodieSchema.createRecord("test_record", null, null, Collections.singletonList(
+          HoodieSchemaField.of("choice", HoodieSchema.createNullable(branchAndRequired.getRight()), null, null)
+      ));
+
+      HoodieSchema pruned = HoodieSchemaUtils.pruneDataSchema(dataSchema, requiredSchema, Collections.emptySet());
+
+      assertEquals(dataUnion, pruned.getFields().get(0).schema());
+    }
+  }
+
+  @Test
   void testPruningPreserveNullable() {
     String dataSchemaStr = "{"
         + "\"type\": \"record\","

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/internal/convert/TestInternalSchemaConverter.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/internal/convert/TestInternalSchemaConverter.java
@@ -209,6 +209,16 @@ public class TestInternalSchemaConverter {
     expectedOutput = getDeeplyNestedFieldSchemaExpectedColumnNames();
     assertEquals(expectedOutput.size(), fieldNames.size());
     assertTrue(fieldNames.containsAll(expectedOutput));
+
+    // A primitive union with two or more non-null branches is a leaf and used to recurse forever (#19825)
+    HoodieSchema schemaWithMultiBranchUnion = createRecord("schemaWithMultiBranchUnion",
+        HoodieSchemaField.of("field1", HoodieSchema.createUnion(
+            HoodieSchema.create(HoodieSchemaType.NULL),
+            HoodieSchema.create(HoodieSchemaType.STRING),
+            HoodieSchema.create(HoodieSchemaType.INT)), null, null),
+        createPrimitiveField("field2", HoodieSchemaType.STRING));
+    fieldNames = InternalSchemaConverter.collectColNamesFromSchema(schemaWithMultiBranchUnion);
+    assertEquals(Arrays.asList("field1", "field2"), fieldNames);
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/internal/convert/TestInternalSchemaConverter.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/internal/convert/TestInternalSchemaConverter.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.schema.HoodieSchemaTestUtils.createArrayField;
 import static org.apache.hudi.common.schema.HoodieSchemaTestUtils.createMapField;
@@ -219,6 +220,23 @@ public class TestInternalSchemaConverter {
         createPrimitiveField("field2", HoodieSchemaType.STRING));
     fieldNames = InternalSchemaConverter.collectColNamesFromSchema(schemaWithMultiBranchUnion);
     assertEquals(Arrays.asList("field1", "field2"), fieldNames);
+
+    // visitSchemaToBuildType keeps the first non-null branch and drops the rest, so a record, array or
+    // map sitting in one of the dropped branches has no ids in the internal schema. Naming its leaves
+    // here made pruneInternalSchema throw "cannot prune col: field1.x which does not exist in hudi
+    // table" (#19825).
+    HoodieSchema schemaWithRecordBranchUnion = createRecord("schemaWithRecordBranchUnion",
+        HoodieSchemaField.of("field1", HoodieSchema.createUnion(
+            HoodieSchema.create(HoodieSchemaType.NULL),
+            HoodieSchema.create(HoodieSchemaType.INT),
+            createRecord("branchRecord", createPrimitiveField("x", HoodieSchemaType.STRING))), null, null),
+        createPrimitiveField("field2", HoodieSchemaType.STRING));
+    fieldNames = InternalSchemaConverter.collectColNamesFromSchema(schemaWithRecordBranchUnion);
+    assertEquals(Arrays.asList("field1", "field2"), fieldNames);
+    InternalSchema prunedInternalSchema = InternalSchemaConverter.pruneHoodieSchemaToInternalSchema(
+        schemaWithRecordBranchUnion, InternalSchemaConverter.convert(schemaWithRecordBranchUnion));
+    assertEquals(Arrays.asList("field1", "field2"),
+        prunedInternalSchema.getRecord().fields().stream().map(Types.Field::name).collect(Collectors.toList()));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -413,6 +413,27 @@ class TestHoodieTableMetadataUtil {
   }
 
   @Test
+  void testMultiBranchUnionColumnsAreNotSupportedForColumnStats() {
+    // A column typed ["null", "string", "int"] has no single value type, so it must be skipped the same
+    // way RECORD/MAP/ARRAY are. Indexing it instead reaches ValueType#fromSchema and #coerceToComparable,
+    // whose throws are caught by readColumnRangeMetadataFrom and drop the whole file's stats (#19825).
+    HoodieSchema multiBranchUnion = HoodieSchema.createUnion(
+        HoodieSchema.create(HoodieSchemaType.NULL),
+        HoodieSchema.create(HoodieSchemaType.STRING),
+        HoodieSchema.create(HoodieSchemaType.INT));
+    HoodieSchema nullableString = HoodieSchema.createNullable(HoodieSchema.create(HoodieSchemaType.STRING));
+
+    for (HoodieIndexVersion indexVersion : new HoodieIndexVersion[] {HoodieIndexVersion.V1, HoodieIndexVersion.V2}) {
+      for (Option<HoodieRecordType> rt : Arrays.<Option<HoodieRecordType>>asList(Option.empty(), Option.of(HoodieRecordType.AVRO), Option.of(HoodieRecordType.SPARK))) {
+        assertFalse(HoodieTableMetadataUtil.isColumnTypeSupported(multiBranchUnion, rt, indexVersion),
+            "A union with two or more non-null branches must be excluded from " + indexVersion + " column stats");
+        assertTrue(HoodieTableMetadataUtil.isColumnTypeSupported(nullableString, rt, indexVersion),
+            "A plain nullable column must stay supported for " + indexVersion + " column stats");
+      }
+    }
+  }
+
+  @Test
   void testCreateRecordIndexUpdateMillisOverloadMatchesStringOverload() {
     String instantTime = "20260610153045678";
     long instantTimeMillis = HoodieMetadataPayload.parseRecordIndexInstantTime(instantTime);

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -533,6 +533,15 @@ class TestHoodieTableMetadataUtil {
         HoodieSchema.create(HoodieSchemaType.DOUBLE), false));
     assertNull(HoodieTableMetadataUtil.coerceToComparable(
         HoodieSchema.create(HoodieSchemaType.NULL), "ignored"));
+    assertEquals(1, HoodieTableMetadataUtil.coerceToComparable(
+        HoodieSchema.createNullable(HoodieSchemaType.INT), true));
+    // A union with two or more non-null branches cannot be coerced and used to recurse forever (#19825)
+    HoodieSchema multiBranchUnion = HoodieSchema.createUnion(
+        HoodieSchema.create(HoodieSchemaType.NULL),
+        HoodieSchema.create(HoodieSchemaType.STRING),
+        HoodieSchema.create(HoodieSchemaType.INT));
+    assertThrows(HoodieNotSupportedException.class,
+        () -> HoodieTableMetadataUtil.coerceToComparable(multiBranchUnion, "ignored"));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/stats/TestValueType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/stats/TestValueType.java
@@ -273,6 +273,12 @@ public class TestValueType {
   public void testFromSchemaUnwrapsUnion() {
     HoodieSchema nullableInt = HoodieSchema.createNullable(HoodieSchemaType.INT);
     assertEquals(ValueType.INT, ValueType.fromSchema(nullableInt));
+    // A union with two or more non-null branches has no single value type and used to recurse forever (#19825)
+    HoodieSchema multiBranchUnion = HoodieSchema.createUnion(
+        HoodieSchema.create(HoodieSchemaType.NULL),
+        HoodieSchema.create(HoodieSchemaType.STRING),
+        HoodieSchema.create(HoodieSchemaType.INT));
+    assertThrows(IllegalArgumentException.class, () -> ValueType.fromSchema(multiBranchUnion));
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -51,7 +51,7 @@ import org.apache.spark.sql.HoodieCatalystExpressionUtils.generateUnsafeProjecti
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{JoinedRow, UnsafeProjection}
-import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, PartitionedFile, SparkColumnarFileReader}
+import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, PartitionedFile, SparkColumnarFileReader, SparkSchemaTransformUtils}
 import org.apache.spark.sql.execution.datasources.orc.OrcUtils
 import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapColumnVector}
 import org.apache.spark.sql.hudi.MultipleColumnarFileFormatReader
@@ -318,6 +318,18 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     partitionSchema.fields.foreach(f => exclusionFields.add(f.name))
     val requestedStructType = StructType(readRequiredSchema.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name) && !isNestedPartitionField(f.name)))
     val requestedSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(requestedStructType, sanitizedTableName), exclusionFields)
+    // pruneDataSchema keeps a union (a member0..memberN struct on the Spark side), a BLOB and a VARIANT
+    // whole, so where Spark's nested schema pruning asked for only some of their inner fields the reader
+    // emits a wider struct than requestedStructType declares. Bind the output projection to the emitted
+    // shape for those columns so it can drop the extra inner fields by name; everywhere else the two
+    // agree and the projection stays the pass-through it is today.
+    val readerStructType = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(requestedSchema)
+    val projectionInputSchema = StructType(requestedStructType.fields.map { f =>
+      readerStructType.getFieldIndex(f.name).map(readerStructType.fields(_).dataType) match {
+        case Some(readType) if SparkSchemaTransformUtils.needsNestedPruning(readType, f.dataType) => f.copy(dataType = readType)
+        case _ => f
+      }
+    })
     val dataStructTypeWithMandatoryPartitionFields = StructType(dataStructType.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name) && !isNestedPartitionField(f.name)))
     val dataSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(dataStructTypeWithMandatoryPartitionFields, sanitizedTableName), exclusionFields)
 
@@ -402,7 +414,7 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
               // Append partition values to rows and project to output schema
               appendPartitionAndProject(
                 reader.getClosableIterator,
-                requestedStructType,
+                projectionInputSchema,
                 remainingPartitionSchema,
                 outputSchema,
                 fileSliceMapping.getPartitionValues,
@@ -493,7 +505,7 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
         //some partition fields read from file, some were not
         getFixedPartitionValues(partitionValues, partitionSchema, fixedPartitionIndexes)
       }
-      val unsafeProjection = generateUnsafeProjection(StructType(inputSchema.fields ++ partitionSchema.fields), to)
+      val unsafeProjection = generateOutputProjection(StructType(inputSchema.fields ++ partitionSchema.fields), to)
       val joinedRow = new JoinedRow()
       makeCloseableFileGroupMappingRecordIterator(iter, d => unsafeProjection(joinedRow(d, fixedPartitionValues)))
     }
@@ -502,8 +514,24 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
   private def projectSchema(iter: ClosableIterator[InternalRow],
                             from: StructType,
                             to: StructType): Iterator[InternalRow] = {
-    val unsafeProjection = generateUnsafeProjection(from, to)
+    val unsafeProjection = generateOutputProjection(from, to)
     makeCloseableFileGroupMappingRecordIterator(iter, d => unsafeProjection(d))
+  }
+
+  /**
+   * The scan's output projection. Stays the by-name top-level projection unless a column comes out of the
+   * reader with nested fields Spark did not ask for (see `projectionInputSchema` in
+   * buildReaderWithPartitionValues), in which case those are dropped by name at every depth.
+   */
+  private def generateOutputProjection(from: StructType, to: StructType): UnsafeProjection = {
+    val hasWiderNestedInput = to.fields.exists { f =>
+      from.getFieldIndex(f.name).exists(i => SparkSchemaTransformUtils.needsNestedPruning(from.fields(i).dataType, f.dataType))
+    }
+    if (hasWiderNestedInput) {
+      SparkSchemaTransformUtils.generateNestedPruningProjection(from, to)
+    } else {
+      generateUnsafeProjection(from, to)
+    }
   }
 
   private def makeCloseableFileGroupMappingRecordIterator(closeableFileGroupRecordIterator: ClosableIterator[InternalRow],

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -318,16 +318,18 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     partitionSchema.fields.foreach(f => exclusionFields.add(f.name))
     val requestedStructType = StructType(readRequiredSchema.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name) && !isNestedPartitionField(f.name)))
     val requestedSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(requestedStructType, sanitizedTableName), exclusionFields)
-    // pruneDataSchema keeps a union (a member0..memberN struct on the Spark side), a BLOB and a VARIANT
-    // whole, so where Spark's nested schema pruning asked for only some of their inner fields the reader
-    // emits a wider struct than requestedStructType declares. Bind the output projection to the emitted
-    // shape for those columns so it can drop the extra inner fields by name; everywhere else the two
-    // agree and the projection stays the pass-through it is today.
+    // The reader emits requestedSchema -- FileGroupReaderSchemaHandler projects its merged rows back
+    // down to it -- and that is wider than requestedStructType wherever pruneDataSchema had to keep a
+    // column whole: a union (a member0..memberN struct on the Spark side), a BLOB or a VARIANT that
+    // Spark's nested schema pruning asked only some inner fields of. Bind the output projection to the
+    // emitted shape rather than to what was asked for, so it resolves by name and drops the rest; a
+    // field the reader does not widen keeps the requested type, which is what it already had.
     val readerStructType = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(requestedSchema)
-    val projectionInputSchema = StructType(requestedStructType.fields.map { f =>
-      readerStructType.getFieldIndex(f.name).map(readerStructType.fields(_).dataType) match {
-        case Some(readType) if SparkSchemaTransformUtils.needsNestedPruning(readType, f.dataType) => f.copy(dataType = readType)
-        case _ => f
+    val requestedFieldsByName = requestedStructType.fields.map(f => f.name -> f).toMap
+    val projectionInputSchema = StructType(readerStructType.fields.map { readerField =>
+      requestedFieldsByName.get(readerField.name) match {
+        case Some(f) if !SparkSchemaTransformUtils.needsNestedPruning(readerField.dataType, f.dataType) => f
+        case _ => readerField
       }
     })
     val dataStructTypeWithMandatoryPartitionFields = StructType(dataStructType.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name) && !isNestedPartitionField(f.name)))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/avro/TestSchemaConverters.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/avro/TestSchemaConverters.scala
@@ -88,6 +88,31 @@ class TestSchemaConverters extends SparkAdapterSupport {
   }
 
   @Test
+  def testMemberStructUnionSurvivesReadPathSchemaSteps(): Unit = {
+    // The two schema steps HoodieFileGroupReaderBasedFileFormat#buildReaderWithPartitionValues takes
+    // before it opens a file, run over a table schema carrying ["null","string","int"]: the walk that
+    // decides logical-timestamp repair, then the prune of the table schema down to what Spark asked
+    // for. Both used to fail on this shape -- the first by recursing forever, the second by rejecting
+    // the union outright (#19825).
+    val tableSchema = HoodieSchema.createRecord("test_record", "hoodie.test", null, util.Arrays.asList(
+      HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.LONG)),
+      HoodieSchemaField.of("choice", HoodieSchema.createUnion(
+        HoodieSchema.create(HoodieSchemaType.NULL),
+        HoodieSchema.create(HoodieSchemaType.STRING),
+        HoodieSchema.create(HoodieSchemaType.INT)), null, null)))
+
+    assertFalse(HoodieSchemaRepair.hasTimestampMillisField(tableSchema))
+
+    // Spark sees the union as the member struct it round-trips through, and asks for it back
+    val requestedStructType = HoodieSparkSchemaConverters.toSqlType(tableSchema)._1.asInstanceOf[StructType]
+    val requestedSchema = HoodieSchemaUtils.pruneDataSchema(
+      tableSchema, HoodieSparkSchemaConverters.toHoodieType(requestedStructType, recordName = "test_record", nameSpace = "hoodie.test"), util.Collections.emptySet[String]())
+
+    assertEquals(HoodieSchemaType.UNION, requestedSchema.getField("choice").get().schema().getType)
+    assertEquals(requestedStructType, HoodieSparkSchemaConverters.toSqlType(requestedSchema)._1)
+  }
+
+  @Test
   def testSchemaWithBlobsRoundTrip(): Unit = {
     val originalSchema = HoodieSchema.createRecord("document", "test", null, util.Arrays.asList(
       HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.LONG)),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/avro/TestSchemaConverters.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/avro/TestSchemaConverters.scala
@@ -20,8 +20,9 @@ package org.apache.spark.sql.avro
 import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.SparkAdapterSupport
 import org.apache.hudi.avro.model.HoodieMetadataColumnStats
-import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaField, HoodieSchemaType}
+import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaField, HoodieSchemaRepair, HoodieSchemaType, HoodieSchemaUtils}
 import org.apache.hudi.common.schema.internal.HoodieSchemaException
+import org.apache.hudi.metadata.stats.ValueType
 
 import org.apache.avro.JsonProperties
 import org.apache.spark.sql.types.{ArrayType, DataTypes, FloatType, MetadataBuilder, StructField, StructType}
@@ -52,6 +53,38 @@ class TestSchemaConverters extends SparkAdapterSupport {
         assertEquals(JsonProperties.NULL_VALUE, convertedField.defaultVal().get())
       }
     }
+  }
+
+  @Test
+  def testMemberStructBecomesMultiBranchUnionThatSchemaWalksCanTraverse(): Unit = {
+    // A struct of nullable member0..memberN fields is spark-avro's encoding of a complex union and
+    // toHoodieType turns it back into one, so a datasource write can land ["null","string","int"] in a
+    // table schema. The recursive schema walks used to loop forever on that shape (#19825).
+    val structType = StructType(Seq(
+      StructField("id", DataTypes.LongType, nullable = false),
+      StructField("choice", StructType(Seq(
+        StructField("member0", DataTypes.StringType, nullable = true),
+        StructField("member1", DataTypes.IntegerType, nullable = true))), nullable = true),
+      StructField("amount", StructType(Seq(
+        StructField("member0", DataTypes.StringType, nullable = true),
+        StructField("member1", DataTypes.createDecimalType(10, 6), nullable = true))), nullable = true)))
+
+    val hoodieSchema = HoodieSparkSchemaConverters.toHoodieType(structType)
+
+    val choice = hoodieSchema.getField("choice").get().schema()
+    assertEquals(HoodieSchemaType.UNION, choice.getType)
+    assertEquals(3, choice.getTypes.size())
+    // getNonNullType() cannot reduce this union to a single branch, which is what tripped the walkers
+    assertEquals(HoodieSchemaType.UNION, choice.getNonNullType.getType)
+
+    assertFalse(HoodieSchemaRepair.hasTimestampMillisField(hoodieSchema))
+    assertTrue(HoodieSchemaUtils.hasDecimalField(hoodieSchema))
+    assertTrue(HoodieSchemaUtils.findNestedField(hoodieSchema, "choice").isPresent)
+    assertFalse(HoodieSchemaUtils.findNestedField(hoodieSchema, "choice.member0").isPresent)
+    assertThrows(classOf[IllegalArgumentException], () => ValueType.fromSchema(choice))
+
+    // and the union still converts back to the member struct it came from
+    assertEquals(structType("choice").dataType, HoodieSparkSchemaConverters.toSqlType(hoodieSchema)._1.asInstanceOf[StructType]("choice").dataType)
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestNestedSchemaPruningOptimization.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestNestedSchemaPruningOptimization.scala
@@ -17,14 +17,26 @@
 
 package org.apache.spark.sql.hudi.common
 
+import org.apache.hudi.client.SparkRDDWriteClient
+import org.apache.hudi.client.common.HoodieSparkEngineContext
+import org.apache.hudi.common.model.{HoodieAvroPayload, HoodieAvroRecord, HoodieKey, HoodieRecord, HoodieTableType}
+import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaType}
+import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
 import org.apache.hudi.common.table.read.CustomPayloadForTesting
+import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
+import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
-import org.apache.spark.sql.DataFrame
+import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.execution.{FileSourceScanExec, ProjectExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StringType, StructField, StructType}
 import org.junit.jupiter.api.Assertions.assertEquals
+
+import scala.collection.JavaConverters._
 
 /**
  * Verifies nested schema pruning on Hudi tables. The pruning itself is performed by Spark's
@@ -145,6 +157,72 @@ class TestNestedSchemaPruningOptimization extends HoodieSparkSqlTestBase {
 
       // Filter on a nested field combined with pruning
       checkAnswer(s"SELECT id, item.price FROM $tableName WHERE item.name = 'a1'")(Seq(1, 10))
+    }
+  }
+
+  test("Test nested schema pruning through a union column") {
+    withTempDir { tmp =>
+      Seq(HoodieTableType.COPY_ON_WRITE, HoodieTableType.MERGE_ON_READ).foreach { tableType =>
+        val tableName = generateTableName
+        val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+
+        // A union with two or more non-null branches reaches a table only from a writer that takes a raw
+        // Avro schema (Streamer, Flink, Kafka Connect, the Java client): a Spark write round-trips its
+        // writer schema through InternalSchema, which keeps the first branch only. Spark reads the union
+        // as the struct of nullable member0..memberN fields spark-avro gives it, and its nested schema
+        // pruning can then ask for a subset of those members, which pruneDataSchema cannot honour: a
+        // union is kept whole (#19825), so the scan's output projection has to drop the rest by name.
+        val schema = HoodieSchema.parse(
+          """{"type":"record","name":"union_record","namespace":"hoodie.test","fields":[
+            |{"name":"id","type":"int"},
+            |{"name":"choice","type":["null","string","int"],"default":null},
+            |{"name":"pick","type":["null","string","int","long"],"default":null},
+            |{"name":"ts","type":"long"}]}""".stripMargin)
+        HoodieTableMetaClient.newTableBuilder()
+          .setTableType(tableType)
+          .setTableName(tableName)
+          .setRecordKeyFields("id")
+          .setOrderingFields("ts")
+          .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+        val jsc = new JavaSparkContext(spark.sparkContext)
+        val writeConfig = HoodieWriteConfig.newBuilder().withPath(tablePath).withSchema(schema.toString).forTable(tableName).build()
+        val client = new SparkRDDWriteClient[HoodieAvroPayload](new HoodieSparkEngineContext(jsc), writeConfig)
+        def record(id: Int, choice: AnyRef, pick: AnyRef, ts: Long): HoodieRecord[HoodieAvroPayload] = {
+          val avroRecord = new GenericData.Record(schema.getAvroSchema)
+          avroRecord.put("id", Int.box(id))
+          avroRecord.put("choice", choice)
+          avroRecord.put("pick", pick)
+          avroRecord.put("ts", Long.box(ts))
+          new HoodieAvroRecord(new HoodieKey(id.toString, ""), new HoodieAvroPayload(HOption.of[GenericRecord](avroRecord)))
+        }
+        try {
+          val insertInstant = client.startCommit()
+          client.commit(insertInstant, client.insert(jsc.parallelize(Seq(record(1, "a1", Long.box(100L), 1000L), record(2, Int.box(7), "b2", 1000L)).asJava), insertInstant))
+          if (tableType == HoodieTableType.MERGE_ON_READ) {
+            // The update writes a log file, so the pruned reads below merge base and log records
+            val updateInstant = client.startCommit()
+            client.commit(updateInstant, client.upsert(jsc.parallelize(Seq(record(1, "a1", Long.box(100L), 1001L)).asJava), updateInstant))
+          }
+        } finally {
+          client.close()
+        }
+        val choiceSchema = new TableSchemaResolver(createMetaClient(spark, tablePath)).getTableSchema.getField("choice").get().schema()
+        assertEquals(HoodieSchemaType.UNION, choiceSchema.getType)
+        assertEquals(3, choiceSchema.getTypes.size())
+
+        spark.read.format("hudi").load(tablePath).createOrReplaceTempView(tableName)
+        // One member out of two: Spark prunes the struct down to it while the reader still emits both
+        val member1DF = spark.sql(s"SELECT id, choice.member1 FROM $tableName")
+        assertEquals(StructType(Seq(StructField("member1", IntegerType, nullable = true))), prunedStructTypeOf(member1DF, "choice"))
+        checkAnswer(s"SELECT id, choice.member1 FROM $tableName")(Seq(1, null), Seq(2, 7))
+        checkAnswer(s"SELECT id, choice.member0 FROM $tableName")(Seq(1, "a1"), Seq(2, null))
+        // Two members out of three, and not the leading ones
+        checkAnswer(s"SELECT id, pick.member0, pick.member2 FROM $tableName")(Seq(1, null, 100L), Seq(2, "b2", null))
+        checkAnswer(s"SELECT id, pick.member2 FROM $tableName")(Seq(1, 100L), Seq(2, null))
+        // The whole struct is not pruned and comes back as written, next to the ordering value the log record carries
+        val tsOfFirstRecord = if (tableType == HoodieTableType.MERGE_ON_READ) 1001L else 1000L
+        checkAnswer(s"SELECT id, choice, ts FROM $tableName")(Seq(1, Row("a1", null), tsOfFirstRecord), Seq(2, Row(null, 7), 1000L))
+      }
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestNestedSchemaPruningOptimization.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestNestedSchemaPruningOptimization.scala
@@ -249,6 +249,34 @@ class TestNestedSchemaPruningOptimization extends HoodieSparkSqlTestBase {
     }
   }
 
+  test("Test a projection of columns named memberN is not read as a union") {
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName
+        val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+
+        // canBeUnion matches a struct whose fields are all nullable and named member0..memberN. At the
+        // root that is a projection of columns that happen to be named that way, not a union, and
+        // converting it to one made pruneDataSchema hand the reader the whole table schema -- so
+        // SELECT member0 came back with _hoodie_commit_time -- or made Avro reject the duplicate
+        // branch types outright.
+        spark.sql(
+          s"""
+             |CREATE TABLE $tableName USING HUDI
+             |TBLPROPERTIES (type = '$tableType', primaryKey = 'id', orderingFields = 'ts')
+             |LOCATION '$tablePath'
+             |AS SELECT 1 AS id, 'a1' AS member0, 'b1' AS member1, 123456 AS ts
+             """.stripMargin)
+        // The update writes a log file on MOR, so the reads below go through the merge path
+        spark.sql(s"UPDATE $tableName SET ts = 123457 WHERE id = 1")
+
+        checkAnswer(s"SELECT member0 FROM $tableName")(Seq("a1"))
+        checkAnswer(s"SELECT member0, member1 FROM $tableName")(Seq("a1", "b1"))
+        checkAnswer(s"SELECT id, member0 FROM $tableName")(Seq(1, "a1"))
+      }
+    }
+  }
+
   test("Test no nested schema pruning when disabled") {
     withTempDir { tmp =>
       val tableName = generateTableName

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestNestedSchemaPruningOptimization.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestNestedSchemaPruningOptimization.scala
@@ -177,6 +177,9 @@ class TestNestedSchemaPruningOptimization extends HoodieSparkSqlTestBase {
             |{"name":"id","type":"int"},
             |{"name":"choice","type":["null","string","int"],"default":null},
             |{"name":"pick","type":["null","string","int","long"],"default":null},
+            |{"name":"nested","type":["null","int",{"type":"record","name":"nested_branch","fields":[
+            |{"name":"x","type":["null","string"],"default":null},
+            |{"name":"y","type":["null","string"],"default":null}]}],"default":null},
             |{"name":"ts","type":"long"}]}""".stripMargin)
         HoodieTableMetaClient.newTableBuilder()
           .setTableType(tableType)
@@ -187,21 +190,32 @@ class TestNestedSchemaPruningOptimization extends HoodieSparkSqlTestBase {
         val jsc = new JavaSparkContext(spark.sparkContext)
         val writeConfig = HoodieWriteConfig.newBuilder().withPath(tablePath).withSchema(schema.toString).forTable(tableName).build()
         val client = new SparkRDDWriteClient[HoodieAvroPayload](new HoodieSparkEngineContext(jsc), writeConfig)
-        def record(id: Int, choice: AnyRef, pick: AnyRef, ts: Long): HoodieRecord[HoodieAvroPayload] = {
+        def nestedBranch(x: String, y: String): GenericRecord = {
+          val branchSchema = schema.getField("nested").get().schema().getTypes.get(2).getAvroSchema
+          val branchRecord = new GenericData.Record(branchSchema)
+          branchRecord.put("x", x)
+          branchRecord.put("y", y)
+          branchRecord
+        }
+        def record(id: Int, choice: AnyRef, pick: AnyRef, nested: AnyRef, ts: Long): HoodieRecord[HoodieAvroPayload] = {
           val avroRecord = new GenericData.Record(schema.getAvroSchema)
           avroRecord.put("id", Int.box(id))
           avroRecord.put("choice", choice)
           avroRecord.put("pick", pick)
+          avroRecord.put("nested", nested)
           avroRecord.put("ts", Long.box(ts))
           new HoodieAvroRecord(new HoodieKey(id.toString, ""), new HoodieAvroPayload(HOption.of[GenericRecord](avroRecord)))
         }
         try {
           val insertInstant = client.startCommit()
-          client.commit(insertInstant, client.insert(jsc.parallelize(Seq(record(1, "a1", Long.box(100L), 1000L), record(2, Int.box(7), "b2", 1000L)).asJava), insertInstant))
+          client.commit(insertInstant, client.insert(jsc.parallelize(Seq(
+            record(1, "a1", Long.box(100L), nestedBranch("n1", "n2"), 1000L),
+            record(2, Int.box(7), "b2", Int.box(9), 1000L)).asJava), insertInstant))
           if (tableType == HoodieTableType.MERGE_ON_READ) {
             // The update writes a log file, so the pruned reads below merge base and log records
             val updateInstant = client.startCommit()
-            client.commit(updateInstant, client.upsert(jsc.parallelize(Seq(record(1, "a1", Long.box(100L), 1001L)).asJava), updateInstant))
+            client.commit(updateInstant, client.upsert(jsc.parallelize(Seq(
+              record(1, "a1", Long.box(100L), nestedBranch("n1", "n2"), 1001L)).asJava), updateInstant))
           }
         } finally {
           client.close()
@@ -219,6 +233,15 @@ class TestNestedSchemaPruningOptimization extends HoodieSparkSqlTestBase {
         // Two members out of three, and not the leading ones
         checkAnswer(s"SELECT id, pick.member0, pick.member2 FROM $tableName")(Seq(1, null, 100L), Seq(2, "b2", null))
         checkAnswer(s"SELECT id, pick.member2 FROM $tableName")(Seq(1, 100L), Seq(2, null))
+        // A record branch: the required schema converts back to a union over a record, and the projection
+        // has to drop both the other member and the inner field Spark did not ask for
+        val nestedDF = spark.sql(s"SELECT id, nested.member1.x FROM $tableName")
+        assertEquals(
+          StructType(Seq(StructField("member1", StructType(Seq(StructField("x", StringType, nullable = true))), nullable = true))),
+          prunedStructTypeOf(nestedDF, "nested"))
+        checkAnswer(s"SELECT id, nested.member1.x FROM $tableName")(Seq(1, "n1"), Seq(2, null))
+        checkAnswer(s"SELECT id, nested.member0 FROM $tableName")(Seq(1, null), Seq(2, 9))
+        checkAnswer(s"SELECT id, nested.member1 FROM $tableName")(Seq(1, Row("n1", "n2")), Seq(2, null))
         // The whole struct is not pruned and comes back as written, next to the ordering value the log record carries
         val tsOfFirstRecord = if (tableType == HoodieTableType.MERGE_ON_READ) 1001L else 1000L
         checkAnswer(s"SELECT id, choice, ts FROM $tableName")(Seq(1, Row("a1", null), tsOfFirstRecord), Seq(2, Row(null, 7), 1000L))


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19825

`HoodieSchema.getNonNullType()` returns `this` for a union with no null branch, and a union of the non-null branches when there are two or more of them. Six recursive schema walkers called themselves on that result inside their `UNION` arm, so any schema carrying a field typed `["null","string","int"]` or `["string","int"]` recursed until `StackOverflowError`. The issue names the first two; a sweep of `getNonNullType()` callers found the other four.

### Summary and Changelog

| Site | Reachable from | Fix |
|---|---|---|
| `HoodieSchemaUtils.hasDecimalField` | Streamer JSON sources (`SourceFormatAdapter`) | iterate every branch |
| `HoodieSchemaRepair.hasTimestampMillisField` | every Spark read (`HoodieFileGroupReaderBasedFileFormat`, on the raw table schema) | iterate every branch |
| `InternalSchemaConverter.collectColNamesFromSchema` | schema-on-read pruning | iterate every branch |
| `ValueType.fromSchema` | column stats (`ValueMetadata`) | `isComplexUnion()` guard, then `IllegalArgumentException` |
| `HoodieTableMetadataUtil.coerceToComparable` | column stats (`FileFormatUtils`) | `isComplexUnion()` guard, then `HoodieNotSupportedException` |
| `HoodieSchemaUtils.findNestedField` | file group reader schema handler, write handles | `isComplexUnion()` guard, then `Option.empty()` |

The iterate-every-branch shape is the one `HoodieSchema#containsBlobType` already uses. The three single-answer walkers ask the new `HoodieSchema#isComplexUnion()` (a union other than the nullable wrapper of one type) before touching `getNonNullType()`, which restores what the strict `getNonNullTypeFromUnion` did before the HoodieSchema migrations (#14311, #18163, #17600) swapped in the lenient call and turned a throw into a loop; `resolveUnionSchema`'s fast path uses the same predicate. The `getNonNullType()` javadoc now states every outcome, including that its result can itself be a union.

Two more sites turned up in review, both older than those migrations:

| Site | Reachable from | Fix |
|---|---|---|
| `HoodieSchemaUtils.pruneDataSchema` | every Spark read, right after `hasTimestampMillisField` | return the data schema unpruned; the scan drops unrequested members by name |
| `HoodieTableMetadataUtil.isColumnTypeSupported` | column stats, before the two throws above | skip the column |

`pruneDataSchema` threw `IllegalArgumentException("Data schema is a union")`, so fixing the walk alone would have traded the `StackOverflowError` for that. A union is a leaf for pruning -- Avro resolves a branch by its type, so dropping one changes the column's type rather than narrowing it -- so the union arm now hands the data schema back whole, as the `default` arm and the BLOB/VARIANT arm already do. Spark reads such a union as a struct of nullable `member0..memberN` fields, and because the format extends `ParquetFileFormat`, Spark's own `SchemaPruning` can ask for a subset of those members. The reader then emits every member while the scan's output projection was bound to Spark's narrower struct, so leaves shifted by ordinal: `SELECT choice.member1` returned the byte length of `member0`. That was already the case on master for a single member (the `default` arm); the union arm would have extended it to several. `HoodieFileGroupReaderBasedFileFormat` now binds its output projection to the shape the reader emits and, only for columns that came back wider, drops the unrequested inner fields by name at every depth (`SparkSchemaTransformUtils.generateNestedPruningProjection`, the counterpart of the existing null-padding projection). The same path covers BLOB and VARIANT, which `pruneDataSchema` also keeps whole.

`isColumnTypeSupported`'s deny lists never named `UNION`, which is why the two column-stats throws were reachable at all. Because `readColumnRangeMetadataFrom` catches `Exception`, one union column dropped the stats for every column in the file. `UNION` now joins `RECORD`/`MAP`/`ARRAY` in the V1 and V2 lists, so the column is skipped up front and the throws stay as guards for direct callers. `isColumnTypeSupported` calls `getNonNullType()` at entry, so plain nullable columns are unaffected and only complex unions are denied.

Tests: multi-branch union cases added to the existing test methods for each site, and `TestHoodieSchema` pins the `isComplexUnion()` / `getNonNullType()` contract including `[T]` and `["null"]`. `TestSchemaConverters` pins the Spark producer and the two schema steps `buildReaderWithPartitionValues` takes before opening a file. `TestNestedSchemaPruningOptimization` reads a COW and a MOR table (with a log file) whose schema carries `["null","string","int"]` and `["null","string","int","long"]` through one-member, two-member and whole-struct projections; the table is written through `SparkRDDWriteClient` with Avro records, the way Streamer, Flink and the Java client write, since a Spark write cannot produce such a schema (see below). Without the projection change the one-member case returns the shifted leaf on master. `TestSparkSchemaTransformUtils` covers the projection on structs, arrays and maps, and that a null struct stays null.

<details>
<summary>Related but out of scope</summary>

- A Spark write cannot land a multi-branch union, and mangles the column when handed one: `HoodieSparkSchemaConverters.canBeUnion` turns a struct of nullable `member0..memberN` fields into `["null","string","int"]` and `CREATE TABLE` stores that in `hoodie.table.create.schema`, but every write routes the writer schema through `InternalSchemaConverter.fixNullOrdering`, whose `visitSchemaToBuildType` keeps the first non-null branch. The commit schema comes out as `["null","string"]`, the parquet column is written as a string, the catalog still says struct, and every read of the table fails with `ClassCastException: StringType$ cannot be cast to StructType`. Reproduced with `CREATE TABLE t (choice STRUCT<member0: STRING, member1: INT>) USING HUDI` followed by an `INSERT` and a `SELECT`; needs its own issue.
- The issue text calls `hasTimestampMillisField` latent because Spark cannot derive such a schema; the read path evaluates it on the commit-metadata table schema, so it is live for any table that carries the union.

</details>

### Impact

No API change beyond the new `HoodieSchema#isComplexUnion()`. Eight paths that previously threw `StackOverflowError`, rejected the schema outright, or silently dropped a file's column stats now return a result or skip the column, and a Spark read that projects some members of a union column returns those members instead of the ones at the same ordinals. Column stats for the union column itself are not collected, the same as for a `RECORD` or `MAP` column.

### Risk Level

low. Behavior only changes for a table or source schema that carries a union of two or more non-null types, and for nested projections through a column the reader returns wider than Spark asked for (union member structs, BLOB, VARIANT), which read the wrong leaf before. Such schemas reach a table from Streamer schema providers, the Java client, Kafka Connect and Flink's `source.avro-schema`; Flink SQL and DDL cannot express one and a Spark write collapses it (see above). For tables that never carried one nothing changes: the output projection stays the identity pass-through it is today unless a column came back wider.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
