### PR TITLE
fix(trino): keep none() when splitting predicates

### DIFF
--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiPredicates.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiPredicates.java
@@ -29,6 +29,10 @@ public class HudiPredicates
 
     public static HudiPredicates from(TupleDomain<ColumnHandle> predicate)
     {
+        if (predicate.isNone()) {
+            return new HudiPredicates(TupleDomain.none(), TupleDomain.none());
+        }
+
         Map<HiveColumnHandle, Domain> partitionColumnPredicates = new HashMap<>();
         Map<HiveColumnHandle, Domain> regularColumnPredicates = new HashMap<>();
 

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
@@ -51,6 +51,7 @@ import static io.trino.plugin.hudi.HudiSessionProperties.getDynamicFilteringWait
 import static io.trino.plugin.hudi.HudiSessionProperties.getMaxOutstandingSplits;
 import static io.trino.plugin.hudi.HudiSessionProperties.getMaxSplitsPerSecond;
 import static io.trino.plugin.hudi.partition.HiveHudiPartitionInfo.NON_PARTITION;
+import static io.trino.spi.connector.FixedSplitSource.emptySplitSource;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -82,6 +83,12 @@ public class HudiSplitManager
             Constraint constraint)
     {
         HudiTableHandle hudiTableHandle = (HudiTableHandle) tableHandle;
+        // The planner turns a none() domain into an empty ValuesNode before applyFilter, so a none() predicate
+        // should never reach here; guard anyway, as computePartitionKeyFilter below throws on a none() domain.
+        if (hudiTableHandle.getPartitionPredicates().isNone() || hudiTableHandle.getRegularPredicates().isNone()) {
+            return emptySplitSource();
+        }
+
         HiveMetastore metastore = metastoreProvider.apply(session.getIdentity(), (HiveTransactionHandle) transaction);
         Lazy<Map<String, Partition>> lazyAllPartitions = Lazy.lazily(() -> {
             HoodieTimer timer = HoodieTimer.start();

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiPredicates.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiPredicates.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.metastore.HiveType.HIVE_STRING;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestHudiPredicates
+{
+    private static final HiveColumnHandle PARTITION_COLUMN = createBaseColumn("part", 0, HIVE_STRING, VARCHAR, PARTITION_KEY, Optional.empty());
+    private static final HiveColumnHandle REGULAR_COLUMN = createBaseColumn("col", 1, HIVE_STRING, VARCHAR, REGULAR, Optional.empty());
+
+    @Test
+    public void testNoneConstraintStaysNone()
+    {
+        HudiPredicates predicates = HudiPredicates.from(TupleDomain.none());
+
+        assertThat(predicates.getPartitionColumnPredicates().isNone()).isTrue();
+        assertThat(predicates.getRegularColumnPredicates().isNone()).isTrue();
+    }
+
+    @Test
+    public void testAllConstraintStaysAll()
+    {
+        HudiPredicates predicates = HudiPredicates.from(TupleDomain.all());
+
+        assertThat(predicates.getPartitionColumnPredicates().isAll()).isTrue();
+        assertThat(predicates.getRegularColumnPredicates().isAll()).isTrue();
+    }
+
+    @Test
+    public void testConstraintSplitByColumnType()
+    {
+        Domain partitionDomain = Domain.singleValue(VARCHAR, Slices.utf8Slice("p1"));
+        Domain regularDomain = Domain.singleValue(VARCHAR, Slices.utf8Slice("v1"));
+        TupleDomain<ColumnHandle> predicate = TupleDomain.withColumnDomains(ImmutableMap.of(
+                PARTITION_COLUMN, partitionDomain,
+                REGULAR_COLUMN, regularDomain));
+
+        HudiPredicates predicates = HudiPredicates.from(predicate);
+
+        assertThat(predicates.getPartitionColumnPredicates())
+                .isEqualTo(TupleDomain.withColumnDomains(ImmutableMap.of(PARTITION_COLUMN, partitionDomain)));
+        assertThat(predicates.getRegularColumnPredicates())
+                .isEqualTo(TupleDomain.withColumnDomains(ImmutableMap.of(REGULAR_COLUMN, regularDomain)));
+    }
+
+    @Test
+    public void testOnlyPartitionColumnConstraintLeavesRegularAll()
+    {
+        Domain partitionDomain = Domain.singleValue(VARCHAR, Slices.utf8Slice("p1"));
+        TupleDomain<ColumnHandle> predicate = TupleDomain.withColumnDomains(ImmutableMap.of(PARTITION_COLUMN, partitionDomain));
+
+        HudiPredicates predicates = HudiPredicates.from(predicate);
+
+        assertThat(predicates.getPartitionColumnPredicates())
+                .isEqualTo(TupleDomain.withColumnDomains(ImmutableMap.of(PARTITION_COLUMN, partitionDomain)));
+        assertThat(predicates.getRegularColumnPredicates().isAll()).isTrue();
+    }
+
+    @Test
+    public void testOnlyRegularColumnConstraintLeavesPartitionAll()
+    {
+        Domain regularDomain = Domain.singleValue(VARCHAR, Slices.utf8Slice("v1"));
+        TupleDomain<ColumnHandle> predicate = TupleDomain.withColumnDomains(ImmutableMap.of(REGULAR_COLUMN, regularDomain));
+
+        HudiPredicates predicates = HudiPredicates.from(predicate);
+
+        assertThat(predicates.getPartitionColumnPredicates().isAll()).isTrue();
+        assertThat(predicates.getRegularColumnPredicates())
+                .isEqualTo(TupleDomain.withColumnDomains(ImmutableMap.of(REGULAR_COLUMN, regularDomain)));
+    }
+}

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSplitSource.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSplitSource.java
@@ -13,24 +13,33 @@
  */
 package io.trino.plugin.hudi;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.plugin.hive.util.AsyncQueue;
 import io.trino.plugin.hive.util.ThrottledAsyncQueue;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilterSnapshot;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static io.trino.testing.TestingConnectorSession.SESSION;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -66,6 +75,29 @@ public class TestHudiSplitSource
 
         assertThat(batch).isCompletedWithValueMatching(List::isEmpty);
         assertThat(splitSource.isFinished()).isTrue();
+    }
+
+    @Test
+    public void testNonePredicateYieldsEmptySplitSource()
+    {
+        // A none() predicate must short-circuit before the metastore is consulted: the split manager would
+        // otherwise hand it to computePartitionKeyFilter, which rejects a none() domain
+        HudiSplitManager splitManager = new HudiSplitManager(
+                (identity, transaction) -> {
+                    throw new AssertionError("metastore must not be consulted for a none() predicate");
+                },
+                executor,
+                scheduler);
+
+        for (HudiTableHandle tableHandle : List.of(
+                createTableHandle(TupleDomain.none(), TupleDomain.all()),
+                createTableHandle(TupleDomain.all(), TupleDomain.none()))) {
+            ConnectorSplitSource splitSource = splitManager.getSplits(
+                    new HiveTransactionHandle(false), SESSION, tableHandle, ImmutableSet.of(), Constraint.alwaysTrue());
+
+            assertThat(splitSource.isFinished()).isTrue();
+            assertThat(splitSource.getNextBatch(10, new DynamicFilterSnapshot(TupleDomain.all(), false)).join()).isEmpty();
+        }
     }
 
     @Test
@@ -117,5 +149,23 @@ public class TestHudiSplitSource
             Thread.sleep(10);
         }
         assertThat(queue.isFinished()).isTrue();
+    }
+
+    private static HudiTableHandle createTableHandle(
+            TupleDomain<HiveColumnHandle> partitionPredicates,
+            TupleDomain<HiveColumnHandle> regularPredicates)
+    {
+        return new HudiTableHandle(
+                TABLE.getSchemaName(),
+                TABLE.getTableName(),
+                "/test/path",
+                HoodieTableType.COPY_ON_WRITE,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                partitionPredicates,
+                regularPredicates,
+                OptionalLong.empty(),
+                "",
+                "101");
     }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Port of trinodb/trino#30958. `HudiPredicates.from` only reads `TupleDomain.getDomains()`, which is empty for both `none()` and `all()`, so a `none()` constraint came back as `all()` on both sides. Our copy is identical to the pre-fix upstream file, and the fix is well past the Trino SHA we pin.

This is contract correctness and parity with upstream, not a behavior change: `PushPredicateIntoTableScan`, the only engine caller of `applyFilter`, turns a `none()` domain into an empty `ValuesNode` before calling the connector, so no query on a Trino version we build against reaches this code today. After the RFC-105 shim lands this repo is the only home of the class, so upstream fixes must be carried here to survive.

### Summary and Changelog

- `HudiPredicates.from` returns `none()` for both sides on a `none()` input. Upstream guard, verbatim.
- `TestHudiPredicates`: upstream's test file, copied verbatim (five cases).
- `HudiSplitManager.getSplits` returns `emptySplitSource()` when either handle predicate is `none()`. The one deviation from upstream, and the same shape `DeltaLakeSplitManager` carries. The two arms stop different things: a `none()` partition predicate would reach `MetastoreUtil.computePartitionKeyFilter`, whose `checkArgument` rejects it; a `none()` regular predicate throws nothing, it empties `TupleDomainUtils.getReferencedColumns`, so every index strategy's `canApply` declines and nothing is pruned.
- `TestHudiSplitSource` gains one test for the guard; its metastore provider throws if the short-circuit is skipped.

Copied code: the `HudiPredicates` guard and `TestHudiPredicates` come from trinodb/trino (Apache License 2.0).

<details>
<summary>Why the other consumers of the table-handle predicates are already safe with none()</summary>

- Every index strategy's `canApply` rejects a `none()` domain: the referenced-column helper in `TupleDomainUtils` returns an empty list for it.
- `HudiPageSourceProvider.remapPredicateColumnIndicesToPhysical` and `ParquetStatisticsDomains` guard `isNone()`.
- `HudiUtil.partitionMatches` returns false for `none()`.
- Dynamic filters that become `none()` are already handled in `HudiSplitSource`.

</details>

### Impact

No user-facing or performance change. There is no input, reachable or hypothetical, on which either change alters a query outcome:

- The engine never hands `applyFilter` a `none()` summary. `PushPredicateIntoTableScan` returns a `ValuesNode` on `newDomain.isNone()` before the `applyFilter` call, and that is the only `Metadata.applyFilter` call site in trino-main.
- Even if it did, the planner would fail in `computeEnforced` before `getSplits` runs, whatever the connector returns as the remaining filter. `computeEnforced` first rejects a `none()` unenforced domain by `checkArgument`, and then reads `predicate.getDomains().get()`, which throws on the `none()` predicate. Iceberg and Delta return `TupleDomain.all()` there, but their `none()` arises from their own extraction over a non-none summary, so their `predicate` argument is well formed; Hudi's would have to be the summary itself.

So the split-manager guard is parity with `DeltaLakeSplitManager`, not hardening: it makes the connector's own contract self-consistent, and it is the right behavior if a future caller ever builds a handle with `none()` predicates.

> Impact and the third Summary bullet were rewritten after merge, from review feedback on this PR. The squashed commit message on master carries the original wording, which claimed the guard turns a would-be failure into zero splits.

### Risk Level

none. Both changes sit behind `isNone()` checks that no reachable input satisfies. `TestHudiPredicates` and `TestHudiSplitSource` pass under JDK 25.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
