### PR TITLE
feat(config)!: support all meta fields except the record key

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
@@ -267,7 +267,7 @@ public class TableCommand {
           + "whose incremental / file-pruning semantics differ between old and new data.")
   public String setMetaFieldsMode(
       @ShellOption(value = {"--target-mode"},
-          help = "One of ALL, NONE, COMMIT_TIME_ONLY, FILE_NAME_ONLY, COMMIT_TIME_AND_FILE_NAME")
+          help = "One of ALL, NONE, COMMIT_TIME_ONLY, FILE_NAME_ONLY, COMMIT_TIME_AND_FILE_NAME, ALL_EXCEPT_RECORD_KEY")
       final String targetModeStr,
       @ShellOption(value = {"--force"}, defaultValue = "false",
           help = "Allow NARROWING the mode on a table that already has commits. Does not permit "

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroParquetWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroParquetWriter.java
@@ -25,6 +25,9 @@ import org.apache.hudi.common.bloom.BloomFilterFactory;
 import org.apache.hudi.common.bloom.BloomFilterTypeCode;
 import org.apache.hudi.common.config.HoodieParquetConfig;
 import org.apache.hudi.common.engine.LocalTaskContextSupplier;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.MetaFieldsMode;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
@@ -50,6 +53,8 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieAvroParquetWriter {
@@ -109,6 +114,42 @@ public class TestHoodieAvroParquetWriter {
     recordKeys.forEach(recordKey -> {
       assertTrue(bloomFilter.mightContain(recordKey));
     });
+  }
+
+  @Test
+  public void testAllExceptRecordKeyWritesOtherMetaFields() throws IOException {
+    HoodieStorage storage = HoodieTestUtils.getStorage(tmpDir.toString());
+    HoodieSchema schema = HoodieTestDataGenerator.HOODIE_SCHEMA_WITH_METADATA_FIELDS;
+    List<GenericRecord> records = new HoodieTestDataGenerator(0xDEED).generateGenericRecords(10);
+    HoodieAvroWriteSupport writeSupport = new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema.toAvroSchema()),
+        schema, Option.empty(), new Properties());
+    HoodieParquetConfig<HoodieAvroWriteSupport> parquetConfig = new HoodieParquetConfig<>(writeSupport,
+        CompressionCodecName.GZIP, ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.DEFAULT_PAGE_SIZE,
+        1024 * 1024 * 1024, storage.getConf(), 0.1, true);
+    StoragePath filePath = new StoragePath(tmpDir.resolve("without-record-key.parquet").toString());
+    LocalTaskContextSupplier taskContext = new LocalTaskContextSupplier();
+    try (HoodieAvroParquetWriter writer = new HoodieAvroParquetWriter(filePath, parquetConfig, "001",
+        taskContext, MetaFieldsMode.ALL_EXCEPT_RECORD_KEY)) {
+      for (GenericRecord record : records) {
+        GenericRecord withMeta = HoodieAvroUtils.rewriteRecord(record, schema.toAvroSchema());
+        writer.writeAvroWithMetadata(new HoodieKey(record.get("_row_key").toString(), "p1"), withMeta);
+      }
+    }
+    List<GenericRecord> written = new ParquetUtils().readAvroRecords(storage, filePath);
+    assertEquals(records.size(), written.size());
+    for (int i = 0; i < written.size(); i++) {
+      GenericRecord record = written.get(i);
+      assertNull(record.get(HoodieRecord.RECORD_KEY_METADATA_FIELD));
+      assertEquals("001", record.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD).toString());
+      assertEquals(HoodieRecord.generateSequenceId("001", taskContext.getPartitionIdSupplier().get(), i),
+          record.get(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD).toString());
+      assertEquals("p1", record.get(HoodieRecord.PARTITION_PATH_METADATA_FIELD).toString());
+      assertEquals(filePath.getName(), record.get(HoodieRecord.FILENAME_METADATA_FIELD).toString());
+      assertEquals(records.get(i).get("_row_key").toString(), record.get("_row_key").toString());
+    }
+    Map<String, String> footer = ParquetUtils.readMetadata(storage, filePath).getFileMetaData().getKeyValueMetaData();
+    assertFalse(footer.containsKey(HoodieBloomFilterWriteSupport.HOODIE_MIN_RECORD_KEY_FOOTER));
+    assertFalse(footer.containsKey(HoodieBloomFilterWriteSupport.HOODIE_MAX_RECORD_KEY_FOOTER));
   }
 
   private static List<String> toJson(List<GenericRecord> records) {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataCreateHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataCreateHandle.java
@@ -168,7 +168,11 @@ public class HoodieRowDataCreateHandle implements Serializable {
           commitInstant = !metaFieldsMode.isCommitTimePopulated() ? null : preserveHoodieMetadata
               ? record.getString(HoodieRecord.COMMIT_TIME_METADATA_FIELD_ORD).toString()
               : instantTime;
-          rowData = HoodieRowDataCreation.create(commitInstant, null, null, null,
+          seqId = !metaFieldsMode.isCommitSeqnoPopulated() ? null : preserveHoodieMetadata
+              ? record.getString(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD_ORD).toString()
+              : HoodieRecord.generateSequenceId(instantTime, taskPartitionId, SEQGEN.getAndIncrement());
+          rowData = HoodieRowDataCreation.create(commitInstant, seqId, null,
+              metaFieldsMode.isPartitionPathPopulated() ? partitionPath : null,
               metaFieldsMode.isFileNamePopulated() ? path.getName() : null,
               record, writeConfig.allowOperationMetadataField(), preserveHoodieMetadata);
         }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataLanceWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataLanceWriter.java
@@ -128,7 +128,9 @@ public class HoodieRowDataLanceWriter extends HoodieBaseLanceWriter<RowData, Str
     } else {
       rowWithMeta = HoodieRowDataCreation.create(
           metaFieldsMode.isCommitTimePopulated() ? instantTime : null,
-          null, null, null,
+          metaFieldsMode.isCommitSeqnoPopulated() ? seqIdGenerator.apply(getWrittenRecordCount()) : null,
+          null,
+          metaFieldsMode.isPartitionPathPopulated() ? key.getPartitionPath() : null,
           metaFieldsMode.isFileNamePopulated() ? fileName : null,
           row, withOperation, true);
     }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataParquetWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataParquetWriter.java
@@ -87,7 +87,9 @@ public class HoodieRowDataParquetWriter extends HoodieBaseParquetWriter<RowData>
     } else {
       rowWithMeta = HoodieRowDataCreation.create(
           metaFieldsMode.isCommitTimePopulated() ? instantTime : null,
-          null, null, null,
+          metaFieldsMode.isCommitSeqnoPopulated() ? seqIdGenerator.apply(getWrittenRecordCount()) : null,
+          null,
+          metaFieldsMode.isPartitionPathPopulated() ? key.getPartitionPath() : null,
           metaFieldsMode.isFileNamePopulated() ? fileName : null,
           row, withOperation, true);
     }

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowDataCreateHandle.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowDataCreateHandle.java
@@ -101,9 +101,9 @@ public class TestHoodieRowDataCreateHandle extends HoodieFlinkClientTestHarness 
       if (preserveMetadata) {
         row = HoodieRowDataCreation.create(
             mode.isCommitTimePopulated() ? "old-instant" : null,
-            mode == MetaFieldsMode.ALL ? "old-sequence" : null,
+            mode.isCommitSeqnoPopulated() ? "old-sequence" : null,
             mode.isRecordKeyPopulated() ? "id1" : null,
-            mode == MetaFieldsMode.ALL ? PARTITION_PATH : null,
+            mode.isPartitionPathPopulated() ? PARTITION_PATH : null,
             mode.isFileNamePopulated() ? "old-file" : null,
             row, false, false);
       }
