### PR TITLE
test(clustering): re-enable testClusteringPlanInflight and fix its timeline transition

### DIFF
--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -40,7 +40,6 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.StoragePath;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -171,9 +170,8 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
         assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, instant.getAction()));
   }
 
-  // replacecommit.inflight doesn't have clustering plan.
-  // Verify that getClusteringPlan fetches content from corresponding requested file.
-  @Disabled("Will fail due to avro issue AVRO-3789. This is fixed in avro 1.11.3")
+  // The inflight instant file carries no clustering plan, so getClusteringPlan has to read it from the
+  // corresponding requested file. Verified for both states of the same instant.
   @Test
   public void testClusteringPlanInflight() throws Exception {
     String partitionPath1 = "partition1";
@@ -182,7 +180,7 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     fileIds1.add(UUID.randomUUID().toString());
     String clusterTime1 = "1";
     HoodieInstant requestedInstant = createRequestedClusterInstant(partitionPath1, clusterTime1, fileIds1);
-    HoodieInstant inflightInstant = metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(requestedInstant, Option.empty());
+    HoodieInstant inflightInstant = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant, Option.empty());
     assertTrue(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline(), requestedInstant, INSTANT_GENERATOR));
     HoodieClusteringPlan requestedClusteringPlan = ClusteringUtils.getClusteringPlan(metaClient, requestedInstant).get().getRight();
     assertTrue(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline(), inflightInstant, INSTANT_GENERATOR));

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -33,6 +33,8 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.InstantGenerator;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV2MigrationHandler;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.util.collection.Pair;
@@ -41,6 +43,8 @@ import org.apache.hudi.storage.StoragePath;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -171,21 +175,37 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
   }
 
   // The inflight instant file carries no clustering plan, so getClusteringPlan has to read it from the
-  // corresponding requested file. Verified for both states of the same instant.
-  @Test
-  public void testClusteringPlanInflight() throws Exception {
+  // corresponding requested file. Table version 8 and above write the instant with the clustering action;
+  // table version 6 still writes it as a replacecommit (see ClusteringPlanActionExecutor), which is the
+  // only shape that exercises the replacecommit arm of isClusteringInstant.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testClusteringPlanInflight(boolean preTableVersion8) throws Exception {
+    if (preTableVersion8) {
+      initMetaClient(true);
+    }
+    String expectedAction = preTableVersion8 ? HoodieTimeline.REPLACE_COMMIT_ACTION : HoodieTimeline.CLUSTERING_ACTION;
+    InstantGenerator instantGenerator = metaClient.getInstantGenerator();
     String partitionPath1 = "partition1";
     List<String> fileIds1 = new ArrayList<>();
     fileIds1.add(UUID.randomUUID().toString());
     fileIds1.add(UUID.randomUUID().toString());
     String clusterTime1 = "1";
     HoodieInstant requestedInstant = createRequestedClusterInstant(partitionPath1, clusterTime1, fileIds1);
-    HoodieInstant inflightInstant = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant, Option.empty());
-    assertTrue(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline(), requestedInstant, INSTANT_GENERATOR));
+    assertEquals(expectedAction, requestedInstant.getAction());
+    assertTrue(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline(), requestedInstant, instantGenerator));
     HoodieClusteringPlan requestedClusteringPlan = ClusteringUtils.getClusteringPlan(metaClient, requestedInstant).get().getRight();
-    assertTrue(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline(), inflightInstant, INSTANT_GENERATOR));
-    HoodieClusteringPlan inflightClusteringPlan = ClusteringUtils.getClusteringPlan(metaClient, inflightInstant).get().getRight();
-    assertEquals(requestedClusteringPlan, inflightClusteringPlan);
+
+    HoodieInstant inflightInstant = metaClient.getActiveTimeline().transitionClusterRequestedToInflight(requestedInstant, Option.empty());
+    assertEquals(expectedAction, inflightInstant.getAction());
+    assertTrue(metaClient.getActiveTimeline().isEmpty(inflightInstant));
+    assertTrue(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline(), inflightInstant, instantGenerator));
+    assertEquals(requestedClusteringPlan, ClusteringUtils.getClusteringPlan(metaClient, inflightInstant).get().getRight());
+
+    HoodieInstant completedInstant = metaClient.getActiveTimeline().transitionClusterInflightToComplete(false, inflightInstant, new HoodieReplaceCommitMetadata());
+    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, completedInstant.getAction());
+    assertTrue(ClusteringUtils.isClusteringInstant(metaClient.getActiveTimeline(), completedInstant, instantGenerator));
+    assertEquals(requestedClusteringPlan, ClusteringUtils.getClusteringPlan(metaClient, completedInstant).get().getRight());
   }
 
   @Test
