### PR TITLE
fix(spark): widen procedure filter numeric comparisons

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -546,6 +546,17 @@ object HoodieProcedureFilterUtils {
    * e.g. a LongType column compares against an IntegerType literal on the widened Long rather
    * than narrowing the column. Returns None when the operands need no widening or cannot be
    * widened, in which case the caller keeps the expression untouched.
+   *
+   * Widening is wider in type but not always lossless in value, and neither case below surfaces
+   * an error to the caller:
+   *  - An integral widened to FloatType or DoubleType rounds values the target cannot represent.
+   *    Without ANSI, LONG with FLOAT widens to FLOAT, so 16777217 compares as 16777216.0f.
+   *  - A decimal operand whose scale leaves fewer integral digits than the other side needs
+   *    overflows the cast: DECIMAL(38,20) with BIGINT widens to DECIMAL(38,20), which holds 18
+   *    integral digits where a Long needs 19. Cast takes its evalMode from SQLConf, so a large
+   *    Long throws under ANSI and yields null without it; either way the per-row Try in
+   *    evaluateExpressionOnRow drops the row. Latent while no procedure declares a decimal
+   *    output column.
    */
   private def widenNumericOperands(operands: Seq[Expression]): Option[Seq[Expression]] = {
     if (operands.exists(!_.resolved)) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.hudi.command.procedures
 
 import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, TypeCoercion, UnresolvedAttribute, UnresolvedFunction}
+import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, DecimalPrecision, TypeCoercion, UnresolvedAttribute, UnresolvedFunction}
 import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, Cast, Coalesce, Divide, EqualNullSafe, Expression, GenericInternalRow, In, Unevaluable}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
