### PR TITLE
test(metadata): cover getColumnsToIndex when the table schema is absent

### DIFF
--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -605,6 +605,48 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
         Lazy.eagerly(Option.of(schema)), true, V1).keySet()));
   }
 
+  /**
+   * The schema-absent branch of {@code getColumnsToIndexWithoutRequiredMetaFields}, which
+   * {@link #testGetColumnsToIndex()} never reaches because every case there supplies a schema.
+   *
+   * <p>Two outcomes, and the difference matters: with no explicit column list the inner call returns an
+   * empty map, so the caller is left with just the always-indexed meta columns rather than failing. With
+   * an explicit list it
+   * throws instead, because the names cannot be resolved to field schemas without a schema to resolve
+   * them against, and silently indexing nothing would look like the config had been honoured.
+   */
+  @Test
+  public void testGetColumnsToIndexWhenTableSchemaIsAbsent() {
+    HoodieTableConfig tableConfig = metaClient.getTableConfig();
+
+    HoodieMetadataConfig noColumnList = HoodieMetadataConfig.newBuilder()
+        .enable(true).withMetadataIndexColumnStats(true)
+        .build();
+    assertListEquality(new ArrayList<>(Arrays.asList(HoodieTableMetadataUtil.META_COLS_TO_ALWAYS_INDEX)),
+        new ArrayList<>(HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, noColumnList,
+            Lazy.eagerly(Option.empty()), false, V1).keySet()));
+
+    HoodieMetadataConfig withColumnList = HoodieMetadataConfig.newBuilder()
+        .enable(true).withMetadataIndexColumnStats(true)
+        .withColumnStatsIndexForColumns("col_1,col_2")
+        .build();
+    Throwable thrown = assertThrows(IllegalArgumentException.class,
+        () -> HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, withColumnList,
+            Lazy.eagerly(Option.empty()), false, V1),
+        "an explicit column list cannot be resolved without a table schema");
+    assertTrue(String.valueOf(thrown.getMessage()).contains("Table schema not found"),
+        () -> "the failure should name the missing schema, but was: " + thrown.getMessage());
+
+    // Table initialisation is the exception: the configured names are recorded without schemas, so col
+    // stats can be enabled before the first commit has produced one. The meta columns are added by the
+    // caller either way.
+    List<String> expectedWhileInitialising = new ArrayList<>(Arrays.asList(HoodieTableMetadataUtil.META_COLS_TO_ALWAYS_INDEX));
+    expectedWhileInitialising.addAll(Arrays.asList("col_1", "col_2"));
+    assertListEquality(expectedWhileInitialising,
+        new ArrayList<>(HoodieTableMetadataUtil.getColumnsToIndex(tableConfig, withColumnList,
+            Lazy.eagerly(Option.empty()), true, V1).keySet()));
+  }
+
   private void assertListEquality(List<String> expected, List<String> actual) {
     Collections.sort(expected);
     Collections.sort(actual);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17410 (https://issues.apache.org/jira/browse/HUDI-9194).

The ticket asks whether `HoodieTableMetadataUtil#getColumnsToIndexWithoutRequiredMetaFields` needs a test case. Reading `TestHoodieTableMetadataUtil#testGetColumnsToIndex`, most of it is already covered through the public `getColumnsToIndex` wrapper: the explicit column list, meta columns appearing inside that list, unsupported column types, nested fields, the max-columns cap, and meta fields disabled.

One branch is not reachable from any existing case. Every case there supplies a table schema, so the path taken when the schema is **absent** is never exercised:

```java
if (tableSchemaLazyOpt.get().isPresent()) {
  ...
} else {
  // initialize col stats index config with empty list of cols
  return Collections.emptyMap();
}
```

and, on the explicit-list side of the same method, the guard that fires when there is no schema to resolve names against:

```java
ValidationUtils.checkArgument(tableSchemaLazyOpt.get().isPresent(),
    "Table schema not found for the table while computing col stats");
```

### Summary and Changelog

- `TestHoodieTableMetadataUtil`: new `testGetColumnsToIndexWhenTableSchemaIsAbsent`, covering the schema-absent branch in the three ways it behaves:
  - **No explicit column list**: the inner call returns nothing, so the caller is left with just the always-indexed meta columns. Col stats initialises rather than failing.
  - **An explicit column list**: `IllegalArgumentException` naming the missing schema. The configured names cannot be resolved to field schemas without one, and quietly indexing nothing would look like the config had been honoured.
  - **The same list while the table is initialising**: the configured names are recorded without their schemas, so col stats can be enabled before the first commit has produced a schema.

No code was copied.

### Impact

Test-only. No production code is touched, and no existing test is modified.

Worth noting for a reader: writing this corrected two assumptions of mine that the run disproved. The schema-absent, no-list case does **not** return an empty map to the caller, because the wrapper still adds `META_COLS_TO_ALWAYS_INDEX`; and the initialising case returns five entries, not two, for the same reason. The test asserts what the code does.

### Risk Level

none

Verified on Spark 3.5 / Scala 2.12:

- `mvn test -pl hudi-hadoop-common -Dtest=TestHoodieTableMetadataUtil` -> `Tests run: 19, Failures: 0, Errors: 0`
- `mvn test-compile checkstyle:check -pl hudi-hadoop-common` -> clean

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
