### PR TITLE
docs(flink): document Lance runtime dependencies

### DIFF
--- a/packaging/hudi-flink-bundle/README.md
+++ b/packaging/hudi-flink-bundle/README.md
@@ -1,0 +1,40 @@
+<!--
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+-->
+
+# `hudi-flink-bundle` module
+
+This module packages the Hudi Flink bundle for reading and writing Hudi tables with Flink.
+
+## Lance dependencies
+
+The Hudi Flink bundle does not include Lance runtime dependencies. To use Lance with Hudi,
+ensure that the Flink runtime includes the following dependencies.
+
+| Dependency | Version |
+|------------|---------|
+| `org.lance:lance-core` | 4.0.0 |
+| `org.apache.arrow:arrow-vector` | 18.3.0 |
+| `org.apache.arrow:arrow-format` | 18.3.0 |
+| `org.apache.arrow:arrow-memory-core` | 18.3.0 |
+| `org.apache.arrow:arrow-memory-netty` | 18.3.0 |
+| `org.apache.arrow:arrow-memory-netty-buffer-patch` | 18.3.0 |
+| `org.apache.arrow:arrow-c-data` | 18.3.0 |
+| `org.questdb:jar-jni` | 1.1.1 |
+| `com.google.flatbuffers:flatbuffers-java` | 25.2.10 |
+| `io.netty:netty-buffer` | 4.1.119.Final |
+| `io.netty:netty-common` | 4.1.119.Final |

--- a/packaging/hudi-flink-bundle/README.md
+++ b/packaging/hudi-flink-bundle/README.md
@@ -23,18 +23,18 @@ This module packages the Hudi Flink bundle for reading and writing Hudi tables w
 ## Lance dependencies
 
 The Hudi Flink bundle does not include Lance runtime dependencies. To use Lance with Hudi,
-ensure that the Flink runtime includes the following dependencies.
+ensure that the Flink runtime includes the following dependencies and their required transitive
+dependencies. Use versions compatible with the dependencies of your Hudi version; see its
+[root POM](../../pom.xml) for the Lance and Arrow versions.
 
-| Dependency | Version |
-|------------|---------|
-| `org.lance:lance-core` | 4.0.0 |
-| `org.apache.arrow:arrow-vector` | 18.3.0 |
-| `org.apache.arrow:arrow-format` | 18.3.0 |
-| `org.apache.arrow:arrow-memory-core` | 18.3.0 |
-| `org.apache.arrow:arrow-memory-netty` | 18.3.0 |
-| `org.apache.arrow:arrow-memory-netty-buffer-patch` | 18.3.0 |
-| `org.apache.arrow:arrow-c-data` | 18.3.0 |
-| `org.questdb:jar-jni` | 1.1.1 |
-| `com.google.flatbuffers:flatbuffers-java` | 25.2.10 |
-| `io.netty:netty-buffer` | 4.1.119.Final |
-| `io.netty:netty-common` | 4.1.119.Final |
+- `org.lance:lance-core`
+- `org.apache.arrow:arrow-vector`
+- `org.apache.arrow:arrow-format`
+- `org.apache.arrow:arrow-memory-core`
+- `org.apache.arrow:arrow-memory-netty`
+- `org.apache.arrow:arrow-memory-netty-buffer-patch`
+- `org.apache.arrow:arrow-c-data`
+- `org.questdb:jar-jni`
+- `com.google.flatbuffers:flatbuffers-java`
+- `io.netty:netty-buffer`
+- `io.netty:netty-common`

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -75,6 +75,20 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <artifactSet>
+                <!-- Lance runtime dependencies are not bundled. Before using Lance with Flink,
+                     add the following JARs and their required transitive dependencies to Flink's lib
+                     directory, using versions compatible with Hudi:
+                     org.lance:lance-core
+                     org.apache.arrow:arrow-vector
+                     org.apache.arrow:arrow-format
+                     org.apache.arrow:arrow-memory-core
+                     org.apache.arrow:arrow-memory-netty
+                     org.apache.arrow:arrow-memory-netty-buffer-patch
+                     org.apache.arrow:arrow-c-data
+                     org.questdb:jar-jni
+                     com.google.flatbuffers:flatbuffers-java
+                     io.netty:netty-buffer
+                     io.netty:netty-common -->
                 <includes combine.children="append">
                   <include>org.apache.hudi:hudi-hadoop-common</include>
                   <include>org.apache.hudi:hudi-common</include>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Related to #19864.

Lance operations fail with missing runtime classes when only the Hudi Flink bundle is deployed. The required external dependencies are not documented.

### Summary and Changelog

- Add a Flink bundle README listing the required Lance runtime dependencies and versions.
- Add a POM comment explaining that these dependencies must be provided separately.

### Impact

Clarifies the runtime requirements for using Lance with Flink. No changes to bundle contents or runtime behavior.

### Risk Level

None. Documentation and comments only.

### Documentation Update

Added `packaging/hudi-flink-bundle/README.md`.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable