### PR TITLE
[HUDI-19827] Add IndexRecord support in dynamic bucket assign

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/DynamicBucketAssignFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/DynamicBucketAssignFunction.java
@@ -118,6 +118,11 @@ public class DynamicBucketAssignFunction
 
   @Override
   public void processElement(HoodieFlinkInternalRow record, Context ctx, Collector<HoodieFlinkInternalRow> out) throws Exception {
+    if (record.isIndexRecord()) {
+      processIndexRecord(record);
+      return;
+    }
+
     String partitionPath = record.getPartitionPath();
     String recordKey = record.getRecordKey();
     String fileGroupId = indexBackend.get(partitionPath, recordKey);
@@ -141,6 +146,25 @@ public class DynamicBucketAssignFunction
     record.setInstantTime(instantTime);
     record.setFileId(bucketInfo.getFileIdPrefix());
     out.collect(record);
+  }
+
+  /**
+   * Processes an index record that carries a pre-computed file group mapping for a record key.
+   * The index record is used for time-bounded bootstrap of the partitioned record level index,
+   * where the file group assignment is already known from the metadata table.
+   *
+   * <p>This method updates the partitioned index backend with the file group assignment
+   * and registers the file group as an update in the bucket assigner so that the file group
+   * is recognized as an existing one.
+   *
+   * @param record the index record carrying the partition path, record key, and file id
+   */
+  protected void processIndexRecord(HoodieFlinkInternalRow record) {
+    String partitionPath = record.getPartitionPath();
+    String recordKey = record.getRecordKey();
+    String fileId = record.getFileId();
+    indexBackend.update(partitionPath, recordKey, fileId);
+    bucketAssigner.addUpdate(partitionPath, fileId);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestDynamicBucketAssignFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestDynamicBucketAssignFunction.java
@@ -63,6 +63,52 @@ class TestDynamicBucketAssignFunction {
   File tempFile;
 
   @Test
+  void testProcessIndexRecordUpdatesBackendAndAssigner() throws Exception {
+    DynamicBucketAssignFunction function = new DynamicBucketAssignFunction(new Configuration());
+    PartitionedIndexBackend indexBackend = mock(PartitionedIndexBackend.class);
+    BucketAssigner bucketAssigner = mock(BucketAssigner.class);
+    setField(function, "indexBackend", indexBackend);
+    setField(function, "bucketAssigner", bucketAssigner);
+
+    // Create an index record that carries a pre-computed file group mapping
+    HoodieFlinkInternalRow indexRecord = new HoodieFlinkInternalRow("key", "partition", "file-1", "2025010100");
+    List<HoodieFlinkInternalRow> output = new ArrayList<>();
+
+    function.processElement(indexRecord, null, collector(output));
+
+    // Index records should NOT be forwarded to output
+    assertEquals(0, output.size());
+    // Should update the partitioned index backend
+    verify(indexBackend).update("partition", "key", "file-1");
+    // Should register the file group as an update in the bucket assigner
+    verify(bucketAssigner).addUpdate("partition", "file-1");
+  }
+
+  @Test
+  void testProcessIndexRecordDoesNotAffectDataRecords() throws Exception {
+    // Verify that having IndexRecord handling doesn't break normal data record processing
+    DynamicBucketAssignFunction function = new DynamicBucketAssignFunction(new Configuration());
+    PartitionedIndexBackend indexBackend = mock(PartitionedIndexBackend.class);
+    BucketAssigner bucketAssigner = mock(BucketAssigner.class);
+    when(indexBackend.get("partition", "key")).thenReturn("existing-file");
+    when(bucketAssigner.addUpdate("partition", "existing-file"))
+        .thenReturn(new BucketInfo(BucketType.UPDATE, "existing-file", "partition"));
+    setField(function, "indexBackend", indexBackend);
+    setField(function, "bucketAssigner", bucketAssigner);
+
+    HoodieFlinkInternalRow record = record("key", "partition", "U");
+    List<HoodieFlinkInternalRow> output = new ArrayList<>();
+
+    function.processElement(record, null, collector(output));
+
+    assertEquals(1, output.size());
+    assertEquals("existing-file", record.getFileId());
+    assertEquals("U", record.getInstantTime());
+    assertEquals("U", record.getOperationType());
+    verify(indexBackend, never()).update("partition", "key", "existing-file");
+  }
+
+  @Test
   void testRoutesExistingRecordToUpdateBucket() throws Exception {
     DynamicBucketAssignFunction function = new DynamicBucketAssignFunction(new Configuration());
     PartitionedIndexBackend indexBackend = mock(PartitionedIndexBackend.class);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19827

Adds IndexRecord support in DynamicBucketAssignFunction for time-bounded bootstrap of partitioned record level index.

### Summary and Changelog

- `DynamicBucketAssignFunction` now handles `IndexRecord` payloads during dynamic bucket assignment
- Added unit tests in `TestDynamicBucketAssignFunction` covering IndexRecord handling

### Impact

No public API or user-facing change; affects Flink dynamic bucket assignment for record-level index bootstrap.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable