### PR TITLE
fix(build): stop hudi-hive-sync-bundle and hudi-gcp-bundle depending on hudi-hadoop-mr-bundle

### DIFF
--- a/packaging/hudi-gcp-bundle/pom.xml
+++ b/packaging/hudi-gcp-bundle/pom.xml
@@ -152,12 +152,9 @@
       <version>${project.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.hudi</groupId>
-      <artifactId>hudi-hadoop-mr-bundle</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
+    <!-- org.apache.hudi:hudi-hadoop-mr and hudi-hadoop-common are shaded in by the artifactSet
+         above; hudi-hive-sync below already brings both in transitively as a library, so the
+         hudi-hadoop-mr-bundle fat jar is not needed here. -->
     <dependency>
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-sync-common</artifactId>

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -162,12 +162,9 @@
       <version>${project.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.hudi</groupId>
-      <artifactId>hudi-hadoop-mr-bundle</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
+    <!-- org.apache.hudi:hudi-hadoop-mr and hudi-hadoop-common are shaded in by the artifactSet
+         above; hudi-hive-sync below already brings both in transitively as a library, so the
+         hudi-hadoop-mr-bundle fat jar is not needed here. -->
     <dependency>
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-hive-sync</artifactId>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19511.

`hudi-hive-sync-bundle` and `hudi-gcp-bundle` both depend on `hudi-hadoop-mr-bundle` (a shaded fat jar) while their own `artifactSet` already lists `org.apache.hudi:hudi-hadoop-mr` and `hudi-hadoop-common` directly, so they shade those classes themselves and never needed the fat jar as a dependency.

This is not simply the `hudi-presto-bundle` fix (#19490) repeated: in that case `hudi-hadoop-mr` was reached *only* through `hudi-hadoop-mr-bundle`'s published dependency-reduced POM. Here, both bundles already depend directly on `hudi-hive-sync` (a plain library, not a bundle), which itself brings in `hudi-hadoop-common` and `hudi-hadoop-mr` transitively:

```
hudi-hive-sync-bundle
+- hudi-common:compile
+- hudi-hadoop-mr-bundle:compile          <-- the fat jar, now removed
\- hudi-hive-sync:compile
   +- hudi-hadoop-common:compile          <-- reached via the library, not the bundle
   +- hudi-hadoop-mr:compile
   \- hudi-sync-common:compile
```

Removing `hudi-hadoop-mr-bundle` does not drop either class from the shaded output — they're still reachable through `hudi-hive-sync`, and still listed directly in the `artifactSet` so the shade plugin still relocates them.

### Summary and Changelog

Removed the `org.apache.hudi:hudi-hadoop-mr-bundle` dependency from `packaging/hudi-hive-sync-bundle/pom.xml` and `packaging/hudi-gcp-bundle/pom.xml`. No source changes. Added a short comment at each removal explaining why the fat jar isn't needed, matching the one already in `hudi-presto-bundle`'s pom.

### Impact

None. Both bundles' shaded output is unchanged — `hudi-hadoop-mr` and `hudi-hadoop-common` are still included, just reached through `hudi-hive-sync` rather than through the now-removed fat jar.

### Risk Level

low. This only removes a redundant dependency edge; verified by inspecting both `artifactSet` blocks (both already list `hudi-hadoop-mr` and `hudi-hadoop-common` directly) and both bundles' existing `hudi-hive-sync` dependency, which is what keeps those classes reachable.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable — none needed; build-graph-only change, no source or behavior change
