### PR TITLE
fix(flink): bootstrap operator for bounded source

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -425,8 +425,8 @@ public class Pipelines {
       boolean bounded) {
     DataStream<HoodieFlinkInternalRow> dataStream1 = rowDataToHoodieRecord(conf, rowType, dataStream);
 
-    boolean isGlobalRLI = OptionsResolver.isGlobalRecordLevelIndex(conf);
-    if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED) || (bounded && !isGlobalRLI)) {
+    boolean isRLI = OptionsResolver.isGlobalRecordLevelIndex(conf) || OptionsResolver.isRecordLevelIndex(conf);
+    if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED) || (bounded && !isRLI)) {
       AbstractBootstrapOperator bootstrapOperator = BootstrapOperatorFactory.createInstance(conf);
       dataStream1 = dataStream1
           .transform(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -415,17 +415,19 @@ public class Pipelines {
 
     final boolean isRLI = OptionsResolver.isGlobalRecordLevelIndex(conf) || OptionsResolver.isRecordLevelIndex(conf);
     // Bounded writes require bootstrap automatically only for non-RLI indexes.
-    final boolean needsBootstrap = conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED) || (bounded && !isRLI);
-    if (!needsBootstrap) {
-      return rowDataToHoodieRecord(conf, rowType, dataStream);
+    if (bounded && !isRLI) {
+      final boolean globalIndex = conf.get(FlinkOptions.INDEX_GLOBAL_ENABLED);
+      if (!globalIndex && OptionsResolver.isPartitionedTable(conf)) {
+        return boundedBootstrap(conf, rowType, dataStream);
+      }
+      return streamBootstrap(conf, rowType, dataStream);
     }
 
-    final boolean globalIndex = conf.get(FlinkOptions.INDEX_GLOBAL_ENABLED);
-    if (bounded && !globalIndex && !isRLI && OptionsResolver.isPartitionedTable(conf)) {
-      return boundedBootstrap(conf, rowType, dataStream);
+    // Unbounded sources and RLI indexes bootstrap only when explicitly enabled.
+    if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED)) {
+      return streamBootstrap(conf, rowType, dataStream);
     }
-
-    return streamBootstrap(conf, rowType, dataStream);
+    return rowDataToHoodieRecord(conf, rowType, dataStream);
   }
 
   private static DataStream<HoodieFlinkInternalRow> streamBootstrap(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -410,11 +410,22 @@ public class Pipelines {
       boolean overwrite) {
     final boolean globalIndex = conf.get(FlinkOptions.INDEX_GLOBAL_ENABLED);
     if (overwrite || OptionsResolver.isBucketIndexType(conf)) {
+      // overwrite and bucket index do not rely on a bootstrapped key index.
       return rowDataToHoodieRecord(conf, rowType, dataStream);
     }
-    if (bounded && !globalIndex && OptionsResolver.isPartitionedTable(conf)) {
+    boolean isRLI = OptionsResolver.isGlobalRecordLevelIndex(conf) || OptionsResolver.isRecordLevelIndex(conf);
+    if (bounded && isRLI && !conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED)) {
+      // RLI bucket assignment (global or partitioned) looks up the record index directly,
+      // so the generic bootstrap step can be skipped unless it is explicitly requested.
+      return rowDataToHoodieRecord(conf, rowType, dataStream);
+    }
+    if (bounded && !globalIndex && !isRLI && OptionsResolver.isPartitionedTable(conf)) {
+      // non-RLI partitioned tables shuffle by partition path and bootstrap per-partition
+      // during batch execution to support batch UPSERT.
       return boundedBootstrap(conf, rowType, dataStream);
     }
+    // streaming execution, or bounded execution for a non-partitioned/global-index/RLI-with-
+    // explicit-bootstrap table: load the index via the generic bootstrap operator.
     return streamBootstrap(conf, rowType, dataStream, bounded);
   }
 
@@ -425,8 +436,7 @@ public class Pipelines {
       boolean bounded) {
     DataStream<HoodieFlinkInternalRow> dataStream1 = rowDataToHoodieRecord(conf, rowType, dataStream);
 
-    boolean isRLI = OptionsResolver.isGlobalRecordLevelIndex(conf) || OptionsResolver.isRecordLevelIndex(conf);
-    if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED) || (bounded && !isRLI)) {
+    if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED) || bounded) {
       AbstractBootstrapOperator bootstrapOperator = BootstrapOperatorFactory.createInstance(conf);
       dataStream1 = dataStream1
           .transform(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -408,46 +408,41 @@ public class Pipelines {
       DataStream<RowData> dataStream,
       boolean bounded,
       boolean overwrite) {
-    final boolean globalIndex = conf.get(FlinkOptions.INDEX_GLOBAL_ENABLED);
     if (overwrite || OptionsResolver.isBucketIndexType(conf)) {
       // overwrite and bucket index do not rely on a bootstrapped key index.
       return rowDataToHoodieRecord(conf, rowType, dataStream);
     }
-    boolean isRLI = OptionsResolver.isGlobalRecordLevelIndex(conf) || OptionsResolver.isRecordLevelIndex(conf);
-    if (bounded && isRLI && !conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED)) {
-      // RLI bucket assignment (global or partitioned) looks up the record index directly,
-      // so the generic bootstrap step can be skipped unless it is explicitly requested.
+
+    final boolean isRLI = OptionsResolver.isGlobalRecordLevelIndex(conf) || OptionsResolver.isRecordLevelIndex(conf);
+    // Bounded writes require bootstrap automatically only for non-RLI indexes.
+    final boolean needsBootstrap = conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED) || (bounded && !isRLI);
+    if (!needsBootstrap) {
       return rowDataToHoodieRecord(conf, rowType, dataStream);
     }
+
+    final boolean globalIndex = conf.get(FlinkOptions.INDEX_GLOBAL_ENABLED);
     if (bounded && !globalIndex && !isRLI && OptionsResolver.isPartitionedTable(conf)) {
-      // non-RLI partitioned tables shuffle by partition path and bootstrap per-partition
-      // during batch execution to support batch UPSERT.
       return boundedBootstrap(conf, rowType, dataStream);
     }
-    // streaming execution, or bounded execution for a non-partitioned/global-index/RLI-with-
-    // explicit-bootstrap table: load the index via the generic bootstrap operator.
-    return streamBootstrap(conf, rowType, dataStream, bounded);
+
+    return streamBootstrap(conf, rowType, dataStream);
   }
 
   private static DataStream<HoodieFlinkInternalRow> streamBootstrap(
       Configuration conf,
       RowType rowType,
-      DataStream<RowData> dataStream,
-      boolean bounded) {
+      DataStream<RowData> dataStream) {
     DataStream<HoodieFlinkInternalRow> dataStream1 = rowDataToHoodieRecord(conf, rowType, dataStream);
+    AbstractBootstrapOperator bootstrapOperator = BootstrapOperatorFactory.createInstance(conf);
 
-    if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED) || bounded) {
-      AbstractBootstrapOperator bootstrapOperator = BootstrapOperatorFactory.createInstance(conf);
-      dataStream1 = dataStream1
-          .transform(
-              "index_bootstrap",
-              new HoodieFlinkInternalRowTypeInfo(rowType),
-              bootstrapOperator)
-          .setParallelism(conf.getOptional(FlinkOptions.INDEX_BOOTSTRAP_TASKS).orElse(dataStream1.getParallelism()))
-          .uid(opUID("index_bootstrap", conf));
-      ((OneInputTransformation<?, ?>) dataStream1.getTransformation()).setChainingStrategy(ChainingStrategy.ALWAYS);
-    }
-
+    dataStream1 = dataStream1
+        .transform(
+            "index_bootstrap",
+            new HoodieFlinkInternalRowTypeInfo(rowType),
+            bootstrapOperator)
+            .setParallelism(conf.getOptional(FlinkOptions.INDEX_BOOTSTRAP_TASKS).orElse(dataStream1.getParallelism()))
+            .uid(opUID("index_bootstrap", conf));
+    ((OneInputTransformation<?, ?>) dataStream1.getTransformation()).setChainingStrategy(ChainingStrategy.ALWAYS);
     return dataStream1;
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestPipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestPipelines.java
@@ -106,6 +106,53 @@ public class TestPipelines {
   }
 
   @Test
