### PR TITLE
feat(flink): support vector columns in Lance reader

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/lance/HoodieFlinkLanceArrowUtils.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/lance/HoodieFlinkLanceArrowUtils.java
@@ -40,6 +40,8 @@ import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.BaseListVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.types.DateUnit;
@@ -174,7 +176,7 @@ public final class HoodieFlinkLanceArrowUtils {
       case ROW:
         return readRow((RowType) type, (StructVector) vector, rowId);
       case ARRAY:
-        return readArray((ArrayType) type, (ListVector) vector, rowId);
+        return readArray((ArrayType) type, vector, rowId);
       default:
         throw unsupported(type);
     }
@@ -319,9 +321,9 @@ public final class HoodieFlinkLanceArrowUtils {
         fields.add(new RowType.RowField(child.getName(), toLogicalType(child, path + "." + child.getName())));
       }
       logicalType = new RowType(field.isNullable(), fields);
-    } else if (arrowType instanceof ArrowType.List) {
+    } else if (arrowType instanceof ArrowType.List || arrowType instanceof ArrowType.FixedSizeList) {
       ValidationUtils.checkArgument(field.getChildren().size() == 1,
-          String.format("Unsupported Arrow schema at '%s': LIST must contain exactly one child field", path));
+          String.format("Unsupported Arrow schema at '%s': list must contain exactly one child field", path));
       Field element = field.getChildren().get(0);
       logicalType = new ArrayType(field.isNullable(), toLogicalType(element, path + "[]"));
     } else {
@@ -338,11 +340,14 @@ public final class HoodieFlinkLanceArrowUtils {
     return row;
   }
 
-  private static ArrayData readArray(ArrayType arrayType, ListVector vector, int rowId) {
-    int startIndex = vector.getElementStartIndex(rowId);
-    int endIndex = vector.getElementEndIndex(rowId);
+  private static ArrayData readArray(ArrayType arrayType, ValueVector vector, int rowId) {
+    BaseListVector listVector = (BaseListVector) vector;
+    FieldVector dataVector = vector instanceof FixedSizeListVector
+        ? ((FixedSizeListVector) vector).getDataVector()
+        : ((ListVector) vector).getDataVector();
+    int startIndex = listVector.getElementStartIndex(rowId);
+    int endIndex = listVector.getElementEndIndex(rowId);
     Object[] values = new Object[endIndex - startIndex];
-    FieldVector dataVector = vector.getDataVector();
     for (int i = 0; i < values.length; i++) {
       values[i] = readValue(arrayType.getElementType(), dataVector, startIndex + i);
     }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/lance/HoodieFlinkLanceArrowUtils.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/lance/HoodieFlinkLanceArrowUtils.java
@@ -221,6 +221,9 @@ public final class HoodieFlinkLanceArrowUtils {
 
   private static void validateLanceVector(String fieldName, HoodieSchema.Vector vectorSchema) {
     HoodieSchema.Vector.VectorElementType elementType = vectorSchema.getVectorElementType();
+    // Keep the on-disk encoding aligned with Spark Lance writes. The current lance-spark
+    // VectorUtils.shouldBeFixedSizeList recognizes only Array<Float> and Array<Double>;
+    // an INT8 vector would otherwise be emitted as a variable-size List instead of FixedSizeList.
     if (elementType != HoodieSchema.Vector.VectorElementType.FLOAT
         && elementType != HoodieSchema.Vector.VectorElementType.DOUBLE) {
       throw new HoodieNotSupportedException(

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
@@ -103,16 +103,24 @@ public class HoodieSchemaConverter {
       String vectorColumns) {
     Map<String, Integer> vectorColumnMap = vectorColumns == null || vectorColumns.trim().isEmpty()
         ? Collections.emptyMap() : VectorColumnParser.parse(vectorColumns);
-    validateVectorColumns(logicalType, vectorColumnMap);
     return convertToSchema(logicalType, rowName, vectorColumnMap);
   }
 
-  private static HoodieSchema convertToSchema(
+  /**
+   * Converts a Flink LogicalType into a HoodieSchema with the specified top-level VECTOR columns.
+   *
+   * @param logicalType   Flink logical type
+   * @param rowName       the record name
+   * @param vectorColumns vector column names and dimensions
+   * @return HoodieSchema matching this logical type
+   */
+  public static HoodieSchema convertToSchema(
       LogicalType logicalType,
       String rowName,
       Map<String, Integer> vectorColumns) {
     ValidationUtils.checkArgument(vectorColumns.isEmpty() || logicalType instanceof RowType,
         "VECTOR columns can only be configured for top-level ROW schemas.");
+    validateVectorColumns(logicalType, vectorColumns);
 
     int precision;
     boolean nullable = logicalType.isNullable();

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
@@ -285,15 +285,15 @@ public class HoodieSchemaConverter {
    * an unknown column is rejected instead of being silently ignored during conversion.
    *
    * @param logicalType   Flink logical type
-   * @param vectorColumns parsed vector columns (normalized column name to dimension), may be empty
+   * @param vectorColumns parsed vector columns (column name to dimension), may be empty
    */
   private static void validateVectorColumns(LogicalType logicalType, Map<String, Integer> vectorColumns) {
     if (vectorColumns.isEmpty()) {
       return;
     }
-    List<String> normalizedFieldNames = ((RowType) logicalType).getFieldNames();
+    List<String> fieldNames = ((RowType) logicalType).getFieldNames();
     vectorColumns.keySet().stream()
-        .filter(vectorColumn -> !normalizedFieldNames.contains(vectorColumn))
+        .filter(vectorColumn -> !fieldNames.contains(vectorColumn))
         .findFirst()
         .ifPresent(vectorColumn -> {
           throw new IllegalArgumentException("VECTOR column '" + vectorColumn + "' does not exist in the table schema.");

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/VectorColumnParser.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/VectorColumnParser.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -33,8 +32,8 @@ import java.util.Map;
  *
  * <p>The option uses {@code colName[:dimension]} entries separated by commas, for example
  * {@code embedding:4,features:3,codes:4}. The dimension defaults to {@value #DEFAULT_VECTOR_DIMENSION}
- * when omitted. Column names are matched case-insensitively. The vector element type is inferred
- * from the Flink array element type: {@code ARRAY<FLOAT>}, {@code ARRAY<DOUBLE>}, or
+ * when omitted. The vector element type is inferred from the Flink array element type:
+ * {@code ARRAY<FLOAT>}, {@code ARRAY<DOUBLE>}, or
  * {@code ARRAY<TINYINT>} map to FLOAT, DOUBLE, and INT8 respectively.
  *
  * <p>The parser validates the descriptor syntax (well-formed entries, no duplicate columns,
@@ -50,10 +49,10 @@ public class VectorColumnParser {
 
   /**
    * Parses the {@code hoodie.vector.columns} descriptor string into a map from the
-   * (lower-cased) column name to its vector dimension, preserving declaration order.
+   * column name to its vector dimension, preserving declaration order.
    *
    * @param vectorColumns comma-separated {@code colName[:dimension]} descriptors
-   * @return map from normalized column name to dimension
+   * @return map from column name to dimension
    * @throws IllegalArgumentException if a descriptor is malformed, duplicated, or has a non-positive dimension
    */
   public static Map<String, Integer> parse(String vectorColumns) {
@@ -69,8 +68,7 @@ public class VectorColumnParser {
             "Invalid VECTOR column descriptor '" + entry + "'. Expected format: columnName[:dimension].");
       }
       String columnName = parts[0].trim();
-      String normalizedColumnName = columnName.toLowerCase(Locale.ROOT);
-      if (parsed.containsKey(normalizedColumnName)) {
+      if (parsed.containsKey(columnName)) {
         throw new IllegalArgumentException("Duplicate VECTOR column descriptor for column: " + columnName);
       }
       int dimension = DEFAULT_VECTOR_DIMENSION;
@@ -89,7 +87,7 @@ public class VectorColumnParser {
       if (dimension <= 0) {
         throw new IllegalArgumentException("VECTOR dimension must be positive for column '" + columnName + "': " + dimension);
       }
-      parsed.put(normalizedColumnName, dimension);
+      parsed.put(columnName, dimension);
     }
     return parsed;
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/VectorConversionUtils.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/VectorConversionUtils.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -76,7 +75,7 @@ public final class VectorConversionUtils {
     Map<String, HoodieSchema.Vector> vectorFields = getVectorFields(tableSchema);
     Map<Integer, HoodieSchema.Vector> vectorColumnInfo = new LinkedHashMap<>();
     for (int i = 0; i < selectedFields.length; i++) {
-      HoodieSchema.Vector vector = vectorFields.get(fullFieldNames[selectedFields[i]].toLowerCase(Locale.ROOT));
+      HoodieSchema.Vector vector = vectorFields.get(fullFieldNames[selectedFields[i]]);
       if (vector != null) {
         vectorColumnInfo.put(i, vector);
       }
@@ -143,7 +142,7 @@ public final class VectorConversionUtils {
     }
     DataType[] readFieldTypes = Arrays.copyOf(fullFieldTypes, fullFieldTypes.length);
     for (int i = 0; i < fullFieldNames.length; i++) {
-      if (vectorFields.containsKey(fullFieldNames[i].toLowerCase(Locale.ROOT))) {
+      if (vectorFields.containsKey(fullFieldNames[i])) {
         readFieldTypes[i] = DataTypes.of(bytesType(fullFieldTypes[i].getLogicalType()));
       }
     }
@@ -192,13 +191,13 @@ public final class VectorConversionUtils {
   }
 
   /**
-   * Returns VECTOR fields keyed by lower-cased field name.
+   * Returns VECTOR fields keyed by field name.
    */
   private static Map<String, HoodieSchema.Vector> getVectorFields(HoodieSchema tableSchema) {
     return tableSchema.getFields().stream()
         .filter(field -> field.schema().getNonNullType().getType() == HoodieSchemaType.VECTOR)
         .collect(Collectors.toMap(
-            field -> field.name().toLowerCase(Locale.ROOT),
+            field -> field.name(),
             field -> (HoodieSchema.Vector) field.schema().getNonNullType()));
   }
 

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/util/TestHoodieSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/util/TestHoodieSchemaConverter.java
@@ -561,6 +561,22 @@ public class TestHoodieSchemaConverter {
   }
 
   @Test
+  public void testVectorColumnNamesAreCaseSensitive() {
+    RowType rowType = (RowType) DataTypes.ROW(
+        DataTypes.FIELD("Embedding", DataTypes.ARRAY(DataTypes.FLOAT().notNull()).notNull()))
+        .notNull()
+        .getLogicalType();
+
+    HoodieSchema schema = HoodieSchemaConverter.convertToSchema(rowType, "test_record", "Embedding:4");
+    HoodieSchema vector = schema.getField("Embedding").get().schema().getNonNullType();
+    assertEquals(HoodieSchemaType.VECTOR, vector.getType());
+    assertEquals(4, ((HoodieSchema.Vector) vector).getDimension());
+
+    assertThrows(IllegalArgumentException.class,
+        () -> HoodieSchemaConverter.convertToSchema(rowType, "test_record", "embedding:4"));
+  }
+
+  @Test
   public void testConvertVectorColumnsValidation() {
     RowType rowType = (RowType) DataTypes.ROW(
         DataTypes.FIELD("embedding", DataTypes.ARRAY(DataTypes.FLOAT().notNull()).notNull()),

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/util/TestVectorConversionUtils.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/util/TestVectorConversionUtils.java
@@ -69,11 +69,11 @@ class TestVectorConversionUtils {
     DataType requested = DataTypes.ROW(
         DataTypes.FIELD("codes", DataTypes.ARRAY(DataTypes.TINYINT()).notNull()),
         DataTypes.FIELD("id", DataTypes.INT().notNull()),
-        DataTypes.FIELD("float_vec", DataTypes.ARRAY(DataTypes.FLOAT()))).notNull();
+        DataTypes.FIELD("Float_Vec", DataTypes.ARRAY(DataTypes.FLOAT()))).notNull();
     HoodieSchema projectedSchema = HoodieSchema.createRecord("projected", null, null, Arrays.asList(
         HoodieSchemaField.of("codes", INT8_VECTOR),
         HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)),
-        HoodieSchemaField.of("float_vec", FLOAT_VECTOR)));
+        HoodieSchemaField.of("Float_Vec", FLOAT_VECTOR)));
     DataType physical = VectorConversionUtils.getParquetReadDataType(
         requested, projectedSchema, detected);
     RowType physicalRow = (RowType) physical.getLogicalType();
@@ -92,6 +92,14 @@ class TestVectorConversionUtils {
     assertEquals(LogicalTypeRoot.VARBINARY, physicalTypes[1].getLogicalType().getTypeRoot());
     assertEquals(LogicalTypeRoot.VARBINARY, physicalTypes[2].getLogicalType().getTypeRoot());
     assertEquals(LogicalTypeRoot.VARBINARY, physicalTypes[3].getLogicalType().getTypeRoot());
+
+    String[] mismatchedNames = {"id", "float_vec", "double_vec", "codes"};
+    Map<Integer, HoodieSchema.Vector> mismatched =
+        VectorConversionUtils.detectVectorColumns(mismatchedNames, selected, schema);
+    assertFalse(mismatched.containsKey(2));
+    DataType[] mismatchedPhysicalTypes =
+        VectorConversionUtils.getParquetReadFieldTypes(mismatchedNames, fieldTypes, schema);
+    assertEquals(LogicalTypeRoot.ARRAY, mismatchedPhysicalTypes[1].getLogicalType().getTypeRoot());
   }
 
   @Test
@@ -149,7 +157,7 @@ class TestVectorConversionUtils {
   private static HoodieSchema vectorRecordSchema() {
     return HoodieSchema.createRecord("vectors", null, null, Arrays.asList(
         HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)),
-        HoodieSchemaField.of("float_vec", FLOAT_VECTOR),
+        HoodieSchemaField.of("Float_Vec", FLOAT_VECTOR),
         HoodieSchemaField.of("double_vec", DOUBLE_VECTOR),
         HoodieSchemaField.of("codes", INT8_VECTOR)));
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FormatUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FormatUtils.java
@@ -87,15 +87,22 @@ public class FormatUtils {
       List<DataType> fieldTypes,
       int[] selectedFields,
       Configuration hadoopConf) {
-    DataType selectedDataType = DataTypes.ROW(Arrays.stream(selectedFields)
+    HoodieSchema requestedSchema = HoodieSchemaConverter.convertToSchema(
+        DataTypes.ROW(Arrays.stream(selectedFields)
             .mapToObj(i -> DataTypes.FIELD(fieldNames.get(i), fieldTypes.get(i)))
             .toArray(DataTypes.Field[]::new))
-        .bridgedTo(RowData.class);
-    HoodieSchema requestedSchema = HoodieSchemaConverter.convertToSchema(selectedDataType.getLogicalType());
+            .getLogicalType());
+    return getLanceRecordIterator(path, requestedSchema, hadoopConf);
+  }
+
+  public static ClosableIterator<RowData> getLanceRecordIterator(
+      String path,
+      HoodieSchema requestedSchema,
+      Configuration hadoopConf) {
     HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(
         new StoragePath(path), StreamerUtil.getLanceReadConfig(hadoopConf));
     try {
-      return reader.getRowDataIterator(selectedDataType, requestedSchema);
+      return reader.getRowDataIterator(requestedSchema);
     } catch (RuntimeException e) {
       reader.close();
       throw new HoodieException("Failed to get iterator from Lance reader: " + path, e);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/HoodieRowDataLanceReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/HoodieRowDataLanceReader.java
@@ -26,6 +26,8 @@ import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.CloseableMappingIterator;
@@ -44,6 +46,9 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
@@ -57,6 +62,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.avro.HoodieBloomFilterWriteSupport.HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY;
 import static org.apache.hudi.common.avro.HoodieBloomFilterWriteSupport.HOODIE_BLOOM_FILTER_TYPE_CODE;
@@ -168,6 +174,7 @@ public class HoodieRowDataLanceReader implements HoodieRowDataFileReader {
   }
 
   public ClosableIterator<RowData> getRowDataIterator(DataType dataType, HoodieSchema requestedSchema) {
+    validateRequestedVectors(requestedSchema);
     RowType rowType = (RowType) dataType.getLogicalType();
     List<String> columnNames = new ArrayList<>(rowType.getFieldCount());
     for (RowType.RowField field : rowType.getFields()) {
@@ -204,7 +211,53 @@ public class HoodieRowDataLanceReader implements HoodieRowDataFileReader {
   @Override
   public HoodieSchema getSchema() {
     RowType rowType = HoodieFlinkLanceArrowUtils.toRowType(arrowSchema);
-    return HoodieSchemaConverter.convertToSchema(rowType);
+    Map<String, String> metadata = arrowSchema.getCustomMetadata();
+    Set<String> vectorColumnNames = HoodieSchema.parseVectorColumnNames(
+        metadata == null ? null : metadata.get(HoodieSchema.VECTOR_COLUMNS_METADATA_KEY));
+    if (vectorColumnNames.isEmpty()) {
+      return HoodieSchemaConverter.convertToSchema(rowType);
+    }
+    String vectorColumns = vectorColumnNames.stream()
+        .map(name -> name + ":" + vectorSchemaFromArrow(getTopLevelField(name)).getDimension())
+        .collect(Collectors.joining(","));
+    return HoodieSchemaConverter.convertToSchema(rowType, "record", vectorColumns);
+  }
+
+  private void validateRequestedVectors(HoodieSchema requestedSchema) {
+    for (HoodieSchemaField field : requestedSchema.getNonNullType().getFields()) {
+      HoodieSchema fieldSchema = field.schema().getNonNullType();
+      if (fieldSchema.getType() != HoodieSchemaType.VECTOR) {
+        continue;
+      }
+      HoodieSchema.Vector expected = (HoodieSchema.Vector) fieldSchema;
+      HoodieSchema.Vector actual = vectorSchemaFromArrow(getTopLevelField(field.name()));
+      if (actual.getDimension() != expected.getDimension()
+          || actual.getVectorElementType() != expected.getVectorElementType()) {
+        throw new HoodieValidationException(
+            "Incompatible Lance VECTOR encoding for column '" + field.name()
+                + "': requested " + expected.toTypeDescriptor()
+                + " but file contains " + actual.toTypeDescriptor());
+      }
+    }
+  }
+
+  private Field getTopLevelField(String name) {
+    return arrowSchema.getFields().stream()
+        .filter(field -> field.getName().equals(name))
+        .findFirst()
+        .orElseThrow(() -> new HoodieValidationException(
+            "Missing Lance column in file schema: " + name));
+  }
+
+  private static HoodieSchema.Vector vectorSchemaFromArrow(Field field) {
+    ArrowType.FixedSizeList listType = (ArrowType.FixedSizeList) field.getType();
+    ArrowType.FloatingPoint elementType =
+        (ArrowType.FloatingPoint) field.getChildren().get(0).getType();
+    HoodieSchema.Vector.VectorElementType vectorElementType =
+        elementType.getPrecision() == FloatingPointPrecision.SINGLE
+            ? HoodieSchema.Vector.VectorElementType.FLOAT
+            : HoodieSchema.Vector.VectorElementType.DOUBLE;
+    return HoodieSchema.createVector(listType.getListSize(), vectorElementType);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/HoodieRowDataLanceReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/HoodieRowDataLanceReader.java
@@ -219,7 +219,7 @@ public class HoodieRowDataLanceReader implements HoodieRowDataFileReader {
     }
     Map<String, Integer> vectorColumns = new LinkedHashMap<>();
     vectorColumnNames.forEach(name -> vectorColumns.put(
-        name, vectorSchemaFromField(getTopLevelField(name)).getDimension()));
+        name, vectorSchemaFromField(arrowSchema.findField(name)).getDimension()));
     return HoodieSchemaConverter.convertToSchema(rowType, "record", vectorColumns);
   }
 
@@ -230,7 +230,7 @@ public class HoodieRowDataLanceReader implements HoodieRowDataFileReader {
         continue;
       }
       HoodieSchema.Vector expected = (HoodieSchema.Vector) fieldSchema;
-      HoodieSchema.Vector actual = vectorSchemaFromField(getTopLevelField(field.name()));
+      HoodieSchema.Vector actual = vectorSchemaFromField(arrowSchema.findField(field.name()));
       if (actual.getDimension() != expected.getDimension()
           || actual.getVectorElementType() != expected.getVectorElementType()) {
         throw new HoodieValidationException(
@@ -239,14 +239,6 @@ public class HoodieRowDataLanceReader implements HoodieRowDataFileReader {
                 + " but file contains " + actual.toTypeDescriptor());
       }
     }
-  }
-
-  private Field getTopLevelField(String name) {
-    Field field = arrowSchema.findField(name);
-    if (field == null) {
-      throw new HoodieValidationException("Missing Lance column in file schema: " + name);
-    }
-    return field;
   }
 
   private static HoodieSchema.Vector vectorSchemaFromField(Field field) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/HoodieRowDataLanceReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/HoodieRowDataLanceReader.java
@@ -51,7 +51,6 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.lance.file.LanceFileReader;
 
@@ -148,14 +147,14 @@ public class HoodieRowDataLanceReader implements HoodieRowDataFileReader {
 
   @Override
   public ClosableIterator<HoodieRecord<RowData>> getRecordIterator(HoodieSchema readerSchema, HoodieSchema requestedSchema) throws IOException {
-    ClosableIterator<RowData> rowDataItr = getRowDataIterator(RowDataQueryContexts.fromSchema(requestedSchema).getRowType(), requestedSchema);
+    ClosableIterator<RowData> rowDataItr = getRowDataIterator(requestedSchema);
     return new CloseableMappingIterator<>(rowDataItr, HoodieFlinkRecord::new);
   }
 
   @Override
   public ClosableIterator<String> getRecordKeyIterator() throws IOException {
     HoodieSchema schema = HoodieSchemaUtils.getRecordKeySchema();
-    ClosableIterator<RowData> rowDataItr = getRowDataIterator(RowDataQueryContexts.fromSchema(schema).getRowType(), schema);
+    ClosableIterator<RowData> rowDataItr = getRowDataIterator(schema);
     return new CloseableMappingIterator<>(rowDataItr, rowData -> rowData.getString(0).toString());
   }
 
@@ -170,12 +169,13 @@ public class HoodieRowDataLanceReader implements HoodieRowDataFileReader {
         && !internalSchemaManager.getMergeSchema(path.getName()).isEmptySchema()) {
       throw new HoodieValidationException("Flink Lance base-file support does not support schema evolution.");
     }
-    return getRowDataIterator(RowDataQueryContexts.fromSchema(requiredSchema).getRowType(), requiredSchema);
+    return getRowDataIterator(requiredSchema);
   }
 
-  public ClosableIterator<RowData> getRowDataIterator(DataType dataType, HoodieSchema requestedSchema) {
+  public ClosableIterator<RowData> getRowDataIterator(HoodieSchema requestedSchema) {
     validateRequestedVectors(requestedSchema);
-    RowType rowType = (RowType) dataType.getLogicalType();
+    RowType rowType = (RowType) RowDataQueryContexts.fromSchema(requestedSchema)
+        .getRowType().getLogicalType();
     List<String> columnNames = new ArrayList<>(rowType.getFieldCount());
     for (RowType.RowField field : rowType.getFields()) {
       columnNames.add(field.getName());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/HoodieRowDataLanceReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/HoodieRowDataLanceReader.java
@@ -58,10 +58,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.avro.HoodieBloomFilterWriteSupport.HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY;
 import static org.apache.hudi.common.avro.HoodieBloomFilterWriteSupport.HOODIE_BLOOM_FILTER_TYPE_CODE;
@@ -217,9 +217,9 @@ public class HoodieRowDataLanceReader implements HoodieRowDataFileReader {
     if (vectorColumnNames.isEmpty()) {
       return HoodieSchemaConverter.convertToSchema(rowType);
     }
-    String vectorColumns = vectorColumnNames.stream()
-        .map(name -> name + ":" + vectorSchemaFromArrow(getTopLevelField(name)).getDimension())
-        .collect(Collectors.joining(","));
+    Map<String, Integer> vectorColumns = new LinkedHashMap<>();
+    vectorColumnNames.forEach(name -> vectorColumns.put(
+        name, vectorSchemaFromField(getTopLevelField(name)).getDimension()));
     return HoodieSchemaConverter.convertToSchema(rowType, "record", vectorColumns);
   }
 
@@ -230,7 +230,7 @@ public class HoodieRowDataLanceReader implements HoodieRowDataFileReader {
         continue;
       }
       HoodieSchema.Vector expected = (HoodieSchema.Vector) fieldSchema;
-      HoodieSchema.Vector actual = vectorSchemaFromArrow(getTopLevelField(field.name()));
+      HoodieSchema.Vector actual = vectorSchemaFromField(getTopLevelField(field.name()));
       if (actual.getDimension() != expected.getDimension()
           || actual.getVectorElementType() != expected.getVectorElementType()) {
         throw new HoodieValidationException(
@@ -242,21 +242,40 @@ public class HoodieRowDataLanceReader implements HoodieRowDataFileReader {
   }
 
   private Field getTopLevelField(String name) {
-    return arrowSchema.getFields().stream()
-        .filter(field -> field.getName().equals(name))
-        .findFirst()
-        .orElseThrow(() -> new HoodieValidationException(
-            "Missing Lance column in file schema: " + name));
+    Field field = arrowSchema.findField(name);
+    if (field == null) {
+      throw new HoodieValidationException("Missing Lance column in file schema: " + name);
+    }
+    return field;
   }
 
-  private static HoodieSchema.Vector vectorSchemaFromArrow(Field field) {
+  private static HoodieSchema.Vector vectorSchemaFromField(Field field) {
+    // Spark Lance currently writes VECTOR columns as FixedSizeList only for FLOAT/DOUBLE.
+    // Restrict restoration to the same types so files have one cross-engine VECTOR contract.
+    if (!(field.getType() instanceof ArrowType.FixedSizeList)
+        || field.getChildren().size() != 1
+        || !(field.getChildren().get(0).getType() instanceof ArrowType.FloatingPoint)) {
+      throw new HoodieValidationException(
+          "Invalid Lance VECTOR encoding for column '" + field.getName()
+              + "': expected FixedSizeList<Float32|Float64> but found " + field);
+    }
+
     ArrowType.FixedSizeList listType = (ArrowType.FixedSizeList) field.getType();
-    ArrowType.FloatingPoint elementType =
-        (ArrowType.FloatingPoint) field.getChildren().get(0).getType();
-    HoodieSchema.Vector.VectorElementType vectorElementType =
-        elementType.getPrecision() == FloatingPointPrecision.SINGLE
-            ? HoodieSchema.Vector.VectorElementType.FLOAT
-            : HoodieSchema.Vector.VectorElementType.DOUBLE;
+    FloatingPointPrecision precision =
+        ((ArrowType.FloatingPoint) field.getChildren().get(0).getType()).getPrecision();
+    HoodieSchema.Vector.VectorElementType vectorElementType;
+    switch (precision) {
+      case SINGLE:
+        vectorElementType = HoodieSchema.Vector.VectorElementType.FLOAT;
+        break;
+      case DOUBLE:
+        vectorElementType = HoodieSchema.Vector.VectorElementType.DOUBLE;
+        break;
+      default:
+        throw new HoodieValidationException(
+            "Invalid Lance VECTOR encoding for column '" + field.getName()
+                + "': expected Float32 or Float64 elements but found " + precision);
+    }
     return HoodieSchema.createVector(listType.getListSize(), vectorElementType);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -20,7 +20,6 @@ package org.apache.hudi.table.format.cow;
 
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.util.HoodieVectorUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.source.ExpressionPredicates.Predicate;
@@ -77,8 +76,9 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
 
   private final String[] fullFieldNames;
   private final DataType[] fullFieldTypes;
+  private final DataType[] readFieldTypes;
   private final int[] selectedFields;
-  private final HoodieSchema tableSchema;
+  private final Map<Integer, HoodieSchema.Vector> vectorColumnInfo;
   private final HoodieSchema requestedSchema;
   private final String partDefaultName;
   private final String partPathField;
@@ -120,15 +120,15 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     this.hiveStylePartitioning = hiveStylePartitioning;
     this.fullFieldNames = fullFieldNames;
     this.fullFieldTypes = fullFieldTypes;
+    this.readFieldTypes = VectorConversionUtils.getParquetReadFieldTypes(fullFieldNames, fullFieldTypes, tableSchema);
     this.selectedFields = selectedFields;
-    this.tableSchema = tableSchema.getNonNullType();
+    this.vectorColumnInfo = VectorConversionUtils.detectVectorColumns(fullFieldNames, selectedFields, tableSchema);
     RowType requestedRowType = (RowType) DataTypes.ROW(Arrays.stream(selectedFields)
             .mapToObj(i -> DataTypes.FIELD(fullFieldNames[i], fullFieldTypes[i]))
             .toArray(DataTypes.Field[]::new))
         .notNull()
         .getLogicalType();
-    this.requestedSchema = DataTypeUtils.toHoodieSchema(
-        requestedRowType, this.tableSchema);
+    this.requestedSchema = DataTypeUtils.toHoodieSchema(requestedRowType, tableSchema);
     this.conf = new SerializableConfiguration(conf);
     this.utcTimestamp = utcTimestamp;
     this.internalSchemaManager = internalSchemaManager;
@@ -136,47 +136,39 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
 
   @Override
   public void open(FileInputSplit fileSplit) throws IOException {
-    this.itr = fileSplit.getPath().getName().endsWith(HoodieFileFormat.LANCE.getFileExtension())
-        ? getLanceRecordIterator(fileSplit.getPath())
-        : getParquetRecordIterator(fileSplit);
+    if (fileSplit.getPath().getName().endsWith(HoodieFileFormat.LANCE.getFileExtension())) {
+      this.itr = getLanceRecordIterator(fileSplit.getPath());
+    } else {
+      LinkedHashMap<String, Object> partObjects = FilePathUtils.generatePartitionSpecs(
+          fileSplit.getPath().getPath(),
+          Arrays.asList(fullFieldNames),
+          Arrays.asList(fullFieldTypes),
+          this.partDefaultName,
+          this.partPathField,
+          this.hiveStylePartitioning
+      );
+
+      ClosableIterator<RowData> rowDataItr = RecordIterators.getParquetRecordIterator(
+          internalSchemaManager,
+          utcTimestamp,
+          true,
+          conf.conf(),
+          fullFieldNames,
+          readFieldTypes,
+          partObjects,
+          selectedFields,
+          2048,
+          fileSplit.getPath(),
+          fileSplit.getStart(),
+          fileSplit.getLength(),
+          predicates);
+      this.itr = vectorColumnInfo.isEmpty() ? rowDataItr : VectorConversionUtils.wrapVectorColumnIterator(rowDataItr, fullFieldTypes, selectedFields, vectorColumnInfo);
+    }
     this.currentReadCount = 0L;
   }
 
   private ClosableIterator<RowData> getLanceRecordIterator(Path path) {
     return FormatUtils.getLanceRecordIterator(path.toString(), requestedSchema, conf.conf());
-  }
-
-  private ClosableIterator<RowData> getParquetRecordIterator(FileInputSplit fileSplit) throws IOException {
-    DataType[] readFieldTypes = VectorConversionUtils.getParquetReadFieldTypes(
-        fullFieldNames, fullFieldTypes, tableSchema);
-    Map<Integer, HoodieSchema.Vector> vectorColumnInfo =
-        HoodieVectorUtils.detectVectorColumns(requestedSchema);
-    LinkedHashMap<String, Object> partObjects = FilePathUtils.generatePartitionSpecs(
-        fileSplit.getPath().getPath(),
-        Arrays.asList(fullFieldNames),
-        Arrays.asList(fullFieldTypes),
-        partDefaultName,
-        partPathField,
-        hiveStylePartitioning);
-
-    ClosableIterator<RowData> rowDataItr = RecordIterators.getParquetRecordIterator(
-        internalSchemaManager,
-        utcTimestamp,
-        true,
-        conf.conf(),
-        fullFieldNames,
-        readFieldTypes,
-        partObjects,
-        selectedFields,
-        2048,
-        fileSplit.getPath(),
-        fileSplit.getStart(),
-        fileSplit.getLength(),
-        predicates);
-    return vectorColumnInfo.isEmpty()
-        ? rowDataItr
-        : VectorConversionUtils.wrapVectorColumnIterator(
-            rowDataItr, fullFieldTypes, selectedFields, vectorColumnInfo);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -20,6 +20,7 @@ package org.apache.hudi.table.format.cow;
 
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.HoodieVectorUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.source.ExpressionPredicates.Predicate;
@@ -27,6 +28,7 @@ import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.table.format.FormatUtils;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.RecordIterators;
+import org.apache.hudi.util.DataTypeUtils;
 import org.apache.hudi.util.VectorConversionUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -37,8 +39,10 @@ import org.apache.flink.api.common.io.compression.InflaterInputStreamFactory;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.parquet.utils.SerializableConfiguration;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
@@ -73,9 +77,9 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
 
   private final String[] fullFieldNames;
   private final DataType[] fullFieldTypes;
-  private final DataType[] readFieldTypes;
   private final int[] selectedFields;
-  private final Map<Integer, HoodieSchema.Vector> vectorColumnInfo;
+  private final HoodieSchema tableSchema;
+  private final HoodieSchema requestedSchema;
   private final String partDefaultName;
   private final String partPathField;
   private final boolean hiveStylePartitioning;
@@ -116,9 +120,15 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     this.hiveStylePartitioning = hiveStylePartitioning;
     this.fullFieldNames = fullFieldNames;
     this.fullFieldTypes = fullFieldTypes;
-    this.readFieldTypes = VectorConversionUtils.getParquetReadFieldTypes(fullFieldNames, fullFieldTypes, tableSchema);
     this.selectedFields = selectedFields;
-    this.vectorColumnInfo = VectorConversionUtils.detectVectorColumns(fullFieldNames, selectedFields, tableSchema);
+    this.tableSchema = tableSchema.getNonNullType();
+    RowType requestedRowType = (RowType) DataTypes.ROW(Arrays.stream(selectedFields)
+            .mapToObj(i -> DataTypes.FIELD(fullFieldNames[i], fullFieldTypes[i]))
+            .toArray(DataTypes.Field[]::new))
+        .notNull()
+        .getLogicalType();
+    this.requestedSchema = DataTypeUtils.toHoodieSchema(
+        requestedRowType, this.tableSchema);
     this.conf = new SerializableConfiguration(conf);
     this.utcTimestamp = utcTimestamp;
     this.internalSchemaManager = internalSchemaManager;
@@ -126,40 +136,47 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
 
   @Override
   public void open(FileInputSplit fileSplit) throws IOException {
-    if (fileSplit.getPath().getName().endsWith(HoodieFileFormat.LANCE.getFileExtension())) {
-      this.itr = getLanceRecordIterator(fileSplit.getPath());
-    } else {
-      LinkedHashMap<String, Object> partObjects = FilePathUtils.generatePartitionSpecs(
-          fileSplit.getPath().getPath(),
-          Arrays.asList(fullFieldNames),
-          Arrays.asList(fullFieldTypes),
-          this.partDefaultName,
-          this.partPathField,
-          this.hiveStylePartitioning
-      );
-
-      ClosableIterator<RowData> rowDataItr = RecordIterators.getParquetRecordIterator(
-          internalSchemaManager,
-          utcTimestamp,
-          true,
-          conf.conf(),
-          fullFieldNames,
-          readFieldTypes,
-          partObjects,
-          selectedFields,
-          2048,
-          fileSplit.getPath(),
-          fileSplit.getStart(),
-          fileSplit.getLength(),
-          predicates);
-      this.itr = vectorColumnInfo.isEmpty() ? rowDataItr : VectorConversionUtils.wrapVectorColumnIterator(rowDataItr, fullFieldTypes, selectedFields, vectorColumnInfo);
-    }
+    this.itr = fileSplit.getPath().getName().endsWith(HoodieFileFormat.LANCE.getFileExtension())
+        ? getLanceRecordIterator(fileSplit.getPath())
+        : getParquetRecordIterator(fileSplit);
     this.currentReadCount = 0L;
   }
 
   private ClosableIterator<RowData> getLanceRecordIterator(Path path) {
-    return FormatUtils.getLanceRecordIterator(
-        path.toString(), Arrays.asList(fullFieldNames), Arrays.asList(fullFieldTypes), selectedFields, conf.conf());
+    return FormatUtils.getLanceRecordIterator(path.toString(), requestedSchema, conf.conf());
+  }
+
+  private ClosableIterator<RowData> getParquetRecordIterator(FileInputSplit fileSplit) throws IOException {
+    DataType[] readFieldTypes = VectorConversionUtils.getParquetReadFieldTypes(
+        fullFieldNames, fullFieldTypes, tableSchema);
+    Map<Integer, HoodieSchema.Vector> vectorColumnInfo =
+        HoodieVectorUtils.detectVectorColumns(requestedSchema);
+    LinkedHashMap<String, Object> partObjects = FilePathUtils.generatePartitionSpecs(
+        fileSplit.getPath().getPath(),
+        Arrays.asList(fullFieldNames),
+        Arrays.asList(fullFieldTypes),
+        partDefaultName,
+        partPathField,
+        hiveStylePartitioning);
+
+    ClosableIterator<RowData> rowDataItr = RecordIterators.getParquetRecordIterator(
+        internalSchemaManager,
+        utcTimestamp,
+        true,
+        conf.conf(),
+        fullFieldNames,
+        readFieldTypes,
+        partObjects,
+        selectedFields,
+        2048,
+        fileSplit.getPath(),
+        fileSplit.getStart(),
+        fileSplit.getLength(),
+        predicates);
+    return vectorColumnInfo.isEmpty()
+        ? rowDataItr
+        : VectorConversionUtils.wrapVectorColumnIterator(
+            rowDataItr, fullFieldTypes, selectedFields, vectorColumnInfo);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -79,7 +79,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
   private final DataType[] readFieldTypes;
   private final int[] selectedFields;
   private final Map<Integer, HoodieSchema.Vector> vectorColumnInfo;
-  private final HoodieSchema requestedSchema;
+  private final HoodieSchema tableSchema;
   private final String partDefaultName;
   private final String partPathField;
   private final boolean hiveStylePartitioning;
@@ -90,6 +90,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
 
   private transient ClosableIterator<RowData> itr;
   private transient long currentReadCount;
+  private transient HoodieSchema requestedSchema;
 
   /**
    * Files filter for determining what files/directories should be included.
@@ -123,12 +124,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     this.readFieldTypes = VectorConversionUtils.getParquetReadFieldTypes(fullFieldNames, fullFieldTypes, tableSchema);
     this.selectedFields = selectedFields;
     this.vectorColumnInfo = VectorConversionUtils.detectVectorColumns(fullFieldNames, selectedFields, tableSchema);
-    RowType requestedRowType = (RowType) DataTypes.ROW(Arrays.stream(selectedFields)
-            .mapToObj(i -> DataTypes.FIELD(fullFieldNames[i], fullFieldTypes[i]))
-            .toArray(DataTypes.Field[]::new))
-        .notNull()
-        .getLogicalType();
-    this.requestedSchema = DataTypeUtils.toHoodieSchema(requestedRowType, tableSchema);
+    this.tableSchema = tableSchema;
     this.conf = new SerializableConfiguration(conf);
     this.utcTimestamp = utcTimestamp;
     this.internalSchemaManager = internalSchemaManager;
@@ -168,7 +164,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
   }
 
   private ClosableIterator<RowData> getLanceRecordIterator(Path path) {
-    return FormatUtils.getLanceRecordIterator(path.toString(), requestedSchema, conf.conf());
+    return FormatUtils.getLanceRecordIterator(path.toString(), getRequestedSchema(), conf.conf());
   }
 
   @Override
@@ -428,4 +424,15 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     }
   }
 
+  private HoodieSchema getRequestedSchema() {
+    if (requestedSchema == null) {
+      RowType requestedRowType = (RowType) DataTypes.ROW(Arrays.stream(selectedFields)
+              .mapToObj(i -> DataTypes.FIELD(fullFieldNames[i], fullFieldTypes[i]))
+              .toArray(DataTypes.Field[]::new))
+          .notNull()
+          .getLogicalType();
+      requestedSchema = DataTypeUtils.toHoodieSchema(requestedRowType, tableSchema);
+    }
+    return requestedSchema;
+  }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestVectorDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestVectorDataSource.java
@@ -51,6 +51,7 @@ import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.FlinkMiniCluster;
 import org.apache.hudi.utils.TestTableEnvs;
+import org.apache.hudi.utils.TestUtils;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
@@ -164,6 +165,65 @@ public class ITTestVectorDataSource {
     List<Row> vectorProjection = collect(tableEnv, "SELECT id, embedding FROM vector_table WHERE id = 'id2'");
     assertEquals(1, vectorProjection.size());
     assertFloatArray(vectorProjection.get(0).getField(1), new float[] {-1.0f, -2.0f, -3.0f, -4.0f});
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = HoodieTableType.class)
+  public void testLanceVectorUpsertRead(HoodieTableType tableType) throws Exception {
+    TableEnvironment tableEnv = TestTableEnvs.getBatchTableEnv();
+    String tablePath = tempDir.resolve("lance_upsert_" + tableType.name()).toUri().toString();
+    Map<String, String> extraOptions = new LinkedHashMap<>();
+    extraOptions.put("hoodie.table.base.file.format", "LANCE");
+    if (tableType == HoodieTableType.MERGE_ON_READ) {
+      extraOptions.put(FlinkOptions.COMPACTION_SCHEDULE_ENABLED.key(), "true");
+      extraOptions.put(FlinkOptions.COMPACTION_ASYNC_ENABLED.key(), "true");
+      extraOptions.put(FlinkOptions.COMPACTION_DELTA_COMMITS.key(), "1");
+    }
+    createVectorTable(
+        tableEnv,
+        "vector_table",
+        tablePath,
+        tableType,
+        "embedding:2,features:3,nullable_embedding:2",
+        null,
+        extraOptions);
+
+    execInsertSql(tableEnv,
+        "INSERT INTO vector_table(id, embedding, features, nullable_embedding, label, tags, ts) VALUES "
+            + "('id1', ARRAY[CAST(1.0 AS FLOAT), CAST(1.5 AS FLOAT)], "
+            + " ARRAY[CAST(10.0 AS DOUBLE), CAST(10.5 AS DOUBLE), CAST(11.0 AS DOUBLE)], "
+            + " ARRAY[CAST(7.0 AS FLOAT), CAST(7.5 AS FLOAT)], 'old1', ARRAY['red', 'blue'], 1), "
+            + "('id2', ARRAY[CAST(2.0 AS FLOAT), CAST(2.5 AS FLOAT)], "
+            + " ARRAY[CAST(20.0 AS DOUBLE), CAST(20.5 AS DOUBLE), CAST(21.0 AS DOUBLE)], "
+            + " CAST(NULL AS ARRAY<FLOAT>), 'old2', ARRAY['green'], 2)");
+    execInsertSql(tableEnv,
+        "INSERT INTO vector_table(id, embedding, features, nullable_embedding, label, tags, ts) VALUES "
+            + "('id1', ARRAY[CAST(9.0 AS FLOAT), CAST(9.5 AS FLOAT)], "
+            + " ARRAY[CAST(90.0 AS DOUBLE), CAST(90.5 AS DOUBLE), CAST(91.0 AS DOUBLE)], "
+            + " CAST(NULL AS ARRAY<FLOAT>), 'new1', ARRAY['black'], 10)");
+
+    if (tableType == HoodieTableType.MERGE_ON_READ) {
+      assertTrue(TestUtils.hasCompleteCompactionInstant(tablePath));
+    }
+
+    List<Row> rows = collect(tableEnv,
+        "SELECT tags, features, id, nullable_embedding, embedding, label "
+            + "FROM vector_table ORDER BY id");
+    assertEquals(2, rows.size());
+
+    assertObjectArray(rows.get(0).getField(0), new Object[] {"black"});
+    assertDoubleArray(rows.get(0).getField(1), new double[] {90.0D, 90.5D, 91.0D});
+    assertEquals("id1", rows.get(0).getField(2));
+    assertNull(rows.get(0).getField(3));
+    assertFloatArray(rows.get(0).getField(4), new float[] {9.0F, 9.5F});
+    assertEquals("new1", rows.get(0).getField(5));
+
+    assertObjectArray(rows.get(1).getField(0), new Object[] {"green"});
+    assertDoubleArray(rows.get(1).getField(1), new double[] {20.0D, 20.5D, 21.0D});
+    assertEquals("id2", rows.get(1).getField(2));
+    assertNull(rows.get(1).getField(3));
+    assertFloatArray(rows.get(1).getField(4), new float[] {2.0F, 2.5F});
+    assertEquals("old2", rows.get(1).getField(5));
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestHoodieRowDataLanceReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestHoodieRowDataLanceReader.java
@@ -21,14 +21,19 @@ package org.apache.hudi.table.format;
 
 import org.apache.hudi.common.bloom.SimpleBloomFilter;
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.schema.internal.InternalSchema;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieValidationException;
+import org.apache.hudi.io.storage.row.HoodieRowDataLanceWriter;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.RowDataQueryContexts;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -37,14 +42,25 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.lance.file.LanceFileReader;
 import org.mockito.MockedStatic;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -76,6 +92,113 @@ import static org.mockito.Mockito.when;
  */
 class TestHoodieRowDataLanceReader {
   private static final StoragePath PATH = new StoragePath("/tmp/test.lance");
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void testReadsVectorsAndRestoresSchemaIdentity() throws Exception {
+    RowType rowType = RowType.of(
+        new LogicalType[] {
+            new IntType(false),
+            new ArrayType(true, new FloatType(false)),
+            new ArrayType(false, new DoubleType(false)),
+            new ArrayType(false, new IntType(false))
+        },
+        new String[] {"id", "embedding", "features", "values"});
+    HoodieSchema hoodieSchema = HoodieSchemaConverter.convertToSchema(
+        rowType, "vector_record", "embedding:2,features:3");
+    StoragePath path = new StoragePath(tempDir.resolve("vectors.lance").toUri());
+
+    try (HoodieRowDataLanceWriter writer = new HoodieRowDataLanceWriter(
+        path,
+        hoodieSchema,
+        "001",
+        mock(TaskContextSupplier.class),
+        Option.empty(),
+        128 * 1024 * 1024L,
+        64 * 1024 * 1024L,
+        16 * 1024 * 1024L,
+        true,
+        false,
+        false)) {
+      writer.writeRow("key1", GenericRowData.of(
+          1,
+          new GenericArrayData(new Object[] {1.25F, 2.5F}),
+          new GenericArrayData(new Object[] {3.5D, 4.5D, 5.5D}),
+          new GenericArrayData(new Object[] {10, 20})));
+      writer.writeRow("key2", GenericRowData.of(
+          2,
+          null,
+          new GenericArrayData(new Object[] {6.5D, 7.5D, 8.5D}),
+          new GenericArrayData(new Object[] {30})));
+    }
+
+    try (HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(path, new HoodieConfig())) {
+      HoodieSchema readSchema = reader.getSchema().getNonNullType();
+      HoodieSchema.Vector floatVector = (HoodieSchema.Vector) readSchema.getField("embedding")
+          .get().schema().getNonNullType();
+      HoodieSchema.Vector doubleVector = (HoodieSchema.Vector) readSchema.getField("features")
+          .get().schema().getNonNullType();
+      assertEquals(HoodieSchemaType.VECTOR, floatVector.getType());
+      assertEquals(2, floatVector.getDimension());
+      assertEquals(HoodieSchema.Vector.VectorElementType.FLOAT, floatVector.getVectorElementType());
+      assertEquals(3, doubleVector.getDimension());
+      assertEquals(HoodieSchema.Vector.VectorElementType.DOUBLE, doubleVector.getVectorElementType());
+      assertEquals(HoodieSchemaType.ARRAY,
+          readSchema.getField("values").get().schema().getNonNullType().getType());
+
+      try (ClosableIterator<RowData> rows = reader.getRowDataIterator(
+          RowDataQueryContexts.fromSchema(hoodieSchema).getRowType(), hoodieSchema)) {
+        RowData first = rows.next();
+        assertEquals(1, first.getInt(0));
+        assertFloatArray(first.getArray(1), 1.25F, 2.5F);
+        assertDoubleArray(first.getArray(2), 3.5D, 4.5D, 5.5D);
+        assertIntArray(first.getArray(3), 10, 20);
+
+        RowData second = rows.next();
+        assertEquals(2, second.getInt(0));
+        assertTrue(second.isNullAt(1));
+        assertDoubleArray(second.getArray(2), 6.5D, 7.5D, 8.5D);
+        assertIntArray(second.getArray(3), 30);
+        assertFalse(rows.hasNext());
+      }
+    }
+
+    RowType projectedRowType = RowType.of(
+        new LogicalType[] {
+            new ArrayType(false, new IntType(false)),
+            new ArrayType(false, new DoubleType(false)),
+            new IntType(false),
+            new ArrayType(true, new FloatType(false))
+        },
+        new String[] {"values", "features", "id", "embedding"});
+    HoodieSchema projectedSchema = HoodieSchemaConverter.convertToSchema(
+        projectedRowType, "projected_record", "features:3,embedding:2");
+    try (HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(path, new HoodieConfig());
+         ClosableIterator<RowData> rows = reader.getRowDataIterator(
+             RowDataQueryContexts.fromSchema(projectedSchema).getRowType(), projectedSchema)) {
+      RowData first = rows.next();
+      assertIntArray(first.getArray(0), 10, 20);
+      assertDoubleArray(first.getArray(1), 3.5D, 4.5D, 5.5D);
+      assertEquals(1, first.getInt(2));
+      assertFloatArray(first.getArray(3), 1.25F, 2.5F);
+    }
+
+    RowType incompatibleRowType = RowType.of(
+        new LogicalType[] {new ArrayType(true, new FloatType(false))},
+        new String[] {"embedding"});
+    HoodieSchema incompatibleSchema = HoodieSchemaConverter.convertToSchema(
+        incompatibleRowType, "incompatible_record", "embedding:3");
+    try (HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(path, new HoodieConfig())) {
+      HoodieValidationException exception = assertThrows(
+          HoodieValidationException.class,
+          () -> reader.getRowDataIterator(
+              RowDataQueryContexts.fromSchema(incompatibleSchema).getRowType(), incompatibleSchema));
+      assertTrue(exception.getMessage().contains("requested VECTOR(3)"));
+      assertTrue(exception.getMessage().contains("file contains VECTOR(2)"));
+    }
+  }
 
   @Test
   void testReadsMetadataAndClosesIdempotently() throws Exception {
@@ -200,6 +323,27 @@ class TestHoodieRowDataLanceReader {
           RowDataQueryContexts.fromSchema(schema).getRowType(), schema));
       verify(dataReader).close();
       reader.close();
+    }
+  }
+
+  private static void assertFloatArray(ArrayData array, float... expected) {
+    assertEquals(expected.length, array.size());
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(expected[i], array.getFloat(i));
+    }
+  }
+
+  private static void assertDoubleArray(ArrayData array, double... expected) {
+    assertEquals(expected.length, array.size());
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(expected[i], array.getDouble(i));
+    }
+  }
+
+  private static void assertIntArray(ArrayData array, int... expected) {
+    assertEquals(expected.length, array.size());
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(expected[i], array.getInt(i));
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestHoodieRowDataLanceReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestHoodieRowDataLanceReader.java
@@ -42,6 +42,10 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.GenericArrayData;
@@ -240,6 +244,32 @@ class TestHoodieRowDataLanceReader {
   }
 
   @Test
+  void testRejectsInvalidVectorArrowTypes() throws Exception {
+    RowType rowType = RowType.of(
+        new LogicalType[] {new ArrayType(false, new FloatType(false))},
+        new String[] {"embedding"});
+    HoodieSchema requestedSchema = HoodieSchemaConverter.convertToSchema(
+        rowType, "vector_record", "embedding:2");
+
+    Field element = new Field(
+        "element", FieldType.notNullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)), null);
+    assertInvalidVectorEncoding(
+        requestedSchema,
+        new Field("embedding", FieldType.nullable(new ArrowType.List()), Collections.singletonList(element)),
+        "expected FixedSizeList<Float32|Float64>");
+
+    Field halfElement = new Field(
+        "element", FieldType.notNullable(new ArrowType.FloatingPoint(FloatingPointPrecision.HALF)), null);
+    assertInvalidVectorEncoding(
+        requestedSchema,
+        new Field(
+            "embedding",
+            FieldType.nullable(new ArrowType.FixedSizeList(2)),
+            Collections.singletonList(halfElement)),
+        "expected Float32 or Float64 elements");
+  }
+
+  @Test
   void testReadsMetadataAndClosesIdempotently() throws Exception {
     SimpleBloomFilter bloomFilter = new SimpleBloomFilter(100, 0.01, MURMUR_HASH);
     bloomFilter.add("key1");
@@ -389,6 +419,19 @@ class TestHoodieRowDataLanceReader {
     LanceFileReader reader = mock(LanceFileReader.class);
     when(reader.schema()).thenReturn(new Schema(Collections.emptyList()));
     return reader;
+  }
+
+  private static void assertInvalidVectorEncoding(
+      HoodieSchema requestedSchema, Field field, String expectedMessage) throws Exception {
+    LanceFileReader metadataReader = mock(LanceFileReader.class);
+    when(metadataReader.schema()).thenReturn(new Schema(Collections.singletonList(field)));
+    try (MockedStatic<LanceFileReader> mocked = mockLanceOpen(metadataReader);
+         HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(PATH, new HoodieConfig())) {
+      HoodieValidationException exception = assertThrows(
+          HoodieValidationException.class,
+          () -> reader.getRowDataIterator(requestedSchema));
+      assertTrue(exception.getMessage().contains(expectedMessage));
+    }
   }
 
   private static MockedStatic<LanceFileReader> mockLanceOpen(LanceFileReader... readers) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestHoodieRowDataLanceReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestHoodieRowDataLanceReader.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.bloom.SimpleBloomFilter;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.schema.internal.InternalSchema;
@@ -97,6 +98,47 @@ class TestHoodieRowDataLanceReader {
   Path tempDir;
 
   @Test
+  void testRestoresMixedCaseVectorFieldName() throws Exception {
+    HoodieSchema hoodieSchema = HoodieSchema.createRecord(
+        "mixed_case_record",
+        null,
+        null,
+        Collections.singletonList(HoodieSchemaField.of(
+            "Embedding",
+            HoodieSchema.createNullable(HoodieSchema.createVector(
+                2, HoodieSchema.Vector.VectorElementType.FLOAT)),
+            null,
+            HoodieSchema.NULL_VALUE)));
+    StoragePath path = new StoragePath(tempDir.resolve("mixed-case-vector.lance").toUri());
+
+    try (HoodieRowDataLanceWriter writer = new HoodieRowDataLanceWriter(
+        path,
+        hoodieSchema,
+        "001",
+        mock(TaskContextSupplier.class),
+        Option.empty(),
+        128 * 1024 * 1024L,
+        64 * 1024 * 1024L,
+        16 * 1024 * 1024L,
+        true,
+        false,
+        false)) {
+      writer.writeRow("key1", GenericRowData.of(
+          new GenericArrayData(new Object[] {1.25F, 2.5F})));
+    }
+
+    try (HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(path, new HoodieConfig())) {
+      HoodieSchema restoredSchema = reader.getSchema().getNonNullType();
+      assertTrue(restoredSchema.getField("Embedding").isPresent());
+      assertFalse(restoredSchema.getField("embedding").isPresent());
+      HoodieSchema.Vector vector = (HoodieSchema.Vector) restoredSchema.getField("Embedding")
+          .get().schema().getNonNullType();
+      assertEquals(2, vector.getDimension());
+      assertEquals(HoodieSchema.Vector.VectorElementType.FLOAT, vector.getVectorElementType());
+    }
+  }
+
+  @Test
   void testReadsVectorsAndRestoresSchemaIdentity() throws Exception {
     RowType rowType = RowType.of(
         new LogicalType[] {
@@ -148,8 +190,7 @@ class TestHoodieRowDataLanceReader {
       assertEquals(HoodieSchemaType.ARRAY,
           readSchema.getField("values").get().schema().getNonNullType().getType());
 
-      try (ClosableIterator<RowData> rows = reader.getRowDataIterator(
-          RowDataQueryContexts.fromSchema(hoodieSchema).getRowType(), hoodieSchema)) {
+      try (ClosableIterator<RowData> rows = reader.getRowDataIterator(hoodieSchema)) {
         RowData first = rows.next();
         assertEquals(1, first.getInt(0));
         assertFloatArray(first.getArray(1), 1.25F, 2.5F);
@@ -176,8 +217,7 @@ class TestHoodieRowDataLanceReader {
     HoodieSchema projectedSchema = HoodieSchemaConverter.convertToSchema(
         projectedRowType, "projected_record", "features:3,embedding:2");
     try (HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(path, new HoodieConfig());
-         ClosableIterator<RowData> rows = reader.getRowDataIterator(
-             RowDataQueryContexts.fromSchema(projectedSchema).getRowType(), projectedSchema)) {
+         ClosableIterator<RowData> rows = reader.getRowDataIterator(projectedSchema)) {
       RowData first = rows.next();
       assertIntArray(first.getArray(0), 10, 20);
       assertDoubleArray(first.getArray(1), 3.5D, 4.5D, 5.5D);
@@ -193,8 +233,7 @@ class TestHoodieRowDataLanceReader {
     try (HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(path, new HoodieConfig())) {
       HoodieValidationException exception = assertThrows(
           HoodieValidationException.class,
-          () -> reader.getRowDataIterator(
-              RowDataQueryContexts.fromSchema(incompatibleSchema).getRowType(), incompatibleSchema));
+          () -> reader.getRowDataIterator(incompatibleSchema));
       assertTrue(exception.getMessage().contains("requested VECTOR(3)"));
       assertTrue(exception.getMessage().contains("file contains VECTOR(2)"));
     }
@@ -319,8 +358,7 @@ class TestHoodieRowDataLanceReader {
 
     try (MockedStatic<LanceFileReader> mocked = mockLanceOpen(metadataReader, dataReader)) {
       HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(PATH, new HoodieConfig());
-      assertThrows(HoodieException.class, () -> reader.getRowDataIterator(
-          RowDataQueryContexts.fromSchema(schema).getRowType(), schema));
+      assertThrows(HoodieException.class, () -> reader.getRowDataIterator(schema));
       verify(dataReader).close();
       reader.close();
     }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cow/TestCopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cow/TestCopyOnWriteInputFormat.java
@@ -117,9 +117,8 @@ class TestCopyOnWriteInputFormat {
 
   @Test
   void testLanceVectorSchemaMismatch() throws Exception {
-    RowType rowType = RowType.of(
-        new LogicalType[] {new ArrayType(false, new FloatType(false))},
-        new String[] {"embedding"});
+    RowType rowType = RowType.of(false,
+        new LogicalType[] {new ArrayType(false, new FloatType(false))}, new String[] {"embedding"});
     HoodieSchema fileSchema = HoodieSchemaConverter.convertToSchema(
         rowType, "file_record", "embedding:2");
     HoodieSchema tableSchema = HoodieSchemaConverter.convertToSchema(

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cow/TestCopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cow/TestCopyOnWriteInputFormat.java
@@ -19,8 +19,15 @@
 
 package org.apache.hudi.table.format.cow;
 
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieValidationException;
+import org.apache.hudi.io.storage.row.HoodieRowDataLanceWriter;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.utils.TestConfigurations;
@@ -28,10 +35,15 @@ import org.apache.hudi.utils.TestConfigurations;
 import org.apache.flink.api.common.io.FilePathFilter;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.fs.FileStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -101,6 +113,58 @@ class TestCopyOnWriteInputFormat {
     FileInputSplit[] splits = inputFormat.createInputSplits(8);
     assertEquals(1, splits.length);
     assertEquals(-1L, splits[0].getLength());
+  }
+
+  @Test
+  void testLanceVectorSchemaMismatch() throws Exception {
+    RowType rowType = RowType.of(
+        new LogicalType[] {new ArrayType(false, new FloatType(false))},
+        new String[] {"embedding"});
+    HoodieSchema fileSchema = HoodieSchemaConverter.convertToSchema(
+        rowType, "file_record", "embedding:2");
+    HoodieSchema tableSchema = HoodieSchemaConverter.convertToSchema(
+        rowType, "table_record", "embedding:3");
+    StoragePath storagePath = new StoragePath(tempDir.resolve("vector.lance").toUri());
+
+    try (HoodieRowDataLanceWriter writer = new HoodieRowDataLanceWriter(
+        storagePath,
+        fileSchema,
+        "001",
+        mock(TaskContextSupplier.class),
+        Option.empty(),
+        128 * 1024 * 1024L,
+        64 * 1024 * 1024L,
+        16 * 1024 * 1024L,
+        true,
+        false,
+        false)) {
+      writer.writeRow("key1", GenericRowData.of(
+          new GenericArrayData(new Object[] {1.0F, 2.0F})));
+    }
+
+    DataType rowDataType = HoodieSchemaConverter.convertToDataType(tableSchema);
+    CopyOnWriteInputFormat inputFormat = new CopyOnWriteInputFormat(
+        new Path[] {new Path(storagePath.toUri())},
+        new String[] {"embedding"},
+        rowDataType.getChildren().toArray(new DataType[0]),
+        new int[] {0},
+        FlinkOptions.PARTITION_DEFAULT_NAME.defaultValue(),
+        FlinkOptions.PARTITION_PATH_FIELD.defaultValue(),
+        false,
+        Collections.emptyList(),
+        Long.MAX_VALUE,
+        new org.apache.hadoop.conf.Configuration(),
+        true,
+        InternalSchemaManager.DISABLED,
+        tableSchema);
+
+    HoodieException exception = assertThrows(
+        HoodieException.class,
+        () -> inputFormat.open(new FileInputSplit(
+            0, new Path(storagePath.toUri()), 0, -1, new String[0])));
+    assertTrue(exception.getCause() instanceof HoodieValidationException);
+    assertTrue(exception.getCause().getMessage().contains("requested VECTOR(3)"));
+    assertTrue(exception.getCause().getMessage().contains("file contains VECTOR(2)"));
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19821.

Following the Lance VECTOR writer support merged in #19831, Flink also needs to read these columns as ArrayData and preserve their VECTOR schema identity. The existing reader only handles variable-length Arrow lists.

### Summary and Changelog

- Read Arrow FixedSizeList values as Flink arrays while retaining ordinary List support.
- Restore VECTOR schema identity from the Lance footer's vector-column metadata and Arrow element type and dimension.
- Validate requested vector dimensions and element types against the file schema.
- Add real Lance file round-trip coverage for FLOAT/DOUBLE vectors, null vectors, ordinary arrays, reordered projections, schema restoration, and incompatible dimensions.
- Add COW/MOR upsert-read coverage, including completed MOR compaction.

### Impact

Enables Flink to read top-level FLOAT and DOUBLE VECTOR columns from Hudi-written Lance files. No configuration or file-format changes. INT8 vectors, nested vectors, and Lance schema evolution remain out of scope. Reading materializes the elements as ArrayData using the existing array conversion path.

### Risk Level

Medium. The change affects Lance array decoding and schema reconstruction. Regression coverage includes ordinary arrays and the existing writer tests.

Validation on Flink 2.1: 21 tests passed, with no failures, errors, or skipped tests; the Maven reactor and Checkstyle passed.

```bash
mvn -Pflink2.1 -pl hudi-flink-datasource/hudi-flink -am \
  '-Dtest=TestHoodieFlinkLanceArrowUtils,TestLanceRowDataWriter,TestHoodieRowDataLanceReader,ITTestVectorDataSource#testLanceVectorUpsertRead' \
  -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -DskipSparkTests -DskipScalaTests test
```

### Documentation Update

The Flink VECTOR/Lance support documentation should describe FLOAT/DOUBLE vector reads. No documentation changes are included in this PR.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