@@ -563,20 +563,34 @@ object HoodieProcedureFilterUtils {
    * enabling it: DECIMAL(38,18) * DECIMAL(2,1) yields a scale-16 product, while casting both to
    * DECIMAL(38,18) first drives the product to scale 6 and rounds 0.0000001 away to zero.
    *
-   * A decimal mixed with a non-decimal is left alone too, and so stays unresolved and rejected the
-   * way it is without this coercion. Matching Spark there means its DecimalPrecision promotion,
-   * including the minimum-precision rule for an integral literal that exists to avoid this same
-   * loss, which is more than this widening should take on; see HUDI #19860.
+   * Spark's DecimalPrecision rule promotes integral operands without changing the existing
+   * decimal's type, including minimum precision for integral literals. It also promotes decimals
+   * mixed with floating-point operands to Double. Null operands take the other operand's type.
    */
   private def applyArithmeticTypeCoercion(arith: BinaryArithmetic): Expression = {
     val operands = Seq(arith.left, arith.right)
-    // dataType throws on an unresolved operand, so that has to be ruled out before reading it.
-    if (operands.exists(operand => !operand.resolved || operand.dataType.isInstanceOf[DecimalType])) {
+    if (operands.exists(!_.resolved) || !operands.forall(operand => isNumericOrNull(operand.dataType))) {
       arith
     } else {
-      widenNumericOperands(operands) match {
-        case Some(Seq(widenedLeft, widenedRight)) => arith.withNewChildren(Seq(widenedLeft, widenedRight))
-        case _ => arith
+      val decimalOperands = operands.exists(_.dataType.isInstanceOf[DecimalType])
+      val promoted = if (decimalOperands) {
+        DecimalPrecision.transform.applyOrElse(arith, identity[Expression])
+      } else {
+        arith
+      }
+      promoted match {
+        case binary: BinaryArithmetic =>
+          val children = Seq(binary.left, binary.right)
+          val widened = if (children.forall(_.dataType.isInstanceOf[DecimalType])) {
+            binary
+          } else {
+            widenNumericOperands(children)
+              .map(binary.withNewChildren).getOrElse(binary)
+          }
+          // Spark 3.3 wraps decimal arithmetic in CheckOverflow after operand promotion.
+          // Later versions calculate the result precision within BinaryArithmetic itself.
+          if (decimalOperands) DecimalPrecision.transform.applyOrElse(widened, identity[Expression]) else widened
+        case other => other
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -546,16 +546,17 @@ object HoodieProcedureFilterUtils {
    * e.g. a LongType column compares against an IntegerType literal on the widened Long rather
    * than narrowing the column. Returns None when the operands need no widening or cannot be
    * widened, in which case the caller keeps the expression untouched.
+   *
+   * Numeric conversion can still lose precision:
+   *  - Large integers may round when converted to Float or Double. For example, Long 16777217
+   *    becomes Float 16777216.
+   *  - Large integers may overflow when converted to a decimal with insufficient space before the
+   *    decimal point. For example, DECIMAL(38,20) allows only 18 digits before the decimal point,
+   *    so the 19-digit Long 9000000000000000000 does not fit.
+   *
+   * Rounding can change comparison results. Overflow causes this filter to drop the row without
+   * reporting an error to the caller.
    */
-  // Numeric conversion can still lose precision:
-  // - Large integers may round when converted to Float or Double.
-  //   For example, Long 16777217 becomes Float 16777216.
-  // - Large integers may overflow when converted to a decimal with
-  //   insufficient space before the decimal point.
-  //   For example, DECIMAL(38,20) allows only 18 digits before the decimal
-  //   point, so the 19-digit Long 9000000000000000000 does not fit.
-  // Rounding can change comparison results. Overflow causes this
-  // filter to drop the row without reporting an error to the caller.
   private def widenNumericOperands(operands: Seq[Expression]): Option[Seq[Expression]] = {
     if (operands.exists(!_.resolved)) {
       // dataType throws on an unresolved operand. Such an expression is rejected up front by

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hudi.command.procedures
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, DecimalPrecision, TypeCoercion, UnresolvedAttribute, UnresolvedFunction}
-import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, Cast, Coalesce, Divide, EqualNullSafe, Expression, GenericInternalRow, In, Unevaluable}
+import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, BinaryComparison, Cast, Coalesce, Divide, EqualNullSafe, Expression, GenericInternalRow, In, Unevaluable}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, DecimalType, DoubleType, NullType, NumericType, StructType}
@@ -363,17 +363,17 @@ object HoodieProcedureFilterUtils {
     // Third pass: handle type coercion for numeric comparisons
     functionResolved.transformUp {
       case eq: org.apache.spark.sql.catalyst.expressions.EqualTo =>
-        applyTypeCoercion(eq.left, eq.right, org.apache.spark.sql.catalyst.expressions.EqualTo.apply, eq)
+        applyTypeCoercion(eq)
       case gt: org.apache.spark.sql.catalyst.expressions.GreaterThan =>
-        applyTypeCoercion(gt.left, gt.right, org.apache.spark.sql.catalyst.expressions.GreaterThan.apply, gt)
+        applyTypeCoercion(gt)
       case gte: org.apache.spark.sql.catalyst.expressions.GreaterThanOrEqual =>
-        applyTypeCoercion(gte.left, gte.right, org.apache.spark.sql.catalyst.expressions.GreaterThanOrEqual.apply, gte)
+        applyTypeCoercion(gte)
       case lt: org.apache.spark.sql.catalyst.expressions.LessThan =>
-        applyTypeCoercion(lt.left, lt.right, org.apache.spark.sql.catalyst.expressions.LessThan.apply, lt)
+        applyTypeCoercion(lt)
       case lte: org.apache.spark.sql.catalyst.expressions.LessThanOrEqual =>
-        applyTypeCoercion(lte.left, lte.right, org.apache.spark.sql.catalyst.expressions.LessThanOrEqual.apply, lte)
+        applyTypeCoercion(lte)
       case eqns: EqualNullSafe =>
-        applyTypeCoercion(eqns.left, eqns.right, EqualNullSafe.apply, eqns)
+        applyTypeCoercion(eqns)
       case in: In =>
         applyInTypeCoercion(in)
       // Divide is a BinaryArithmetic but accepts only Double or Decimal, so it needs its own
@@ -539,13 +539,23 @@ object HoodieProcedureFilterUtils {
     }
   }
 
-  private def applyTypeCoercion[T <: Expression](left: Expression,
-                                                 right: Expression,
-                                                 constructor: (Expression, Expression) => T,
-                                                 original: T): T = {
-    widenNumericOperands(Seq(left, right)) match {
-      case Some(Seq(widenedLeft, widenedRight)) => constructor(widenedLeft, widenedRight)
-      case _ => original
+  private def applyTypeCoercion(original: BinaryComparison): Expression = {
+    if (!original.childrenResolved) {
+      original
+    } else {
+      // Spark can replace an integral/decimal-literal inequality with an integral comparison,
+      // avoiding a lossy cast of the column. It also gives integral literals minimum decimal
+      // precision before finding the common comparison type.
+      val promoted = DecimalPrecision.transform.applyOrElse(original, identity[Expression])
+      // Mixed decimal/integral promotion creates two decimal operands. Apply the decimal-pair
+      // rule next, just as a subsequent analyzer iteration would.
+      val comparison = DecimalPrecision.transform.applyOrElse(promoted, identity[Expression])
+      comparison match {
+        case binary: BinaryComparison =>
+          widenNumericOperands(Seq(binary.left, binary.right))
+            .map(binary.withNewChildren).getOrElse(binary)
+        case other => other
+      }
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -556,10 +556,28 @@ object HoodieProcedureFilterUtils {
     }
   }
 
+  /**
+   * Arithmetic keeps its decimal operands exactly as they are. Unlike a comparison,
+   * BinaryArithmetic.checkInputDataTypes accepts two decimals of different precision and scale and
+   * derives the result type from them, so widening to a common type changes the answer rather than
+   * enabling it: DECIMAL(38,18) * DECIMAL(2,1) yields a scale-16 product, while casting both to
+   * DECIMAL(38,18) first drives the product to scale 6 and rounds 0.0000001 away to zero.
+   *
+   * A decimal mixed with a non-decimal is left alone too, and so stays unresolved and rejected the
+   * way it is without this coercion. Matching Spark there means its DecimalPrecision promotion,
+   * including the minimum-precision rule for an integral literal that exists to avoid this same
+   * loss, which is more than this widening should take on; see HUDI #19860.
+   */
   private def applyArithmeticTypeCoercion(arith: BinaryArithmetic): Expression = {
-    widenNumericOperands(Seq(arith.left, arith.right)) match {
-      case Some(Seq(widenedLeft, widenedRight)) => arith.withNewChildren(Seq(widenedLeft, widenedRight))
-      case _ => arith
+    val operands = Seq(arith.left, arith.right)
+    // dataType throws on an unresolved operand, so that has to be ruled out before reading it.
+    if (operands.exists(operand => !operand.resolved || operand.dataType.isInstanceOf[DecimalType])) {
+      arith
+    } else {
+      widenNumericOperands(operands) match {
+        case Some(Seq(widenedLeft, widenedRight)) => arith.withNewChildren(Seq(widenedLeft, widenedRight))
+        case _ => arith
+      }
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -19,12 +19,13 @@ package org.apache.spark.sql.hudi.command.procedures
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, DecimalPrecision, TypeCoercion, UnresolvedAttribute, UnresolvedFunction}
-import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, BinaryComparison, Cast, Coalesce, Divide, EqualNullSafe, Expression, GenericInternalRow, In, Unevaluable}
+import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, BinaryComparison, Cast, Coalesce, Divide, EqualNullSafe, Expression, GenericInternalRow, In, IntegralDivide, Unevaluable}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DataType, DecimalType, DoubleType, NullType, NumericType, StructType}
+import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DecimalType, DoubleType, IntegerType, LongType, NullType, NumericType, ShortType, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
+import java.time.DateTimeException
 import java.util.Locale
 
 import scala.collection.JavaConverters._
@@ -60,17 +61,15 @@ object HoodieProcedureFilterUtils {
         val parsedExpr = sparkSession.sessionState.sqlParser.parseExpression(filterExpression)
 
         // Binding and resolution depend only on the schema, so run the three passes once for the
-        // whole batch instead of per row. A failure leaves no row able to match, which is what the
-        // per-row evaluation below would have done for every row anyway.
-        Try(bindAndResolveExpression(parsedExpr, schema)) match {
-          case Success(boundExpr) => rows.filter(row => evaluateExpressionOnRow(boundExpr, row, schema))
-          case Failure(_) => Seq.empty[Row]
-        }
+        // whole batch instead of per row.
+        val boundExpr = bindAndResolveExpression(parsedExpr, schema)
+        rows.filter(row => evaluateExpressionOnRow(boundExpr, row, schema))
       } match {
         case Success(filteredRows) => filteredRows
-        // Surface an ANSI overflow with Spark's own exception rather than restating it as a
-        // filter-expression problem: the expression is fine, the data does not fit.
-        case Failure(arithmetic: ArithmeticException) => throw arithmetic
+        // Surface an overflowing ANSI cast or arithmetic, or an ANSI cast of a malformed string,
+        // with Spark's own exception rather than restating it as a filter-expression problem: the
+        // expression is fine, the data does not fit.
+        case Failure(e @ (_: ArithmeticException | _: NumberFormatException | _: DateTimeException)) => throw e
         case Failure(exception) =>
           throw new IllegalArgumentException(
             s"Failed to parse or evaluate filter expression '$filterExpression': ${exception.getMessage}",
@@ -376,10 +375,13 @@ object HoodieProcedureFilterUtils {
         applyTypeCoercion(eqns)
       case in: In =>
         applyInTypeCoercion(in)
-      // Divide is a BinaryArithmetic but accepts only Double or Decimal, so it needs its own
-      // target type and has to be matched before the general arithmetic case below.
+      // Divide and IntegralDivide are BinaryArithmetic but accept only Double or Decimal, and only
+      // Long or Decimal, respectively, so each needs its own target type and has to be matched
+      // before the general arithmetic case below.
       case divide: Divide =>
         applyDivideTypeCoercion(divide)
+      case idiv: IntegralDivide =>
+        applyIntegralDivideTypeCoercion(idiv)
       case arith: BinaryArithmetic =>
         applyArithmeticTypeCoercion(arith)
       case coalesce: Coalesce =>
@@ -406,10 +408,11 @@ object HoodieProcedureFilterUtils {
       }
     } match {
       case Success(result) => result
-      // Spark raises SparkArithmeticException, an ArithmeticException, for an overflowing ANSI
-      // cast or arithmetic. Swallowing it would silently drop a row the same query keeps, so let
-      // it out and let the caller fail the way the equivalent query does.
-      case Failure(arithmetic: ArithmeticException) => throw arithmetic
+      // Spark raises SparkArithmeticException for an overflowing ANSI cast or arithmetic, and
+      // SparkNumberFormatException or SparkDateTimeException for an ANSI cast of a malformed
+      // string; each extends the matching JDK type. Swallowing one would silently drop a row the
+      // same query keeps, so let it out and let the caller fail the way the equivalent query does.
+      case Failure(e @ (_: ArithmeticException | _: NumberFormatException | _: DateTimeException)) => throw e
       case Failure(_) => false
     }
   }
@@ -513,6 +516,11 @@ object HoodieProcedureFilterUtils {
           val names = unsupportedExpressions.toSeq.sorted
           val detail = if (names.nonEmpty) s": ${names.mkString(", ")}" else ""
           Left(s"Unsupported filter expression$detail")
+        } else if (resolvedExpr.dataType != BooleanType) {
+          // Spark rejects any non-boolean filter condition, string included, with
+          // DATATYPE_MISMATCH.FILTER_NOT_BOOLEAN. Without this a resolvable expression such as
+          // "ts + 1" would report zero matching rows instead of the error the same query raises.
+          Left(s"Filter expression must be boolean, got ${resolvedExpr.dataType.simpleString}")
         } else {
           Right(())
         }
@@ -552,7 +560,7 @@ object HoodieProcedureFilterUtils {
       val comparison = DecimalPrecision.transform.applyOrElse(promoted, identity[Expression])
       comparison match {
         case binary: BinaryComparison =>
-          widenNumericOperands(Seq(binary.left, binary.right))
+          widenOperands(Seq(binary.left, binary.right))
             .map(binary.withNewChildren).getOrElse(binary)
         case other => other
       }
@@ -560,7 +568,7 @@ object HoodieProcedureFilterUtils {
   }
 
   private def applyInTypeCoercion(in: In): Expression = {
-    widenNumericOperands(in.value +: in.list) match {
+    widenOperands(in.value +: in.list) match {
       case Some(widened) => In(widened.head, widened.tail)
       case _ => in
     }
@@ -594,7 +602,7 @@ object HoodieProcedureFilterUtils {
           val widened = if (children.forall(_.dataType.isInstanceOf[DecimalType])) {
             binary
           } else {
-            widenNumericOperands(children)
+            widenOperands(children)
               .map(binary.withNewChildren).getOrElse(binary)
           }
           // Spark 3.3 wraps decimal arithmetic in CheckOverflow after operand promotion.
@@ -629,12 +637,35 @@ object HoodieProcedureFilterUtils {
     }
   }
 
+  /**
+   * IntegralDivide accepts only Long or Decimal, and its operands are never widened against each
+   * other, so a same-typed Int pair leaves "id div 2" unresolved while "ts div 2" resolves. Mirror
+   * the analyzer's IntegralDivision rule, which promotes each narrower integral operand on its own
+   * before the arithmetic widening runs.
+   */
+  private def applyIntegralDivideTypeCoercion(divide: IntegralDivide): Expression = {
+    if (!divide.childrenResolved) {
+      divide
+    } else {
+      val promoted = divide.withNewChildren(Seq(divide.left, divide.right).map { operand =>
+        operand.dataType match {
+          case ByteType | ShortType | IntegerType => castTo(operand, LongType)
+          case _ => operand
+        }
+      })
+      promoted match {
+        case arith: BinaryArithmetic => applyArithmeticTypeCoercion(arith)
+        case other => other
+      }
+    }
+  }
+
   /** Spark's own guard for the numeric coercion rules, which admit a null literal. */
   private def isNumericOrNull(dataType: DataType): Boolean =
     dataType.isInstanceOf[NumericType] || dataType.isInstanceOf[NullType]
 
   private def applyCoalesceTypeCoercion(coalesce: Coalesce): Expression = {
-    widenNumericOperands(coalesce.children) match {
+    widenOperands(coalesce.children) match {
       case Some(widened) => Coalesce(widened)
       case _ => coalesce
     }
@@ -643,9 +674,10 @@ object HoodieProcedureFilterUtils {
   /**
    * Widens comparison operands of differing numeric types to their common wider type, so that
    * e.g. a LongType column compares against an IntegerType literal on the widened Long rather
-   * than narrowing the column. A NullType operand widens along with them, the way Spark plans
-   * `ts IN (1000, null)`. Returns None when the operands need no widening or cannot be widened,
-   * in which case the caller keeps the expression untouched.
+   * than narrowing the column. A NullType operand takes the type of its peers whatever that type
+   * is, the way Spark plans `ts IN (1000, null)` and `name IN ('a1', null)`. Returns None when the
+   * operands need no widening or cannot be widened, in which case the caller keeps the expression
+   * untouched.
    *
    * Numeric conversion can still lose precision:
    *  - Large integers may round when converted to Float or Double. For example, Long 16777217
@@ -658,7 +690,7 @@ object HoodieProcedureFilterUtils {
    * follows the session's ANSI mode the way Spark's own Cast does: without ANSI the cast yields
    * null and the row is filtered out, with ANSI it raises and the failure reaches the caller.
    */
-  private def widenNumericOperands(operands: Seq[Expression]): Option[Seq[Expression]] = {
+  private def widenOperands(operands: Seq[Expression]): Option[Seq[Expression]] = {
     if (operands.exists(!_.resolved)) {
       // dataType throws on an unresolved operand. Leaving it untouched lets validateFilterExpression
       // report its own message ("Invalid column references", "Unsupported functions") instead of an
@@ -666,7 +698,14 @@ object HoodieProcedureFilterUtils {
       None
     } else {
       val operandTypes = operands.map(_.dataType)
-      if (operandTypes.distinct.length == 1 || !operandTypes.forall(isNumericOrNull)) {
+      val nonNullTypes = operandTypes.filterNot(_.isInstanceOf[NullType]).distinct
+      if (operandTypes.distinct.length == 1) {
+        None
+      } else if (nonNullTypes.length == 1) {
+        // Only nulls differ from a single peer type, so the nulls take that type whether or not it
+        // is numeric. Nothing else needs widening.
+        Some(operands.map(operand => castTo(operand, nonNullTypes.head)))
+      } else if (!operandTypes.forall(isNumericOrNull)) {
         None
       } else {
         findWiderNumericType(operandTypes)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -68,6 +68,9 @@ object HoodieProcedureFilterUtils {
         }
       } match {
         case Success(filteredRows) => filteredRows
+        // Surface an ANSI overflow with Spark's own exception rather than restating it as a
+        // filter-expression problem: the expression is fine, the data does not fit.
+        case Failure(arithmetic: ArithmeticException) => throw arithmetic
         case Failure(exception) =>
           throw new IllegalArgumentException(
             s"Failed to parse or evaluate filter expression '$filterExpression': ${exception.getMessage}",
@@ -399,6 +402,10 @@ object HoodieProcedureFilterUtils {
       }
     } match {
       case Success(result) => result
+      // Spark raises SparkArithmeticException, an ArithmeticException, for an overflowing ANSI
+      // cast or arithmetic. Swallowing it would silently drop a row the same query keeps, so let
+      // it out and let the caller fail the way the equivalent query does.
+      case Failure(arithmetic: ArithmeticException) => throw arithmetic
       case Failure(_) => false
     }
   }
@@ -573,8 +580,9 @@ object HoodieProcedureFilterUtils {
    *    decimal point. For example, DECIMAL(38,20) allows only 18 digits before the decimal point,
    *    so the 19-digit Long 9000000000000000000 does not fit.
    *
-   * Rounding can change comparison results. Overflow causes this filter to drop the row without
-   * reporting an error to the caller.
+   * Rounding can change comparison results, silently, exactly as it does in a query. Overflow
+   * follows the session's ANSI mode the way Spark's own Cast does: without ANSI the cast yields
+   * null and the row is filtered out, with ANSI it raises and the failure reaches the caller.
    */
   private def widenNumericOperands(operands: Seq[Expression]): Option[Seq[Expression]] = {
     if (operands.exists(!_.resolved)) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.hudi.command.procedures
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, TypeCoercion, UnresolvedAttribute, UnresolvedFunction}
-import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, Cast, Coalesce, EqualNullSafe, Expression, GenericInternalRow, In, Unevaluable}
+import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, Cast, Coalesce, Divide, EqualNullSafe, Expression, GenericInternalRow, In, Unevaluable}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DataType, DecimalType, NullType, NumericType, StructType}
+import org.apache.spark.sql.types.{DataType, DecimalType, DoubleType, NullType, NumericType, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import java.util.Locale
@@ -376,6 +376,10 @@ object HoodieProcedureFilterUtils {
         applyTypeCoercion(eqns.left, eqns.right, EqualNullSafe.apply, eqns)
       case in: In =>
         applyInTypeCoercion(in)
+      // Divide is a BinaryArithmetic but accepts only Double or Decimal, so it needs its own
+      // target type and has to be matched before the general arithmetic case below.
+      case divide: Divide =>
+        applyDivideTypeCoercion(divide)
       case arith: BinaryArithmetic =>
         applyArithmeticTypeCoercion(arith)
       case coalesce: Coalesce =>
@@ -556,6 +560,23 @@ object HoodieProcedureFilterUtils {
     widenNumericOperands(Seq(arith.left, arith.right)) match {
       case Some(Seq(widenedLeft, widenedRight)) => arith.withNewChildren(Seq(widenedLeft, widenedRight))
       case _ => arith
+    }
+  }
+
+  /**
+   * Divide only accepts Double or Decimal, so widening its operands to their common numeric type
+   * leaves an integral pair unresolved and "ts / 2 > 500" rejected while "price / 2 > 5" works.
+   * Mirror the analyzer's Division rule instead: promote an integral pair to Double, and let a
+   * pair that already involves a decimal widen the way the other arithmetic does.
+   */
+  private def applyDivideTypeCoercion(divide: Divide): Expression = {
+    val operands = Seq(divide.left, divide.right)
+    if (operands.exists(!_.resolved) || !operands.forall(_.dataType.isInstanceOf[NumericType])) {
+      divide
+    } else if (operands.exists(_.dataType.isInstanceOf[DecimalType])) {
+      applyArithmeticTypeCoercion(divide)
+    } else {
+      divide.withNewChildren(operands.map(operand => castTo(operand, DoubleType)))
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -18,10 +18,11 @@
 package org.apache.spark.sql.hudi.command.procedures
 
 import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.sql.catalyst.analysis.{TypeCoercion, UnresolvedAttribute, UnresolvedFunction}
-import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, GenericInternalRow, Unevaluable}
+import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, TypeCoercion, UnresolvedAttribute, UnresolvedFunction}
+import org.apache.spark.sql.catalyst.expressions.{Cast, EqualNullSafe, Expression, GenericInternalRow, In, Unevaluable}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.types.{DataType, NumericType, StructType}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{DataType, DecimalType, NumericType, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import java.util.Locale
@@ -58,8 +59,12 @@ object HoodieProcedureFilterUtils {
       Try {
         val parsedExpr = sparkSession.sessionState.sqlParser.parseExpression(filterExpression)
 
-        rows.filter { row =>
-          evaluateExpressionOnRow(parsedExpr, row, schema)
+        // Binding and resolution depend only on the schema, so run the three passes once for the
+        // whole batch instead of per row. A failure leaves no row able to match, which is what the
+        // per-row evaluation below would have done for every row anyway.
+        Try(bindAndResolveExpression(parsedExpr, schema)) match {
+          case Success(boundExpr) => rows.filter(row => evaluateExpressionOnRow(boundExpr, row, schema))
+          case Failure(_) => Seq.empty[Row]
         }
       } match {
         case Success(filteredRows) => filteredRows
@@ -364,15 +369,18 @@ object HoodieProcedureFilterUtils {
         applyTypeCoercion(lt.left, lt.right, org.apache.spark.sql.catalyst.expressions.LessThan.apply, lt)
       case lte: org.apache.spark.sql.catalyst.expressions.LessThanOrEqual =>
         applyTypeCoercion(lte.left, lte.right, org.apache.spark.sql.catalyst.expressions.LessThanOrEqual.apply, lte)
+      case eqns: EqualNullSafe =>
+        applyTypeCoercion(eqns.left, eqns.right, EqualNullSafe.apply, eqns)
+      case in: In =>
+        applyInTypeCoercion(in)
     }
   }
 
-  private def evaluateExpressionOnRow(expression: Expression, row: Row, schema: StructType): Boolean = {
+  private def evaluateExpressionOnRow(boundExpr: Expression, row: Row, schema: StructType): Boolean = {
 
     val internalRow = convertRowToInternalRow(row, schema)
 
     Try {
-      val boundExpr = bindAndResolveExpression(expression, schema)
       val result = boundExpr.eval(internalRow)
 
       result match {
@@ -516,21 +524,65 @@ object HoodieProcedureFilterUtils {
     }
   }
 
-  private def applyTypeCoercion[T <: org.apache.spark.sql.catalyst.expressions.Expression](
-                                                                                            left: org.apache.spark.sql.catalyst.expressions.Expression,
-                                                                                            right: org.apache.spark.sql.catalyst.expressions.Expression,
-                                                                                            constructor: (org.apache.spark.sql.catalyst.expressions.Expression, org.apache.spark.sql.catalyst.expressions.Expression) => T,
-                                                                                            original: T): T = {
-    (left.dataType, right.dataType) match {
-      case (_: NumericType, _: NumericType) =>
-        TypeCoercion.findWiderTypeForTwo(left.dataType, right.dataType)
-          .map { widerType =>
-            val coercedLeft = if (left.dataType == widerType) left else Cast(left, widerType)
-            val coercedRight = if (right.dataType == widerType) right else Cast(right, widerType)
-            constructor(coercedLeft, coercedRight)
-          }
-          .getOrElse(original)
+  private def applyTypeCoercion[T <: Expression](left: Expression,
+                                                 right: Expression,
+                                                 constructor: (Expression, Expression) => T,
+                                                 original: T): T = {
+    widenNumericOperands(Seq(left, right)) match {
+      case Some(Seq(widenedLeft, widenedRight)) => constructor(widenedLeft, widenedRight)
       case _ => original
     }
+  }
+
+  private def applyInTypeCoercion(in: In): Expression = {
+    widenNumericOperands(in.value +: in.list) match {
+      case Some(widened) => In(widened.head, widened.tail)
+      case _ => in
+    }
+  }
+
+  /**
+   * Widens comparison operands of differing numeric types to their common wider type, so that
+   * e.g. a LongType column compares against an IntegerType literal on the widened Long rather
+   * than narrowing the column. Returns None when the operands need no widening or cannot be
+   * widened, in which case the caller keeps the expression untouched.
+   */
+  private def widenNumericOperands(operands: Seq[Expression]): Option[Seq[Expression]] = {
+    if (operands.exists(!_.resolved)) {
+      // dataType throws on an unresolved operand. Such an expression is rejected up front by
+      // validateFilterExpression, so leave it alone here rather than failing the whole transform.
+      None
+    } else {
+      val operandTypes = operands.map(_.dataType)
+      // Decimal ordering is already precision- and scale-independent, while DecimalType.bounded
+      // clamps precision at 38, so widening decimals against each other can narrow one side into
+      // a null (non-ANSI) or an overflow error (ANSI). Compare those as they are.
+      if (operandTypes.distinct.length == 1
+        || !operandTypes.forall(_.isInstanceOf[NumericType])
+        || operandTypes.forall(_.isInstanceOf[DecimalType])) {
+        None
+      } else {
+        findWiderNumericType(operandTypes)
+          .map(widerType => operands.map(operand => castTo(operand, widerType)))
+      }
+    }
+  }
+
+  /**
+   * Mirrors the analyzer's choice of coercion rules, so that a filter widens the way the same
+   * comparison would in a SQL query. The two disagree: for BIGINT with FLOAT, AnsiTypeCoercion
+   * gives DOUBLE while TypeCoercion follows numericPrecedence and gives FLOAT. Spark 4 defaults
+   * to ANSI mode, Spark 3 does not.
+   */
+  private def findWiderNumericType(types: Seq[DataType]): Option[DataType] = {
+    if (SQLConf.get.ansiEnabled) {
+      AnsiTypeCoercion.findWiderCommonType(types)
+    } else {
+      TypeCoercion.findWiderCommonType(types)
+    }
+  }
+
+  private def castTo(expression: Expression, dataType: DataType): Expression = {
+    if (expression.dataType == dataType) expression else Cast(expression, dataType)
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -18,10 +18,10 @@
 package org.apache.spark.sql.hudi.command.procedures
 
 import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedFunction}
-import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow, Unevaluable}
+import org.apache.spark.sql.catalyst.analysis.{TypeCoercion, UnresolvedAttribute, UnresolvedFunction}
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, GenericInternalRow, Unevaluable}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.types.{DataType, StructType}
+import org.apache.spark.sql.types.{DataType, NumericType, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import java.util.Locale
@@ -521,11 +521,15 @@ object HoodieProcedureFilterUtils {
                                                                                             right: org.apache.spark.sql.catalyst.expressions.Expression,
                                                                                             constructor: (org.apache.spark.sql.catalyst.expressions.Expression, org.apache.spark.sql.catalyst.expressions.Expression) => T,
                                                                                             original: T): T = {
-    (left, right) match {
-      case (boundRef: org.apache.spark.sql.catalyst.expressions.BoundReference, literal: org.apache.spark.sql.catalyst.expressions.Literal)
-        if boundRef.dataType == org.apache.spark.sql.types.LongType && literal.dataType == org.apache.spark.sql.types.IntegerType =>
-        val castExpr = org.apache.spark.sql.catalyst.expressions.Cast(boundRef, org.apache.spark.sql.types.IntegerType)
-        constructor(castExpr, literal)
+    (left.dataType, right.dataType) match {
+      case (_: NumericType, _: NumericType) =>
+        TypeCoercion.findWiderTypeForTwo(left.dataType, right.dataType)
+          .map { widerType =>
+            val coercedLeft = if (left.dataType == widerType) left else Cast(left, widerType)
+            val coercedRight = if (right.dataType == widerType) right else Cast(right, widerType)
+            constructor(coercedLeft, coercedRight)
+          }
+          .getOrElse(original)
       case _ => original
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -546,18 +546,16 @@ object HoodieProcedureFilterUtils {
    * e.g. a LongType column compares against an IntegerType literal on the widened Long rather
    * than narrowing the column. Returns None when the operands need no widening or cannot be
    * widened, in which case the caller keeps the expression untouched.
-   *
-   * Widening is wider in type but not always lossless in value, and neither case below surfaces
-   * an error to the caller:
-   *  - An integral widened to FloatType or DoubleType rounds values the target cannot represent.
-   *    Without ANSI, LONG with FLOAT widens to FLOAT, so 16777217 compares as 16777216.0f.
-   *  - A decimal operand whose scale leaves fewer integral digits than the other side needs
-   *    overflows the cast: DECIMAL(38,20) with BIGINT widens to DECIMAL(38,20), which holds 18
-   *    integral digits where a Long needs 19. Cast takes its evalMode from SQLConf, so a large
-   *    Long throws under ANSI and yields null without it; either way the per-row Try in
-   *    evaluateExpressionOnRow drops the row. Latent while no procedure declares a decimal
-   *    output column.
    */
+  // Numeric conversion can still lose precision:
+  // - Large integers may round when converted to Float or Double.
+  //   For example, Long 16777217 becomes Float 16777216.
+  // - Large integers may overflow when converted to a decimal with
+  //   insufficient space before the decimal point.
+  //   For example, DECIMAL(38,20) allows only 18 digits before the decimal
+  //   point, so the 19-digit Long 9000000000000000000 does not fit.
+  // Rounding can change comparison results. Overflow causes this
+  // filter to drop the row without reporting an error to the caller.
   private def widenNumericOperands(operands: Seq[Expression]): Option[Seq[Expression]] = {
     if (operands.exists(!_.resolved)) {
       // dataType throws on an unresolved operand. Such an expression is rejected up front by

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -566,12 +566,19 @@ object HoodieProcedureFilterUtils {
   /**
    * Divide only accepts Double or Decimal, so widening its operands to their common numeric type
    * leaves an integral pair unresolved and "ts / 2 > 500" rejected while "price / 2 > 5" works.
-   * Mirror the analyzer's Division rule instead: promote an integral pair to Double, and let a
-   * pair that already involves a decimal widen the way the other arithmetic does.
+   * Mirror the analyzer's Division rule instead: leave a pair that involves a decimal to the same
+   * widening as the other arithmetic, and promote everything else to Double. Like Spark, that
+   * includes a null operand, so "ts / null" resolves and evaluates to null rather than failing
+   * validation. The rule is unchanged between the two majors this builds against, only relocated:
+   *
+   * 3.5.5 object Division, in
+   * https://github.com/apache/spark/blob/v3.5.5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+   * 4.1.1
+   * https://github.com/apache/spark/blob/v4.1.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DivisionTypeCoercion.scala
    */
   private def applyDivideTypeCoercion(divide: Divide): Expression = {
     val operands = Seq(divide.left, divide.right)
-    if (operands.exists(!_.resolved) || !operands.forall(_.dataType.isInstanceOf[NumericType])) {
+    if (operands.exists(!_.resolved) || !operands.forall(operand => isNumericOrNull(operand.dataType))) {
       divide
     } else if (operands.exists(_.dataType.isInstanceOf[DecimalType])) {
       applyArithmeticTypeCoercion(divide)
@@ -579,6 +586,10 @@ object HoodieProcedureFilterUtils {
       divide.withNewChildren(operands.map(operand => castTo(operand, DoubleType)))
     }
   }
+
+  /** Spark's own guard for the numeric coercion rules, which admit a null literal. */
+  private def isNumericOrNull(dataType: DataType): Boolean =
+    dataType.isInstanceOf[NumericType] || dataType.isInstanceOf[NullType]
 
   private def applyCoalesceTypeCoercion(coalesce: Coalesce): Expression = {
     widenNumericOperands(coalesce.children) match {
@@ -613,8 +624,7 @@ object HoodieProcedureFilterUtils {
       None
     } else {
       val operandTypes = operands.map(_.dataType)
-      if (operandTypes.distinct.length == 1
-        || !operandTypes.forall(t => t.isInstanceOf[NumericType] || t.isInstanceOf[NullType])) {
+      if (operandTypes.distinct.length == 1 || !operandTypes.forall(isNumericOrNull)) {
         None
       } else {
         findWiderNumericType(operandTypes)
@@ -632,6 +642,11 @@ object HoodieProcedureFilterUtils {
    * Reads SQLConf.get rather than the SparkSession because Cast takes its eval mode from that same
    * thread-local at construction, and the two-argument Cast(child, dataType) is the only form that
    * is portable across Spark 3.3 to 4.x (3.3 takes ansiEnabled, 3.4+ takes evalMode).
+   *
+   * Decimal pairs go through Spark's own precision rules, which likewise only moved between the
+   * majors: 3.5.5 analysis/DecimalPrecision.scala, 4.1.1 analysis/DecimalPrecisionTypeCoercion
+   * .scala. Parity for a comparison whose common precision would exceed 38 is not settled here;
+   * see HUDI #19860.
    */
   private def findWiderNumericType(types: Seq[DataType]): Option[DataType] = {
     if (SQLConf.get.ansiEnabled) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedureFilterUtils.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.hudi.command.procedures
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, TypeCoercion, UnresolvedAttribute, UnresolvedFunction}
-import org.apache.spark.sql.catalyst.expressions.{Cast, EqualNullSafe, Expression, GenericInternalRow, In, Unevaluable}
+import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, Cast, Coalesce, EqualNullSafe, Expression, GenericInternalRow, In, Unevaluable}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DataType, DecimalType, NumericType, StructType}
+import org.apache.spark.sql.types.{DataType, DecimalType, NullType, NumericType, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import java.util.Locale
@@ -373,6 +373,10 @@ object HoodieProcedureFilterUtils {
         applyTypeCoercion(eqns.left, eqns.right, EqualNullSafe.apply, eqns)
       case in: In =>
         applyInTypeCoercion(in)
+      case arith: BinaryArithmetic =>
+        applyArithmeticTypeCoercion(arith)
+      case coalesce: Coalesce =>
+        applyCoalesceTypeCoercion(coalesce)
     }
   }
 
@@ -541,11 +545,26 @@ object HoodieProcedureFilterUtils {
     }
   }
 
+  private def applyArithmeticTypeCoercion(arith: BinaryArithmetic): Expression = {
+    widenNumericOperands(Seq(arith.left, arith.right)) match {
+      case Some(Seq(widenedLeft, widenedRight)) => arith.withNewChildren(Seq(widenedLeft, widenedRight))
+      case _ => arith
+    }
+  }
+
+  private def applyCoalesceTypeCoercion(coalesce: Coalesce): Expression = {
+    widenNumericOperands(coalesce.children) match {
+      case Some(widened) => Coalesce(widened)
+      case _ => coalesce
+    }
+  }
+
   /**
    * Widens comparison operands of differing numeric types to their common wider type, so that
    * e.g. a LongType column compares against an IntegerType literal on the widened Long rather
-   * than narrowing the column. Returns None when the operands need no widening or cannot be
-   * widened, in which case the caller keeps the expression untouched.
+   * than narrowing the column. A NullType operand widens along with them, the way Spark plans
+   * `ts IN (1000, null)`. Returns None when the operands need no widening or cannot be widened,
+   * in which case the caller keeps the expression untouched.
    *
    * Numeric conversion can still lose precision:
    *  - Large integers may round when converted to Float or Double. For example, Long 16777217
@@ -559,17 +578,14 @@ object HoodieProcedureFilterUtils {
    */
   private def widenNumericOperands(operands: Seq[Expression]): Option[Seq[Expression]] = {
     if (operands.exists(!_.resolved)) {
-      // dataType throws on an unresolved operand. Such an expression is rejected up front by
-      // validateFilterExpression, so leave it alone here rather than failing the whole transform.
+      // dataType throws on an unresolved operand. Leaving it untouched lets validateFilterExpression
+      // report its own message ("Invalid column references", "Unsupported functions") instead of an
+      // UnresolvedException, and keeps Or/And short-circuiting intact at eval time.
       None
     } else {
       val operandTypes = operands.map(_.dataType)
-      // Decimal ordering is already precision- and scale-independent, while DecimalType.bounded
-      // clamps precision at 38, so widening decimals against each other can narrow one side into
-      // a null (non-ANSI) or an overflow error (ANSI). Compare those as they are.
       if (operandTypes.distinct.length == 1
-        || !operandTypes.forall(_.isInstanceOf[NumericType])
-        || operandTypes.forall(_.isInstanceOf[DecimalType])) {
+        || !operandTypes.forall(t => t.isInstanceOf[NumericType] || t.isInstanceOf[NullType])) {
         None
       } else {
         findWiderNumericType(operandTypes)
@@ -583,6 +599,10 @@ object HoodieProcedureFilterUtils {
    * comparison would in a SQL query. The two disagree: for BIGINT with FLOAT, AnsiTypeCoercion
    * gives DOUBLE while TypeCoercion follows numericPrecedence and gives FLOAT. Spark 4 defaults
    * to ANSI mode, Spark 3 does not.
+   *
+   * Reads SQLConf.get rather than the SparkSession because Cast takes its eval mode from that same
+   * thread-local at construction, and the two-argument Cast(child, dataType) is the only form that
+   * is portable across Spark 3.3 to 4.x (3.3 takes ansiEnabled, 3.4+ takes evalMode).
    */
   private def findWiderNumericType(types: Seq[DataType]): Option[DataType] = {
     if (SQLConf.get.ansiEnabled) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestFsViewProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestFsViewProcedure.scala
@@ -60,6 +60,19 @@ class TestFsViewProcedure extends HoodieSparkProcedureTestBase {
       assertResult(2){
         result1.length
       }
+
+      // filter runs against the procedure output schema, where data_file_size is a LongType
+      // column, so an integer literal on either side has to widen to compare. See HUDI #19632.
+      val filtered = spark.sql(
+        s"""call show_fsview_all(table => '$tableName', filter => 'data_file_size > 0')""".stripMargin).collect()
+      assertResult(2){
+        filtered.length
+      }
+      val reversedFilter = spark.sql(
+        s"""call show_fsview_all(table => '$tableName', filter => '0 < data_file_size')""".stripMargin).collect()
+      assertResult(2){
+        reversedFilter.length
+      }
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestFsViewProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestFsViewProcedure.scala
@@ -74,9 +74,10 @@ class TestFsViewProcedure extends HoodieSparkProcedureTestBase {
       assertResult(2){
         decimalFilter.length
       }
-      // A filter that keeps nothing, so the pair above is not just a filter being ignored.
+      // A filter that keeps nothing, widened the same way, so the pair above is not just a filter
+      // being ignored.
       val emptyFilter = spark.sql(
-        s"""call show_fsview_all(table => '$tableName', filter => 'data_file_size > 9999999999')""".stripMargin).collect()
+        s"""call show_fsview_all(table => '$tableName', filter => 'data_file_size > 9999999999.0')""".stripMargin).collect()
       assertResult(0){
         emptyFilter.length
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestFsViewProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestFsViewProcedure.scala
@@ -62,16 +62,23 @@ class TestFsViewProcedure extends HoodieSparkProcedureTestBase {
       }
 
       // filter runs against the procedure output schema, where data_file_size is a LongType
-      // column, so an integer literal on either side has to widen to compare. See HUDI #19632.
-      val filtered = spark.sql(
-        s"""call show_fsview_all(table => '$tableName', filter => 'data_file_size > 0')""".stripMargin).collect()
-      assertResult(2){
-        filtered.length
-      }
+      // column, so a literal of any numeric type, on either side, has to widen to compare.
+      // See HUDI #19632.
       val reversedFilter = spark.sql(
         s"""call show_fsview_all(table => '$tableName', filter => '0 < data_file_size')""".stripMargin).collect()
       assertResult(2){
         reversedFilter.length
+      }
+      val decimalFilter = spark.sql(
+        s"""call show_fsview_all(table => '$tableName', filter => 'data_file_size >= 0.0')""".stripMargin).collect()
+      assertResult(2){
+        decimalFilter.length
+      }
+      // A filter that keeps nothing, so the pair above is not just a filter being ignored.
+      val emptyFilter = spark.sql(
+        s"""call show_fsview_all(table => '$tableName', filter => 'data_file_size > 9999999999')""".stripMargin).collect()
+      assertResult(0){
+        emptyFilter.length
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -69,9 +69,6 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(2)(keep(scalarRows, "id <= 2", scalarSchema).length)
     assertResult(Seq(scalarRows(1)))(keep(scalarRows, "id != 1", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "name = 'a1'", scalarSchema))
-    // The literal must match the column type, so use an explicit double literal here; the plain
-    // 15.0 (decimal) form is pinned in the numeric-coercion test below.
-    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "price > 15.0d", scalarSchema))
     // Bare boolean column evaluates to a Boolean result directly.
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "flag", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "flag = true", scalarSchema))
@@ -84,13 +81,19 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Seq(scalarRows(1)))(keep(scalarRows, "ts >= 2000", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "ts < 2000", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "ts <= 1000", scalarSchema))
-    // The integer literal is widened, preserving Long values beyond the Int range.
-    val bigRow = Seq(Row(3, "c3", 30.0d, 3000000000L, true, -9,
-      Date.valueOf("2024-03-16"), Timestamp.valueOf("2024-03-16 12:30:00")))
-    assertResult(bigRow)(keep(bigRow, "ts > 2000", scalarSchema))
+    // The integer literal is widened rather than the column narrowed, so a Long past the Int
+    // range keeps its value instead of wrapping to -1294967296 and matching "ts < 2000".
+    val bigRow = Row(3, "c3", 30.0d, 3000000000L, true, -9,
+      Date.valueOf("2024-03-16"), Timestamp.valueOf("2024-03-16 12:30:00"))
+    val withBigRow = scalarRows :+ bigRow
+    assertResult(Seq(scalarRows(1), bigRow))(keep(withBigRow, "ts > 1500", scalarSchema))
+    assertResult(Seq(scalarRows.head))(keep(withBigRow, "ts < 2000", scalarSchema))
     // Coercion applies symmetrically when the literal is on the left.
-    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "1500 < ts", scalarSchema))
-    assertResult(Seq(scalarRows.head))(keep(scalarRows, "1000 = ts", scalarSchema))
+    assertResult(Seq(scalarRows(1), bigRow))(keep(withBigRow, "1500 < ts", scalarSchema))
+    assertResult(Seq(scalarRows.head))(keep(withBigRow, "1000 = ts", scalarSchema))
+    // IN and <=> widen through the same path as the binary comparisons.
+    assertResult(scalarRows)(keep(withBigRow, "ts IN (1000, 2000)", scalarSchema))
+    assertResult(Seq(scalarRows.head))(keep(withBigRow, "ts <=> 1000", scalarSchema))
   }
 
   test("evaluateFilter coerces numeric column and literal type pairs") {
@@ -99,19 +102,52 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
       "sh" -> ShortType,
       "by" -> ByteType,
       "dec" -> DecimalType(10, 2))
-    val rows = Seq(Row(2.5f, 3.toShort, 4.toByte, new java.math.BigDecimal("3.00")))
+    // Two rows, so an assertion that matches everything is distinguishable from one that
+    // coerces correctly.
+    val rows = Seq(
+      Row(2.5f, 3.toShort, 4.toByte, new java.math.BigDecimal("3.00")),
+      Row(0.5f, 9.toShort, 9.toByte, new java.math.BigDecimal("0.50")))
+    val matched = Seq(rows.head)
 
     // Literals whose parsed type already matches the column type evaluate correctly.
-    assertResult(rows)(keep(rows, "f > 1.0f", schema))
-    assertResult(rows)(keep(rows, "dec > 1.00", schema))
+    assertResult(matched)(keep(rows, "f > 1.0f", schema))
+    assertResult(matched)(keep(rows, "dec > 1.00", schema))
 
     // Mismatched numeric types are widened to Spark's common type.
-    assertResult(rows)(keep(rows, "sh = 3", schema))
-    assertResult(rows)(keep(rows, "by = 4", schema))
-    assertResult(rows)(keep(rows, "f > 1.0d", schema))
-    assertResult(rows)(keep(rows, "dec > 1", schema))
+    assertResult(matched)(keep(rows, "sh = 3", schema))
+    assertResult(matched)(keep(rows, "by = 4", schema))
+    assertResult(matched)(keep(rows, "f > 1.0d", schema))
+    assertResult(matched)(keep(rows, "dec > 1", schema))
+    // Reversed operands widen the same way.
+    assertResult(matched)(keep(rows, "3 = sh", schema))
+    assertResult(rows)(keep(rows, "by < 300", schema))
     // A plain 15.0 decimal literal is coerced with the double column.
     assertResult(Seq(scalarRows(1)))(keep(scalarRows, "price > 15.0", scalarSchema))
+  }
+
+  test("evaluateFilter compares decimal columns without widening them") {
+    // DecimalType.bounded clamps precision at 38, so widening DECIMAL(38,0) towards DECIMAL(38,18)
+    // would overflow the integral side into a null (non-ANSI) or an error (ANSI). Decimal ordering
+    // is already precision- and scale-independent, so an all-decimal comparison is left alone.
+    val schema = schemaOf("big" -> DecimalType(38, 0), "frac" -> DecimalType(38, 18))
+    val rows = Seq(Row(new java.math.BigDecimal("1" + "0" * 30), new java.math.BigDecimal("1.5")))
+    assertResult(rows)(keep(rows, "big > frac", schema))
+    assertResult(Seq.empty)(keep(rows, "frac > big", schema))
+  }
+
+  test("evaluateFilter widens with the coercion rules of the active ANSI mode") {
+    // The two coercion objects disagree on BIGINT with FLOAT: AnsiTypeCoercion widens to DOUBLE,
+    // TypeCoercion follows numericPrecedence to FLOAT. 16777217 is the first Long that a Float
+    // cannot hold, so it survives the widening under ANSI and rounds down to 16777216.0f without
+    // it. A filter has to widen the way the same comparison would in a query.
+    val rows = Seq(Row(1, "n1", 1.0d, 16777217L, true, 0,
+      Date.valueOf("2024-01-01"), Timestamp.valueOf("2024-01-01 00:00:00")))
+    withSQLConf("spark.sql.ansi.enabled" -> "true") {
+      assertResult(rows)(keep(rows, "ts > 16777216.0f", scalarSchema))
+    }
+    withSQLConf("spark.sql.ansi.enabled" -> "false") {
+      assertResult(Seq.empty)(keep(rows, "ts > 16777216.0f", scalarSchema))
+    }
   }
 
   test("evaluateFilter silently drops rows for expressions it cannot resolve") {
@@ -148,9 +184,8 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   }
 
   test("evaluateFilter resolves numeric and cast functions") {
-    // The util only special-cases a long column vs an integer literal; every other numeric
-    // comparison relies on the literal already matching the expression's result type. So the
-    // literals below are typed to match: round/double yield double, ceil/floor/long yield long.
+    // Literals are typed to match each function's result type (round/double yield double,
+    // ceil/floor/long yield long); the widening above would cover a mismatch either way.
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "abs(neg) = 5", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "round(price) = 10.0d", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "round(price, 1) = 10.0d", scalarSchema))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -77,32 +77,23 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "flag = true", scalarSchema))
   }
 
-  test("evaluateFilter coerces Long columns against integer literals") {
+  test("evaluateFilter widens Long columns and integer literals") {
     // Exercises applyTypeCoercion for every comparison operator (Long boundRef vs Int literal).
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "ts = 1000", scalarSchema))
     assertResult(Seq(scalarRows(1)))(keep(scalarRows, "ts > 1500", scalarSchema))
     assertResult(Seq(scalarRows(1)))(keep(scalarRows, "ts >= 2000", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "ts < 2000", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "ts <= 1000", scalarSchema))
-    // Known limitation: the coercion narrows the Long column to Int instead of widening the Int
-    // literal, so a Long value beyond Int range never matches (wrong results under non-ANSI Spark,
-    // swallowed overflow error under ANSI). Pinned here so a fix flips this assertion; see #19632.
+    // The integer literal is widened, preserving Long values beyond the Int range.
     val bigRow = Seq(Row(3, "c3", 30.0d, 3000000000L, true, -9,
       Date.valueOf("2024-03-16"), Timestamp.valueOf("2024-03-16 12:30:00")))
-    assertResult(Seq.empty)(keep(bigRow, "ts > 2000", scalarSchema))
-    // Known limitation: the coercion only matches column-on-left, so a literal-on-left comparison
-    // never coerces and drops every row instead of mirroring the equivalent column-on-left filter.
-    // Pinned here so a fix flips these assertions; see #19632.
-    assertResult(Seq.empty)(keep(scalarRows, "1500 < ts", scalarSchema))
-    assertResult(Seq.empty)(keep(scalarRows, "1000 = ts", scalarSchema))
+    assertResult(bigRow)(keep(bigRow, "ts > 2000", scalarSchema))
+    // Coercion applies symmetrically when the literal is on the left.
+    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "1500 < ts", scalarSchema))
+    assertResult(Seq(scalarRows.head))(keep(scalarRows, "1000 = ts", scalarSchema))
   }
 
-  test("evaluateFilter does not coerce other numeric column/literal type pairs") {
-    // Known limitation: applyTypeCoercion only special-cases a Long column against an Int literal.
-    // Every other numeric column/literal pair is left alone, so the mismatched comparison fails to
-    // evaluate; the per-row Try swallows the failure and drops the row. The filter therefore
-    // returns no rows instead of erroring on the type mismatch.
-    // Pinned here so a fix flips the Seq.empty assertions; see #19632.
+  test("evaluateFilter coerces numeric column and literal type pairs") {
     val schema = schemaOf(
       "f" -> FloatType,
       "sh" -> ShortType,
@@ -114,13 +105,13 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(rows)(keep(rows, "f > 1.0f", schema))
     assertResult(rows)(keep(rows, "dec > 1.00", schema))
 
-    // Mismatched literal types no-match even though the values would satisfy the predicate.
-    assertResult(Seq.empty)(keep(rows, "sh = 3", schema))
-    assertResult(Seq.empty)(keep(rows, "by = 4", schema))
-    assertResult(Seq.empty)(keep(rows, "f > 1.0d", schema))
-    assertResult(Seq.empty)(keep(rows, "dec > 1", schema))
-    // Same gap for a double column: a plain 15.0 parses as decimal, not double.
-    assertResult(Seq.empty)(keep(scalarRows, "price > 15.0", scalarSchema))
+    // Mismatched numeric types are widened to Spark's common type.
+    assertResult(rows)(keep(rows, "sh = 3", schema))
+    assertResult(rows)(keep(rows, "by = 4", schema))
+    assertResult(rows)(keep(rows, "f > 1.0d", schema))
+    assertResult(rows)(keep(rows, "dec > 1", schema))
+    // A plain 15.0 decimal literal is coerced with the double column.
+    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "price > 15.0", scalarSchema))
   }
 
   test("evaluateFilter silently drops rows for expressions it cannot resolve") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -179,8 +179,9 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     val rows = Seq(Row(new java.math.BigDecimal("1" + "0" * 30), new java.math.BigDecimal("1.5")))
     // Spark 3 only. There the widening picks DECIMAL(38,18), and the precision-38 clamp leaves it
     // 20 integral digits, too few for this 31-digit value, so the cast overflows and the ANSI mode
-    // decides what happens. Spark 4 does not reach an overflow for this pair and its procedure
-    // behaviour here has not been characterised, so nothing is pinned for it.
+    // decides what happens. Parity for a comparison whose common precision would exceed 38 is not
+    // settled on Spark 4 and needs the validation path checked against plain SQL, so nothing is
+    // pinned for it here. Tracked by HUDI #19860.
     if (!HoodieSparkUtils.gteqSpark4_0) {
       withSQLConf("spark.sql.ansi.enabled" -> "false") {
         // The cast yields null and the row drops.

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.hudi.command.procedures.HoodieProcedureFilterUtils
 import org.apache.spark.sql.types._
 
-import java.math.BigDecimal
+import java.math.{BigDecimal => JBigDecimal}
 import java.sql.{Date, Timestamp}
 
 /**
@@ -43,7 +43,8 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   private def validate(expr: String, schema: StructType = scalarSchema): Either[String, Unit] =
     HoodieProcedureFilterUtils.validateFilterExpression(expr, schema, spark)
 
-  private def scalarRow(id: Int, ts: Long): Row =
+  // Not the scalarRows factory: only id and ts matter to the widening tests that use it.
+  private def tsRow(id: Int, ts: Long): Row =
     Row(id, s"n$id", 10.0d * id, ts, true, -id,
       Date.valueOf("2024-01-01"), Timestamp.valueOf("2024-01-01 00:00:00"))
 
@@ -93,7 +94,7 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "ts <= 1000", scalarSchema))
     // The integer literal is widened rather than the column narrowed, so a Long past the Int
     // range keeps its value instead of wrapping to -1294967296 and matching "ts < 2000".
-    val bigRow = scalarRow(3, 3000000000L)
+    val bigRow = tsRow(3, 3000000000L)
     val withBigRow = scalarRows :+ bigRow
     assertResult(Seq(scalarRows(1), bigRow))(keep(withBigRow, "ts > 1500", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(withBigRow, "ts < 2000", scalarSchema))
@@ -117,6 +118,11 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Right(()))(validate("ts IN (1000, null)"))
     assertResult(Seq.empty)(keep(scalarRows, "ts <=> null", scalarSchema))
     assertResult(Right(()))(validate("ts <=> null"))
+    // A null operand takes its peers' type whether or not that type is numeric.
+    assertResult(Seq(scalarRows.head))(keep(scalarRows, "name IN ('a1', null)", scalarSchema))
+    assertResult(Right(()))(validate("name IN ('a1', null)"))
+    assertResult(Seq.empty)(keep(scalarRows, "name <=> null", scalarSchema))
+    assertResult(Right(()))(validate("name <=> null"))
   }
 
   test("evaluateFilter coerces numeric column and literal type pairs") {
@@ -128,13 +134,16 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     // Two rows, so an assertion that matches everything is distinguishable from one that
     // coerces correctly.
     val rows = Seq(
-      Row(2.5f, 3.toShort, 4.toByte, new BigDecimal("3.00")),
-      Row(0.5f, 9.toShort, 9.toByte, new BigDecimal("0.50")))
+      Row(2.5f, 3.toShort, 4.toByte, new JBigDecimal("3.00")),
+      Row(0.5f, 9.toShort, 9.toByte, new JBigDecimal("0.50")))
     val matched = Seq(rows.head)
 
-    // Literals whose parsed type already matches the column type evaluate correctly.
+    // A literal whose parsed type already matches the column type evaluates correctly.
     assertResult(matched)(keep(rows, "f > 1.0f", schema))
+    // A decimal literal of another precision or scale widens to the common decimal type, or the
+    // comparison stays unresolved and validateFilterExpression rejects the filter.
     assertResult(matched)(keep(rows, "dec > 1.00", schema))
+    assertResult(matched)(keep(rows, "dec > 1.5", schema))
 
     // Mismatched numeric types are widened to Spark's common type.
     assertResult(matched)(keep(rows, "sh = 3", schema))
@@ -143,27 +152,19 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(matched)(keep(rows, "dec > 1", schema))
     // Reversed operands widen the same way.
     assertResult(matched)(keep(rows, "3 = sh", schema))
-    assertResult(rows)(keep(rows, "by < 300", schema))
+    // 130 narrowed to a Byte is -126, so narrowing the literal would keep neither row.
+    assertResult(rows)(keep(rows, "by < 130", schema))
     // The same pairs have to pass validation, which every filterable procedure runs first.
     assertResult(Right(()))(validate("sh = 3", schema))
     assertResult(Right(()))(validate("dec > 1", schema))
-  }
-
-  test("evaluateFilter widens decimal comparisons the way Spark does") {
-    val schema = schemaOf("dec" -> DecimalType(10, 2))
-    val rows = Seq(Row(new BigDecimal("3.00")), Row(new BigDecimal("0.50")))
-    // A decimal literal of a different scale has to widen, or the comparison stays unresolved
-    // and validateFilterExpression rejects the filter before any procedure evaluates it.
-    assertResult(Seq(rows.head))(keep(rows, "dec > 1.00", schema))
-    assertResult(Seq(rows.head))(keep(rows, "dec > 1.5", schema))
     assertResult(Right(()))(validate("dec > 1.00", schema))
   }
 
-  test("evaluateFilter surfaces an ANSI overflow instead of dropping the row") {
+  test("evaluateFilter surfaces an ANSI error instead of dropping the row") {
     // An overflowing Long addition wraps to a negative without ANSI and raises with it, exactly
     // as it does in a query. The raise has to reach the caller: swallowing it into "no match"
     // would report an empty result for a filter the query answers with an error.
-    val rows = Seq(scalarRow(1, 1000L))
+    val rows = Seq(tsRow(1, 1000L))
     withSQLConf("spark.sql.ansi.enabled" -> "false") {
       // 1000 + Long.MaxValue wraps to a negative, so the row genuinely fails "> 0".
       assertResult(Seq.empty)(keep(rows, "ts + 9223372036854775807 > 0", scalarSchema))
@@ -173,16 +174,26 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
         keep(rows, "ts + 9223372036854775807 > 0", scalarSchema)
       }
     }
+    // An ANSI cast of a malformed string raises SparkNumberFormatException, not an
+    // ArithmeticException, and has to reach the caller the same way.
+    withSQLConf("spark.sql.ansi.enabled" -> "false") {
+      assertResult(Seq.empty)(keep(scalarRows, "int(name) > 1", scalarSchema))
+    }
+    withSQLConf("spark.sql.ansi.enabled" -> "true") {
+      intercept[NumberFormatException] {
+        keep(scalarRows, "int(name) > 1", scalarSchema)
+      }
+    }
   }
 
   test("evaluateFilter follows ANSI mode when a decimal widening overflows") {
     val schema = schemaOf("big" -> DecimalType(38, 0), "frac" -> DecimalType(38, 18))
-    val rows = Seq(Row(new BigDecimal("1" + "0" * 30), new BigDecimal("1.5")))
-    // Spark 3 only. There the widening picks DECIMAL(38,18), and the precision-38 clamp leaves it
-    // 20 integral digits, too few for this 31-digit value, so the cast overflows and the ANSI mode
-    // decides what happens. Parity for a comparison whose common precision would exceed 38 is not
-    // settled on Spark 4 and needs the validation path checked against plain SQL, so nothing is
-    // pinned for it here. Tracked by HUDI #19860.
+    val rows = Seq(Row(new JBigDecimal("1" + "0" * 30), new JBigDecimal("1.5")))
+    // On Spark 3 the widening picks DECIMAL(38,18), and the precision-38 clamp leaves it 20
+    // integral digits, too few for this 31-digit value, so the cast overflows and the ANSI mode
+    // decides what happens. Spark 4 casts the fractional operand down instead, planning the same
+    // filter as `big > cast(frac as decimal(38,0))`, so nothing overflows and the row survives in
+    // either mode.
     if (!HoodieSparkUtils.gteqSpark4_0) {
       withSQLConf("spark.sql.ansi.enabled" -> "false") {
         // The cast yields null and the row drops.
@@ -193,6 +204,13 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
           keep(rows, "big > frac", schema)
         }
       }
+    } else {
+      for (ansi <- Seq("false", "true")) {
+        withSQLConf("spark.sql.ansi.enabled" -> ansi) {
+          assertResult(rows)(keep(rows, "big > frac", schema))
+          assertResult(Right(()))(validate("big > frac", schema))
+        }
+      }
     }
   }
 
@@ -201,7 +219,7 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     // TypeCoercion follows numericPrecedence to FLOAT. 16777217 is the first Long that a Float
     // cannot hold, so it survives the widening under ANSI and rounds down to 16777216.0f without
     // it. A filter has to widen the way the same comparison would in a query.
-    val rows = Seq(scalarRow(1, 16777217L))
+    val rows = Seq(tsRow(1, 16777217L))
     withSQLConf("spark.sql.ansi.enabled" -> "true") {
       assertResult(rows)(keep(rows, "ts > 16777216.0f", scalarSchema))
     }
@@ -222,6 +240,8 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   }
 
   test("evaluateFilter widens arithmetic and coalesce operands") {
+    import scala.collection.JavaConverters._
+
     assertResult(Seq(scalarRows(1)))(keep(scalarRows, "ts + 1 > 1500", scalarSchema))
     assertResult(Right(()))(validate("ts + 1 > 1500"))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "coalesce(ts, 0) = 1000", scalarSchema))
@@ -238,17 +258,29 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Right(()))(validate("ts / null > 0"))
     assertResult(Seq.empty)(keep(scalarRows, "null / ts > 0", scalarSchema))
     assertResult(Right(()))(validate("null / ts > 0"))
-  }
-
-  test("evaluateFilter keeps the operand types of decimal arithmetic") {
-    // BinaryArithmetic derives the result precision from the operands, so the operands have to
-    // reach it unwidened. DECIMAL(38,18) * DECIMAL(2,1) gives a scale-16 product that still holds
-    // 0.0000001, whereas casting both to DECIMAL(38,18) first drives the product to scale 6 and
-    // rounds the value away to zero, dropping a row Spark keeps.
-    val schema = schemaOf("dec" -> DecimalType(38, 18))
-    val rows = Seq(Row(new BigDecimal("0.0000001")))
-    assertResult(rows)(keep(rows, "dec * 1.0 > 0.0", schema))
-    assertResult(Right(()))(validate("dec * 1.0 > 0.0", schema))
+    // The remaining arithmetic operators go through the same widening.
+    assertResult(Seq(scalarRows.head))(keep(scalarRows, "ts % 3 = 1", scalarSchema))
+    assertResult(Right(()))(validate("ts % 3 = 1"))
+    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "ts - 1 > 1500", scalarSchema))
+    assertResult(Right(()))(validate("ts - 1 > 1500"))
+    // IntegralDivide accepts only Long or Decimal and never widens its operands against each
+    // other, so an Int pair has to be promoted a side at a time the way Spark's rule does.
+    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "ts div 3 > 500", scalarSchema))
+    assertResult(Right(()))(validate("ts div 3 > 500"))
+    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "id div 2 > 0", scalarSchema))
+    assertResult(Right(()))(validate("id div 2 > 0"))
+    // Coalesce widens across more than two children, and across widths as well as kinds.
+    assertResult(Seq(scalarRows.head))(keep(scalarRows, "coalesce(ts, id, 0) = 1000", scalarSchema))
+    assertResult(Right(()))(validate("coalesce(ts, id, 0) = 1000"))
+    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "coalesce(ts, price) > 1500", scalarSchema))
+    assertResult(Right(()))(validate("coalesce(ts, price) > 1500"))
+    // div is the operator this coercion newly reaches, so check it against Spark itself.
+    val df = spark.createDataFrame(scalarRows.asJava, scalarSchema)
+    Seq("id div 2 > 0", "ts div 3 > 500").foreach { filter =>
+      withClue(s"filter=$filter: ") {
+        assertResult(df.filter(filter).collect().toSeq)(keep(scalarRows, filter, scalarSchema))
+      }
+    }
   }
 
   test("evaluateFilter matches Spark for mixed decimal arithmetic") {
@@ -256,19 +288,20 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
 
     val schema = schemaOf("dec" -> DecimalType(38, 18), "i" -> IntegerType, "f" -> FloatType)
     val rows = Seq(
-      Row(new BigDecimal("0.0000001"), 1, 0.5f),
-      Row(new BigDecimal("-2.5"), 2, 0.25f))
+      Row(new JBigDecimal("0.0000001"), 1, 0.5f),
+      Row(new JBigDecimal("-2.5"), 2, 0.25f))
     val filters = Seq(
       "dec + 1 > 0", "1 + dec > 0", "dec * 1 > 0", "1L * dec > 0",
       "dec + i > 0", "i * dec > 0", "dec / 2 > 0", "2 / dec > 0",
       "dec + 0.5f > 0", "0.5f + dec > 0", "dec * f > 0", "f / dec > 0",
       "dec + 0.5d > 0", "0.5d / dec > 0",
       "dec / null > 0", "null / dec > 0", "dec + null > 0", "null * dec > 0",
+      // DECIMAL(38,18) * DECIMAL(2,1) gives a scale-16 product that still holds 0.0000001, which
+      // widening both operands to DECIMAL(38,18) first would round away to zero.
       "dec * 1.0 > 0.0")
     for (ansi <- Seq("false", "true"); minimumPrecision <- Seq("false", "true")) {
       withSQLConf("spark.sql.ansi.enabled" -> ansi,
-        "spark.sql.legacy.literal.pickMinimumPrecision" -> minimumPrecision,
-        "spark.sql.decimalOperations.allowPrecisionLoss" -> "true") {
+        "spark.sql.legacy.literal.pickMinimumPrecision" -> minimumPrecision) {
         val df = spark.createDataFrame(rows.asJava, schema)
         filters.foreach { filter =>
           withClue(s"filter=$filter, ansi=$ansi, minimumPrecision=$minimumPrecision: ") {
@@ -285,16 +318,22 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
 
     val schema = schemaOf("ts" -> LongType, "dec" -> DecimalType(38, 30))
     val rows = Seq(
-      Row(3000000000L, new BigDecimal("0.00000000000000000000000000001")),
-      Row(0L, new BigDecimal("0")),
-      Row(-3000000000L, new BigDecimal("-0.00000000000000000000000000001")))
+      Row(3000000000L, new JBigDecimal("0.00000000000000000000000000001")),
+      Row(0L, new JBigDecimal("0")),
+      Row(-3000000000L, new JBigDecimal("-0.00000000000000000000000000001")))
     val tiny = "0.000000000000000000000000000001"
+    // A decimal literal past the Long range is folded to a constant by DecimalPrecision, so the
+    // comparison never reaches the widening.
+    val huge = "99999999999999999999.0"
     val filters = Seq(
       s"ts > $tiny", s"ts >= $tiny", s"ts < $tiny", s"ts <= $tiny",
       s"$tiny < ts", s"$tiny <= ts", s"$tiny > ts", s"$tiny >= ts",
+      s"ts > $huge", s"ts < $huge", s"$huge < ts",
       "dec > 0", "0 < dec", "dec = 0", "dec <=> 0", "dec <= 0")
+    // spark.sql.legacy.decimal.retainFractionDigitsOnTruncate is undefined before Spark 4.
+    val retainFractionSettings = if (HoodieSparkUtils.gteqSpark4_0) Seq("false", "true") else Seq("false")
     for (ansi <- Seq("false", "true"); minimumPrecision <- Seq("false", "true");
-         retainFraction <- Seq("false", "true")) {
+         retainFraction <- retainFractionSettings) {
       withSQLConf("spark.sql.ansi.enabled" -> ansi,
         "spark.sql.legacy.literal.pickMinimumPrecision" -> minimumPrecision,
         "spark.sql.legacy.decimal.retainFractionDigitsOnTruncate" -> retainFraction) {
@@ -391,6 +430,9 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   test("evaluateFilter maps a string result of true / false to a boolean decision") {
     // string(flag) yields the literal strings "true"/"false", exercising the string->boolean branch.
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "string(flag)", scalarSchema))
+    // The mapping is for direct callers: Spark rejects a string filter condition, so a filterable
+    // procedure never gets past validation with one.
+    assert(validate("string(flag)").isLeft)
   }
 
   test("evaluateFilter treats non-boolean-valued expressions as no-match") {
@@ -451,7 +493,7 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
       Seq(1, 2, 3),
       List(1, 2, 3).map(Int.box).asJava,
       Array(1, 2, 3),
-      new BigDecimal("12.50"),
+      new JBigDecimal("12.50"),
       scala.math.BigDecimal("34.75"),
       Array[Byte](1, 2, 3),
       java.util.UUID.randomUUID(),
@@ -512,6 +554,10 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assert(validate("date_format(t, 'yyyy') = '2024'").isLeft)
     assert(validate("any_value(id) = 1").isLeft)
     assert(validate("id = (select 1)").isLeft)
+    // Spark rejects any non-boolean filter condition. Without this these resolve and report zero
+    // matching rows instead of the error the same query raises.
+    assert(validate("ts + 1").left.exists(_.contains("boolean")))
+    assert(validate("name").left.exists(_.contains("boolean")))
 
     assertResult(Right(()))(validate("upper(name) = 'A1'"))
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.hudi.procedure
 
+import org.apache.hudi.HoodieSparkUtils
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.hudi.command.procedures.HoodieProcedureFilterUtils
 import org.apache.spark.sql.types._
@@ -154,10 +156,48 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Seq(rows.head))(keep(rows, "dec > 1.00", schema))
     assertResult(Seq(rows.head))(keep(rows, "dec > 1.5", schema))
     assertResult(Right(()))(validate("dec > 1.00", schema))
-    // Not asserted here: a pair like DECIMAL(38,0) against DECIMAL(38,18), where the wider type
-    // runs into the precision-38 clamp. Spark resolves that differently per version -- 3.5 widens
-    // and overflows the cast, 4.1 declines to widen at all -- so there is no single expected
-    // result to pin. The lossy shapes are documented on widenNumericOperands instead.
+  }
+
+  test("evaluateFilter surfaces an ANSI overflow instead of dropping the row") {
+    // Overflow has to reach the caller under ANSI and yield null without it, the way the same
+    // arithmetic behaves in a query. Swallowing it would drop a row the query would keep.
+    val rows = Seq(scalarRow(1, 1000L))
+    withSQLConf("spark.sql.ansi.enabled" -> "false") {
+      assertResult(Seq.empty)(keep(rows, "ts + 9223372036854775807 > 0", scalarSchema))
+    }
+    withSQLConf("spark.sql.ansi.enabled" -> "true") {
+      intercept[ArithmeticException] {
+        keep(rows, "ts + 9223372036854775807 > 0", scalarSchema)
+      }
+    }
+  }
+
+  test("evaluateFilter follows ANSI mode when a decimal widening overflows") {
+    val schema = schemaOf("big" -> DecimalType(38, 0), "frac" -> DecimalType(38, 18))
+    val rows = Seq(Row(new java.math.BigDecimal("1" + "0" * 30), new java.math.BigDecimal("1.5")))
+    if (HoodieSparkUtils.gteqSpark4_0) {
+      // Spark 4 declines to widen a decimal pair that would lose precision, in either ANSI mode,
+      // so the comparison stays on Decimal ordering, which is scale-independent, and keeps the
+      // row. Nothing overflows, so there is no failure to surface.
+      withSQLConf("spark.sql.ansi.enabled" -> "false") {
+        assertResult(rows)(keep(rows, "big > frac", schema))
+      }
+      withSQLConf("spark.sql.ansi.enabled" -> "true") {
+        assertResult(rows)(keep(rows, "big > frac", schema))
+      }
+    } else {
+      // Spark 3 widens to DECIMAL(38,18), which the precision-38 clamp leaves 20 integral digits,
+      // too few for this 31-digit value. The overflow then follows the session's ANSI mode.
+      withSQLConf("spark.sql.ansi.enabled" -> "false") {
+        // The cast yields null and the row drops, the answer Spark SQL gives for the same filter.
+        assertResult(Seq.empty)(keep(rows, "big > frac", schema))
+      }
+      withSQLConf("spark.sql.ansi.enabled" -> "true") {
+        intercept[ArithmeticException] {
+          keep(rows, "big > frac", schema)
+        }
+      }
+    }
   }
 
   test("evaluateFilter widens with the coercion rules of the active ANSI mode") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -280,6 +280,35 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     }
   }
 
+  test("evaluateFilter matches Spark for high-precision decimal comparisons") {
+    import scala.collection.JavaConverters._
+
+    val schema = schemaOf("ts" -> LongType, "dec" -> DecimalType(38, 30))
+    val rows = Seq(
+      Row(3000000000L, new BigDecimal("0.00000000000000000000000000001")),
+      Row(0L, new BigDecimal("0")),
+      Row(-3000000000L, new BigDecimal("-0.00000000000000000000000000001")))
+    val tiny = "0.000000000000000000000000000001"
+    val filters = Seq(
+      s"ts > $tiny", s"ts >= $tiny", s"ts < $tiny", s"ts <= $tiny",
+      s"$tiny < ts", s"$tiny <= ts", s"$tiny > ts", s"$tiny >= ts",
+      "dec > 0", "0 < dec", "dec = 0", "dec <=> 0", "dec <= 0")
+    for (ansi <- Seq("false", "true"); minimumPrecision <- Seq("false", "true");
+         retainFraction <- Seq("false", "true")) {
+      withSQLConf("spark.sql.ansi.enabled" -> ansi,
+        "spark.sql.legacy.literal.pickMinimumPrecision" -> minimumPrecision,
+        "spark.sql.legacy.decimal.retainFractionDigitsOnTruncate" -> retainFraction) {
+        val df = spark.createDataFrame(rows.asJava, schema)
+        filters.foreach { filter =>
+          withClue(s"filter=$filter, ansi=$ansi, minimumPrecision=$minimumPrecision, retainFraction=$retainFraction: ") {
+            assertResult(Right(()))(validate(filter, schema))
+            assertResult(df.filter(filter).collect().toSeq)(keep(rows, filter, schema))
+          }
+        }
+      }
+    }
+  }
+
   test("evaluateFilter binds quoted column names") {
     // show_column_stats_overlap, the second procedure named in #19632, outputs columns like
     // "Average overlap" and "50% overlap".

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -159,10 +159,12 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   }
 
   test("evaluateFilter surfaces an ANSI overflow instead of dropping the row") {
-    // Overflow has to reach the caller under ANSI and yield null without it, the way the same
-    // arithmetic behaves in a query. Swallowing it would drop a row the query would keep.
+    // An overflowing Long addition wraps to a negative without ANSI and raises with it, exactly
+    // as it does in a query. The raise has to reach the caller: swallowing it into "no match"
+    // would report an empty result for a filter the query answers with an error.
     val rows = Seq(scalarRow(1, 1000L))
     withSQLConf("spark.sql.ansi.enabled" -> "false") {
+      // 1000 + Long.MaxValue wraps to a negative, so the row genuinely fails "> 0".
       assertResult(Seq.empty)(keep(rows, "ts + 9223372036854775807 > 0", scalarSchema))
     }
     withSQLConf("spark.sql.ansi.enabled" -> "true") {
@@ -175,21 +177,13 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   test("evaluateFilter follows ANSI mode when a decimal widening overflows") {
     val schema = schemaOf("big" -> DecimalType(38, 0), "frac" -> DecimalType(38, 18))
     val rows = Seq(Row(new java.math.BigDecimal("1" + "0" * 30), new java.math.BigDecimal("1.5")))
-    if (HoodieSparkUtils.gteqSpark4_0) {
-      // Spark 4 declines to widen a decimal pair that would lose precision, in either ANSI mode,
-      // so the comparison stays on Decimal ordering, which is scale-independent, and keeps the
-      // row. Nothing overflows, so there is no failure to surface.
+    // Spark 3 only. There the widening picks DECIMAL(38,18), and the precision-38 clamp leaves it
+    // 20 integral digits, too few for this 31-digit value, so the cast overflows and the ANSI mode
+    // decides what happens. Spark 4 does not reach an overflow for this pair and its procedure
+    // behaviour here has not been characterised, so nothing is pinned for it.
+    if (!HoodieSparkUtils.gteqSpark4_0) {
       withSQLConf("spark.sql.ansi.enabled" -> "false") {
-        assertResult(rows)(keep(rows, "big > frac", schema))
-      }
-      withSQLConf("spark.sql.ansi.enabled" -> "true") {
-        assertResult(rows)(keep(rows, "big > frac", schema))
-      }
-    } else {
-      // Spark 3 widens to DECIMAL(38,18), which the precision-38 clamp leaves 20 integral digits,
-      // too few for this 31-digit value. The overflow then follows the session's ANSI mode.
-      withSQLConf("spark.sql.ansi.enabled" -> "false") {
-        // The cast yields null and the row drops, the answer Spark SQL gives for the same filter.
+        // The cast yields null and the row drops.
         assertResult(Seq.empty)(keep(rows, "big > frac", schema))
       }
       withSQLConf("spark.sql.ansi.enabled" -> "true") {
@@ -230,6 +224,12 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Right(()))(validate("ts + 1 > 1500"))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "coalesce(ts, 0) = 1000", scalarSchema))
     assertResult(Right(()))(validate("coalesce(ts, 0) = 1000"))
+    // Divide accepts only Double or Decimal, so an integral pair has to become Double rather
+    // than a wider integral. Otherwise "ts / 2" stays unresolved while "price / 2" resolves.
+    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "ts / 2 > 500", scalarSchema))
+    assertResult(Right(()))(validate("ts / 2 > 500"))
+    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "price / 2 > 5", scalarSchema))
+    assertResult(Right(()))(validate("price / 2 > 5"))
   }
 
   test("evaluateFilter binds quoted column names") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.hudi.command.procedures.HoodieProcedureFilterUtils
 import org.apache.spark.sql.types._
 
+import java.math.BigDecimal
 import java.sql.{Date, Timestamp}
 
 /**
@@ -127,8 +128,8 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     // Two rows, so an assertion that matches everything is distinguishable from one that
     // coerces correctly.
     val rows = Seq(
-      Row(2.5f, 3.toShort, 4.toByte, new java.math.BigDecimal("3.00")),
-      Row(0.5f, 9.toShort, 9.toByte, new java.math.BigDecimal("0.50")))
+      Row(2.5f, 3.toShort, 4.toByte, new BigDecimal("3.00")),
+      Row(0.5f, 9.toShort, 9.toByte, new BigDecimal("0.50")))
     val matched = Seq(rows.head)
 
     // Literals whose parsed type already matches the column type evaluate correctly.
@@ -150,7 +151,7 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
 
   test("evaluateFilter widens decimal comparisons the way Spark does") {
     val schema = schemaOf("dec" -> DecimalType(10, 2))
-    val rows = Seq(Row(new java.math.BigDecimal("3.00")), Row(new java.math.BigDecimal("0.50")))
+    val rows = Seq(Row(new BigDecimal("3.00")), Row(new BigDecimal("0.50")))
     // A decimal literal of a different scale has to widen, or the comparison stays unresolved
     // and validateFilterExpression rejects the filter before any procedure evaluates it.
     assertResult(Seq(rows.head))(keep(rows, "dec > 1.00", schema))
@@ -176,7 +177,7 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
 
   test("evaluateFilter follows ANSI mode when a decimal widening overflows") {
     val schema = schemaOf("big" -> DecimalType(38, 0), "frac" -> DecimalType(38, 18))
-    val rows = Seq(Row(new java.math.BigDecimal("1" + "0" * 30), new java.math.BigDecimal("1.5")))
+    val rows = Seq(Row(new BigDecimal("1" + "0" * 30), new BigDecimal("1.5")))
     // Spark 3 only. There the widening picks DECIMAL(38,18), and the precision-38 clamp leaves it
     // 20 integral digits, too few for this 31-digit value, so the cast overflows and the ANSI mode
     // decides what happens. Parity for a comparison whose common precision would exceed 38 is not
@@ -245,9 +246,38 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     // 0.0000001, whereas casting both to DECIMAL(38,18) first drives the product to scale 6 and
     // rounds the value away to zero, dropping a row Spark keeps.
     val schema = schemaOf("dec" -> DecimalType(38, 18))
-    val rows = Seq(Row(new java.math.BigDecimal("0.0000001")))
+    val rows = Seq(Row(new BigDecimal("0.0000001")))
     assertResult(rows)(keep(rows, "dec * 1.0 > 0.0", schema))
     assertResult(Right(()))(validate("dec * 1.0 > 0.0", schema))
+  }
+
+  test("evaluateFilter matches Spark for mixed decimal arithmetic") {
+    import scala.collection.JavaConverters._
+
+    val schema = schemaOf("dec" -> DecimalType(38, 18), "i" -> IntegerType, "f" -> FloatType)
+    val rows = Seq(
+      Row(new BigDecimal("0.0000001"), 1, 0.5f),
+      Row(new BigDecimal("-2.5"), 2, 0.25f))
+    val filters = Seq(
+      "dec + 1 > 0", "1 + dec > 0", "dec * 1 > 0", "1L * dec > 0",
+      "dec + i > 0", "i * dec > 0", "dec / 2 > 0", "2 / dec > 0",
+      "dec + 0.5f > 0", "0.5f + dec > 0", "dec * f > 0", "f / dec > 0",
+      "dec + 0.5d > 0", "0.5d / dec > 0",
+      "dec / null > 0", "null / dec > 0", "dec + null > 0", "null * dec > 0",
+      "dec * 1.0 > 0.0")
+    for (ansi <- Seq("false", "true"); minimumPrecision <- Seq("false", "true")) {
+      withSQLConf("spark.sql.ansi.enabled" -> ansi,
+        "spark.sql.legacy.literal.pickMinimumPrecision" -> minimumPrecision,
+        "spark.sql.decimalOperations.allowPrecisionLoss" -> "true") {
+        val df = spark.createDataFrame(rows.asJava, schema)
+        filters.foreach { filter =>
+          withClue(s"filter=$filter, ansi=$ansi, minimumPrecision=$minimumPrecision: ") {
+            assertResult(Right(()))(validate(filter, schema))
+            assertResult(df.filter(filter).collect().toSeq)(keep(rows, filter, schema))
+          }
+        }
+      }
+    }
   }
 
   test("evaluateFilter binds quoted column names") {
@@ -392,7 +422,7 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
       Seq(1, 2, 3),
       List(1, 2, 3).map(Int.box).asJava,
       Array(1, 2, 3),
-      new java.math.BigDecimal("12.50"),
+      new BigDecimal("12.50"),
       scala.math.BigDecimal("34.75"),
       Array[Byte](1, 2, 3),
       java.util.UUID.randomUUID(),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -40,6 +40,10 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   private def validate(expr: String, schema: StructType = scalarSchema): Either[String, Unit] =
     HoodieProcedureFilterUtils.validateFilterExpression(expr, schema, spark)
 
+  private def scalarRow(id: Int, ts: Long): Row =
+    Row(id, s"n$id", 10.0d * id, ts, true, -id,
+      Date.valueOf("2024-01-01"), Timestamp.valueOf("2024-01-01 00:00:00"))
+
   // A rich scalar schema reused across the function tests.
   private val scalarSchema = schemaOf(
     "id" -> IntegerType,
@@ -69,6 +73,9 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(2)(keep(scalarRows, "id <= 2", scalarSchema).length)
     assertResult(Seq(scalarRows(1)))(keep(scalarRows, "id != 1", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "name = 'a1'", scalarSchema))
+    // A plain 15.0 decimal literal is coerced with the double column.
+    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "price > 15.0", scalarSchema))
+    assertResult(Right(()))(validate("price > 15.0"))
     // Bare boolean column evaluates to a Boolean result directly.
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "flag", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "flag = true", scalarSchema))
@@ -83,8 +90,7 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "ts <= 1000", scalarSchema))
     // The integer literal is widened rather than the column narrowed, so a Long past the Int
     // range keeps its value instead of wrapping to -1294967296 and matching "ts < 2000".
-    val bigRow = Row(3, "c3", 30.0d, 3000000000L, true, -9,
-      Date.valueOf("2024-03-16"), Timestamp.valueOf("2024-03-16 12:30:00"))
+    val bigRow = scalarRow(3, 3000000000L)
     val withBigRow = scalarRows :+ bigRow
     assertResult(Seq(scalarRows(1), bigRow))(keep(withBigRow, "ts > 1500", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(withBigRow, "ts < 2000", scalarSchema))
@@ -94,6 +100,20 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     // IN and <=> widen through the same path as the binary comparisons.
     assertResult(scalarRows)(keep(withBigRow, "ts IN (1000, 2000)", scalarSchema))
     assertResult(Seq(scalarRows.head))(keep(withBigRow, "ts <=> 1000", scalarSchema))
+    // An IN list of mixed integral widths widens to the single common type.
+    assertResult(scalarRows)(keep(withBigRow, "ts IN (1000, 2000L)", scalarSchema))
+    // Every filterable procedure calls validateFilterExpression before evaluateFilter, and each of
+    // these shapes was rejected there before the operands widened.
+    assertResult(Right(()))(validate("1500 < ts"))
+    assertResult(Right(()))(validate("ts IN (1000, 2000)"))
+    assertResult(Right(()))(validate("ts <=> 1000"))
+    // A non-numeric operand still bails out of the widening and stays unresolved.
+    assert(validate("id IN (1, 'x')").isLeft)
+    // A null operand widens with the numeric ones, the plan Spark builds for the same filter.
+    assertResult(Seq(scalarRows.head))(keep(scalarRows, "ts IN (1000, null)", scalarSchema))
+    assertResult(Right(()))(validate("ts IN (1000, null)"))
+    assertResult(Seq.empty)(keep(scalarRows, "ts <=> null", scalarSchema))
+    assertResult(Right(()))(validate("ts <=> null"))
   }
 
   test("evaluateFilter coerces numeric column and literal type pairs") {
@@ -121,18 +141,23 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     // Reversed operands widen the same way.
     assertResult(matched)(keep(rows, "3 = sh", schema))
     assertResult(rows)(keep(rows, "by < 300", schema))
-    // A plain 15.0 decimal literal is coerced with the double column.
-    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "price > 15.0", scalarSchema))
+    // The same pairs have to pass validation, which every filterable procedure runs first.
+    assertResult(Right(()))(validate("sh = 3", schema))
+    assertResult(Right(()))(validate("dec > 1", schema))
   }
 
-  test("evaluateFilter compares decimal columns without widening them") {
-    // DecimalType.bounded clamps precision at 38, so widening DECIMAL(38,0) towards DECIMAL(38,18)
-    // would overflow the integral side into a null (non-ANSI) or an error (ANSI). Decimal ordering
-    // is already precision- and scale-independent, so an all-decimal comparison is left alone.
-    val schema = schemaOf("big" -> DecimalType(38, 0), "frac" -> DecimalType(38, 18))
-    val rows = Seq(Row(new java.math.BigDecimal("1" + "0" * 30), new java.math.BigDecimal("1.5")))
-    assertResult(rows)(keep(rows, "big > frac", schema))
-    assertResult(Seq.empty)(keep(rows, "frac > big", schema))
+  test("evaluateFilter widens decimal comparisons the way Spark does") {
+    val schema = schemaOf("dec" -> DecimalType(10, 2))
+    val rows = Seq(Row(new java.math.BigDecimal("3.00")), Row(new java.math.BigDecimal("0.50")))
+    // A decimal literal of a different scale has to widen, or the comparison stays unresolved
+    // and validateFilterExpression rejects the filter before any procedure evaluates it.
+    assertResult(Seq(rows.head))(keep(rows, "dec > 1.00", schema))
+    assertResult(Seq(rows.head))(keep(rows, "dec > 1.5", schema))
+    assertResult(Right(()))(validate("dec > 1.00", schema))
+    // Not asserted here: a pair like DECIMAL(38,0) against DECIMAL(38,18), where the wider type
+    // runs into the precision-38 clamp. Spark resolves that differently per version -- 3.5 widens
+    // and overflows the cast, 4.1 declines to widen at all -- so there is no single expected
+    // result to pin. The lossy shapes are documented on widenNumericOperands instead.
   }
 
   test("evaluateFilter widens with the coercion rules of the active ANSI mode") {
@@ -140,14 +165,41 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     // TypeCoercion follows numericPrecedence to FLOAT. 16777217 is the first Long that a Float
     // cannot hold, so it survives the widening under ANSI and rounds down to 16777216.0f without
     // it. A filter has to widen the way the same comparison would in a query.
-    val rows = Seq(Row(1, "n1", 1.0d, 16777217L, true, 0,
-      Date.valueOf("2024-01-01"), Timestamp.valueOf("2024-01-01 00:00:00")))
+    val rows = Seq(scalarRow(1, 16777217L))
     withSQLConf("spark.sql.ansi.enabled" -> "true") {
       assertResult(rows)(keep(rows, "ts > 16777216.0f", scalarSchema))
     }
     withSQLConf("spark.sql.ansi.enabled" -> "false") {
       assertResult(Seq.empty)(keep(rows, "ts > 16777216.0f", scalarSchema))
+      // The rounded-down Long still clears a smaller Float, so the widening runs either way.
+      assertResult(rows)(keep(rows, "ts > 16777215.0f", scalarSchema))
     }
+    // Column against column splits the same way, and only the widening reaches it.
+    val pairSchema = schemaOf("l" -> LongType, "f" -> FloatType)
+    val pairRows = Seq(Row(16777217L, 16777216.0f))
+    withSQLConf("spark.sql.ansi.enabled" -> "true") {
+      assertResult(pairRows)(keep(pairRows, "l > f", pairSchema))
+    }
+    withSQLConf("spark.sql.ansi.enabled" -> "false") {
+      assertResult(Seq.empty)(keep(pairRows, "l > f", pairSchema))
+    }
+  }
+
+  test("evaluateFilter widens arithmetic and coalesce operands") {
+    assertResult(Seq(scalarRows(1)))(keep(scalarRows, "ts + 1 > 1500", scalarSchema))
+    assertResult(Right(()))(validate("ts + 1 > 1500"))
+    assertResult(Seq(scalarRows.head))(keep(scalarRows, "coalesce(ts, 0) = 1000", scalarSchema))
+    assertResult(Right(()))(validate("coalesce(ts, 0) = 1000"))
+  }
+
+  test("evaluateFilter binds quoted column names") {
+    // show_column_stats_overlap, the second procedure named in #19632, outputs columns like
+    // "Average overlap" and "50% overlap".
+    val schema = schemaOf("Average overlap" -> DoubleType, "50% overlap" -> IntegerType)
+    val rows = Seq(Row(0.75d, 10), Row(0.25d, 20))
+    assertResult(Seq(rows.head))(keep(rows, "`Average overlap` > 0.5", schema))
+    assertResult(Right(()))(validate("`Average overlap` > 0.5", schema))
+    assertResult(Seq(rows(1)))(keep(rows, "`50% overlap` > 15", schema))
   }
 
   test("evaluateFilter silently drops rows for expressions it cannot resolve") {
@@ -156,6 +208,9 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Seq.empty)(keep(scalarRows, "if(name = 'a1', true, false)", scalarSchema))
     assertResult(Seq(scalarRows.head))(
       keep(scalarRows, "case when name = 'a1' then true else false end", scalarSchema))
+    // Or short-circuits on the resolved side, which is what the unresolved-operand guard preserves.
+    assertResult(Seq(scalarRows.head))(
+      keep(scalarRows, "id = 1 OR concat(name, 'x') = 'a1x'", scalarSchema))
   }
 
   test("evaluateFilter handles AND / OR / NOT / IN / BETWEEN") {
@@ -335,7 +390,7 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
 
     assert(validate("if(name = 'a1', true, false)").isLeft)
     assert(validate("substring(name, 2)").isLeft)
-    assert(validate("id = 1 OR concat(name, 'x') = 'a1x'").isLeft)
+    assert(validate("id = 1 OR concat(name, 'x') = 'a1x'").left.exists(_.contains("Unsupported functions: concat")))
     assert(validate("hour(t) = 12").isLeft)
     assert(validate("date_format(t, 'yyyy') = '2024'").isLeft)
     assert(validate("any_value(id) = 1").isLeft)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -239,6 +239,17 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Right(()))(validate("null / ts > 0"))
   }
 
+  test("evaluateFilter keeps the operand types of decimal arithmetic") {
+    // BinaryArithmetic derives the result precision from the operands, so the operands have to
+    // reach it unwidened. DECIMAL(38,18) * DECIMAL(2,1) gives a scale-16 product that still holds
+    // 0.0000001, whereas casting both to DECIMAL(38,18) first drives the product to scale 6 and
+    // rounds the value away to zero, dropping a row Spark keeps.
+    val schema = schemaOf("dec" -> DecimalType(38, 18))
+    val rows = Seq(Row(new java.math.BigDecimal("0.0000001")))
+    assertResult(rows)(keep(rows, "dec * 1.0 > 0.0", schema))
+    assertResult(Right(()))(validate("dec * 1.0 > 0.0", schema))
+  }
+
   test("evaluateFilter binds quoted column names") {
     // show_column_stats_overlap, the second procedure named in #19632, outputs columns like
     // "Average overlap" and "50% overlap".

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -26,6 +26,8 @@ import org.apache.spark.sql.types._
 import java.math.{BigDecimal => JBigDecimal}
 import java.sql.{Date, Timestamp}
 
+import scala.collection.JavaConverters._
+
 /**
  * Direct unit tests for [[HoodieProcedureFilterUtils]] which evaluates SQL filter
  * expressions against procedure output rows. Covers primitive/date/decimal/complex
@@ -240,8 +242,6 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   }
 
   test("evaluateFilter widens arithmetic and coalesce operands") {
-    import scala.collection.JavaConverters._
-
     assertResult(Seq(scalarRows(1)))(keep(scalarRows, "ts + 1 > 1500", scalarSchema))
     assertResult(Right(()))(validate("ts + 1 > 1500"))
     assertResult(Seq(scalarRows.head))(keep(scalarRows, "coalesce(ts, 0) = 1000", scalarSchema))
@@ -284,8 +284,6 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   }
 
   test("evaluateFilter matches Spark for mixed decimal arithmetic") {
-    import scala.collection.JavaConverters._
-
     val schema = schemaOf("dec" -> DecimalType(38, 18), "i" -> IntegerType, "f" -> FloatType)
     val rows = Seq(
       Row(new JBigDecimal("0.0000001"), 1, 0.5f),
@@ -314,8 +312,6 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   }
 
   test("evaluateFilter matches Spark for high-precision decimal comparisons") {
-    import scala.collection.JavaConverters._
-
     val schema = schemaOf("ts" -> LongType, "dec" -> DecimalType(38, 30))
     val rows = Seq(
       Row(3000000000L, new JBigDecimal("0.00000000000000000000000000001")),
@@ -453,7 +449,6 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   }
 
   test("evaluateFilter converts map columns and resolves map functions") {
-    import scala.collection.JavaConverters._
     val schema = schemaOf("id" -> IntegerType,
       "mScala" -> MapType(StringType, IntegerType),
       "mJava" -> MapType(StringType, IntegerType))
@@ -475,7 +470,6 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
   }
 
   test("evaluateFilter converts array / decimal / binary / uuid / java-time columns without error") {
-    import scala.collection.JavaConverters._
     val schema = schemaOf(
       "id" -> IntegerType,
       "arrScala" -> ArrayType(IntegerType),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHoodieProcedureFilterUtils.scala
@@ -231,6 +231,12 @@ class TestHoodieProcedureFilterUtils extends HoodieSparkProcedureTestBase {
     assertResult(Right(()))(validate("ts / 2 > 500"))
     assertResult(Seq(scalarRows(1)))(keep(scalarRows, "price / 2 > 5", scalarSchema))
     assertResult(Right(()))(validate("price / 2 > 5"))
+    // Spark's rule admits a null operand on either side, so these resolve and evaluate to null
+    // rather than being rejected as an unsupported filter expression.
+    assertResult(Seq.empty)(keep(scalarRows, "ts / null > 0", scalarSchema))
+    assertResult(Right(()))(validate("ts / null > 0"))
+    assertResult(Seq.empty)(keep(scalarRows, "null / ts > 0", scalarSchema))
+    assertResult(Right(()))(validate("null / ts > 0"))
   }
 
   test("evaluateFilter binds quoted column names") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestMetadataProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestMetadataProcedure.scala
@@ -270,6 +270,21 @@ class TestMetadataProcedure extends HoodieSparkProcedureTestBase {
           metadataStats(0)(9)
         }
       }
+      // The filter runs against the procedure output schema, where "Average overlap" is a
+      // DoubleType column that a decimal literal has to widen against. See HUDI #19632.
+      val kept = spark.sql(
+        s"""call show_metadata_column_stats_overlap(table => '$tableName', targetColumns => 'c1',
+           | filter => '`Average overlap` >= 0.0')""".stripMargin).collect()
+      assertResult(1) {
+        kept.length
+      }
+      // Average overlap is a mean file count, never negative, so this keeps nothing.
+      val dropped = spark.sql(
+        s"""call show_metadata_column_stats_overlap(table => '$tableName', targetColumns => 'c1',
+           | filter => '`Average overlap` < 0.0')""".stripMargin).collect()
+      assertResult(0) {
+        dropped.length
+      }
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Procedure filters narrowed Long columns to Int and left other mixed numeric expressions unresolved, so large Long values matched wrongly and reversed or mixed-type comparisons failed validation.

Fixes #19632. Related decimal parity work: #19860.

### Summary and Changelog

- Widen numeric comparison operands to their common type with `TypeCoercion` or `AnsiTypeCoercion`, chosen by `SQLConf.get.ansiEnabled`, instead of narrowing the column.
- Apply Spark's `DecimalPrecision` rules before the generic widening, for comparisons and for arithmetic with decimal operands, so literal precision and decimal result scale match Spark.
- Widen `IN`, `<=>`, `coalesce` and arithmetic operands; non-decimal `/` promotes to Double, `div` promotes narrow integrals to BIGINT, and a null operand takes its peer's type.
- Propagate ANSI arithmetic and cast errors instead of silently dropping the row.
- Reject a non-boolean filter at validation, as Spark does.
- Bind and resolve once per batch; leave unresolved operands alone so validation keeps its messages.

<details>
<summary>Before and after, by user-visible case (compares master with <code>a6cc9da55868</code>)</summary>

Examples use procedure output columns: `ts` is BIGINT, `price` is DOUBLE, and `dec` is DECIMAL. "Rejected" means the procedure fails filter validation before returning results. Matching behavior has been checked on Spark 3.5.5 and 4.1.1 for the covered cases and settings.

| User-visible case | Before this PR | After this PR | Spark parity |
| --- | --- | --- | --- |
| Large BIGINT: `ts > 2000`, with `ts = 3000000000` | Incorrectly excludes the row: narrowing to INT wraps without ANSI or throws an exception that is swallowed with ANSI | Keeps the row in both ANSI modes; the BIGINT value is preserved | Matches tested cases on 3.5.5 and 4.1.1 |
| Large BIGINT: `ts < 2000`, with `ts = 3000000000` | Incorrectly keeps the row without ANSI because narrowing wraps to a negative value | Correctly excludes the row in both ANSI modes | Matches tested cases on 3.5.5 and 4.1.1 |
| Reversed or mixed-type comparisons: `1500 < ts`, `price > 15.0`, `dec > 1.00` with `dec DECIMAL(10,2)` | Rejected because operand types are not resolved to compatible types | Accepted; operands are converted using the active Spark rules | Matches tested cases on 3.5.5 and 4.1.1 |
| Numeric membership and null-safe equality: `ts IN (1000, null)`, `ts <=> 1000`, `ts <=> null` | Rejected for these mixed-type operands | Accepted, with normal SQL membership and null semantics | Matches tested cases on 3.5.5 and 4.1.1 |
| Mixed arithmetic and fallback values: `ts + 1 > 1500`, `ts / 2 > 500`, `coalesce(ts, 0) > 1500` | Rejected for these mixed-type operands | Accepted; addition preserves BIGINT capacity and non-decimal `/` uses Double | Matches tested cases on 3.5.5 and 4.1.1 |
| Mixed decimal arithmetic: `dec + 1 > 0`, `dec / null > 0` | Rejected | Accepted using Spark's decimal promotion rules; division by null produces no matching row | Matches tested cases on 3.5.5 and 4.1.1 |
| High-precision mixed comparisons: BIGINT `3000000000` greater than a decimal literal of `10^-30`; `DECIMAL(38,30)` value `10^-29 > 0` | Rejected because the mixed operand types remain unresolved | Uses Spark's specialized decimal comparison rules; both examples keep the row under the tested default precision settings and either ANSI mode | Matches tested cases on 3.5.5 and 4.1.1; precision settings affect results |
| ANSI arithmetic failure in an otherwise valid filter: `ts + 1L > 0L`, with `ts = Long.MaxValue` | Swallows the overflow and silently excludes the row | Fails the procedure with the arithmetic exception, matching Spark; without ANSI, the addition still wraps and the row is excluded | Matches tested ANSI and non-ANSI arithmetic error behavior |
| ANSI cast of a malformed string: `int(name) > 1` | Accepted; with ANSI the cast error is swallowed and the row excluded | Fails the procedure with the cast exception under ANSI; without ANSI the cast yields null and the row is excluded | Matches tested cases on 3.5.5 and 4.1.1 |
| Non-boolean filter: `ts + 1`, `name` | `ts + 1` rejected as unresolved; `name` accepted and returns no rows | Both rejected at validation as non-boolean | Matches Spark, which raises `FILTER_NOT_BOOLEAN` for both |
| Integral division on an INT column: `id div 2 > 0` | Rejected: `div` accepts only BIGINT or DECIMAL and same-typed INT operands were never promoted | Accepted; INT operands are promoted to BIGINT the way Spark's `IntegralDivision` rule does | Matches tested cases on 3.5.5 and 4.1.1 |
| Null with a non-numeric peer: `name IN ('a1', null)`, `name <=> null` | Rejected | Accepted; the null takes the peer's type | Matches tested cases on 3.5.5 and 4.1.1 |


Release consideration: applications that previously received an empty or incomplete result may now receive matching rows, or an arithmetic or cast error when ANSI mode is enabled. A filter whose result is not boolean, such as a bare non-boolean column, is now rejected at validation instead of returning no rows. Null results still do not match a filter. Filtering does not change the output schema or rewrite returned column values. Decimal and floating-point conversions still follow Spark's rounding and overflow rules; full SQL parity is not claimed.

</details>

### Impact

Previously rejected numeric filters are accepted and wide integral values are preserved. A non-boolean filter, and under ANSI an arithmetic or cast error, now fails the procedure instead of returning no rows. No public API change; procedure filters still support a subset of Spark SQL expressions.

<details>
<summary>Remaining limits</summary>

Numeric conversion is not always lossless. Floating-point conversion can round values. Decimal conversion can round or overflow according to the active Spark rules and settings. ANSI arithmetic and cast errors now reach the caller; non-ANSI decimal cast overflow produces null and excludes the row. Non-ANSI integral arithmetic can wrap rather than return null.

The previously reported high-precision mixed comparison mismatches are fixed: a large Long compared with a tiny decimal literal on Spark 3.5.5, and a tiny `DECIMAL(38,30)` compared with integer zero on Spark 4.1.1. The extreme decimal/decimal example in #19860 has also been checked against SQL; it should not be described as a confirmed remaining mismatch.

Filters still run after `limit` in the `show_*` procedures, so a filter only sees the first `limit` rows; tracked in #19862.

</details>

### Risk Level

Moderate. Changes affect numeric filter acceptance, precision, and error propagation across Spark versions. Tests compare results with Spark SQL; complete SQL parity and the full version matrix are not claimed.

### Documentation Update

Coercion behavior and known verification limits are documented here and in the related issues.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

<details>
<summary>Validation at <code>a6cc9da55868</code></summary>

- The production source compiles against catalyst 3.3.4, 3.5.5 and 4.1.1 (standalone scalac); at `df61fa197caa` it also compiled against 3.4.3, 4.0.2 and 4.2.0.
- Spark 3.5.5 / Scala 2.12 / JDK 11: `TestHoodieProcedureFilterUtils` 26/26 with the module's test base, `TestFsViewProcedure` 6/6, and the `show_metadata_column_stats_overlap` test in `TestMetadataProcedure`, all through a standalone ScalaTest runner on the module classpath.
- Spark 4.1.1 / Scala 2.13 / JDK 17: `TestHoodieProcedureFilterUtils` 26/26 with a stubbed test base that carries the real `withSQLConf`.
- At `df61fa197caa`, every assertion of the two SQL-parity tests was replayed against `df.filter` on all six Spark versions with no divergence, and the widened expression trees were compared with the analyzer's output on 3.3.4, 3.5.5 and 4.1.1 across about 120 filters in both ANSI modes. Targeted checks of extreme decimal/decimal comparisons, including rounding-sensitive equality and ANSI overflow, matched SQL.
- Scalastyle and `git diff --check` pass.
- The suite runs 26 tests, down from 28, after folding two duplicate decimal tests into their SQL-parity siblings. Only the spark3.5 Azure lane executes this suite in CI; the other profiles are covered by the local runs above.

</details>
