### PR TITLE
fix(schema): lowercase projected names with Locale.ROOT

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -35,6 +35,7 @@ import org.apache.avro.generic.GenericData;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -470,9 +471,11 @@ public final class HoodieSchemaUtils {
    *
    * <p>Field names are matched case-insensitively and the projected field keeps the schema's original casing:
    * Avro field names are case-sensitive while Hive lowercases column projections before they reach the reader
-   * (see {@code HoodieRealtimeRecordReaderUtils#generateProjectionSchema}), so both sides are lowercased for the
-   * lookup. A schema with two fields that differ only in case cannot be projected and fails on the duplicate
-   * lowercase key.</p>
+   * (see {@code HoodieRealtimeRecordReaderUtils#generateProjectionSchema}), so both sides are lowercased with
+   * {@code Locale.ROOT} for the lookup. The default locale would map an upper-case I to dotless-i under a Turkish
+   * or Azeri locale and break the match with {@code HiveHoodieReaderContext}, which pre-lowercases with
+   * {@code Locale.ROOT}. A schema with two fields that differ only in case cannot be projected and fails on the
+   * duplicate lowercase key.</p>
    *
    * @param originalSchema the source schema
    * @param fieldNames     the list of field names to include in the projection
@@ -485,10 +488,11 @@ public final class HoodieSchemaUtils {
     ValidationUtils.checkArgument(fieldNames != null, "Field names cannot be null");
 
     Map<String, HoodieSchemaField> schemaFieldsMap = originalSchema.getFields().stream()
-        .map(r -> Pair.of(r.name().toLowerCase(), r)).collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+        .map(r -> Pair.of(r.name().toLowerCase(Locale.ROOT), r))
+        .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
     List<HoodieSchemaField> projectedFields = new ArrayList<>(fieldNames.size());
     for (String fn : fieldNames) {
-      HoodieSchemaField field = schemaFieldsMap.get(fn.toLowerCase());
+      HoodieSchemaField field = schemaFieldsMap.get(fn.toLowerCase(Locale.ROOT));
       if (field == null) {
         throw new HoodieException("Field " + fn + " not found in log schema. Query cannot proceed! "
             + "Derived Schema Fields: " + new ArrayList<>(schemaFieldsMap.keySet()));

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
@@ -1058,8 +1058,8 @@ public class TestHoodieSchemaUtils {
   public void testGenerateProjectionSchemaIgnoresDefaultLocale() {
     // Under tr-TR, String#toLowerCase() maps an upper-case I to dotless-i (U+0131), so a default-locale lowercase
     // on one side of the lookup and Locale.ROOT on the other (HiveHoodieReaderContext) cannot match for any name
-    // that contains an upper-case I. Surefire runs this module single-forked and sequentially, so toggling the
-    // default locale here does not leak into other tests.
+    // that contains an upper-case I. Surefire reuses one JVM across the module's tests, so the finally block below
+    // is what keeps the toggle from reaching any test that runs after this one.
     Locale saved = Locale.getDefault();
     Locale.setDefault(Locale.forLanguageTag("tr-TR"));
     try {

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -1044,13 +1045,39 @@ public class TestHoodieSchemaUtils {
     assertTrue(fieldNames1.contains("timestamp"));
 
     // Field names are matched case-insensitively; HiveHoodieReaderContext lowercases names before calling this.
-    HoodieSchema schema2 = HoodieSchemaUtils.generateProjectionSchema(originalSchema, Arrays.asList("_ROW_KEY"));
+    HoodieSchema schema2 = HoodieSchemaUtils.generateProjectionSchema(originalSchema, Arrays.asList("PII_COL"));
     assertEquals(1, schema2.getFields().size());
-    assertEquals("_row_key", schema2.getFields().get(0).name());
+    assertEquals("pii_col", schema2.getFields().get(0).name());
 
     Throwable caughtException = assertThrows(HoodieException.class, () ->
         HoodieSchemaUtils.generateProjectionSchema(originalSchema, Arrays.asList("_row_key", "timestamp", "fake_field")));
     assertTrue(caughtException.getMessage().contains("Field fake_field not found in log schema. Query cannot proceed!"));
+  }
+
+  @Test
+  public void testGenerateProjectionSchemaIgnoresDefaultLocale() {
+    // Under tr-TR, String#toLowerCase() maps an upper-case I to dotless-i (U+0131), so a default-locale lowercase
+    // on one side of the lookup and Locale.ROOT on the other (HiveHoodieReaderContext) cannot match for any name
+    // that contains an upper-case I. Surefire runs this module single-forked and sequentially, so toggling the
+    // default locale here does not leak into other tests.
+    Locale saved = Locale.getDefault();
+    Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+    try {
+      HoodieSchema originalSchema = HoodieSchema.parse(EXAMPLE_SCHEMA);
+      // Request upper-cased, schema lower-cased.
+      HoodieSchema projected = HoodieSchemaUtils.generateProjectionSchema(originalSchema, Arrays.asList("PII_COL"));
+      assertEquals(1, projected.getFields().size());
+      assertEquals("pii_col", projected.getFields().get(0).name());
+
+      // Schema upper-cased, request pre-lowercased with Locale.ROOT the way HiveHoodieReaderContext does it.
+      HoodieSchema upperCaseSchema = HoodieSchema.parse("{\"type\": \"record\",\"name\": \"rec\",\"fields\": ["
+          + "{\"name\": \"ID\", \"type\": \"string\"},{\"name\": \"value\", \"type\": \"int\"}]}");
+      HoodieSchema projectedUpper = HoodieSchemaUtils.generateProjectionSchema(upperCaseSchema, Arrays.asList("id"));
+      assertEquals(1, projectedUpper.getFields().size());
+      assertEquals("ID", projectedUpper.getFields().get(0).name());
+    } finally {
+      Locale.setDefault(saved);
+    }
   }
 
   @Test

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -194,7 +194,7 @@ public abstract class AbstractRealtimeRecordReader {
     List<HoodieSchemaField> hiveSchemaFields = new ArrayList<>();
 
     for (String columnName : hiveColumns) {
-      HoodieSchemaField field = schemaFieldsMap.get(columnName.toLowerCase());
+      HoodieSchemaField field = schemaFieldsMap.get(columnName.toLowerCase(Locale.ROOT));
 
       if (field != null) {
         hiveSchemaFields.add(HoodieSchemaUtils.createNewSchemaField(field));

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
@@ -63,6 +63,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -135,7 +136,7 @@ public class HoodieRealtimeRecordReaderUtils {
      */
     List<HoodieSchemaField> projectedFields = new ArrayList<>();
     for (String fn : fieldNames) {
-      HoodieSchemaField field = schemaFieldsMap.get(fn.toLowerCase());
+      HoodieSchemaField field = schemaFieldsMap.get(fn.toLowerCase(Locale.ROOT));
       if (field == null) {
         throw new HoodieException("Field " + fn + " not found in log schema. Query cannot proceed! "
             + "Derived Schema Fields: " + new ArrayList<>(schemaFieldsMap.keySet()));
@@ -150,7 +151,7 @@ public class HoodieRealtimeRecordReaderUtils {
   }
 
   public static Map<String, HoodieSchemaField> getNameToFieldMap(HoodieSchema schema) {
-    return schema.getFields().stream().map(r -> Pair.of(r.name().toLowerCase(), r))
+    return schema.getFields().stream().map(r -> Pair.of(r.name().toLowerCase(Locale.ROOT), r))
         .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
   }
 
@@ -311,8 +312,8 @@ public class HoodieRealtimeRecordReaderUtils {
    */
   public static HoodieSchema addPartitionFields(HoodieSchema schema, List<String> partitioningFields) {
     final Set<String> firstLevelFieldNames =
-        schema.getFields().stream().map(HoodieSchemaField::name).map(String::toLowerCase).collect(Collectors.toSet());
-    List<String> fieldsToAdd = partitioningFields.stream().map(String::toLowerCase)
+        schema.getFields().stream().map(f -> f.name().toLowerCase(Locale.ROOT)).collect(Collectors.toSet());
+    List<String> fieldsToAdd = partitioningFields.stream().map(f -> f.toLowerCase(Locale.ROOT))
         .filter(x -> !firstLevelFieldNames.contains(x)).collect(Collectors.toList());
 
     return appendNullSchemaFields(schema, fieldsToAdd);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19826

`HoodieSchemaUtils.generateProjectionSchema` matches field names case-insensitively by lowercasing both the schema's field names and the requested names with the JVM default locale, while `HiveHoodieReaderContext` pre-lowercases the requested names with `Locale.ROOT`. Under a `tr_TR` or `az_AZ` default locale an upper-case `I` in a column name becomes dotless-i (U+0131) on the schema side only, the lookup misses and the Hive read fails with `Field id not found in log schema. Query cannot proceed!`.

### Summary and Changelog

Both sides of the lookup now lowercase with `Locale.ROOT`, so the match no longer depends on the JVM's default locale. The legacy realtime reader path lowercased the same way and is aligned in the same commit.

<details>
<summary>Sites changed, and why the other callers were not affected</summary>

- `HoodieSchemaUtils.generateProjectionSchema`: schema-side map key and request-side lookup; javadoc states the `Locale.ROOT` contract.
- `HoodieRealtimeRecordReaderUtils.generateProjectionSchema`, `getNameToFieldMap` and `addPartitionFields` (the last one also used the lowercased partition name as the appended null field's name).
- `AbstractRealtimeRecordReader.constructHiveOrderedSchema`.

`HoodieFileGroupReaderBasedRecordReader`, `HoodieAvroParquetReader`, `MergeIntoHoodieTableCommand` and `BaseBootstrapMetadataHandler` pass names through unchanged, so both sides were already lowercased by the same call. `HiveAvroSerializer` lowercases schema names one-sidedly for Hive's struct type info and is left as is.
</details>

Tests: `testGenerateProjectionSchema` now projects `PII_COL` (a name with an `I`), and the new `testGenerateProjectionSchemaIgnoresDefaultLocale` sets the default locale to `tr-TR` in a try/finally and covers both directions (upper-cased request, and an upper-cased schema field requested pre-lowercased like `HiveHoodieReaderContext` does). hudi-common runs single-forked and sequentially under surefire, so the toggle cannot leak. The new test fails without the fix.

### Impact

Hive reads under a Turkish or Azeri default JVM locale no longer fail on columns whose name contains an upper-case `I`. No behaviour change under any other locale.

### Risk Level

low. The change is confined to the locale argument of existing lowercase calls.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
