### PR TITLE
refactor(hudi-common): remove duplicate generateProjectionSchema and timestamp-millis helpers

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaRepair.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaRepair.java
@@ -20,7 +20,6 @@
 package org.apache.hudi.common.schema;
 
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +40,7 @@ import java.util.List;
  *
  * <p>{@link #hasTimestampMillisField(HoodieSchema)} is the cheap pre-check used to decide whether the
  * repair is worth wiring in at all. Its sibling in the metadata-table domain is
- * {@code HoodieTableMetadataUtil#isTimestampMillisField}, which answers the same question for one field
+ * {@code HoodieSchemaUtils#isTimestampMillisField}, which answers the same question for one field
  * schema rather than recursively for a whole table schema.</p>
  */
 public class HoodieSchemaRepair {
@@ -250,7 +249,7 @@ public class HoodieSchemaRepair {
         return hasTimestampMillisField(tableSchema.getNonNullType());
 
       case TIMESTAMP:
-        return HoodieTableMetadataUtil.isTimestampMillisField(tableSchema);
+        return HoodieSchemaUtils.isTimestampMillisField(tableSchema);
 
       default:
         return false;

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaRepair.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaRepair.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.common.schema;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -249,8 +250,7 @@ public class HoodieSchemaRepair {
         return hasTimestampMillisField(tableSchema.getNonNullType());
 
       case TIMESTAMP:
-        HoodieSchema.Timestamp timestampType = (HoodieSchema.Timestamp) tableSchema;
-        return timestampType.getPrecision() == HoodieSchema.TimePrecision.MILLIS;
+        return HoodieTableMetadataUtil.isTimestampMillisField(tableSchema);
 
       default:
         return false;

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaRepair.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaRepair.java
@@ -39,7 +39,7 @@ import java.util.List;
  * {@code org.apache.hudi.common.schema.internal.utils.AvroSchemaEvolutionUtils}.</p>
  *
  * <p>{@link #hasTimestampMillisField(HoodieSchema)} is the cheap pre-check used to decide whether the
- * repair is worth wiring in at all. Its sibling in the metadata-table domain is
+ * repair is worth wiring in at all. Its per-field sibling is
  * {@code HoodieSchemaUtils#isTimestampMillisField}, which answers the same question for one field
  * schema rather than recursively for a whole table schema.</p>
  */

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -1046,4 +1046,19 @@ public final class HoodieSchemaUtils {
 
     return createNewSchemaFromFieldsWithReference(schema, fields);
   }
+
+  /**
+   * Checks if a schema field is of type timestamp_millis (timestamp-millis or local-timestamp-millis).
+   *
+   * @param fieldSchema The schema of the field to check
+   * @return true if the field is of type timestamp_millis, false otherwise
+   */
+  public static boolean isTimestampMillisField(HoodieSchema fieldSchema) {
+    HoodieSchema nonNullableSchema = fieldSchema.getNonNullType();
+    if (nonNullableSchema.getType() == HoodieSchemaType.TIMESTAMP) {
+      HoodieSchema.Timestamp timestampSchema = (HoodieSchema.Timestamp) nonNullableSchema;
+      return timestampSchema.getPrecision().equals(HoodieSchema.TimePrecision.MILLIS);
+    }
+    return false;
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -538,7 +538,7 @@ public final class HoodieSchemaUtils {
     ValidationUtils.checkArgument(schemaFieldsMap != null, "Schema fields map cannot be null");
     ValidationUtils.checkArgument(fieldNames != null, "Field names cannot be null");
 
-    /**
+    /*
      * Avro & Presto field names seems to be case sensitive (support fields differing only in case) whereas
      * Hive/Impala/SparkSQL(default) are case-insensitive. Spark allows this to be configurable using
      * spark.sql.caseSensitive=true

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -529,13 +529,11 @@ public final class HoodieSchemaUtils {
    * @param writeSchema      the source schema
    * @param schemaFieldsMap  prebuilt case-insensitive field-name map
    * @param fieldNames       the list of field names to include in the projection
-   * @param isError          whether the projected schema is an error schema
    * @return new HoodieSchema containing only the specified fields
    */
   public static HoodieSchema generateProjectionSchema(HoodieSchema writeSchema,
                                                       Map<String, HoodieSchemaField> schemaFieldsMap,
-                                                      List<String> fieldNames,
-                                                      boolean isError) {
+                                                      List<String> fieldNames) {
     ValidationUtils.checkArgument(writeSchema != null, "Write schema cannot be null");
     ValidationUtils.checkArgument(schemaFieldsMap != null, "Schema fields map cannot be null");
     ValidationUtils.checkArgument(fieldNames != null, "Field names cannot be null");
@@ -562,7 +560,7 @@ public final class HoodieSchemaUtils {
     }
 
     return HoodieSchema.createRecord(writeSchema.getName(), writeSchema.getDoc().orElse(null),
-            writeSchema.getNamespace().orElse(null), isError, projectedFields);
+            writeSchema.getNamespace().orElse(null), writeSchema.isError(), projectedFields);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -521,6 +521,41 @@ public final class HoodieSchemaUtils {
   }
 
   /**
+   * Generate a reader schema off the provided writeSchema, to just project out the provided columns.
+   *
+   * <p>This overload is intended for callers that already have a name-to-field map,
+   * such as the realtime reader.</p>
+   *
+   * @param writeSchema      the source schema
+   * @param schemaFieldsMap  prebuilt case-insensitive field-name map
+   * @param fieldNames       the list of field names to include in the projection
+   * @param isError          whether the projected schema is an error schema
+   * @return new HoodieSchema containing only the specified fields
+   */
+  public static HoodieSchema generateProjectionSchema(HoodieSchema writeSchema,
+                                                      Map<String, HoodieSchemaField> schemaFieldsMap,
+                                                      List<String> fieldNames,
+                                                      boolean isError) {
+    ValidationUtils.checkArgument(writeSchema != null, "Write schema cannot be null");
+    ValidationUtils.checkArgument(schemaFieldsMap != null, "Schema fields map cannot be null");
+    ValidationUtils.checkArgument(fieldNames != null, "Field names cannot be null");
+
+    List<HoodieSchemaField> projectedFields = new ArrayList<>(fieldNames.size());
+    for (String fn : fieldNames) {
+      HoodieSchemaField field = schemaFieldsMap.get(fn.toLowerCase(Locale.ROOT));
+      if (field == null) {
+        throw new HoodieException("Field " + fn + " not found in log schema. Query cannot proceed! "
+                + "Derived Schema Fields: " + new ArrayList<>(schemaFieldsMap.keySet()));
+      } else {
+        projectedFields.add(createNewSchemaField(field));
+      }
+    }
+
+    return HoodieSchema.createRecord(writeSchema.getName(), writeSchema.getDoc().orElse(null),
+            writeSchema.getNamespace().orElse(null), isError, projectedFields);
+  }
+
+  /**
    * Prunes the data schema to only include fields that are required by the required schema,
    * plus any mandatory fields specified.
    *

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -540,6 +540,16 @@ public final class HoodieSchemaUtils {
     ValidationUtils.checkArgument(schemaFieldsMap != null, "Schema fields map cannot be null");
     ValidationUtils.checkArgument(fieldNames != null, "Field names cannot be null");
 
+    /**
+     * Avro & Presto field names seems to be case sensitive (support fields differing only in case) whereas
+     * Hive/Impala/SparkSQL(default) are case-insensitive. Spark allows this to be configurable using
+     * spark.sql.caseSensitive=true
+     *
+     * For a RT table setup with no delta-files (for a latest file-slice) -> we translate parquet schema to Avro Here
+     * the field-name case is dependent on parquet schema. Hive (1.x/2.x/CDH) translate column projections to
+     * lower-cases
+     *
+     */
     List<HoodieSchemaField> projectedFields = new ArrayList<>(fieldNames.size());
     for (String fn : fieldNames) {
       HoodieSchemaField field = schemaFieldsMap.get(fn.toLowerCase(Locale.ROOT));

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -65,7 +65,6 @@ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.schema.HoodieSchema.TimePrecision;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
@@ -495,24 +494,9 @@ public class HoodieTableMetadataUtil {
     return indexDefinition.getSourceFields().stream()
         .filter(indexCol -> {
           Option<Pair<String, HoodieSchemaField>> fieldPairOpt = HoodieSchemaUtils.getNestedField(tableSchema, indexCol);
-          return fieldPairOpt.isPresent() && !isTimestampMillisField(fieldPairOpt.get().getRight().schema());
+          return fieldPairOpt.isPresent() && !HoodieSchemaUtils.isTimestampMillisField(fieldPairOpt.get().getRight().schema());
         })
         .collect(Collectors.toList());
-  }
-
-  /**
-   * Checks if a schema field is of type timestamp_millis (timestamp-millis or local-timestamp-millis).
-   *
-   * @param fieldSchema The schema of the field to check
-   * @return true if the field is of type timestamp_millis, false otherwise
-   */
-  public static boolean isTimestampMillisField(HoodieSchema fieldSchema) {
-    HoodieSchema nonNullableSchema = fieldSchema.getNonNullType();
-    if (nonNullableSchema.getType() == HoodieSchemaType.TIMESTAMP) {
-      HoodieSchema.Timestamp timestampSchema = (HoodieSchema.Timestamp) nonNullableSchema;
-      return timestampSchema.getPrecision().equals(TimePrecision.MILLIS);
-    }
-    return false;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -506,7 +506,7 @@ public class HoodieTableMetadataUtil {
    * @param fieldSchema The schema of the field to check
    * @return true if the field is of type timestamp_millis, false otherwise
    */
-  static boolean isTimestampMillisField(HoodieSchema fieldSchema) {
+  public static boolean isTimestampMillisField(HoodieSchema fieldSchema) {
     HoodieSchema nonNullableSchema = fieldSchema.getNonNullType();
     if (nonNullableSchema.getType() == HoodieSchemaType.TIMESTAMP) {
       HoodieSchema.Timestamp timestampSchema = (HoodieSchema.Timestamp) nonNullableSchema;

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
@@ -2370,4 +2370,32 @@ public class TestHoodieSchemaUtils {
         () -> HoodieSchemaUtils.createDeleteLogSchema(tableSchema, Collections.singletonList("not_a_field")));
     assertEquals("Ordering field not_a_field not found in table schema", exception.getMessage());
   }
+
+  @Test
+  void testIsTimestampMillisField() {
+    // Test timestamp-millis
+    HoodieSchema timestampMillisSchema = HoodieSchema.createTimestampMillis();
+    assertTrue(HoodieSchemaUtils.isTimestampMillisField(timestampMillisSchema),
+        "Should return true for timestamp-millis");
+
+    // Test nullable timestamp-millis
+    HoodieSchema nullableTimestampMillisSchema = HoodieSchema.createNullable(HoodieSchema.createTimestampMillis());
+    assertTrue(HoodieSchemaUtils.isTimestampMillisField(nullableTimestampMillisSchema),
+        "Should return true for nullable timestamp-millis");
+
+    // Test timestamp-micros (should return false)
+    HoodieSchema timestampMicrosSchema = HoodieSchema.createTimestampMicros();
+    assertFalse(HoodieSchemaUtils.isTimestampMillisField(timestampMicrosSchema),
+        "Should return false for timestamp-micros");
+
+    // Test regular long (should return false)
+    HoodieSchema longSchema = HoodieSchema.create(HoodieSchemaType.LONG);
+    assertFalse(HoodieSchemaUtils.isTimestampMillisField(longSchema),
+        "Should return false for regular long");
+
+    // Test string (should return false)
+    HoodieSchema stringSchema = HoodieSchema.create(HoodieSchemaType.STRING);
+    assertFalse(HoodieSchemaUtils.isTimestampMillisField(stringSchema),
+        "Should return false for string");
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -356,34 +356,6 @@ class TestHoodieTableMetadataUtil {
   }
 
   @Test
-  void testIsTimestampMillisField() {
-    // Test timestamp-millis
-    HoodieSchema timestampMillisSchema = HoodieSchema.createTimestampMillis();
-    assertTrue(HoodieTableMetadataUtil.isTimestampMillisField(timestampMillisSchema),
-        "Should return true for timestamp-millis");
-
-    // Test nullable timestamp-millis
-    HoodieSchema nullableTimestampMillisSchema = HoodieSchema.createNullable(HoodieSchema.createTimestampMillis());
-    assertTrue(HoodieTableMetadataUtil.isTimestampMillisField(nullableTimestampMillisSchema),
-        "Should return true for nullable timestamp-millis");
-
-    // Test timestamp-micros (should return false)
-    HoodieSchema timestampMicrosSchema = HoodieSchema.createTimestampMicros();
-    assertFalse(HoodieTableMetadataUtil.isTimestampMillisField(timestampMicrosSchema),
-        "Should return false for timestamp-micros");
-
-    // Test regular long (should return false)
-    HoodieSchema longSchema = HoodieSchema.create(HoodieSchemaType.LONG);
-    assertFalse(HoodieTableMetadataUtil.isTimestampMillisField(longSchema),
-        "Should return false for regular long");
-
-    // Test string (should return false)
-    HoodieSchema stringSchema = HoodieSchema.create(HoodieSchemaType.STRING);
-    assertFalse(HoodieTableMetadataUtil.isTimestampMillisField(stringSchema),
-        "Should return false for string");
-  }
-
-  @Test
   void testVectorColumnsAreNotSupportedForV2ColumnStats() {
     HoodieSchema vectorSchema = HoodieSchema.createNullable(HoodieSchema.createVector(128));
     HoodieSchema stringSchema = HoodieSchema.createNullable(HoodieSchema.create(HoodieSchemaType.STRING));

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -183,7 +183,7 @@ public abstract class AbstractRealtimeRecordReader {
     // TODO(vc): In the future, the reader schema should be updated based on log files & be able
     // to null out fields not present before
 
-    readerSchema = HoodieRealtimeRecordReaderUtils.generateProjectionSchema(writerSchema, schemaFieldsMap, projectionFields);
+    readerSchema = HoodieSchemaUtils.generateProjectionSchema(writerSchema, schemaFieldsMap, projectionFields,writerSchema.isError());
     LOG.info(String.format("About to read compacted logs %s for base split %s, projecting cols %s",
         split.getDeltaLogPaths(), split.getPath(), projectionFields));
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -183,7 +183,7 @@ public abstract class AbstractRealtimeRecordReader {
     // TODO(vc): In the future, the reader schema should be updated based on log files & be able
     // to null out fields not present before
 
-    readerSchema = HoodieSchemaUtils.generateProjectionSchema(writerSchema, schemaFieldsMap, projectionFields, writerSchema.isError());
+    readerSchema = HoodieSchemaUtils.generateProjectionSchema(writerSchema, schemaFieldsMap, projectionFields);
     LOG.info(String.format("About to read compacted logs %s for base split %s, projecting cols %s",
         split.getDeltaLogPaths(), split.getPath(), projectionFields));
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -183,7 +183,7 @@ public abstract class AbstractRealtimeRecordReader {
     // TODO(vc): In the future, the reader schema should be updated based on log files & be able
     // to null out fields not present before
 
-    readerSchema = HoodieSchemaUtils.generateProjectionSchema(writerSchema, schemaFieldsMap, projectionFields,writerSchema.isError());
+    readerSchema = HoodieSchemaUtils.generateProjectionSchema(writerSchema, schemaFieldsMap, projectionFields, writerSchema.isError());
     LOG.info(String.format("About to read compacted logs %s for base split %s, projecting cols %s",
         split.getDeltaLogPaths(), split.getPath(), projectionFields));
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
@@ -119,37 +119,6 @@ public class HoodieRealtimeRecordReaderUtils {
     return builder.toString();
   }
 
-  /**
-   * Generate a reader schema off the provided writeSchema, to just project out the provided columns.
-   */
-  public static HoodieSchema generateProjectionSchema(HoodieSchema writeSchema, Map<String, HoodieSchemaField> schemaFieldsMap,
-                                                List<String> fieldNames) {
-    /**
-     * Avro & Presto field names seems to be case sensitive (support fields differing only in case) whereas
-     * Hive/Impala/SparkSQL(default) are case-insensitive. Spark allows this to be configurable using
-     * spark.sql.caseSensitive=true
-     *
-     * For a RT table setup with no delta-files (for a latest file-slice) -> we translate parquet schema to Avro Here
-     * the field-name case is dependent on parquet schema. Hive (1.x/2.x/CDH) translate column projections to
-     * lower-cases
-     *
-     */
-    List<HoodieSchemaField> projectedFields = new ArrayList<>();
-    for (String fn : fieldNames) {
-      HoodieSchemaField field = schemaFieldsMap.get(fn.toLowerCase(Locale.ROOT));
-      if (field == null) {
-        throw new HoodieException("Field " + fn + " not found in log schema. Query cannot proceed! "
-            + "Derived Schema Fields: " + new ArrayList<>(schemaFieldsMap.keySet()));
-      } else {
-        projectedFields.add(HoodieSchemaUtils.createNewSchemaField(field));
-      }
-    }
-
-    HoodieSchema projectedSchema = HoodieSchema.createRecord(writeSchema.getName(), writeSchema.getDoc().orElse(null),
-        writeSchema.getNamespace().orElse(null), writeSchema.isError(), projectedFields);
-    return projectedSchema;
-  }
-
   public static Map<String, HoodieSchemaField> getNameToFieldMap(HoodieSchema schema) {
     return schema.getFields().stream().map(r -> Pair.of(r.name().toLowerCase(Locale.ROOT), r))
         .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19841.

Several schema-related utilities contain duplicated logic. Projection schema generation is implemented in both `HoodieSchemaUtils` and `HoodieRealtimeRecordReaderUtils`, while timestamp-millis detection is duplicated between `HoodieSchemaRepair` and `HoodieTableMetadataUtil`.

### Summary and Changelog

- Add a shared projection schema generation overload to `HoodieSchemaUtils`.
- Preserve the source schema's error flag when creating projection schemas.
- Update `AbstractRealtimeRecordReader` to use the common utility.
- Remove the duplicate projection schema generation method from `HoodieRealtimeRecordReaderUtils`.
- Reuse `HoodieTableMetadataUtil.isTimestampMillisField` in `HoodieSchemaRepair`.
- Make the timestamp-millis predicate accessible across the relevant packages.

### Impact

No user-facing behavior or storage-format change is introduced.

The refactoring preserves existing schema projection and timestamp-millis detection behavior while reducing duplicated implementation logic. No new public feature or configuration is added.

### Risk Level

Low. The changes consolidate existing implementations and update callers to use the shared utilities. The affected schema utility, schema repair, and realtime reader test coverage will be used to verify that behavior remains unchanged.

### Documentation Update

none

### Contributor's checklist
- [x] Read through contributor's guide 
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable