### PR TITLE
fix(build): remove redundant hadoop mr bundle dependencies

### DIFF
--- a/packaging/hudi-gcp-bundle/pom.xml
+++ b/packaging/hudi-gcp-bundle/pom.xml
@@ -154,12 +154,6 @@
 
     <dependency>
       <groupId>org.apache.hudi</groupId>
-      <artifactId>hudi-hadoop-mr-bundle</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-sync-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -164,12 +164,6 @@
 
     <dependency>
       <groupId>org.apache.hudi</groupId>
-      <artifactId>hudi-hadoop-mr-bundle</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-hive-sync</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19511. Both hudi-hive-sync-bundle and hudi-gcp-bundle directly shade hudi-hadoop-common and hudi-hadoop-mr, but also declare hudi-hadoop-mr-bundle, a second fat-jar dependency.

### Summary and Changelog

- Remove the redundant hudi-hadoop-mr-bundle dependency from hudi-hive-sync-bundle and hudi-gcp-bundle.
- Keep the change aligned with the minimal cleanup in #19490 for hudi-presto-bundle.
- No source code was copied.

### Impact

Build dependency metadata only. Direct verification found no change to the shipped jar entries: hudi-hive-sync-bundle remains at 10,672 entries and hudi-gcp-bundle remains at 5,361 entries.

### Risk Level: low

The removed dependency is redundant with artifacts already shaded by both targets. Java 11 reactor and repository-resolution builds both succeed, and each generated dependency-reduced POM loses only hudi-hadoop-mr-bundle.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable