### PR TITLE
fix(heartbeat): don't fail a durable commit when heartbeat cleanup races a refresh

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
@@ -196,15 +196,34 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   private void stopHeartbeatScheduler(Heartbeat heartbeat) {
     log.info("Stopping heartbeat for instant {}", heartbeat.getInstantTime());
     shutdownHeartbeatScheduler(heartbeat);
+    // Callers delete the heartbeat file next. A refresh landing after that delete recreates the
+    // file, and on storage that enforces preconditions it also changes the object generation, so a
+    // generation-matched delete is rejected (e.g. GCS 412 conditionNotMet).
+    awaitHeartbeatSchedulerTermination(heartbeat);
     heartbeat.setHeartbeatStopped(true);
     log.info("Stopped heartbeat for instant {}", heartbeat.getInstantTime());
   }
 
+  /** Stops further refreshes without waiting; safe to call from the scheduler thread itself. */
   private void shutdownHeartbeatScheduler(Heartbeat heartbeat) {
     if (heartbeat.getScheduledFuture() != null) {
       heartbeat.getScheduledFuture().cancel(false);
     }
-    heartbeat.getHeartbeatScheduler().shutdownNow();
+    heartbeat.getHeartbeatScheduler().shutdown();
+  }
+
+  private void awaitHeartbeatSchedulerTermination(Heartbeat heartbeat) {
+    // An in-flight tick can be parked on the bounded write, so allow for that plus one interval.
+    long timeoutMs = this.heartbeatWriteTimeoutMs + this.heartbeatIntervalInMs;
+    try {
+      if (!heartbeat.getHeartbeatScheduler().awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
+        log.warn("Timed out after {} ms awaiting an in-flight heartbeat refresh for instant {}",
+            timeoutMs, heartbeat.getInstantTime());
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.warn("Interrupted awaiting heartbeat scheduler termination for instant {}", heartbeat.getInstantTime());
+    }
   }
 
   public static Boolean heartbeatExists(HoodieStorage storage, String basePath, String instantTime) throws IOException {
@@ -238,6 +257,10 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
       Long newHeartbeatTime = System.currentTimeMillis();
       writeHeartbeatFile(instantTime);
       Heartbeat heartbeat = instantToHeartbeatMap.get(instantTime);
+      if (heartbeat == null) {
+        // stop() removed the entry while this refresh was in flight.
+        return;
+      }
       if (heartbeat.getLastHeartbeatTime() != null && isHeartbeatExpired(instantTime)) {
         // A previous refresh was delayed past the tolerable interval. Stop refreshing this heartbeat
         // (cancel the scheduler) and do NOT advance the last heartbeat time, so the heartbeat stays expired
@@ -262,8 +285,8 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
       log.warn("Heartbeat file write for instant {} did not complete within {} ms; will retry on next tick",
           instantTime, this.heartbeatWriteTimeoutMs);
     } catch (IOException io) {
-      boolean isHeartbeatStopped = instantToHeartbeatMap.get(instantTime).isHeartbeatStopped();
-      if (isHeartbeatStopped) {
+      Heartbeat heartbeat = instantToHeartbeatMap.get(instantTime);
+      if (heartbeat == null || heartbeat.isHeartbeatStopped()) {
         log.info("update heart beat failed, because the instant time {} was stopped", instantTime);
         return;
       }
@@ -308,9 +331,15 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   }
 
   @Override
-  public synchronized void close() {
+  public void close() {
+    // Not synchronized: stopHeartbeatTimers() now awaits in-flight refreshes, and holding the monitor
+    // across that would block a refresh needing getHeartbeatWriteExecutor() until the await expires.
     this.stopHeartbeatTimers();
     this.instantToHeartbeatMap.clear();
+    shutdownHeartbeatWriteExecutor();
+  }
+
+  private synchronized void shutdownHeartbeatWriteExecutor() {
     if (heartbeatWriteExecutor != null) {
       heartbeatWriteExecutor.shutdownNow();
       heartbeatWriteExecutor = null;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/WriterHeartbeatUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/WriterHeartbeatUtils.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
@@ -58,8 +59,10 @@ public class WriterHeartbeatUtils {
       } else {
         log.info("Deleted the heartbeat for instant {}", instantTime);
       }
-    } catch (IOException io) {
-      log.error("Unable to delete heartbeat for instant {}", instantTime, io);
+    } catch (IOException | HoodieIOException e) {
+      // HoodieStorage.deleteFile throws HoodieIOException when the object still exists after a
+      // rejected delete. Never fatal: the commit is already durable by postCommit.
+      log.error("Unable to delete heartbeat for instant {}", instantTime, e);
     }
     return deleted;
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestHoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestHoodieHeartbeatClient.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.client.heartbeat;
 
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -162,6 +164,156 @@ public class TestHoodieHeartbeatClient extends HoodieCommonTestHarness {
           .until(() -> hoodieHeartbeatClient.getHeartbeat(instantTime1).getNumHeartbeats() >= 2);
     } finally {
       hoodieHeartbeatClient.close();
+    }
+  }
+
+  /**
+   * stop() must not delete the heartbeat file while a scheduled refresh is still writing it. A
+   * refresh landing after the delete recreates the file, and on storage that enforces preconditions
+   * it changes the object generation so a generation-matched delete is rejected (e.g. GCS 412).
+   */
+  @Test
+  public void testStopWaitsForInFlightHeartbeatRefresh() throws Exception {
+    // A longer interval also widens the bounded-write timeout, so a slow CI box cannot let the write
+    // time out before the test releases it, which would let the delete run first.
+    long interval = 5000L;
+    CountDownLatch refreshEntered = new CountDownLatch(1);
+    CountDownLatch releaseRefresh = new CountDownLatch(1);
+    OrderRecordingStorage storage = new OrderRecordingStorage(
+        (FileSystem) metaClient.getStorage().getFileSystem(), refreshEntered, releaseRefresh);
+    HoodieHeartbeatClient client = new HoodieHeartbeatClient(
+        storage, metaClient.getBasePath().toString(), interval, numTolerableMisses);
+    try {
+      client.start(instantTime1);
+      assertTrue(refreshEntered.await(20, SECONDS), "Scheduled heartbeat refresh never started");
+
+      Thread stopper = new Thread(() -> client.stop(instantTime1));
+      stopper.start();
+      // Without awaiting termination, stop() runs straight through and never parks here.
+      await().atMost(20, SECONDS).until(() -> stopper.getState() == Thread.State.TIMED_WAITING
+          || stopper.getState() == Thread.State.WAITING
+          || stopper.getState() == Thread.State.BLOCKED);
+
+      releaseRefresh.countDown();
+      stopper.join(SECONDS.toMillis(20));
+      assertFalse(stopper.isAlive(), "stop() did not complete after the refresh was released");
+
+      assertTrue(storage.events().contains("delete"), "stop() never deleted the heartbeat file");
+      assertEquals("delete", storage.events().get(storage.events().size() - 1),
+          "No heartbeat refresh may follow the delete; events were " + storage.events());
+    } finally {
+      releaseRefresh.countDown();
+      client.close();
+    }
+  }
+
+  /**
+   * A rejected heartbeat delete must never propagate. HoodieStorage.deleteFile throws
+   * HoodieIOException (unchecked) when the object still exists after the delete was refused, which is
+   * what a generation-matched delete does on storage that enforces preconditions. Callers reach this
+   * from postCommit, where the commit is already durable.
+   */
+  @Test
+  public void testDeleteHeartbeatFileSwallowsHoodieIOException() {
+    ThrowOnDeleteStorage storage =
+        new ThrowOnDeleteStorage((FileSystem) metaClient.getStorage().getFileSystem());
+    assertFalse(WriterHeartbeatUtils.deleteHeartbeatFile(storage, basePath, instantTime1),
+        "A refused heartbeat delete must be reported via the return value, never thrown");
+  }
+
+  /** Interrupting a thread parked in stop() must re-assert the interrupt rather than swallow it. */
+  @Test
+  public void testStopReassertsInterruptWhileAwaiting() throws Exception {
+    // A longer interval widens the bounded-write window, so the await is still parked when interrupted.
+    long interval = 5000L;
+    CountDownLatch refreshEntered = new CountDownLatch(1);
+    CountDownLatch releaseRefresh = new CountDownLatch(1);
+    OrderRecordingStorage storage = new OrderRecordingStorage(
+        (FileSystem) metaClient.getStorage().getFileSystem(), refreshEntered, releaseRefresh);
+    HoodieHeartbeatClient client = new HoodieHeartbeatClient(
+        storage, metaClient.getBasePath().toString(), interval, numTolerableMisses);
+    try {
+      client.start(instantTime1);
+      assertTrue(refreshEntered.await(20, SECONDS), "Scheduled heartbeat refresh never started");
+
+      AtomicBoolean interruptPreserved = new AtomicBoolean();
+      Thread stopper = new Thread(() -> {
+        client.stop(instantTime1);
+        interruptPreserved.set(Thread.currentThread().isInterrupted());
+      });
+      stopper.start();
+      await().atMost(20, SECONDS).until(() -> stopper.getState() == Thread.State.TIMED_WAITING
+          || stopper.getState() == Thread.State.WAITING
+          || stopper.getState() == Thread.State.BLOCKED);
+      stopper.interrupt();
+      stopper.join(SECONDS.toMillis(20));
+
+      assertFalse(stopper.isAlive(), "stop() did not return after being interrupted");
+      assertTrue(interruptPreserved.get(), "stop() swallowed the interrupt");
+    } finally {
+      releaseRefresh.countDown();
+      client.close();
+    }
+  }
+
+  /** Refuses every delete with HoodieIOException, as a precondition-enforcing store does. */
+  private static class ThrowOnDeleteStorage extends HoodieHadoopStorage {
+
+    ThrowOnDeleteStorage(FileSystem fs) {
+      super(fs);
+    }
+
+    @Override
+    public boolean deleteFile(StoragePath path) {
+      throw new HoodieIOException("Failed to delete invalid data file: " + path);
+    }
+  }
+
+  /**
+   * Records create/delete order and blocks the first scheduled refresh until released. The block
+   * ignores interruption, as a storage write already in flight would.
+   */
+  private static class OrderRecordingStorage extends HoodieHadoopStorage {
+
+    private final List<String> events = new CopyOnWriteArrayList<>();
+    private final AtomicBoolean gated = new AtomicBoolean(false);
+    private final CountDownLatch refreshEntered;
+    private final CountDownLatch releaseRefresh;
+
+    OrderRecordingStorage(FileSystem fs, CountDownLatch refreshEntered, CountDownLatch releaseRefresh) {
+      super(fs);
+      this.refreshEntered = refreshEntered;
+      this.releaseRefresh = releaseRefresh;
+    }
+
+    List<String> events() {
+      return events;
+    }
+
+    @Override
+    public OutputStream create(StoragePath path, boolean overwrite) throws IOException {
+      // The first create is start()'s synchronous beat; gate only the first scheduled refresh.
+      if (!events.isEmpty() && gated.compareAndSet(false, true)) {
+        refreshEntered.countDown();
+        boolean released = false;
+        while (!released) {
+          try {
+            releaseRefresh.await();
+            released = true;
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        }
+      }
+      OutputStream stream = super.create(path, overwrite);
+      events.add("create");
+      return stream;
+    }
+
+    @Override
+    public boolean deleteFile(StoragePath path) throws IOException {
+      events.add("delete");
+      return super.deleteFile(path);
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A commit that has already been made durable can be reported back to the caller as a **failed** write,
purely because of heartbeat file cleanup.

`stop()` cancels the heartbeat scheduler with `shutdownNow()` and immediately deletes the heartbeat
file, without waiting for a refresh that is already in flight. The refresh recreates the file, and on
storage that enforces preconditions it also changes the object generation, so the generation-matched
delete is rejected. Observed in production on GCS as `412 conditionNotMet`, retried four times by the
connector and then given up on:

```
Precondition not met while deleting '.../.hoodie/.heartbeat/<instant>' at generation <gen>.
Attempt 1. Retrying: {"code":412, ... "reason":"conditionNotMet"}
```

`HoodieHadoopStorage.delete` reports a failed delete by throwing `HoodieIOException` when the object
still exists afterwards, which is exactly the outcome here. That exception is unchecked, so it escapes
the `IOException`-only catch in `WriterHeartbeatUtils.deleteHeartbeatFile`, propagates out of
`BaseHoodieWriteClient.postCommit` and aborts `commitStats` — after `commit()` has already completed.
The write is on storage, but the caller is told the round failed.

### Summary and Changelog

Users no longer see a successful commit reported as a failure because of heartbeat cleanup.

- `HoodieHeartbeatClient.stopHeartbeatScheduler`: `shutdown()` plus `awaitTermination()` before the
  caller deletes the heartbeat file, so a refresh in flight completes first and the delete then reads
  a settled object. `shutdownNow()` interrupts rather than waits, which is what left the window open.
  The await is deliberately **not** placed in `shutdownHeartbeatScheduler`, because the missed-refresh
  path in `updateHeartbeat` calls that from the scheduler thread and must not await itself. The bound
  is `heartbeatWriteTimeoutMs + heartbeatIntervalInMs`, since an in-flight tick can be parked on the
  bounded write.
- `WriterHeartbeatUtils.deleteHeartbeatFile`: also catch `HoodieIOException`. By the time `postCommit`
  runs the cleanup the commit is durable, and no caller consumes the return value
  (`HoodieHeartbeatClient.stop`, `BaseHoodieTableServiceClient` x2 all discard it), so a failed cleanup
  of a transient lease marker must never be fatal. The existing `log.error` is kept, so a leaked file
  is still visible.

The two changes are complementary rather than redundant: a write that exceeds `heartbeatWriteTimeoutMs`
is deliberately abandoned by `writeHeartbeatFile`, and an abandoned write can still land after the
delete. The await closes the ordering race for refreshes that complete normally; the widened catch is
what keeps the abandoned-write tail non-fatal.

Test: `TestHoodieHeartbeatClient#testStopWaitsForInFlightHeartbeatRefresh` gates a scheduled refresh
mid-write, asserts `stop()` parks rather than deleting, and asserts no refresh is recorded after the
delete. It fails on current master (the stopper never parks) and passes with this change.

### Impact

No public API change. `deleteHeartbeatFile` keeps its signature and its documented "returns whether
the file was deleted" contract; this makes the implementation honour that contract instead of sometimes
throwing. `stop()` may now block briefly behind an in-flight heartbeat refresh, bounded as described
above.

### Risk Level

low

Confined to the heartbeat classes. No new locks and nothing held across storage IO. The widened catch is
on a path whose result every caller discards. Verified with JDK 11: module compiles, 0 checkstyle
violations, and all 9 tests in `TestHoodieHeartbeatClient` pass, including the two existing
scheduler-liveness tests (`testSlowHeartbeatWriteDoesNotBlockScheduler`,
`testScheduledHeartbeatRetriesAfterWriteFailure`). The new test was confirmed to fail against
unmodified master.

### Documentation Update

none — no new config, no default changed, no user-facing behaviour beyond the removal of a spurious
failure.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