+  void testBoundedGlobalRLISkipsBootstrapOperator() {
+    // Global RLI bucket assignment queries the metadata table directly, so the generic
+    // index-bootstrap step (which loads existing keys into state for the default bucket
+    // assigner) must not be wired in for bounded/batch execution.
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX.name());
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, false);
+    DataStream<RowData> input = rowDataInput();
+
+    DataStream<HoodieFlinkInternalRow> bounded =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, true, false);
+
+    assertEquals("row_data_to_hoodie_record", bounded.getTransformation().getName());
+  }
+
+  @Test
+  void testBoundedPartitionedRLISkipsBootstrapOperator() {
+    // Partitioned (non-global) RLI is routed to the DynamicBucketAssignOperator, which also
+    // looks up the record index directly rather than consuming bootstrapped state, so it must
+    // be treated the same as global RLI and skip the generic bootstrap operator when bounded.
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.RECORD_LEVEL_INDEX.name());
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, false);
+    DataStream<RowData> input = rowDataInput();
+
+    DataStream<HoodieFlinkInternalRow> bounded =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, true, false);
+
+    assertEquals("row_data_to_hoodie_record", bounded.getTransformation().getName());
+  }
+
+  @Test
+  void testBoundedPartitionedRLIStillBootstrapsWhenExplicitlyEnabled() {
+    // INDEX_BOOTSTRAP_ENABLED is an explicit override and must still wire in the bootstrap
+    // operator even for RLI index types.
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.RECORD_LEVEL_INDEX.name());
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, true);
+    DataStream<RowData> input = rowDataInput();
+
+    DataStream<HoodieFlinkInternalRow> bounded =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, true, false);
+
+    assertEquals("index_bootstrap", bounded.getTransformation().getName());
+  }
+
+  @Test
   void testPartitionedRLIWithRocksDBBackendUsesPartitionedRLIBootstrapOperator() {
     // HoodieTableFactory no longer forces INDEX_BOOTSTRAP_ENABLED to false for RECORD_LEVEL_INDEX,
     // so a user that wants time-bounded RLI bootstrap sets the flag explicitly alongside the

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestPipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestPipelines.java
@@ -127,6 +127,7 @@ public class TestPipelines {
     // looks up the record index directly rather than consuming bootstrapped state, so it must
     // be treated the same as global RLI and skip the generic bootstrap operator when bounded.
     Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_GLOBAL_ENABLED, false);
     conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.RECORD_LEVEL_INDEX.name());
     conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, false);
     DataStream<RowData> input = rowDataInput();