@@ -439,7 +459,10 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     HoodieClusteringPlan clusteringPlan =
         ClusteringUtils.createClusteringPlan(CLUSTERING_STRATEGY_CLASS, STRATEGY_PARAMS, fileSliceGroups, Collections.emptyMap());
 
-    HoodieInstant clusteringInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTERING_ACTION, clusterTime);
+    // Table version 6 has no clustering action and schedules clustering as a replacecommit, see ClusteringPlanActionExecutor.
+    String action = TimelineLayoutVersion.LAYOUT_VERSION_2.equals(metaClient.getTimelineLayoutVersion())
+        ? HoodieTimeline.CLUSTERING_ACTION : HoodieTimeline.REPLACE_COMMIT_ACTION;
+    HoodieInstant clusteringInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, action, clusterTime);
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder()
         .setClusteringPlan(clusteringPlan).setOperationType(WriteOperationType.CLUSTER.name()).build();
     metaClient.getActiveTimeline().saveToPendingClusterCommit(clusteringInstant, requestedReplaceMetadata);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17333 (https://issues.apache.org/jira/browse/HUDI-8686).

`TestClusteringUtils#testClusteringPlanInflight` was disabled with:

```java
@Disabled("Will fail due to avro issue AVRO-3789. This is fixed in avro 1.11.3")
```

The root `pom.xml` now pins `<avro.version>1.11.4</avro.version>`, so the stated reason no longer applies. Removing the annotation alone does **not** make the test pass, though. It fails with:

```
java.lang.IllegalArgumentException
  at org.apache.hudi.common.util.ValidationUtils.checkArgument(ValidationUtils.java:33)
  at org.apache.hudi.common.table.timeline.versioning.v2.ActiveTimelineV2.transitionReplaceRequestedToInflight(ActiveTimelineV2.java:476)
  at org.apache.hudi.common.util.TestClusteringUtils.testClusteringPlanInflight(TestClusteringUtils.java:183)
```

which has nothing to do with avro. `createRequestedClusterInstant` builds the instant with `CLUSTERING_ACTION`:

```java
HoodieInstant clusteringInstant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.CLUSTERING_ACTION, clusterTime);
```

while the test transitioned it through `transitionReplaceRequestedToInflight`, whose first precondition is that the action *is* `REPLACE_COMMIT`:

```java
ValidationUtils.checkArgument(requestedInstant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION));
```

Clustering gained its own timeline action, so the replace-commit transition is no longer correct for a clustering instant. `testGetOldestInstantToRetainForClustering`, in the same class and on the same kind of instant, already uses `transitionClusterRequestedToInflight`.

### Summary and Changelog

`TestClusteringUtils` no longer skips a case, so the behaviour it covers is verified again: that an inflight clustering instant carries no plan in its own file, and `ClusteringUtils.getClusteringPlan` therefore has to read it from the corresponding requested file.

- `TestClusteringUtils#testClusteringPlanInflight`: dropped `@Disabled` and the now-unused `Disabled` import; switched the transition to `transitionClusterRequestedToInflight`.
- Corrected the comment above the test, which said `replacecommit.inflight`.
- Follow-up 51454e819891: `testClusteringPlanInflight` is parameterized over table version, so the table-version-6 lane drives a `replacecommit` instant through the `REPLACE_COMMIT` arm of `isClusteringInstant`; it also asserts the inflight file is empty and that the plan is readable from the completed instant. `createRequestedClusterInstant` picks the action the way `ClusteringPlanActionExecutor` does.

No production code touched. No code was copied.

### Impact

Test-only. One previously skipped test now runs; no existing test is modified.

Worth stating plainly since it changes what the ticket is about: the avro reason recorded on the annotation was stale, and the real blocker was the timeline action split. Anyone re-enabling this by deleting the annotation alone would hit a failure that looks unrelated to the note explaining the skip.

The annotation was right when #9717 added it: the transition was still legal then. #11553 (HUDI-7905) later migrated every other `transitionReplaceRequestedToInflight` in this file and deleted the `createRequestedReplaceInstant` helper, but skipped this test because it was disabled, which is where the mismatch entered.

### Risk Level

none

Verified on Spark 3.5 / Scala 2.12:

- `mvn test -pl hudi-hadoop-common -Dtest=TestClusteringUtils` -> `Tests run: 11, Failures: 0, Errors: 0, Skipped: 0` (previously 11 run with 1 skipped)
- `mvn test-compile checkstyle:check -pl hudi-hadoop-common` -> clean
- After 51454e819891: `Tests run: 12, Failures: 0, Errors: 0, Skipped: 0`, 0 checkstyle violations (JDK 17, `-pl hudi-hadoop-common -am`)

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