@@ -115,13 +115,13 @@ public class TestHoodieRowDataCreateHandle extends HoodieFlinkClientTestHarness 
       assertEquals("id1", stored.get("id").toString());
       assertEquals(mode.isCommitTimePopulated() ? (preserveMetadata ? "old-instant" : INSTANT_TIME) : null,
           Objects.toString(stored.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD), null));
-      assertEquals(mode != MetaFieldsMode.ALL, stored.get(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD) == null);
-      if (preserveMetadata && mode == MetaFieldsMode.ALL) {
+      assertEquals(!mode.isCommitSeqnoPopulated(), stored.get(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD) == null);
+      if (preserveMetadata && mode.isCommitSeqnoPopulated()) {
         assertEquals("old-sequence", stored.get(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD).toString());
       }
       assertEquals(mode.isRecordKeyPopulated() ? "id1" : null,
           Objects.toString(stored.get(HoodieRecord.RECORD_KEY_METADATA_FIELD), null));
-      assertEquals(mode == MetaFieldsMode.ALL ? PARTITION_PATH : null,
+      assertEquals(mode.isPartitionPathPopulated() ? PARTITION_PATH : null,
           Objects.toString(stored.get(HoodieRecord.PARTITION_PATH_METADATA_FIELD), null));
       assertEquals(mode.isFileNamePopulated() ? file.getName() : null,
           Objects.toString(stored.get(HoodieRecord.FILENAME_METADATA_FIELD), null));

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowDataLanceWriter.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowDataLanceWriter.java
@@ -22,6 +22,7 @@ import org.apache.hudi.client.model.HoodieRowDataCreation;
 import org.apache.hudi.common.engine.LocalTaskContextSupplier;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.MetaFieldsMode;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
@@ -82,9 +83,9 @@ public class TestHoodieRowDataLanceWriter {
          ArrowReader arrowReader = reader.readAll(null, null, Integer.MAX_VALUE)) {
       assertTrue(arrowReader.loadNextBatch());
       VectorSchemaRoot root = arrowReader.getVectorSchemaRoot();
-      boolean[] populated = {mode.isCommitTimePopulated(), mode == MetaFieldsMode.ALL,
-          mode.isRecordKeyPopulated(), mode == MetaFieldsMode.ALL, mode.isFileNamePopulated()};
-      String[] expected = {"001", null, "key1", "partition", path.getName()};
+      boolean[] populated = {mode.isCommitTimePopulated(), mode.isCommitSeqnoPopulated(),
+          mode.isRecordKeyPopulated(), mode.isPartitionPathPopulated(), mode.isFileNamePopulated()};
+      String[] expected = {"001", HoodieRecord.generateSequenceId("001", 0, 0), "key1", "partition", path.getName()};
       for (int i = 0; i < populated.length; i++) {
         assertEquals(!populated[i], root.getVector(i).isNull(0));
         if (populated[i] && expected[i] != null) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetWriter.java
@@ -87,6 +87,12 @@ public class HoodieSparkParquetWriter extends HoodieBaseParquetWriter<InternalRo
         if (metaFieldsMode.isCommitTimePopulated()) {
           row.update(COMMIT_TIME_METADATA_FIELD.ordinal(), instantTime);
         }
+        if (metaFieldsMode.isCommitSeqnoPopulated()) {
+          row.update(COMMIT_SEQNO_METADATA_FIELD.ordinal(), UTF8String.fromString(seqIdGenerator.apply(getWrittenRecordCount())));
+        }
+        if (metaFieldsMode.isPartitionPathPopulated()) {
+          row.update(PARTITION_PATH_METADATA_FIELD.ordinal(), UTF8String.fromString(key.getPartitionPath()));
+        }
         if (metaFieldsMode.isFileNamePopulated()) {
           row.update(FILENAME_METADATA_FIELD.ordinal(), fileName);
         }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
@@ -175,7 +175,7 @@ public class HoodieRowCreateHandle implements Serializable {
 
   /**
    * Selective meta-field write path: populate only the meta columns opted in via
-   * {@code hoodie.meta.fields.mode} — {@code _hoodie_commit_time} and/or {@code _hoodie_file_name}.
+   * {@code hoodie.meta.fields.mode}.
    * The other meta columns stay null on disk. Record key is never populated in this path, so the
    * record key is not registered with the write support (bloom filter / RLI hooks are meaningless
    * without the record-key column).
@@ -186,6 +186,14 @@ public class HoodieRowCreateHandle implements Serializable {
       if (metaFieldsMode.isCommitTimePopulated()) {
         metaFields[HoodieRecord.COMMIT_TIME_METADATA_FIELD_ORD] = shouldPreserveHoodieMetadata
             ? row.getUTF8String(HoodieRecord.COMMIT_TIME_METADATA_FIELD_ORD) : commitTime;
+      }
+      if (metaFieldsMode.isCommitSeqnoPopulated()) {
+        metaFields[HoodieRecord.COMMIT_SEQNO_METADATA_FIELD_ORD] = shouldPreserveHoodieMetadata
+            ? row.getUTF8String(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD_ORD)
+            : UTF8String.fromString(seqIdGenerator.apply(GLOBAL_SEQ_NO.getAndIncrement()));
+      }
+      if (metaFieldsMode.isPartitionPathPopulated()) {
+        metaFields[HoodieRecord.PARTITION_PATH_META_FIELD_ORD] = UTF8String.fromString(partitionPath);
       }
       if (metaFieldsMode.isFileNamePopulated()) {
         // Always the file being written, never the source row's value — even when

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/MetaFieldsMode.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/MetaFieldsMode.java
@@ -33,19 +33,9 @@ import java.util.stream.Collectors;
 /**
  * Which of Hudi's meta columns are physically populated on disk.
  *
- * <p>Selective modes exist so that tables that opt out of the default {@code populate.meta.fields=true}
- * can still keep the two columns that matter for downstream operations without paying for the other
- * three:
- *
- * <ul>
- *   <li>{@code _hoodie_commit_time} — required for incremental queries.</li>
- *   <li>{@code _hoodie_file_name} — useful for file-level pruning / investigation lookups.</li>
- * </ul>
- *
- * <p>The remaining three meta columns ({@code _hoodie_commit_seqno}, {@code _hoodie_record_key},
- * {@code _hoodie_partition_path}) are all-or-nothing — either populate every meta column ({@link #ALL})
- * or none of them beyond the two selectable ones. If you need any of the remaining columns, set
- * {@code hoodie.populate.meta.fields=true}.
+ * <p>Selective modes let tables populate only the meta columns they need. Commit time supports
+ * incremental queries, and file name supports file-level lookups. {@link #ALL_EXCEPT_RECORD_KEY}
+ * also retains commit sequence number and partition path while omitting the record key.
  *
  * <p>This enum is the single source of truth for meta-column population. When the mode property is
  * absent, the {@code resolve} overloads fall back to the deprecated {@code
@@ -65,43 +55,51 @@ public enum MetaFieldsMode {
   /**
    * All five Hudi meta columns are populated — today's default.
    */
-  ALL(true, true),
+  ALL(true, true, true, true),
 
   /**
    * No Hudi meta columns are populated. Incremental queries are unsupported. File-level pruning
    * that depends on {@code _hoodie_file_name} is unsupported.
    */
-  NONE(false, false),
+  NONE(false, false, false, false),
 
   /**
    * Only {@code _hoodie_commit_time} is populated. Incremental queries remain functional; other
    * meta columns stay null on disk.
    */
-  COMMIT_TIME_ONLY(true, false),
+  COMMIT_TIME_ONLY(true, false, false, false),
 
   /**
    * Only {@code _hoodie_file_name} is populated. Useful for file-level lookups and debugging;
    * incremental queries are unsupported.
    */
-  FILE_NAME_ONLY(false, true),
+  FILE_NAME_ONLY(false, true, false, false),
 
   /**
    * Both {@code _hoodie_commit_time} and {@code _hoodie_file_name} are populated.
    */
-  COMMIT_TIME_AND_FILE_NAME(true, true);
+  COMMIT_TIME_AND_FILE_NAME(true, true, false, false),
+
+  /**
+   * All meta columns except {@code _hoodie_record_key} are populated.
+   */
+  ALL_EXCEPT_RECORD_KEY(true, true, true, true);
 
   private final boolean commitTimePopulated;
   private final boolean fileNamePopulated;
+  private final boolean commitSeqnoPopulated;
+  private final boolean partitionPathPopulated;
 
-  MetaFieldsMode(boolean commitTimePopulated, boolean fileNamePopulated) {
+  MetaFieldsMode(boolean commitTimePopulated, boolean fileNamePopulated,
+                 boolean commitSeqnoPopulated, boolean partitionPathPopulated) {
     this.commitTimePopulated = commitTimePopulated;
     this.fileNamePopulated = fileNamePopulated;
+    this.commitSeqnoPopulated = commitSeqnoPopulated;
+    this.partitionPathPopulated = partitionPathPopulated;
   }
 
   /**
-   * @return true when all five meta columns are populated (i.e. this is {@link #ALL}). Selective
-   * modes never populate {@code _hoodie_record_key}, {@code _hoodie_partition_path}, or
-   * {@code _hoodie_commit_seqno}.
+   * @return true when the record key is populated (i.e. this is {@link #ALL}).
    */
   public boolean isRecordKeyPopulated() {
     return this == ALL;
@@ -114,7 +112,7 @@ public enum MetaFieldsMode {
    * <p>These are the modes the deprecated {@code hoodie.populate.meta.fields} boolean cannot
    * express, so they are what callers gate on when a code path only understands all-or-nothing meta
    * fields — writer engines not yet wired for selective population, table versions that predate the
-   * mode property, and validation that must not let a two-state writer speak for a five-state table.
+   * mode property, and validation that must not let a two-state writer speak for a selective-mode table.
    */
   public boolean isSelective() {
     return this != ALL && this != NONE;
@@ -220,6 +218,8 @@ public enum MetaFieldsMode {
     }
     return (commitTimePopulated && !other.commitTimePopulated)
         || (fileNamePopulated && !other.fileNamePopulated)
+        || (commitSeqnoPopulated && !other.commitSeqnoPopulated)
+        || (partitionPathPopulated && !other.partitionPathPopulated)
         || (isRecordKeyPopulated() && !other.isRecordKeyPopulated());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -356,7 +356,8 @@ public class HoodieTableConfig extends HoodieConfig {
       .key("hoodie.meta.fields.mode")
       .noDefaultValue()
       .withDocumentation("Which Hudi meta columns are physically populated on disk. Allowed values are "
-          + "ALL, NONE, COMMIT_TIME_ONLY, FILE_NAME_ONLY and COMMIT_TIME_AND_FILE_NAME. "
+          + "ALL, NONE, COMMIT_TIME_ONLY, FILE_NAME_ONLY, COMMIT_TIME_AND_FILE_NAME and ALL_EXCEPT_RECORD_KEY. "
+          + "ALL_EXCEPT_RECORD_KEY populates every meta column except _hoodie_record_key. "
           + "Selective modes are supported by Spark and Flink COPY_ON_WRITE writers. This supersedes the "
           + "deprecated hoodie.populate.meta.fields boolean, which is consulted only when this property is unset "
           + "(true maps to ALL, false maps to NONE). Supported on any table version 1.x can write, not just the "

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestMetaFieldsMode.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestMetaFieldsMode.java
@@ -27,10 +27,12 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.hudi.common.model.MetaFieldsMode.ALL;
+import static org.apache.hudi.common.model.MetaFieldsMode.ALL_EXCEPT_RECORD_KEY;
 import static org.apache.hudi.common.model.MetaFieldsMode.COMMIT_TIME_AND_FILE_NAME;
 import static org.apache.hudi.common.model.MetaFieldsMode.COMMIT_TIME_ONLY;
 import static org.apache.hudi.common.model.MetaFieldsMode.FILE_NAME_ONLY;
@@ -107,6 +109,7 @@ class TestMetaFieldsMode {
     assertTrue(COMMIT_TIME_ONLY.isSelective());
     assertTrue(FILE_NAME_ONLY.isSelective());
     assertTrue(COMMIT_TIME_AND_FILE_NAME.isSelective());
+    assertTrue(ALL_EXCEPT_RECORD_KEY.isSelective());
   }
 
   @ParameterizedTest
@@ -124,11 +127,13 @@ class TestMetaFieldsMode {
     assertFalse(COMMIT_TIME_ONLY.toLegacyPopulateMetaFields());
     assertFalse(FILE_NAME_ONLY.toLegacyPopulateMetaFields());
     assertFalse(COMMIT_TIME_AND_FILE_NAME.toLegacyPopulateMetaFields());
+    assertFalse(ALL_EXCEPT_RECORD_KEY.toLegacyPopulateMetaFields());
   }
 
   @Test
   void recordKeyIsPopulatedOnlyByAll() {
     assertTrue(ALL.isRecordKeyPopulated());
+    assertFalse(ALL_EXCEPT_RECORD_KEY.isRecordKeyPopulated());
     assertFalse(COMMIT_TIME_AND_FILE_NAME.isRecordKeyPopulated());
     assertFalse(COMMIT_TIME_ONLY.isRecordKeyPopulated());
     assertFalse(FILE_NAME_ONLY.isRecordKeyPopulated());
@@ -137,7 +142,7 @@ class TestMetaFieldsMode {
 
   @ParameterizedTest
   @CsvSource({
-      // Every ordered pair of the five modes: is the first wider than the second?
+      // Every ordered pair of the six modes: is the first wider than the second?
       "ALL,                       ALL,                       false",
       "ALL,                       NONE,                      true",
       "ALL,                       COMMIT_TIME_ONLY,          true",
@@ -164,10 +169,52 @@ class TestMetaFieldsMode {
       "COMMIT_TIME_AND_FILE_NAME, NONE,                      true",
       "COMMIT_TIME_AND_FILE_NAME, COMMIT_TIME_ONLY,          true",
       "COMMIT_TIME_AND_FILE_NAME, FILE_NAME_ONLY,            true",
-      "COMMIT_TIME_AND_FILE_NAME, COMMIT_TIME_AND_FILE_NAME, false"
+      "COMMIT_TIME_AND_FILE_NAME, COMMIT_TIME_AND_FILE_NAME, false",
+      "ALL,                       ALL_EXCEPT_RECORD_KEY,    true",
+      "NONE,                      ALL_EXCEPT_RECORD_KEY,    false",
+      "COMMIT_TIME_ONLY,          ALL_EXCEPT_RECORD_KEY,    false",
+      "FILE_NAME_ONLY,            ALL_EXCEPT_RECORD_KEY,    false",
+      "COMMIT_TIME_AND_FILE_NAME, ALL_EXCEPT_RECORD_KEY,    false",
+      "ALL_EXCEPT_RECORD_KEY,    ALL,                       false",
+      "ALL_EXCEPT_RECORD_KEY,    NONE,                      true",
+      "ALL_EXCEPT_RECORD_KEY,    COMMIT_TIME_ONLY,          true",
+      "ALL_EXCEPT_RECORD_KEY,    FILE_NAME_ONLY,            true",
+      "ALL_EXCEPT_RECORD_KEY,    COMMIT_TIME_AND_FILE_NAME, true",
+      "ALL_EXCEPT_RECORD_KEY,    ALL_EXCEPT_RECORD_KEY,    false"
   })
   void isWiderThanCoversEveryOrderedPair(MetaFieldsMode writer, MetaFieldsMode table, boolean wider) {
     assertEquals(wider, writer.isWiderThan(table));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "ALL, true, true, true, true, true",
+      "NONE, false, false, false, false, false",
+      "COMMIT_TIME_ONLY, true, false, false, false, false",
+      "FILE_NAME_ONLY, false, false, false, false, true",
+      "COMMIT_TIME_AND_FILE_NAME, true, false, false, false, true",
+      "ALL_EXCEPT_RECORD_KEY, true, true, false, true, true"
+  })
+  void columnPopulation(MetaFieldsMode mode, boolean commitTime, boolean commitSeqno,
+                        boolean recordKey, boolean partitionPath, boolean fileName) {
+    assertEquals(commitTime, mode.isCommitTimePopulated());
+    assertEquals(commitSeqno, mode.isCommitSeqnoPopulated());
+    assertEquals(recordKey, mode.isRecordKeyPopulated());
+    assertEquals(partitionPath, mode.isPartitionPathPopulated());
+    assertEquals(fileName, mode.isFileNamePopulated());
+  }
+
+  @ParameterizedTest
+  @EnumSource(MetaFieldsMode.class)
+  void resolveEveryModeThroughAllOverloads(MetaFieldsMode mode) {
+    Properties props = new Properties();
+    props.setProperty(HoodieTableConfig.META_FIELDS_MODE.key(), " " + mode.name().toLowerCase(Locale.ROOT) + " ");
+    props.setProperty(HoodieTableConfig.POPULATE_META_FIELDS.key(), "true");
+    assertEquals(mode, MetaFieldsMode.resolve(props));
+    assertEquals(mode, MetaFieldsMode.resolve(HoodieConfig.copy(props)));
+    Map<String, String> propsMap = new HashMap<>();
+    props.forEach((key, value) -> propsMap.put(key.toString(), value.toString()));
+    assertEquals(mode, MetaFieldsMode.resolve(propsMap));
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/client/TestFlinkWriteClientFunctional.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/client/TestFlinkWriteClientFunctional.java
@@ -254,10 +254,10 @@ class TestFlinkWriteClientFunctional extends HoodieFlinkClientTestHarness {
         String expectedInstant = id.equals("id1") ? updateInstant : insertInstant;
         assertEquals(mode.isCommitTimePopulated() ? expectedInstant : null,
             Objects.toString(row.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD), null));
-        assertEquals(mode != MetaFieldsMode.ALL, row.get(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD) == null);
+        assertEquals(!mode.isCommitSeqnoPopulated(), row.get(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD) == null);
         assertEquals(mode.isRecordKeyPopulated() ? id : null,
             Objects.toString(row.get(HoodieRecord.RECORD_KEY_METADATA_FIELD), null));
-        assertEquals(mode == MetaFieldsMode.ALL ? PARTITION_PATH : null,
+        assertEquals(mode.isPartitionPathPopulated() ? PARTITION_PATH : null,
             Objects.toString(row.get(HoodieRecord.PARTITION_PATH_METADATA_FIELD), null));
         assertEquals(mode.isFileNamePopulated(), row.get(HoodieRecord.FILENAME_METADATA_FIELD) != null);
         if (id.equals("id1")) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestBulkInsertWriteHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestBulkInsertWriteHelper.java
@@ -102,9 +102,9 @@ public class TestBulkInsertWriteHelper {
         if (preserveMetadata) {
           // Clustering reads rows with metadata columns, but selective modes leave keys null.
           row = HoodieRowDataCreation.create(mode.isCommitTimePopulated() ? expectedCommitTime : null,
-              mode == MetaFieldsMode.ALL ? "old-sequence" : null,
+              mode.isCommitSeqnoPopulated() ? "old-sequence" : null,
               mode.isRecordKeyPopulated() ? row.getString(0).toString() : null,
-              mode == MetaFieldsMode.ALL ? row.getString(4).toString() : null,
+              mode.isPartitionPathPopulated() ? row.getString(4).toString() : null,
               mode.isFileNamePopulated() ? "old.parquet" : null, row, false, false);
         }
         helper.write(row);
@@ -126,10 +126,10 @@ public class TestBulkInsertWriteHelper {
           assertEquals(row.get("partition").toString(), status.getStat().getPartitionPath());
           assertEquals(mode.isCommitTimePopulated() ? expectedCommitTime : null,
               Objects.toString(row.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD), null));
-          assertEquals(mode != MetaFieldsMode.ALL, row.get(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD) == null);
+          assertEquals(!mode.isCommitSeqnoPopulated(), row.get(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD) == null);
           assertEquals(mode.isRecordKeyPopulated() ? row.get("uuid").toString() : null,
               Objects.toString(row.get(HoodieRecord.RECORD_KEY_METADATA_FIELD), null));
-          assertEquals(mode == MetaFieldsMode.ALL ? status.getStat().getPartitionPath() : null,
+          assertEquals(mode.isPartitionPathPopulated() ? status.getStat().getPartitionPath() : null,
               Objects.toString(row.get(HoodieRecord.PARTITION_PATH_METADATA_FIELD), null));
           assertEquals(mode.isFileNamePopulated() ? file.getName() : null,
               Objects.toString(row.get(HoodieRecord.FILENAME_METADATA_FIELD), null));

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroParquetWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroParquetWriter.java
@@ -111,6 +111,13 @@ public class HoodieAvroParquetWriter
         if (metaFieldsMode.isCommitTimePopulated()) {
           genericRecord.put(HoodieRecord.COMMIT_TIME_METADATA_FIELD, instantTime);
         }
+        if (metaFieldsMode.isCommitSeqnoPopulated()) {
+          genericRecord.put(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD,
+              HoodieRecord.generateSequenceId(instantTime, taskContextSupplier.getPartitionIdSupplier().get(), getWrittenRecordCount()));
+        }
+        if (metaFieldsMode.isPartitionPathPopulated()) {
+          genericRecord.put(HoodieRecord.PARTITION_PATH_METADATA_FIELD, key.getPartitionPath());
+        }
         if (metaFieldsMode.isFileNamePopulated()) {
           genericRecord.put(HoodieRecord.FILENAME_METADATA_FIELD, fileName);
         }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestMetaFieldsModeE2E.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestMetaFieldsModeE2E.java
@@ -179,9 +179,9 @@ class TestMetaFieldsModeE2E extends SparkClientFunctionalTestHarness {
         .map(row -> row.getString(0)).sorted().collect(Collectors.toList()),
         "concat must preserve both existing records and the duplicate insert");
     assertMetaColumn(latest, 3, HoodieRecord.COMMIT_TIME_METADATA_FIELD, mode.isCommitTimePopulated(), mode);
-    assertMetaColumn(latest, 3, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, mode == MetaFieldsMode.ALL, mode);
+    assertMetaColumn(latest, 3, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, mode.isCommitSeqnoPopulated(), mode);
     assertMetaColumn(latest, 3, HoodieRecord.RECORD_KEY_METADATA_FIELD, mode.isRecordKeyPopulated(), mode);
-    assertMetaColumn(latest, 3, HoodieRecord.PARTITION_PATH_METADATA_FIELD, mode == MetaFieldsMode.ALL, mode);
+    assertMetaColumn(latest, 3, HoodieRecord.PARTITION_PATH_METADATA_FIELD, mode.isPartitionPathPopulated(), mode);
     assertMetaColumn(latest, 3, HoodieRecord.FILENAME_METADATA_FIELD, mode.isFileNamePopulated(), mode);
     if (mode.isFileNamePopulated()) {
       for (Row row : latest.collectAsList()) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestMetaFieldsModeE2E.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestMetaFieldsModeE2E.java
@@ -46,6 +46,7 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -137,11 +138,9 @@ class TestMetaFieldsModeE2E extends SparkClientFunctionalTestHarness {
         expectedMode.isCommitTimePopulated(), expectedMode);
     assertMetaColumn(raw, total, HoodieRecord.FILENAME_METADATA_FIELD,
         expectedMode.isFileNamePopulated(), expectedMode);
-    // Record key, partition path, and commit seq no are ALL-only.
-    boolean allMode = expectedMode == MetaFieldsMode.ALL;
-    assertMetaColumn(raw, total, HoodieRecord.RECORD_KEY_METADATA_FIELD, allMode, expectedMode);
-    assertMetaColumn(raw, total, HoodieRecord.PARTITION_PATH_METADATA_FIELD, allMode, expectedMode);
-    assertMetaColumn(raw, total, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, allMode, expectedMode);
+    assertMetaColumn(raw, total, HoodieRecord.RECORD_KEY_METADATA_FIELD, expectedMode.isRecordKeyPopulated(), expectedMode);
+    assertMetaColumn(raw, total, HoodieRecord.PARTITION_PATH_METADATA_FIELD, expectedMode.isPartitionPathPopulated(), expectedMode);
+    assertMetaColumn(raw, total, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, expectedMode.isCommitSeqnoPopulated(), expectedMode);
   }
 
   private static void assertMetaColumn(Dataset<Row> raw, long total, String column,
@@ -188,6 +187,27 @@ class TestMetaFieldsModeE2E extends SparkClientFunctionalTestHarness {
       for (Row row : latest.collectAsList()) {
         assertTrue(row.<String>getAs("actual_file").endsWith("/" + row.getAs(HoodieRecord.FILENAME_METADATA_FIELD)));
       }
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"bulk_insert,true,false", "insert,false,false", "insert,false,true"})
+  void allExceptRecordKeyPopulatesOtherColumns(String operation, boolean rowWriter, boolean sparkRecords) {
+    Map<String, String> options = baseOptions();
+    options.put(HoodieTableConfig.META_FIELDS_MODE.key(), MetaFieldsMode.ALL_EXCEPT_RECORD_KEY.name());
+    options.put(DataSourceWriteOptions.OPERATION().key(), operation);
+    options.put("hoodie.datasource.write.row.writer.enable", Boolean.toString(rowWriter));
+    if (sparkRecords) {
+      options.put("hoodie.write.record.merge.custom.implementation.classes", "org.apache.hudi.DefaultSparkRecordMerger");
+    }
+    HoodieTableConfig tableConfig = writeSampleAndGetTableConfig(options, basePath());
+    assertEquals(MetaFieldsMode.ALL_EXCEPT_RECORD_KEY, tableConfig.getMetaFieldsMode());
+    assertMetaColumnPopulation(basePath(), MetaFieldsMode.ALL_EXCEPT_RECORD_KEY);
+    List<Row> rows = spark().read().parquet(basePath() + "/*/*.parquet").collectAsList();
+    for (Row row : rows) {
+      assertEquals("p1", row.getAs(HoodieRecord.PARTITION_PATH_METADATA_FIELD));
+      assertTrue(row.<String>getAs(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD)
+          .startsWith(row.<String>getAs(HoodieRecord.COMMIT_TIME_METADATA_FIELD) + "_"));
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowCreateHandle.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowCreateHandle.java
@@ -35,6 +35,7 @@ import org.apache.hudi.testutils.SparkDatasetTestUtils;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.functions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,9 +44,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getJavaVersion;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -130,6 +133,44 @@ public class TestHoodieRowCreateHandle extends HoodieSparkClientTestHarness {
       fileNames.add(handle.getFileName());
       // verify output
       assertOutput(writeStatus, size, fileId, partitionPath, instantTime, totalInputRows, fileNames, fileAbsPaths, populateMetaFields);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testAllExceptRecordKeyPreservesMetadata(boolean preserveMetadata) throws Exception {
+    HoodieWriteConfig config = SparkDatasetTestUtils.getConfigBuilder(basePath, timelineServicePort)
+        .withMetaFieldsMode(MetaFieldsMode.ALL_EXCEPT_RECORD_KEY).build();
+    Properties tableProps = new Properties();
+    tableProps.setProperty(HoodieTableConfig.META_FIELDS_MODE.key(), MetaFieldsMode.ALL_EXCEPT_RECORD_KEY.name());
+    tableProps.setProperty(HoodieTableConfig.POPULATE_META_FIELDS.key(), "false");
+    HoodieTableConfig.update(metaClient.getStorage(), metaClient.getMetaPath(), tableProps);
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieTable table = HoodieSparkTable.create(config, context, metaClient);
+    String partitionPath = HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS[0];
+    HoodieRowCreateHandle handle = new HoodieRowCreateHandle(table, config, partitionPath,
+        UUID.randomUUID().toString(), "002", 0, 0, 0, SparkDatasetTestUtils.STRUCT_TYPE.asNullable(), preserveMetadata);
+    Dataset<Row> input = SparkDatasetTestUtils.getRandomRows(sqlContext, 10, partitionPath, false)
+        .withColumn(HoodieRecord.COMMIT_TIME_METADATA_FIELD, functions.lit("001"))
+        .withColumn(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, functions.concat(functions.lit("001_0_"), functions.col(SparkDatasetTestUtils.RECORD_KEY_FIELD_NAME)));
+    WriteStatus status = writeAndGetWriteStatus(input, handle);
+    assertFalse(status.hasErrors());
+    List<Row> written = sqlContext.read().parquet(basePath + "/" + status.getStat().getPath()).collectAsList();
+    Map<String, Row> original = input.collectAsList().stream()
+        .collect(Collectors.toMap(row -> row.getString(5), row -> row));
+    assertEquals(10, written.size());
+    for (Row row : written) {
+      Row source = original.get(row.getString(5));
+      assertNull(row.get(2));
+      assertEquals(partitionPath, row.getString(3));
+      assertEquals(handle.getFileName(), row.getString(4));
+      if (preserveMetadata) {
+        assertEquals(source.getString(0), row.getString(0));
+        assertEquals(source.getString(1), row.getString(1));
+      } else {
+        assertEquals("002", row.getString(0));
+        assertTrue(row.getString(1).startsWith("002_0_"));
+      }
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowCreateHandle.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowCreateHandle.java
@@ -157,19 +157,19 @@ public class TestHoodieRowCreateHandle extends HoodieSparkClientTestHarness {
     assertFalse(status.hasErrors());
     List<Row> written = sqlContext.read().parquet(basePath + "/" + status.getStat().getPath()).collectAsList();
     Map<String, Row> original = input.collectAsList().stream()
-        .collect(Collectors.toMap(row -> row.getString(5), row -> row));
+        .collect(Collectors.toMap(row -> row.<String>getAs(SparkDatasetTestUtils.RECORD_KEY_FIELD_NAME), row -> row));
     assertEquals(10, written.size());
     for (Row row : written) {
-      Row source = original.get(row.getString(5));
-      assertNull(row.get(2));
-      assertEquals(partitionPath, row.getString(3));
-      assertEquals(handle.getFileName(), row.getString(4));
+      Row source = original.get(row.<String>getAs(SparkDatasetTestUtils.RECORD_KEY_FIELD_NAME));
+      assertNull(row.getAs(HoodieRecord.RECORD_KEY_METADATA_FIELD));
+      assertEquals(partitionPath, row.<String>getAs(HoodieRecord.PARTITION_PATH_METADATA_FIELD));
+      assertEquals(handle.getFileName(), row.<String>getAs(HoodieRecord.FILENAME_METADATA_FIELD));
       if (preserveMetadata) {
-        assertEquals(source.getString(0), row.getString(0));
-        assertEquals(source.getString(1), row.getString(1));
+        assertEquals(source.<String>getAs(HoodieRecord.COMMIT_TIME_METADATA_FIELD), row.<String>getAs(HoodieRecord.COMMIT_TIME_METADATA_FIELD));
+        assertEquals(source.<String>getAs(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD), row.<String>getAs(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD));
       } else {
-        assertEquals("002", row.getString(0));
-        assertTrue(row.getString(1).startsWith("002_0_"));
+        assertEquals("002", row.<String>getAs(HoodieRecord.COMMIT_TIME_METADATA_FIELD));
+        assertTrue(row.<String>getAs(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD).startsWith("002_0_"));
       }
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieStreamerMetaFieldsMode.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieStreamerMetaFieldsMode.java
@@ -54,7 +54,7 @@ public class TestHoodieStreamerMetaFieldsMode extends HoodieDeltaStreamerTestBas
    */
   @ParameterizedTest
   @EnumSource(value = MetaFieldsMode.class,
-      names = {"COMMIT_TIME_ONLY", "FILE_NAME_ONLY", "COMMIT_TIME_AND_FILE_NAME"})
+      names = {"COMMIT_TIME_ONLY", "FILE_NAME_ONLY", "COMMIT_TIME_AND_FILE_NAME", "ALL_EXCEPT_RECORD_KEY"})
   public void testStreamerRespectsMetaFieldsMode(MetaFieldsMode mode) throws Exception {
     String tablePath = basePath + "/streamer_meta_fields_mode_" + mode.name();
     HoodieDeltaStreamer.Config cfg = TestHelpers.makeConfig(tablePath, WriteOperationType.INSERT);
@@ -256,10 +256,9 @@ public class TestHoodieStreamerMetaFieldsMode extends HoodieDeltaStreamerTestBas
         expectedMode.isCommitTimePopulated(), expectedMode);
     assertMetaColumn(raw, total, HoodieRecord.FILENAME_METADATA_FIELD,
         expectedMode.isFileNamePopulated(), expectedMode);
-    boolean allMode = expectedMode == MetaFieldsMode.ALL;
-    assertMetaColumn(raw, total, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, allMode, expectedMode);
-    assertMetaColumn(raw, total, HoodieRecord.RECORD_KEY_METADATA_FIELD, allMode, expectedMode);
-    assertMetaColumn(raw, total, HoodieRecord.PARTITION_PATH_METADATA_FIELD, allMode, expectedMode);
+    assertMetaColumn(raw, total, HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, expectedMode.isCommitSeqnoPopulated(), expectedMode);
+    assertMetaColumn(raw, total, HoodieRecord.RECORD_KEY_METADATA_FIELD, expectedMode.isRecordKeyPopulated(), expectedMode);
+    assertMetaColumn(raw, total, HoodieRecord.PARTITION_PATH_METADATA_FIELD, expectedMode.isPartitionPathPopulated(), expectedMode);
   }
 
   private static void assertMetaColumn(Dataset<Row> raw, long total, String column,


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Tables that omit `_hoodie_record_key` currently cannot retain `_hoodie_commit_seqno` and `_hoodie_partition_path`: those columns are populated only by `ALL`. Add `ALL_EXCEPT_RECORD_KEY` so a table can retain commit time, commit sequence number, partition path, and file name without storing the record-key meta column.

### Summary and Changelog

- Add `ALL_EXCEPT_RECORD_KEY` to `MetaFieldsMode`, with explicit `commitSeqnoPopulated` and `partitionPathPopulated` members and getters.
- Include both flags in `isWiderThan`, so transitions that add either column are treated as widening.
- Populate the selected columns in the Avro and Spark Parquet writers and Spark row-create handle.
- Support the new mode in Flink's Parquet writer, Lance writer, and row-create handle, including generated and preserved commit metadata. Write the destination file name when that column is enabled.
- Update the configuration description and CLI help. Update Spark concat, Flink COW insert/update/concat, bulk-insert, and preservation assertions to use each column's population flag instead of assuming sequence number and partition path are ALL-only.
- Use named column access in the Spark metadata-preservation test.

No code was copied from external sources.

### Impact

Users can set `hoodie.meta.fields.mode=ALL_EXCEPT_RECORD_KEY` on supported Spark and Flink COPY_ON_WRITE tables. This adds a public enum value and two public population predicates, and changes physical column population only for tables selecting the new mode. Existing modes, defaults, and file schemas are unchanged.

The compatibility boundary is opt-in: older builds cannot parse the new enum value. The new mode inherits the existing selective-mode restrictions, including the Java-writer and MERGE_ON_READ restrictions, and maps to `false` for the deprecated `hoodie.populate.meta.fields` boolean. Record-key-dependent features remain subject to existing validation. Storage savings were not benchmarked.

### Risk Level

medium

The change touches Avro, Spark, and Flink metadata population and table-mode transitions. Validation on the branch rebased onto master `eccfee6dfe7d` passed 218 cases:

- Flink 2.2 reactor: 143 cases across `TestMetaFieldsMode` (75), `TestHoodieWriteConfigMetaFieldsMode` (24), `TestHoodieRowDataCreateHandle` (14), `TestHoodieRowDataLanceWriter#testMetaFieldsMode` (6), `TestBulkInsertWriteHelper#testMetaFieldsMode` (12), and the COW metadata/concat methods of `TestFlinkWriteClientFunctional` (12). The mode matrices exercise all six modes, including insert, update, delete, concat, bulk insert, and metadata preservation.
- Spark 3.5: the full `TestMetaFieldsModeE2E` class (62 cases) and `TestHoodieRowCreateHandle#testAllExceptRecordKeyPreservesMetadata` (2 cases). This includes mode persistence across table versions, row and non-row writes, concat, clustering, incremental reads, and multi-partition upserts.
- Common/Flink dependency configuration: `TestHoodieAvroParquetWriter` (2 cases) and `TestHoodieTableConfigMetaFieldsMode` (9 cases).

Compilation, applicable Checkstyle checks, and `git diff --check` passed. The standalone Avro test initially encountered a missing Hadoop runtime dependency under the Spark profile; it passed under the common/Flink configuration. Streamer assertions were updated, but its suite and the full repository suite were not run.

### Documentation Update

Updated `HoodieTableConfig.META_FIELDS_MODE`, `MetaFieldsMode` Javadoc, and CLI help to describe the new mode and preserve master's Spark/Flink COPY_ON_WRITE support documentation. A Hudi website documentation follow-up is still needed to list `ALL_EXCEPT_RECORD_KEY`, its populated columns, and the selective-mode restrictions; website changes are not included in this code PR.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