@@ -142,6 +143,7 @@ public class TestPipelines {
     // INDEX_BOOTSTRAP_ENABLED is an explicit override and must still wire in the bootstrap
     // operator even for RLI index types.
     Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_GLOBAL_ENABLED, false);
     conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.RECORD_LEVEL_INDEX.name());
     conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, true);
     DataStream<RowData> input = rowDataInput();

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestPipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestPipelines.java
@@ -106,6 +106,71 @@ public class TestPipelines {
   }
 
   @Test
+  void testBootstrapSkippedForBucketIndex() {
+    // Bucket index assigns buckets by hashing the record key directly, so it never relies on
+    // a bootstrapped key index, regardless of the bounded/streaming mode.
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, true);
+    DataStream<RowData> input = rowDataInput();
+
+    DataStream<HoodieFlinkInternalRow> bounded =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, true, false);
+    assertEquals("row_data_to_hoodie_record", bounded.getTransformation().getName());
+
+    DataStream<HoodieFlinkInternalRow> streaming =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, false, false);
+    assertEquals("row_data_to_hoodie_record", streaming.getTransformation().getName());
+  }
+
+  @Test
+  void testStreamingNonRLIWithoutBootstrapEnabledSkipsBootstrapOperator() {
+    // Streaming execution only wires in the bootstrap operator when the flag is explicitly
+    // turned on; the bounded-write auto-bootstrap rule does not apply here.
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, false);
+    DataStream<RowData> input = rowDataInput();
+
+    DataStream<HoodieFlinkInternalRow> streaming =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, false, false);
+
+    assertEquals("row_data_to_hoodie_record", streaming.getTransformation().getName());
+  }
+
+  @Test
+  void testBoundedGlobalIndexNonRLIPartitionedUsesStreamBootstrap() {
+    // The per-partition batch bootstrap path is reserved for non-global, non-RLI indexes;
+    // a global (non-RLI) index must fall back to the generic streaming bootstrap operator
+    // even for bounded/batch execution, since it is not safe to shuffle by partition path.
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_GLOBAL_ENABLED, true);
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, false);
+    DataStream<RowData> input = rowDataInput();
+
+    DataStream<HoodieFlinkInternalRow> bounded =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, true, false);
+
+    assertEquals("index_bootstrap", bounded.getTransformation().getName());
+  }
+
+  @Test
+  void testBoundedNonPartitionedTableUsesStreamBootstrap() {
+    // The per-partition batch bootstrap path shuffles by partition path, so it only applies to
+    // partitioned tables; a non-partitioned table must use the generic streaming bootstrap
+    // operator for bounded execution instead.
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.INDEX_GLOBAL_ENABLED, false);
+    conf.set(FlinkOptions.PARTITION_PATH_FIELD, "");
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, false);
+    DataStream<RowData> input = rowDataInput();
+
+    DataStream<HoodieFlinkInternalRow> bounded =
+        Pipelines.bootstrap(conf, TestConfigurations.ROW_TYPE, input, true, false);
+
+    assertEquals("index_bootstrap", bounded.getTransformation().getName());
+  }
+
+  @Test
   void testBoundedGlobalRLISkipsBootstrapOperator() {
     // Global RLI bucket assignment queries the metadata table directly, so the generic
     // index-bootstrap step (which loads existing keys into state for the default bucket


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fix the bootstrap initialization for bounded source.

### Summary and Changelog

The bounded-source pipeline in Pipelines.bootstrap() decided whether to skip the generic index-bootstrap operator by checking only isGlobalRecordLevelIndex(conf). That left non-global (partitioned) Record Level Index configs out of the exemption, so a bounded/batch job using partitioned RLI would incorrectly still wire in the bootstrap operator — even though RLI-based bucket assignment (via the metadata table / DynamicBucketAssignOperator) doesn't consume that bootstrapped state.

The fix widens the check to isGlobalRecordLevelIndex(conf) || isRecordLevelIndex(conf), so both global and partitioned RLI skip the redundant bootstrap step for bounded sources, unless INDEX_BOOTSTRAP_ENABLED is explicitly set (which still forces bootstrap regardless of index type).


### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
