### PR TITLE
feat(metadata): support RLI and SI for parquet files written outside Hudi

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -46,6 +46,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
@@ -973,6 +974,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
 
   @Override
   public void completeStreamingCommit(String instantTime, HoodieEngineContext context, List<HoodieWriteStat> partialWriteStats, HoodieCommitMetadata metadata) {
+    checkClusteringKeepsRecordKeys(metadata);
     if (metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(instantTime)) {
       LOG.info("Skipping streaming metadata commit completion for already completed instant {}", instantTime);
       getWriteClient().postCommit(instantTime);
@@ -1060,10 +1062,26 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    */
   @Override
   public void update(HoodieCommitMetadata commitMetadata, String instantTime) {
+    checkClusteringKeepsRecordKeys(commitMetadata);
     mayBeReinitMetadataReader();
     maybeInitializeNewFileGroupsForPartitionedRLI(commitMetadata, instantTime);
     processAndCommit(instantTime, new BatchMetadataConversionFunction(instantTime, commitMetadata, getMetadataPartitionsToUpdate()));
     closeInternal();
+  }
+
+  /**
+   * Fails when a clustering commit reaches a table without record keys that has a record index or a secondary index.
+   * Those indexes key the rows of such a table by file path and row position, and clustering rewrites the rows into
+   * new files, so neither index could follow them. The check runs ahead of both the streaming and the batch update
+   * path, because the streaming path never reaches the indexers for these two partitions.
+   */
+  private void checkClusteringKeepsRecordKeys(HoodieCommitMetadata commitMetadata) {
+    if (commitMetadata.getOperationType() != WriteOperationType.CLUSTER || getStreamingMetadataPartitionsToUpdate().getLeft().isEmpty()) {
+      return;
+    }
+    ValidationUtils.checkState(dataMetaClient.getTableConfig().hasRecordKey(),
+        "Table " + dataMetaClient.getBasePath() + " cannot be clustered because it has no record key: the record index and the "
+            + "secondary index key its rows by file path and row position, which clustering changes");
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
@@ -329,14 +329,18 @@ public class SecondaryIndexRecordGenerationUtils {
     ReaderContextFactory<T> readerContextFactory = engineContext.getReaderContextFactory(metaClient);
     engineContext.setJobStatus(activeModule, "Secondary Index: reading secondary keys from " + fileSlices.size() + " file slices");
     HoodieFileFormat baseFileFormat = metaClient.getTableConfig().getBaseFileFormat();
+    // a file slice without a base file has only log files, whose schema is the table schema. It is resolved once here
+    // rather than in every task, because resolving it loads the timeline
+    Option<HoodieSchema> tableSchema = fileSlices.stream().anyMatch(slice -> !slice.getFileSlice().getBaseFile().isPresent())
+        ? Option.of(resolveTableSchema(metaClient))
+        : Option.empty();
     return engineContext.parallelize(fileSlices, parallelism).flatMap(partitionAndBaseFile -> {
       final FileSlice fileSlice = partitionAndBaseFile.getFileSlice();
       // the storage path keeps the directory prefix of a file written outside Hudi, which its file name alone loses
       Option<StoragePath> dataFilePath = fileSlice.getBaseFile().map(HoodieBaseFile::getStoragePath);
-      // a file slice without a base file has only log files, whose schema is the table schema
       HoodieSchema readerSchema = dataFilePath.isPresent()
           ? HoodieIOFactory.getIOFactory(metaClient.getStorage()).getFileFormatUtils(baseFileFormat).readSchema(metaClient.getStorage(), dataFilePath.get())
-          : resolveTableSchema(metaClient);
+          : tableSchema.get();
       ClosableIterator<Pair<String, String>> secondaryIndexGenerator = createSecondaryIndexRecordGenerator(
           readerContextFactory.getContext(), metaClient, fileSlice, readerSchema, indexDefinition,
           metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().map(HoodieInstant::requestedTime).orElse(""), props, false);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
@@ -28,10 +28,12 @@ import org.apache.hudi.common.engine.ReaderContextFactory;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
@@ -41,6 +43,7 @@ import org.apache.hudi.common.table.read.HoodieFileGroupReader;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.TableFileSystemView;
+import org.apache.hudi.common.util.ExternalFilePathUtil;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
@@ -64,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -86,6 +90,8 @@ public class SecondaryIndexRecordGenerationUtils {
    * @param dataMetaClient  data table meta client
    * @param engineContext   engine context
    * @param writeConfig     hoodie write config.
+   * @param commitMetadata  metadata of the commit the write stats belong to. Provides the schema when the table has no
+   *                        completed commit yet, and the replaced file groups for a replace commit.
    * @return {@link HoodieData} of {@link HoodieRecord} to be updated in the metadata table for the given secondary index partition
    */
   @VisibleForTesting
@@ -95,7 +101,8 @@ public class SecondaryIndexRecordGenerationUtils {
                                                                                       HoodieMetadataConfig metadataConfig,
                                                                                       HoodieTableMetaClient dataMetaClient,
                                                                                       HoodieEngineContext engineContext,
-                                                                                      HoodieWriteConfig writeConfig) {
+                                                                                      HoodieWriteConfig writeConfig,
+                                                                                      HoodieCommitMetadata commitMetadata) {
     TypedProperties props = writeConfig.getProps();
     // Secondary index cannot support logs having inserts with current offering. So, lets validate that.
     if (allWriteStats.stream().anyMatch(writeStat -> {
@@ -107,7 +114,10 @@ public class SecondaryIndexRecordGenerationUtils {
 
     HoodieSchema tableSchema;
     try {
-      tableSchema = tryResolveSchemaForTable(dataMetaClient).get();
+      // a table without any completed commit, e.g. one that registers files written outside Hudi for the first time,
+      // only has the schema of the current commit.
+      tableSchema = tryResolveSchemaForTable(dataMetaClient)
+          .orElseGet(() -> HoodieSchema.parse(commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY)));
     } catch (Exception e) {
       throw new HoodieException("Failed to get latest schema for " + dataMetaClient.getBasePath(), e);
     }
@@ -197,12 +207,56 @@ public class SecondaryIndexRecordGenerationUtils {
       return records.iterator();
     });
 
+    if (commitMetadata instanceof HoodieReplaceCommitMetadata) {
+      secondaryIndexRecords = secondaryIndexRecords.union(convertReplacedFileGroupsToSecondaryIndexRecords(
+          (HoodieReplaceCommitMetadata) commitMetadata, writeStatsByFileId.keySet(), instantTime, indexDefinition, metadataConfig,
+          dataMetaClient, engineContext, writeConfig, tableSchema));
+    }
+
     // Deduplicate secondary index records by grouping by the secondary index key
     // (secondaryKey$recordKey). This handles the case where a record moves from one file group to
     // another (partition path update), which generates both a delete (from old fileId) and an
     // insert (to new fileId). Similar to how Record Level Index handles partition path update,
     // we prefer non-deleted records.
     return HoodieTableMetadataUtil.reduceByKeys(secondaryIndexRecords, parallelism, false);
+  }
+
+  /**
+   * Generates delete records for every record of the file groups that the given replace commit replaces without
+   * writing to them again, e.g. files written outside Hudi that are superseded by newer files. Records that the same
+   * commit writes again are kept by {@link HoodieTableMetadataUtil#reduceByKeys}, which prefers the non-deleted record.
+   */
+  private static <T> HoodieData<HoodieRecord> convertReplacedFileGroupsToSecondaryIndexRecords(HoodieReplaceCommitMetadata replaceCommitMetadata,
+                                                                                               Set<String> writtenFileIds,
+                                                                                               String instantTime,
+                                                                                               HoodieIndexDefinition indexDefinition,
+                                                                                               HoodieMetadataConfig metadataConfig,
+                                                                                               HoodieTableMetaClient dataMetaClient,
+                                                                                               HoodieEngineContext engineContext,
+                                                                                               HoodieWriteConfig writeConfig,
+                                                                                               HoodieSchema tableSchema) {
+    List<Pair<String, String>> replacedFileGroups = replaceCommitMetadata.getPartitionToReplaceFileIds().entrySet().stream()
+        .flatMap(partitionAndFileIds -> partitionAndFileIds.getValue().stream()
+            .filter(fileId -> !writtenFileIds.contains(fileId))
+            .map(fileId -> Pair.of(partitionAndFileIds.getKey(), fileId)))
+        .collect(Collectors.toList());
+    if (replacedFileGroups.isEmpty()) {
+      return engineContext.emptyHoodieData();
+    }
+    TypedProperties props = writeConfig.getProps();
+    ReaderContextFactory<T> readerContextFactory = engineContext.getReaderContextFactory(dataMetaClient);
+    int parallelism = Math.max(Math.min(replacedFileGroups.size(), metadataConfig.getSecondaryIndexParallelism()), 1);
+    return engineContext.parallelize(replacedFileGroups, parallelism).flatMap(partitionAndFileId -> {
+      Option<FileSlice> replacedFileSlice = getSliceView(writeConfig, dataMetaClient)
+          .getLatestMergedFileSliceBeforeOrOn(partitionAndFileId.getKey(), instantTime, partitionAndFileId.getValue());
+      if (!replacedFileSlice.isPresent()) {
+        return Collections.<HoodieRecord>emptyIterator();
+      }
+      ClosableIterator<Pair<String, String>> recordKeyAndSecondaryKeyIterator = createSecondaryIndexRecordGenerator(
+          readerContextFactory.getContext(), dataMetaClient, replacedFileSlice.get(), tableSchema, indexDefinition, instantTime, props, false);
+      return new CloseableMappingIterator<>(recordKeyAndSecondaryKeyIterator,
+          pair -> createSecondaryIndexRecord(pair.getKey(), pair.getValue(), indexDefinition.getIndexName(), true));
+    });
   }
 
   private static TableFileSystemView.SliceView getSliceView(HoodieWriteConfig config, HoodieTableMetaClient dataMetaClient) {
@@ -287,6 +341,12 @@ public class SecondaryIndexRecordGenerationUtils {
                                                                                                 boolean allowInflightInstants) throws IOException {
     String secondaryKeyField = indexDefinition.getSourceFieldsKey();
     HoodieSchema requestedSchema = getRequestedSchemaForSecondaryIndex(metaClient, tableSchema, secondaryKeyField);
+    // Files written outside Hudi may carry neither the record key meta field nor record key fields. Their rows are
+    // keyed by the file path relative to the table base path and the row position, the same key the record index uses.
+    boolean hasRecordKeyMetaField = tableSchema.getField(RECORD_KEY_METADATA_FIELD).isPresent();
+    boolean hasRecordKeyFields = metaClient.getTableConfig().getRecordKeyFields().map(fields -> fields.length > 0).orElse(false);
+    Option<String> relativeFilePath = fileSlice.getBaseFile()
+        .map(baseFile -> FSUtils.getRelativePartitionPath(metaClient.getBasePath(), baseFile.getStoragePath()));
     HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>builder()
         .withReaderContext(readerContext)
         .withBaseFileOption(fileSlice.getBaseFile())
@@ -303,6 +363,7 @@ public class SecondaryIndexRecordGenerationUtils {
     return new ClosableIterator<Pair<String, String>>() {
       private final ClosableIterator<T> recordIterator = fileGroupReader.getClosableIterator();
       private Pair<String, String> nextValidRecord;
+      private long rowPosition = 0;
 
       @Override
       public void close() {
@@ -319,15 +380,30 @@ public class SecondaryIndexRecordGenerationUtils {
         while (recordIterator.hasNext()) {
           T record = recordIterator.next();
           Object secondaryKey = readerContext.getRecordContext().getValue(record, requestedSchema, secondaryKeyField);
-            nextValidRecord = Pair.of(
-                readerContext.getRecordContext().getRecordKey(record, requestedSchema),
-                secondaryKey == null ? null : secondaryKey.toString()
-            );
+          nextValidRecord = Pair.of(getRecordKey(record), secondaryKey == null ? null : secondaryKey.toString());
+          rowPosition++;
           return true;
         }
 
         // If no valid records are found
         return false;
+      }
+
+      private String getRecordKey(T record) {
+        Object recordKey;
+        if (hasRecordKeyMetaField) {
+          recordKey = readerContext.getRecordContext().getValue(record, requestedSchema, RECORD_KEY_METADATA_FIELD);
+        } else if (hasRecordKeyFields) {
+          recordKey = readerContext.getRecordContext().getRecordKey(record, requestedSchema);
+        } else {
+          recordKey = null;
+        }
+        if (recordKey != null) {
+          return recordKey.toString();
+        }
+        ValidationUtils.checkArgument(relativeFilePath.isPresent(),
+            "Record key is missing in file group " + fileSlice.getFileId() + " and no base file is available to generate one");
+        return ExternalFilePathUtil.generateRecordKeyForRow(relativeFilePath.get(), rowPosition);
       }
 
       @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -117,7 +118,10 @@ public class SecondaryIndexRecordGenerationUtils {
       // a table without any completed commit, e.g. one that registers files written outside Hudi for the first time,
       // only has the schema of the current commit.
       tableSchema = tryResolveSchemaForTable(dataMetaClient)
-          .orElseGet(() -> HoodieSchema.parse(commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY)));
+          .orElseGet(() -> Option.ofNullable(commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY))
+              .map(HoodieSchema::parse)
+              .orElseThrow(() -> new HoodieException("The table has no completed commit to resolve its schema from and the commit metadata has no "
+                  + HoodieCommitMetadata.SCHEMA_KEY)));
     } catch (Exception e) {
       throw new HoodieException("Failed to get latest schema for " + dataMetaClient.getBasePath(), e);
     }
@@ -207,7 +211,9 @@ public class SecondaryIndexRecordGenerationUtils {
       return records.iterator();
     });
 
-    if (commitMetadata instanceof HoodieReplaceCommitMetadata) {
+    if (commitMetadata instanceof HoodieReplaceCommitMetadata && WriteOperationType.isUnknown(commitMetadata.getOperationType())) {
+      // a replace commit without a known operation type registers files written outside Hudi and drops the replaced
+      // file groups without rewriting their records under the same key
       secondaryIndexRecords = secondaryIndexRecords.union(convertReplacedFileGroupsToSecondaryIndexRecords(
           (HoodieReplaceCommitMetadata) commitMetadata, writeStatsByFileId.keySet(), instantTime, indexDefinition, metadataConfig,
           dataMetaClient, engineContext, writeConfig, tableSchema));
@@ -312,7 +318,8 @@ public class SecondaryIndexRecordGenerationUtils {
     return engineContext.parallelize(fileSlices, parallelism).flatMap(partitionAndBaseFile -> {
       final String partition = partitionAndBaseFile.getPartitionPath();
       final FileSlice fileSlice = partitionAndBaseFile.getFileSlice();
-      Option<StoragePath> dataFilePath = Option.ofNullable(fileSlice.getBaseFile().map(baseFile -> FSUtils.getAbsoluteFilePath(basePath, partition, baseFile.getFileName())).orElseGet(null));
+      // the storage path keeps the directory prefix of a file written outside Hudi, which its file name alone loses
+      Option<StoragePath> dataFilePath = fileSlice.getBaseFile().map(HoodieBaseFile::getStoragePath);
       HoodieSchema readerSchema;
       if (dataFilePath.isPresent()) {
         readerSchema = HoodieIOFactory.getIOFactory(metaClient.getStorage())
@@ -341,12 +348,18 @@ public class SecondaryIndexRecordGenerationUtils {
                                                                                                 boolean allowInflightInstants) throws IOException {
     String secondaryKeyField = indexDefinition.getSourceFieldsKey();
     HoodieSchema requestedSchema = getRequestedSchemaForSecondaryIndex(metaClient, tableSchema, secondaryKeyField);
-    // Files written outside Hudi may carry neither the record key meta field nor record key fields. Their rows are
-    // keyed by the file path relative to the table base path and the row position, the same key the record index uses.
-    boolean hasRecordKeyMetaField = tableSchema.getField(RECORD_KEY_METADATA_FIELD).isPresent();
-    boolean hasRecordKeyFields = metaClient.getTableConfig().getRecordKeyFields().map(fields -> fields.length > 0).orElse(false);
-    Option<String> relativeFilePath = fileSlice.getBaseFile()
-        .map(baseFile -> FSUtils.getRelativePartitionPath(metaClient.getBasePath(), baseFile.getStoragePath()));
+    // a table without record keys, e.g. one that registers files written outside Hudi, keys every row by the path of its
+    // base file relative to the table and the row position, the same key the record index generates from the base file.
+    // The positions of a merged file slice would not line up with the base file, so such a slice must not have log files.
+    boolean generateRecordKeys = !metaClient.getTableConfig().hasRecordKey();
+    if (generateRecordKeys) {
+      ValidationUtils.checkState(fileSlice.getBaseFile().isPresent() && !fileSlice.hasLogFiles(),
+          "File group " + fileSlice.getFileId() + " in partition " + fileSlice.getPartitionPath() + " needs a base file and no log files "
+              + "to key its rows by position, because the table has no record key");
+    }
+    Option<String> relativeFilePath = generateRecordKeys
+        ? Option.of(FSUtils.getRelativePartitionPath(metaClient.getBasePath(), fileSlice.getBaseFile().get().getStoragePath()))
+        : Option.empty();
     HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>builder()
         .withReaderContext(readerContext)
         .withBaseFileOption(fileSlice.getBaseFile())
@@ -390,20 +403,10 @@ public class SecondaryIndexRecordGenerationUtils {
       }
 
       private String getRecordKey(T record) {
-        Object recordKey;
-        if (hasRecordKeyMetaField) {
-          recordKey = readerContext.getRecordContext().getValue(record, requestedSchema, RECORD_KEY_METADATA_FIELD);
-        } else if (hasRecordKeyFields) {
-          recordKey = readerContext.getRecordContext().getRecordKey(record, requestedSchema);
-        } else {
-          recordKey = null;
+        if (relativeFilePath.isPresent()) {
+          return ExternalFilePathUtil.generateRecordKeyForRow(relativeFilePath.get(), rowPosition);
         }
-        if (recordKey != null) {
-          return recordKey.toString();
-        }
-        ValidationUtils.checkArgument(relativeFilePath.isPresent(),
-            "Record key is missing in file group " + fileSlice.getFileId() + " and no base file is available to generate one");
-        return ExternalFilePathUtil.generateRecordKeyForRow(relativeFilePath.get(), rowPosition);
+        return readerContext.getRecordContext().getRecordKey(record, requestedSchema);
       }
 
       @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
@@ -204,7 +204,8 @@ public class SecondaryIndexRecordGenerationUtils {
       return records.iterator();
     });
 
-    if (commitMetadata instanceof HoodieReplaceCommitMetadata && WriteOperationType.isUnknown(commitMetadata.getOperationType())) {
+    if (commitMetadata instanceof HoodieReplaceCommitMetadata && WriteOperationType.isUnknown(commitMetadata.getOperationType())
+        && !dataMetaClient.getTableConfig().hasRecordKey()) {
       // a replace commit without a known operation type registers files written outside Hudi and drops the replaced
       // file groups without rewriting their records under the same key
       secondaryIndexRecords = secondaryIndexRecords.union(convertReplacedFileGroupsToSecondaryIndexRecords(

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
@@ -46,6 +46,7 @@ import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.TableFileSystemView;
 import org.apache.hudi.common.util.ExternalFilePathUtil;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.ClosableIterator;
@@ -58,6 +59,8 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
+
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -79,6 +82,7 @@ import static org.apache.hudi.metadata.HoodieTableMetadataUtil.tryResolveSchemaF
 /**
  * Utility methods for generating secondary index records during initialization and updates.
  */
+@Slf4j
 public class SecondaryIndexRecordGenerationUtils {
 
   /**
@@ -113,18 +117,7 @@ public class SecondaryIndexRecordGenerationUtils {
       throw new HoodieIOException("Secondary index cannot support logs having inserts with current offering. Please disable secondary index.");
     }
 
-    HoodieSchema tableSchema;
-    try {
-      // a table without any completed commit, e.g. one that registers files written outside Hudi for the first time,
-      // only has the schema of the current commit.
-      tableSchema = tryResolveSchemaForTable(dataMetaClient)
-          .orElseGet(() -> Option.ofNullable(commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY))
-              .map(HoodieSchema::parse)
-              .orElseThrow(() -> new HoodieException("The table has no completed commit to resolve its schema from and the commit metadata has no "
-                  + HoodieCommitMetadata.SCHEMA_KEY)));
-    } catch (Exception e) {
-      throw new HoodieException("Failed to get latest schema for " + dataMetaClient.getBasePath(), e);
-    }
+    HoodieSchema tableSchema = resolveTableSchema(dataMetaClient, commitMetadata);
     Map<String, List<HoodieWriteStat>> writeStatsByFileId = allWriteStats.stream().collect(Collectors.groupingBy(HoodieWriteStat::getFileId));
     int parallelism = Math.max(Math.min(writeStatsByFileId.size(), metadataConfig.getSecondaryIndexParallelism()), 1);
 
@@ -228,9 +221,35 @@ public class SecondaryIndexRecordGenerationUtils {
   }
 
   /**
+   * Resolves the schema of the table from its completed commits. A table without any completed commit, e.g. one
+   * that registers files written outside Hudi for the first time, only has the schema of the current commit, which
+   * Hudi stores as an empty string when the commit carries no schema.
+   */
+  private static HoodieSchema resolveTableSchema(HoodieTableMetaClient dataMetaClient, HoodieCommitMetadata commitMetadata) {
+    Option<HoodieSchema> tableSchema;
+    try {
+      tableSchema = tryResolveSchemaForTable(dataMetaClient);
+    } catch (Exception e) {
+      throw new HoodieException("Failed to get latest schema for " + dataMetaClient.getBasePath(), e);
+    }
+    if (tableSchema.isPresent()) {
+      return tableSchema.get();
+    }
+    String commitSchema = commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY);
+    if (StringUtils.isNullOrEmpty(commitSchema)) {
+      throw new HoodieException("Table " + dataMetaClient.getBasePath() + " has no completed commit to resolve its schema from and the commit "
+          + "metadata carries no " + HoodieCommitMetadata.SCHEMA_KEY);
+    }
+    return HoodieSchema.parse(commitSchema);
+  }
+
+  /**
    * Generates delete records for every record of the file groups that the given replace commit replaces without
-   * writing to them again, e.g. files written outside Hudi that are superseded by newer files. Records that the same
-   * commit writes again are kept by {@link HoodieTableMetadataUtil#reduceByKeys}, which prefers the non-deleted record.
+   * writing to them again, e.g. files written outside Hudi that are superseded by newer files. A file group that
+   * the same commit writes again is skipped, because its rewritten records reach the index through the write stats.
+   * A keyed table that takes this path can delete and insert the same key in one commit when a record moves
+   * between file groups; {@link HoodieTableMetadataUtil#reduceByKeys} then prefers the non-deleted record.
+   * A table without record keys never writes a file group it replaces, because the record index rejects such a commit.
    */
   private static <T> HoodieData<HoodieRecord> convertReplacedFileGroupsToSecondaryIndexRecords(HoodieReplaceCommitMetadata replaceCommitMetadata,
                                                                                                Set<String> writtenFileIds,
@@ -256,6 +275,8 @@ public class SecondaryIndexRecordGenerationUtils {
       Option<FileSlice> replacedFileSlice = getSliceView(writeConfig, dataMetaClient)
           .getLatestMergedFileSliceBeforeOrOn(partitionAndFileId.getKey(), instantTime, partitionAndFileId.getValue());
       if (!replacedFileSlice.isPresent()) {
+        log.warn("Replaced file group {} in partition {} has no file slice to read the secondary keys to delete from",
+            partitionAndFileId.getValue(), partitionAndFileId.getKey());
         return Collections.<HoodieRecord>emptyIterator();
       }
       ClosableIterator<Pair<String, String>> recordKeyAndSecondaryKeyIterator = createSecondaryIndexRecordGenerator(
@@ -305,34 +326,30 @@ public class SecondaryIndexRecordGenerationUtils {
       return engineContext.emptyHoodieData();
     }
     final int parallelism = Math.min(fileSlices.size(), secondaryIndexMaxParallelism);
-    final StoragePath basePath = metaClient.getBasePath();
-    HoodieSchema tableSchema;
-    try {
-      tableSchema = new TableSchemaResolver(metaClient).getTableSchema();
-    } catch (Exception e) {
-      throw new HoodieException("Failed to get latest schema for " + metaClient.getBasePath(), e);
-    }
     ReaderContextFactory<T> readerContextFactory = engineContext.getReaderContextFactory(metaClient);
     engineContext.setJobStatus(activeModule, "Secondary Index: reading secondary keys from " + fileSlices.size() + " file slices");
     HoodieFileFormat baseFileFormat = metaClient.getTableConfig().getBaseFileFormat();
     return engineContext.parallelize(fileSlices, parallelism).flatMap(partitionAndBaseFile -> {
-      final String partition = partitionAndBaseFile.getPartitionPath();
       final FileSlice fileSlice = partitionAndBaseFile.getFileSlice();
       // the storage path keeps the directory prefix of a file written outside Hudi, which its file name alone loses
       Option<StoragePath> dataFilePath = fileSlice.getBaseFile().map(HoodieBaseFile::getStoragePath);
-      HoodieSchema readerSchema;
-      if (dataFilePath.isPresent()) {
-        readerSchema = HoodieIOFactory.getIOFactory(metaClient.getStorage())
-            .getFileFormatUtils(baseFileFormat)
-            .readSchema(metaClient.getStorage(), dataFilePath.get());
-      } else {
-        readerSchema = tableSchema;
-      }
+      // a file slice without a base file has only log files, whose schema is the table schema
+      HoodieSchema readerSchema = dataFilePath.isPresent()
+          ? HoodieIOFactory.getIOFactory(metaClient.getStorage()).getFileFormatUtils(baseFileFormat).readSchema(metaClient.getStorage(), dataFilePath.get())
+          : resolveTableSchema(metaClient);
       ClosableIterator<Pair<String, String>> secondaryIndexGenerator = createSecondaryIndexRecordGenerator(
           readerContextFactory.getContext(), metaClient, fileSlice, readerSchema, indexDefinition,
           metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().map(HoodieInstant::requestedTime).orElse(""), props, false);
       return new CloseableMappingIterator<>(secondaryIndexGenerator, pair -> createSecondaryIndexRecord(pair.getKey(), pair.getValue(), indexDefinition.getIndexName(), false));
     });
+  }
+
+  private static HoodieSchema resolveTableSchema(HoodieTableMetaClient metaClient) {
+    try {
+      return new TableSchemaResolver(metaClient).getTableSchema();
+    } catch (Exception e) {
+      throw new HoodieException("Failed to get latest schema for " + metaClient.getBasePath(), e);
+    }
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/BaseIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/BaseIndexer.java
@@ -21,9 +21,7 @@ package org.apache.hudi.metadata.index;
 
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
-import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
@@ -33,8 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
 import java.util.List;
-
-import static org.apache.hudi.common.util.ValidationUtils.checkState;
 
 /**
  * Base implementation of {@link Indexer} that handles common metadata-partition bootstrap flow,
@@ -74,16 +70,5 @@ public abstract class BaseIndexer implements Indexer {
   @Override
   public List<IndexPartitionAndRecords> buildRestore(IndexRestoreContext context) {
     return Collections.emptyList();
-  }
-
-  /**
-   * Fails when a clustering commit reaches a table without record keys. The record index and the secondary index
-   * key the rows of such a table by file path and row position, and clustering rewrites the rows into new files,
-   * so neither index could follow them. Every other operation type either keeps the keys or registers new files.
-   */
-  protected void checkClusteringKeepsRecordKeys(HoodieCommitMetadata commitMetadata) {
-    checkState(commitMetadata.getOperationType() != WriteOperationType.CLUSTER || dataTableMetaClient.getTableConfig().hasRecordKey(),
-        "Table " + dataTableMetaClient.getBasePath() + " cannot be clustered because it has no record key: the record index and the "
-            + "secondary index key its rows by file path and row position, which clustering changes");
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/BaseIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/BaseIndexer.java
@@ -21,7 +21,9 @@ package org.apache.hudi.metadata.index;
 
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
@@ -31,6 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
 import java.util.List;
+
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
 
 /**
  * Base implementation of {@link Indexer} that handles common metadata-partition bootstrap flow,
@@ -70,5 +74,16 @@ public abstract class BaseIndexer implements Indexer {
   @Override
   public List<IndexPartitionAndRecords> buildRestore(IndexRestoreContext context) {
     return Collections.emptyList();
+  }
+
+  /**
+   * Fails when a clustering commit reaches a table without record keys. The record index and the secondary index
+   * key the rows of such a table by file path and row position, and clustering rewrites the rows into new files,
+   * so neither index could follow them. Every other operation type either keeps the keys or registers new files.
+   */
+  protected void checkClusteringKeepsRecordKeys(HoodieCommitMetadata commitMetadata) {
+    checkState(commitMetadata.getOperationType() != WriteOperationType.CLUSTER || dataTableMetaClient.getTableConfig().hasRecordKey(),
+        "Table " + dataTableMetaClient.getBasePath() + " cannot be clustered because it has no record key: the record index and the "
+            + "secondary index key its rows by file path and row position, which clustering changes");
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/partitionstats/PartitionStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/partitionstats/PartitionStatsIndexer.java
@@ -114,7 +114,7 @@ public class PartitionStatsIndexer extends BaseIndexer {
     checkState(MetadataPartitionType.COLUMN_STATS.isMetadataPartitionAvailable(dataTableMetaClient),
         "Column stats partition must be enabled to generate partition stats. Please enable: " + HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key());
     // Generate Hoodie Pair data of partition name and list of column range metadata for all the files in that partition
-    boolean isDeletePartition = context.commitMetadata().getOperationType().equals(WriteOperationType.DELETE_PARTITION);
+    boolean isDeletePartition = WriteOperationType.DELETE_PARTITION.equals(context.commitMetadata().getOperationType());
     final HoodieData<HoodieRecord> records = convertMetadataToPartitionStatsRecords(
         context.commitMetadata(), context.instantTime(), engineContext, dataTableWriteConfig,
         dataTableMetaClient, context.tableMetadata(), dataTableWriteConfig.getMetadataConfig(),

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
@@ -53,6 +53,7 @@ import org.apache.hudi.common.util.Lazy;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -144,8 +145,9 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
 
   @Override
   public List<IndexPartitionAndRecords> buildUpdate(IndexUpdateContext context) {
+    checkClusteringKeepsRecordKeys(context.commitMetadata());
     HoodieData<HoodieRecord> updatesFromWriteStatuses = convertMetadataToRecordIndexRecords(engineContext, context.commitMetadata(),
-        dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient, dataTableWriteConfig.getWritesFileIdEncoding(), context.instantTime());
+        dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient, getFileIdEncoding(dataTableMetaClient, dataTableWriteConfig), context.instantTime());
     HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpserts(updatesFromWriteStatuses, context.commitMetadata(), context.lazyFileSystemView());
     return Collections.singletonList(IndexPartitionAndRecords.of(RECORD_INDEX.getPartitionPath(), updatesFromWriteStatuses.union(additionalUpdates)));
   }
@@ -263,7 +265,7 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
     // a table without record keys, e.g. one that registers files written outside Hudi, keys every row by the path of
     // its base file relative to the table and the row position, the same way the record index update path does
     final boolean generateRecordKeys = !metaClient.getTableConfig().hasRecordKey();
-    final int fileIdEncoding = dataWriteConfig.getWritesFileIdEncoding();
+    final int fileIdEncoding = getFileIdEncoding(metaClient, dataWriteConfig);
     ReaderContextFactory<T> readerContextFactory = engineContext.getReaderContextFactory(metaClient);
     return engineContext.parallelize(fileSlices, parallelism).flatMap(partitionAndFileSlice -> {
       final String partition = partitionAndFileSlice.getPartitionPath();
@@ -276,12 +278,11 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
                 + "position, because the table has no record key");
         StoragePath dataFilePath = fileSlice.getBaseFile().get().getStoragePath();
         HoodieStorage storage = metaClient.getStorage();
-        Set<String> recordKeys = HoodieIOFactory.getIOFactory(storage)
+        ClosableIterator<String> recordKeys = HoodieIOFactory.getIOFactory(storage)
             .getFileFormatUtils(metaClient.getTableConfig().getBaseFileFormat())
-            .readRowKeys(storage, dataFilePath, metaClient.getBasePath());
-        return recordKeys.stream()
-            .map(recordKey -> (HoodieRecord) HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partition, fileId, baseFileInstantTimeMillis, fileIdEncoding))
-            .iterator();
+            .getRowKeyIterator(storage, dataFilePath, metaClient.getBasePath());
+        return new CloseableMappingIterator<>(recordKeys,
+            recordKey -> HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partition, fileId, baseFileInstantTimeMillis, fileIdEncoding));
       }
       HoodieReaderContext<T> readerContext = readerContextFactory.getContext();
       HoodieSchema dataSchema = resolveDataSchemaForRLIBootstrap(metaClient, dataWriteConfig);
@@ -328,6 +329,17 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
       }
     }
     return HoodieSchemaCache.intern(HoodieSchemaUtils.addMetadataFields(rawSchema, dataWriteConfig.allowOperationMetadataField()));
+  }
+
+  /**
+   * Returns the encoding of the file ids stored in the record index. The file ids of a table without record keys are
+   * the names of its files, which were written by another system and are not UUIDs, so they are stored as raw strings
+   * whatever the write config says. The record index stores the encoding with every record.
+   */
+  static int getFileIdEncoding(HoodieTableMetaClient metaClient, HoodieWriteConfig dataWriteConfig) {
+    return metaClient.getTableConfig().hasRecordKey()
+        ? dataWriteConfig.getWritesFileIdEncoding()
+        : HoodieMetadataPayload.RECORD_INDEX_FIELD_FILEID_ENCODING_RAW_STRING;
   }
 
   protected int estimateFileGroupCount(HoodieData<HoodieRecord> records) {
@@ -504,7 +516,11 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
       // a replace commit without a known operation type registers files written outside Hudi. The replaced file groups
       // are dropped without their records being rewritten under the same key, so the records of the replaced base files
       // are deleted from RLI unless this commit wrote the same key again.
-      HoodiePairData<HoodieKey, HoodieRecord> replacedRecordsByKey = getRecordIndexReplacedFileGroupRecords((HoodieReplaceCommitMetadata) commitMetadata, fsView)
+      HoodieReplaceCommitMetadata replaceCommitMetadata = (HoodieReplaceCommitMetadata) commitMetadata;
+      if (!dataTableMetaClient.getTableConfig().hasRecordKey()) {
+        checkReplacedFileGroupsAreNotWritten(replaceCommitMetadata);
+      }
+      HoodiePairData<HoodieKey, HoodieRecord> replacedRecordsByKey = getRecordIndexReplacedFileGroupRecords(replaceCommitMetadata, fsView)
           .mapToPair(record -> Pair.of(record.getKey(), record));
       HoodiePairData<HoodieKey, HoodieRecord> writtenRecordsByKey = updatesFromWriteStatuses
           .mapToPair(record -> Pair.of(record.getKey(), record));
@@ -518,15 +534,38 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
   }
 
   /**
+   * Fails when the given commit writes a file group it replaces. For a table without record keys, the file id of a
+   * file is its path below the partition, so such a commit registers a file again under its own name: the previous
+   * content is gone, the keys to delete would be read from the new content, and the file system view hides a replaced
+   * file group even when the same commit writes it again. Only a commit that writes other file ids can be indexed.
+   */
+  private void checkReplacedFileGroupsAreNotWritten(HoodieReplaceCommitMetadata replaceCommitMetadata) {
+    replaceCommitMetadata.getPartitionToReplaceFileIds().forEach((partition, replacedFileIds) -> {
+      Set<String> writtenFileIds = replaceCommitMetadata.getPartitionToWriteStats().getOrDefault(partition, Collections.emptyList()).stream()
+          .map(HoodieWriteStat::getFileId).collect(Collectors.toSet());
+      List<String> rewrittenFileIds = replacedFileIds.stream().filter(writtenFileIds::contains).collect(Collectors.toList());
+      checkState(rewrittenFileIds.isEmpty(), "Table " + dataTableMetaClient.getBasePath() + " has no record key, so a commit cannot write the file "
+          + "groups it replaces in partition " + partition + ", because their rows are keyed by file path and position: " + rewrittenFileIds);
+    });
+  }
+
+  /**
    * Reads the record keys of the latest base file of every file group replaced by the given commit and
-   * returns a delete record for each of them.
+   * returns a delete record for each of them. The caller keeps the keys that the same commit writes again.
    */
   private HoodieData<HoodieRecord> getRecordIndexReplacedFileGroupRecords(HoodieReplaceCommitMetadata replaceCommitMetadata, Lazy<HoodieTableFileSystemView> fsView) {
     List<Pair<String, HoodieBaseFile>> replacedBaseFiles = replaceCommitMetadata.getPartitionToReplaceFileIds().entrySet().stream()
         .flatMap(partitionAndFileIds -> partitionAndFileIds.getValue().stream()
-            .map(fileId -> fsView.get().getLatestBaseFile(partitionAndFileIds.getKey(), fileId))
+            .map(fileId -> {
+              Option<HoodieBaseFile> baseFile = fsView.get().getLatestBaseFile(partitionAndFileIds.getKey(), fileId);
+              if (!baseFile.isPresent()) {
+                log.warn("Replaced file group {} in partition {} has no base file to read the record keys to delete from",
+                    fileId, partitionAndFileIds.getKey());
+              }
+              return baseFile.map(file -> Pair.of(partitionAndFileIds.getKey(), file));
+            })
             .filter(Option::isPresent)
-            .map(baseFile -> Pair.of(partitionAndFileIds.getKey(), baseFile.get())))
+            .map(Option::get))
         .collect(Collectors.toList());
     if (replacedBaseFiles.isEmpty()) {
       return engineContext.emptyHoodieData();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
@@ -145,7 +145,6 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
 
   @Override
   public List<IndexPartitionAndRecords> buildUpdate(IndexUpdateContext context) {
-    checkClusteringKeepsRecordKeys(context.commitMetadata());
     HoodieData<HoodieRecord> updatesFromWriteStatuses = convertMetadataToRecordIndexRecords(engineContext, context.commitMetadata(),
         dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient, getFileIdEncoding(dataTableMetaClient, dataTableWriteConfig), context.instantTime());
     HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpserts(updatesFromWriteStatuses, context.commitMetadata(), context.lazyFileSystemView());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
@@ -478,9 +478,46 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
     } else if (operationType == WriteOperationType.DELETE_PARTITION) {
       // all records from the target partition(s) to be deleted from RLI
       return getRecordIndexReplacedRecords((HoodieReplaceCommitMetadata) commitMetadata, fsView);
+    } else if (commitMetadata instanceof HoodieReplaceCommitMetadata && operationType != WriteOperationType.CLUSTER) {
+      // a replace commit that is neither a table service nor an overwrite, e.g. files written outside Hudi being
+      // registered in the table. The replaced file groups are dropped without their records being rewritten under
+      // the same key, so the records of the replaced base files are deleted from RLI unless this commit wrote them again.
+      return getRecordIndexReplacedFileGroupRecords((HoodieReplaceCommitMetadata) commitMetadata, fsView)
+          .mapToPair(r -> Pair.of(r.getKey(), r))
+          .leftOuterJoin(updatesFromWriteStatuses.mapToPair(r -> Pair.of(r.getKey(), r)))
+          .values()
+          .filter(p -> !p.getRight().isPresent())
+          .map(Pair::getLeft);
     } else {
       return engineContext.emptyHoodieData();
     }
+  }
+
+  /**
+   * Reads the record keys of the latest base file of every file group replaced by the given commit and
+   * returns a delete record for each of them.
+   */
+  private HoodieData<HoodieRecord> getRecordIndexReplacedFileGroupRecords(HoodieReplaceCommitMetadata replaceCommitMetadata, Lazy<HoodieTableFileSystemView> fsView) {
+    List<Pair<String, HoodieBaseFile>> replacedBaseFiles = replaceCommitMetadata.getPartitionToReplaceFileIds().entrySet().stream()
+        .flatMap(partitionAndFileIds -> partitionAndFileIds.getValue().stream()
+            .map(fileId -> fsView.get().getLatestBaseFile(partitionAndFileIds.getKey(), fileId))
+            .filter(Option::isPresent)
+            .map(baseFile -> Pair.of(partitionAndFileIds.getKey(), baseFile.get())))
+        .collect(Collectors.toList());
+    if (replacedBaseFiles.isEmpty()) {
+      return engineContext.emptyHoodieData();
+    }
+    String basePath = dataTableMetaClient.getBasePath().toString();
+    StorageConfiguration<?> storageConfiguration = dataTableMetaClient.getStorageConf();
+    boolean isPartitionedRLI = dataTableWriteConfig.getMetadataConfig().isRecordLevelIndexEnabled();
+    int parallelism = Math.min(replacedBaseFiles.size(), dataTableWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism());
+    engineContext.setJobStatus(this.getClass().getSimpleName(), "Record Index: reading record keys from " + replacedBaseFiles.size() + " replaced base files");
+    return engineContext.parallelize(replacedBaseFiles, parallelism).flatMap(partitionAndBaseFile -> {
+      StoragePath dataFilePath = partitionAndBaseFile.getValue().getStoragePath();
+      HoodieStorage storage = HoodieStorageUtils.getStorage(dataFilePath, storageConfiguration);
+      return BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForReplacedBaseFile(
+          basePath, partitionAndBaseFile.getKey(), dataFilePath, storage, isPartitionedRLI);
+    });
   }
 
   private HoodieData<HoodieRecord> getRecordIndexReplacedRecords(HoodieReplaceCommitMetadata replaceCommitMetadata, Lazy<HoodieTableFileSystemView> fsView) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
@@ -22,6 +22,7 @@ package org.apache.hudi.metadata.index.record;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.ReaderContextFactory;
@@ -31,6 +32,7 @@ import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieDeltaWriteStat;
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
@@ -258,11 +260,29 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
 
     engineContext.setJobStatus(activeModule, "Record Index: reading record keys from " + fileSlices.size() + " file slices");
     final int parallelism = Math.min(fileSlices.size(), recordIndexMaxParallelism);
+    // a table without record keys, e.g. one that registers files written outside Hudi, keys every row by the path of
+    // its base file relative to the table and the row position, the same way the record index update path does
+    final boolean generateRecordKeys = !metaClient.getTableConfig().hasRecordKey();
+    final int fileIdEncoding = dataWriteConfig.getWritesFileIdEncoding();
     ReaderContextFactory<T> readerContextFactory = engineContext.getReaderContextFactory(metaClient);
     return engineContext.parallelize(fileSlices, parallelism).flatMap(partitionAndFileSlice -> {
       final String partition = partitionAndFileSlice.getPartitionPath();
       final FileSlice fileSlice = partitionAndFileSlice.getFileSlice();
       final String fileId = fileSlice.getFileId();
+      long baseFileInstantTimeMillis = HoodieMetadataPayload.parseRecordIndexInstantTime(fileSlice.getBaseInstantTime());
+      if (generateRecordKeys) {
+        checkState(fileSlice.getBaseFile().isPresent() && !fileSlice.hasLogFiles(),
+            "File group " + fileId + " in partition " + partition + " needs a base file and no log files to key its rows by "
+                + "position, because the table has no record key");
+        StoragePath dataFilePath = fileSlice.getBaseFile().get().getStoragePath();
+        HoodieStorage storage = metaClient.getStorage();
+        Set<String> recordKeys = HoodieIOFactory.getIOFactory(storage)
+            .getFileFormatUtils(metaClient.getTableConfig().getBaseFileFormat())
+            .readRowKeys(storage, dataFilePath, metaClient.getBasePath());
+        return recordKeys.stream()
+            .map(recordKey -> (HoodieRecord) HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partition, fileId, baseFileInstantTimeMillis, fileIdEncoding))
+            .iterator();
+      }
       HoodieReaderContext<T> readerContext = readerContextFactory.getContext();
       HoodieSchema dataSchema = resolveDataSchemaForRLIBootstrap(metaClient, dataWriteConfig);
       HoodieSchema requestedSchema = metaClient.getTableConfig().populateMetaFields() ? getRecordKeySchema()
@@ -281,11 +301,10 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
           .withShouldUseRecordPosition(false)
           .withProps(metaClient.getTableConfig().getProps())
           .build();
-      long baseFileInstantTimeMillis = HoodieMetadataPayload.parseRecordIndexInstantTime(fileSlice.getBaseInstantTime());
       return new CloseableMappingIterator<>(fileGroupReader.getClosableIterator(), record -> {
         String recordKey = readerContext.getRecordContext().getRecordKey(record, requestedSchema);
         return HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partition, fileId,
-            baseFileInstantTimeMillis, 0);
+            baseFileInstantTimeMillis, fileIdEncoding);
       });
     });
   }
@@ -366,6 +385,8 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
       int parallelism = Math.max(Math.min(writeStatsByFileId.size(), metadataConfig.getRecordIndexMaxParallelism()), 1);
       String basePath = dataTableMetaClient.getBasePath().toString();
       StorageConfiguration storageConfiguration = dataTableMetaClient.getStorageConf();
+      // a table without record keys, e.g. one that registers files written outside Hudi, keys every row by file path and position
+      boolean generateRecordKeys = !dataTableMetaClient.getTableConfig().hasRecordKey();
       Option<HoodieSchema> writerSchemaOpt = HoodieTableMetadataUtil.tryResolveSchemaForTable(dataTableMetaClient);
       Option<HoodieSchema> finalWriterSchemaOpt = writerSchemaOpt;
       ReaderContextFactory<T> readerContextFactory = engineContext.getReaderContextFactory(dataTableMetaClient);
@@ -389,7 +410,8 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
                   .flatMap(writeStat -> {
                     HoodieStorage storage = HoodieStorageUtils.getStorage(new StoragePath(writeStat.getPath()), storageConfiguration);
                     return CollectionUtils.toStream(BaseFileRecordParsingUtils
-                        .generateRLIMetadataHoodieRecordsForBaseFile(basePath, writeStat, writesFileIdEncoding, instantTime, storage, metadataConfig.isRecordLevelIndexEnabled()));
+                        .generateRLIMetadataHoodieRecordsForBaseFile(basePath, writeStat, writesFileIdEncoding, instantTime, storage,
+                            metadataConfig.isRecordLevelIndexEnabled(), generateRecordKeys));
                   })
                   .iterator();
             }
@@ -478,15 +500,17 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
     } else if (operationType == WriteOperationType.DELETE_PARTITION) {
       // all records from the target partition(s) to be deleted from RLI
       return getRecordIndexReplacedRecords((HoodieReplaceCommitMetadata) commitMetadata, fsView);
-    } else if (commitMetadata instanceof HoodieReplaceCommitMetadata && operationType != WriteOperationType.CLUSTER) {
-      // a replace commit that is neither a table service nor an overwrite, e.g. files written outside Hudi being
-      // registered in the table. The replaced file groups are dropped without their records being rewritten under
-      // the same key, so the records of the replaced base files are deleted from RLI unless this commit wrote them again.
-      return getRecordIndexReplacedFileGroupRecords((HoodieReplaceCommitMetadata) commitMetadata, fsView)
-          .mapToPair(r -> Pair.of(r.getKey(), r))
-          .leftOuterJoin(updatesFromWriteStatuses.mapToPair(r -> Pair.of(r.getKey(), r)))
+    } else if (commitMetadata instanceof HoodieReplaceCommitMetadata && WriteOperationType.isUnknown(operationType)) {
+      // a replace commit without a known operation type registers files written outside Hudi. The replaced file groups
+      // are dropped without their records being rewritten under the same key, so the records of the replaced base files
+      // are deleted from RLI unless this commit wrote the same key again.
+      HoodiePairData<HoodieKey, HoodieRecord> replacedRecordsByKey = getRecordIndexReplacedFileGroupRecords((HoodieReplaceCommitMetadata) commitMetadata, fsView)
+          .mapToPair(record -> Pair.of(record.getKey(), record));
+      HoodiePairData<HoodieKey, HoodieRecord> writtenRecordsByKey = updatesFromWriteStatuses
+          .mapToPair(record -> Pair.of(record.getKey(), record));
+      return replacedRecordsByKey.leftOuterJoin(writtenRecordsByKey)
           .values()
-          .filter(p -> !p.getRight().isPresent())
+          .filter(replacedRecordAndRewrite -> !replacedRecordAndRewrite.getRight().isPresent())
           .map(Pair::getLeft);
     } else {
       return engineContext.emptyHoodieData();
@@ -510,13 +534,14 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
     String basePath = dataTableMetaClient.getBasePath().toString();
     StorageConfiguration<?> storageConfiguration = dataTableMetaClient.getStorageConf();
     boolean isPartitionedRLI = dataTableWriteConfig.getMetadataConfig().isRecordLevelIndexEnabled();
+    boolean generateRecordKeys = !dataTableMetaClient.getTableConfig().hasRecordKey();
     int parallelism = Math.min(replacedBaseFiles.size(), dataTableWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism());
     engineContext.setJobStatus(this.getClass().getSimpleName(), "Record Index: reading record keys from " + replacedBaseFiles.size() + " replaced base files");
     return engineContext.parallelize(replacedBaseFiles, parallelism).flatMap(partitionAndBaseFile -> {
       StoragePath dataFilePath = partitionAndBaseFile.getValue().getStoragePath();
       HoodieStorage storage = HoodieStorageUtils.getStorage(dataFilePath, storageConfiguration);
       return BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForReplacedBaseFile(
-          basePath, partitionAndBaseFile.getKey(), dataFilePath, storage, isPartitionedRLI);
+          basePath, partitionAndBaseFile.getKey(), dataFilePath, storage, isPartitionedRLI, generateRecordKeys);
     });
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
@@ -511,14 +511,13 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
     } else if (operationType == WriteOperationType.DELETE_PARTITION) {
       // all records from the target partition(s) to be deleted from RLI
       return getRecordIndexReplacedRecords((HoodieReplaceCommitMetadata) commitMetadata, fsView);
-    } else if (commitMetadata instanceof HoodieReplaceCommitMetadata && WriteOperationType.isUnknown(operationType)) {
+    } else if (commitMetadata instanceof HoodieReplaceCommitMetadata && WriteOperationType.isUnknown(operationType)
+        && !dataTableMetaClient.getTableConfig().hasRecordKey()) {
       // a replace commit without a known operation type registers files written outside Hudi. The replaced file groups
       // are dropped without their records being rewritten under the same key, so the records of the replaced base files
       // are deleted from RLI unless this commit wrote the same key again.
       HoodieReplaceCommitMetadata replaceCommitMetadata = (HoodieReplaceCommitMetadata) commitMetadata;
-      if (!dataTableMetaClient.getTableConfig().hasRecordKey()) {
-        checkReplacedFileGroupsAreNotWritten(replaceCommitMetadata);
-      }
+      checkReplacedFileGroupsAreNotWritten(replaceCommitMetadata);
       HoodiePairData<HoodieKey, HoodieRecord> replacedRecordsByKey = getRecordIndexReplacedFileGroupRecords(replaceCommitMetadata, fsView)
           .mapToPair(record -> Pair.of(record.getKey(), record));
       HoodiePairData<HoodieKey, HoodieRecord> writtenRecordsByKey = updatesFromWriteStatuses

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -144,7 +145,12 @@ public class SecondaryIndexer extends BaseIndexer {
     List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
         .flatMap(Collection::stream).collect(Collectors.toList());
     // Return early if there are no write stats, or if this helper is reached for a table-service operation.
-    if (allWriteStats.isEmpty() || WriteOperationType.isCompactionOrClustering(commitMetadata.getOperationType())) {
+    // A replace commit without a known operation type, e.g. one that only drops files written outside Hudi,
+    // has no write stats but still removes the records of the replaced file groups from the index.
+    boolean dropsReplacedFileGroups = commitMetadata instanceof HoodieReplaceCommitMetadata
+        && WriteOperationType.isUnknown(commitMetadata.getOperationType())
+        && !((HoodieReplaceCommitMetadata) commitMetadata).getPartitionToReplaceFileIds().isEmpty();
+    if ((allWriteStats.isEmpty() && !dropsReplacedFileGroups) || WriteOperationType.isCompactionOrClustering(commitMetadata.getOperationType())) {
       return engineContext.emptyHoodieData();
     }
     HoodieIndexDefinition indexDefinition = HoodieTableMetadataUtil.getHoodieIndexDefinition(indexPartition, dataTableMetaClient);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
@@ -113,7 +113,6 @@ public class SecondaryIndexer extends BaseIndexer {
     if (!SECONDARY_INDEX.isMetadataPartitionAvailable(dataTableMetaClient)) {
       return Collections.emptyList();
     }
-    checkClusteringKeepsRecordKeys(context.commitMetadata());
     // If write operation type based on commit metadata is COMPACT or CLUSTER then no need to update,
     // because these operations do not change the secondary key - record key mapping.
     WriteOperationType operationType = context.commitMetadata().getOperationType();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
@@ -113,6 +113,7 @@ public class SecondaryIndexer extends BaseIndexer {
     if (!SECONDARY_INDEX.isMetadataPartitionAvailable(dataTableMetaClient)) {
       return Collections.emptyList();
     }
+    checkClusteringKeepsRecordKeys(context.commitMetadata());
     // If write operation type based on commit metadata is COMPACT or CLUSTER then no need to update,
     // because these operations do not change the secondary key - record key mapping.
     WriteOperationType operationType = context.commitMetadata().getOperationType();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
@@ -115,7 +115,7 @@ public class SecondaryIndexer extends BaseIndexer {
     // If write operation type based on commit metadata is COMPACT or CLUSTER then no need to update,
     // because these operations do not change the secondary key - record key mapping.
     WriteOperationType operationType = context.commitMetadata().getOperationType();
-    if (operationType.isInsertOverwriteOrDeletePartition()) {
+    if (operationType != null && operationType.isInsertOverwriteOrDeletePartition()) {
       throw new HoodieIndexException(String.format("Can not perform operation %s on secondary index", operationType));
     } else if (operationType == WriteOperationType.COMPACT || operationType == WriteOperationType.CLUSTER) {
       return Collections.emptyList();
@@ -149,6 +149,6 @@ public class SecondaryIndexer extends BaseIndexer {
     }
     HoodieIndexDefinition indexDefinition = HoodieTableMetadataUtil.getHoodieIndexDefinition(indexPartition, dataTableMetaClient);
     return convertWriteStatsToSecondaryIndexRecords(allWriteStats, instantTime, indexDefinition,
-        dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient, engineContext, dataTableWriteConfig);
+        dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient, engineContext, dataTableWriteConfig, commitMetadata);
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
@@ -145,10 +145,11 @@ public class SecondaryIndexer extends BaseIndexer {
     List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
         .flatMap(Collection::stream).collect(Collectors.toList());
     // Return early if there are no write stats, or if this helper is reached for a table-service operation.
-    // A replace commit without a known operation type, e.g. one that only drops files written outside Hudi,
-    // has no write stats but still removes the records of the replaced file groups from the index.
+    // A replace commit without a known operation type on a table without a record key, e.g. one that only drops files
+    // written outside Hudi, has no write stats but still removes the records of the replaced file groups from the index.
     boolean dropsReplacedFileGroups = commitMetadata instanceof HoodieReplaceCommitMetadata
         && WriteOperationType.isUnknown(commitMetadata.getOperationType())
+        && !dataTableMetaClient.getTableConfig().hasRecordKey()
         && !((HoodieReplaceCommitMetadata) commitMetadata).getPartitionToReplaceFileIds().isEmpty();
     if ((allWriteStats.isEmpty() && !dropsReplacedFileGroups) || WriteOperationType.isCompactionOrClustering(commitMetadata.getOperationType())) {
       return engineContext.emptyHoodieData();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RecordBasedIndexingCatchupTask.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RecordBasedIndexingCatchupTask.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
 import org.apache.hudi.table.HoodieTable;
 
@@ -52,8 +53,8 @@ public class RecordBasedIndexingCatchupTask extends AbstractIndexingCatchupTask 
 
   @Override
   public void updateIndexForWriteAction(HoodieInstant instant) throws IOException {
-    HoodieCommitMetadata commitMetadata =
-        metaClient.getActiveTimeline().readCommitMetadata(instant);
+    // a replace commit is read as such, so that the replaced file groups reach the indexes
+    HoodieCommitMetadata commitMetadata = TimelineUtils.getCommitMetadata(instant, metaClient.getActiveTimeline());
     metadataWriter.update(commitMetadata, instant.requestedTime());
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/WriteStatBasedIndexingCatchupTask.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/WriteStatBasedIndexingCatchupTask.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
 import org.apache.hudi.table.HoodieTable;
 
@@ -52,8 +53,8 @@ public class WriteStatBasedIndexingCatchupTask extends AbstractIndexingCatchupTa
 
   @Override
   public void updateIndexForWriteAction(HoodieInstant instant) throws IOException {
-    HoodieCommitMetadata commitMetadata =
-        metaClient.getActiveTimeline().readCommitMetadata(instant);
+    // a replace commit is read as such, so that the replaced file groups reach the indexes
+    HoodieCommitMetadata commitMetadata = TimelineUtils.getCommitMetadata(instant, metaClient.getActiveTimeline());
     metadataWriter.update(commitMetadata, instant.requestedTime());
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
@@ -45,6 +46,7 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.metadata.index.Indexer;
+import org.apache.hudi.storage.StoragePath;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -122,6 +124,62 @@ class TestHoodieBackedTableMetadataWriter {
 
     verify(writeClient).postCommit(instantTime);
     verifyNoMoreInteractions(writeClient);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true", "false"})
+  void rejectsClusteringOfTableWithoutRecordKeysOnBothUpdatePaths(boolean streamingWrite) throws Exception {
+    // the record index and the secondary index key the rows of such a table by file path and position, which
+    // clustering changes, so the check must sit ahead of the streaming and the batch path alike
+    HoodieBackedTableMetadataWriter<List<HoodieRecord>, List<?>> writer = writerForClustering(false, true);
+    HoodieCommitMetadata clusteringMetadata = new HoodieCommitMetadata();
+    clusteringMetadata.setOperationType(WriteOperationType.CLUSTER);
+
+    IllegalStateException clustering = assertThrows(IllegalStateException.class, () -> {
+      if (streamingWrite) {
+        writer.completeStreamingCommit("001", mock(HoodieEngineContext.class), Collections.emptyList(), clusteringMetadata);
+      } else {
+        writer.update(clusteringMetadata, "001");
+      }
+    });
+    assertTrue(clustering.getMessage().contains("cannot be clustered because it has no record key"), clustering.getMessage());
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true,true", "false,false"})
+  void allowsClusteringWhenRecordKeysOrPositionalIndexesAreAbsent(boolean hasRecordKey, boolean recordIndexEnabled) throws Exception {
+    // a table with record keys keeps them through clustering, and a table without a record index or a secondary
+    // index has nothing keyed by position
+    HoodieBackedTableMetadataWriter<List<HoodieRecord>, List<?>> writer = writerForClustering(hasRecordKey, recordIndexEnabled);
+    HoodieCommitMetadata clusteringMetadata = new HoodieCommitMetadata();
+    clusteringMetadata.setOperationType(WriteOperationType.CLUSTER);
+    HoodieTableMetaClient metadataMetaClient = mock(HoodieTableMetaClient.class, RETURNS_DEEP_STUBS);
+    BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
+    when(metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant("001")).thenReturn(true);
+    when(writer.initializeWriteClient()).thenReturn(writeClient);
+    writer.metadataMetaClient = metadataMetaClient;
+
+    writer.completeStreamingCommit("001", mock(HoodieEngineContext.class), Collections.emptyList(), clusteringMetadata);
+
+    verify(writeClient).postCommit("001");
+  }
+
+  private static HoodieBackedTableMetadataWriter<List<HoodieRecord>, List<?>> writerForClustering(boolean hasRecordKey, boolean recordIndexEnabled)
+      throws Exception {
+    HoodieBackedTableMetadataWriter<List<HoodieRecord>, List<?>> writer = mock(HoodieBackedTableMetadataWriter.class, CALLS_REAL_METHODS);
+    HoodieTableMetaClient dataMetaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    when(dataMetaClient.getTableConfig()).thenReturn(tableConfig);
+    when(dataMetaClient.getBasePath()).thenReturn(new StoragePath("/tmp/table"));
+    when(tableConfig.hasRecordKey()).thenReturn(hasRecordKey);
+    when(tableConfig.getMetadataPartitions()).thenReturn(Collections.emptySet());
+    writer.dataMetaClient = dataMetaClient;
+    Map<MetadataPartitionType, Indexer> enabledIndexers = new HashMap<>();
+    if (recordIndexEnabled) {
+      enabledIndexers.put(MetadataPartitionType.RECORD_INDEX, mock(Indexer.class));
+    }
+    setField(writer, "enabledIndexerMap", enabledIndexers);
+    return writer;
   }
 
   @ParameterizedTest

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestSecondaryIndexRecordGenerationUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestSecondaryIndexRecordGenerationUtils.java
@@ -20,8 +20,14 @@
 package org.apache.hudi.metadata;
 
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
@@ -32,13 +38,17 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -92,6 +102,7 @@ class TestSecondaryIndexRecordGenerationUtils {
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
     when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(metaClient.getBasePath()).thenReturn(new StoragePath("/tmp/table"));
     when(tableConfig.getPayloadClass()).thenReturn("org.apache.hudi.common.model.DefaultHoodieRecordPayload");
     HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
     when(metadataConfig.getSecondaryIndexParallelism()).thenReturn(1);
@@ -111,11 +122,39 @@ class TestSecondaryIndexRecordGenerationUtils {
           Collections.emptyList(), "001", null, metadataConfig, metaClient, engineContext, writeConfig, commitMetadataWithSchema)
           .collectAsList().isEmpty());
 
-      // without a schema in the commit metadata the failure names the missing key
+      // Hudi stores an empty schema in the commit metadata when the commit carries none; the failure names the key
+      HoodieCommitMetadata commitMetadataWithoutSchema = new HoodieCommitMetadata();
+      commitMetadataWithoutSchema.addMetadata(HoodieCommitMetadata.SCHEMA_KEY, "");
       HoodieException missingSchema = assertThrows(HoodieException.class,
           () -> SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords(
-              Collections.emptyList(), "001", null, metadataConfig, metaClient, engineContext, writeConfig, new HoodieCommitMetadata()));
-      assertTrue(missingSchema.getCause().getMessage().contains(HoodieCommitMetadata.SCHEMA_KEY), missingSchema.getCause().getMessage());
+              Collections.emptyList(), "001", null, metadataConfig, metaClient, engineContext, writeConfig, commitMetadataWithoutSchema));
+      assertEquals("Table /tmp/table has no completed commit to resolve its schema from and the commit metadata carries no schema",
+          missingSchema.getMessage());
     }
+  }
+
+  @Test
+  void rejectsLogFilesOnTableWithoutRecordKeys() {
+    // the rows of such a table are keyed by their position in the base file, which the rows of a merged file slice
+    // would not line up with
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.hasRecordKey()).thenReturn(false);
+    when(tableConfig.getRecordKeyFields()).thenReturn(Option.empty());
+    HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
+    when(indexDefinition.getSourceFieldsKey()).thenReturn("name");
+    HoodieSchema schema = HoodieSchema.createRecord("external", null, null, false, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)),
+        HoodieSchemaField.of("name", HoodieSchema.create(HoodieSchemaType.STRING))));
+    FileSlice fileSlice = new FileSlice("p1", "001", "file1");
+    fileSlice.setBaseFile(new HoodieBaseFile(new StoragePathInfo(
+        new StoragePath("/tmp/table/p1/file1_001_hudiext"), 100L, false, (short) 0, 0L, 0L)));
+    fileSlice.addLogFile(new HoodieLogFile(new StoragePath("/tmp/table/p1/.file1_001.log.1_0-0-0")));
+
+    IllegalStateException logFiles = assertThrows(IllegalStateException.class,
+        () -> SecondaryIndexRecordGenerationUtils.getRecordKeyToSecondaryKey(
+            metaClient, mock(HoodieReaderContext.class), fileSlice, schema, indexDefinition, "001", new TypedProperties(), false));
+    assertTrue(logFiles.getMessage().contains("needs a base file and no log files"), logFiles.getMessage());
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestSecondaryIndexRecordGenerationUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestSecondaryIndexRecordGenerationUtils.java
@@ -19,8 +19,16 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
@@ -30,10 +38,16 @@ import org.mockito.MockedStatic;
 
 import java.util.Collections;
 
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests validation and error propagation before secondary-index record generation.
@@ -68,6 +82,40 @@ class TestSecondaryIndexRecordGenerationUtils {
       assertThrows(HoodieException.class,
           () -> SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords(
               Collections.emptyList(), "001", null, null, metaClient, null, writeConfig, null));
+    }
+  }
+
+  @Test
+  void fallsBackToTheCommitSchemaWhenTheTableHasNoCompletedCommit() {
+    // The first commit of a table that registers files written outside Hudi has no completed commit to resolve
+    // the table schema from, so the schema of the commit itself is used.
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getPayloadClass()).thenReturn("org.apache.hudi.common.model.DefaultHoodieRecordPayload");
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    when(metadataConfig.getSecondaryIndexParallelism()).thenReturn(1);
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath("/tmp/table").build();
+    HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieSchema schema = HoodieSchema.createRecord("external", null, null, false, Collections.singletonList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT))));
+
+    try (MockedStatic<HoodieTableMetadataUtil> metadataUtil = mockStatic(HoodieTableMetadataUtil.class, CALLS_REAL_METHODS)) {
+      metadataUtil.when(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(metaClient)).thenReturn(Option.empty());
+      metadataUtil.when(() -> HoodieTableMetadataUtil.reduceByKeys(any(), anyInt(), anyBoolean()))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      HoodieCommitMetadata commitMetadataWithSchema = new HoodieCommitMetadata();
+      commitMetadataWithSchema.addMetadata(HoodieCommitMetadata.SCHEMA_KEY, schema.toString());
+      assertTrue(SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords(
+          Collections.emptyList(), "001", null, metadataConfig, metaClient, engineContext, writeConfig, commitMetadataWithSchema)
+          .collectAsList().isEmpty());
+
+      // without a schema in the commit metadata the failure names the missing key
+      HoodieException missingSchema = assertThrows(HoodieException.class,
+          () -> SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords(
+              Collections.emptyList(), "001", null, metadataConfig, metaClient, engineContext, writeConfig, new HoodieCommitMetadata()));
+      assertTrue(missingSchema.getCause().getMessage().contains(HoodieCommitMetadata.SCHEMA_KEY), missingSchema.getCause().getMessage());
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestSecondaryIndexRecordGenerationUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestSecondaryIndexRecordGenerationUtils.java
@@ -51,7 +51,7 @@ class TestSecondaryIndexRecordGenerationUtils {
 
     assertThrows(HoodieIOException.class,
         () -> SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords(
-            Collections.singletonList(writeStat), "001", null, null, null, null, writeConfig));
+            Collections.singletonList(writeStat), "001", null, null, null, null, writeConfig, null));
   }
 
   @Test
@@ -67,7 +67,7 @@ class TestSecondaryIndexRecordGenerationUtils {
 
       assertThrows(HoodieException.class,
           () -> SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords(
-              Collections.emptyList(), "001", null, null, metaClient, null, writeConfig));
+              Collections.emptyList(), "001", null, null, metaClient, null, writeConfig, null));
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/partitionstats/TestPartitionStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/partitionstats/TestPartitionStatsIndexer.java
@@ -32,6 +32,9 @@ import org.apache.hudi.metadata.index.model.IndexUpdateContext;
 import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.MockedStatic;
 
 import java.io.IOException;
@@ -146,9 +149,12 @@ class TestPartitionStatsIndexer {
         new HoodieCommitMetadata())));
   }
 
-  @Test
+  /** A writer may leave the operation type unset, e.g. one that registers files written outside Hudi. */
+  @ParameterizedTest
+  @NullSource
+  @EnumSource(value = WriteOperationType.class, names = "UPSERT")
   @SuppressWarnings("unchecked")
-  void testBuildUpdateWithNonEmptyCommitMetadataProducesPartitionEntry() {
+  void testBuildUpdateWithNonEmptyCommitMetadataProducesPartitionEntry(WriteOperationType operationType) {
     HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
     HoodieEngineContext testDataEngineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
     HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
@@ -164,7 +170,7 @@ class TestPartitionStatsIndexer {
     when(recordMerger.getRecordType()).thenReturn(HoodieRecord.HoodieRecordType.AVRO);
 
     HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
-    commitMetadata.setOperationType(WriteOperationType.UPSERT);
+    commitMetadata.setOperationType(operationType);
     HoodieWriteStat writeStat = new HoodieWriteStat();
     writeStat.setPartitionPath("p1");
     writeStat.setPath("p1/fileid-1_1-0-1_012.parquet");

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestPartitionedRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestPartitionedRecordIndexer.java
@@ -167,6 +167,8 @@ class TestPartitionedRecordIndexer {
     when(metadataConfig.isRecordLevelIndexEnabled()).thenReturn(true);
     when(dataMetaClient.getTableConfig()).thenReturn(tableConfig);
     when(tableConfig.getBaseFileFormat()).thenReturn(HoodieFileFormat.PARQUET);
+    // the table carries record keys, so none are generated
+    when(tableConfig.hasRecordKey()).thenReturn(true);
     when(dataMetaClient.getBasePath()).thenReturn(new StoragePath("/tmp/hudi-partitioned-record-index-test"));
     doReturn(getDefaultStorageConf()).when(dataMetaClient).getStorageConf();
 
@@ -198,7 +200,7 @@ class TestPartitionedRecordIndexer {
       mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.reduceByKeys(any(), anyInt(), anyBoolean()))
           .thenAnswer(invocation -> invocation.getArgument(0));
       mockedBaseFileParsingUtils.when(() -> BaseFileRecordParsingUtils
-              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean()))
+              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean(), eq(false)))
           .thenReturn(Collections.singletonList(
               HoodieMetadataPayload.createRecordIndexUpdate(
                   "rk1", "p1", fileId, "20240101010101", 0)).iterator());
@@ -217,7 +219,7 @@ class TestPartitionedRecordIndexer {
       assertEquals("p1", payload.getDataPartition());
 
       mockedBaseFileParsingUtils.verify(() -> BaseFileRecordParsingUtils
-          .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), anyInt(), any(), any(), eq(true), anyBoolean()));
+          .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), anyInt(), any(), any(), eq(true), eq(false)));
       mockedMetadataUtil.verify(() -> HoodieTableMetadataUtil
           .reduceByKeys(any(), anyInt(), eq(true)));
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestPartitionedRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestPartitionedRecordIndexer.java
@@ -198,7 +198,7 @@ class TestPartitionedRecordIndexer {
       mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.reduceByKeys(any(), anyInt(), anyBoolean()))
           .thenAnswer(invocation -> invocation.getArgument(0));
       mockedBaseFileParsingUtils.when(() -> BaseFileRecordParsingUtils
-              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean()))
+              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean()))
           .thenReturn(Collections.singletonList(
               HoodieMetadataPayload.createRecordIndexUpdate(
                   "rk1", "p1", fileId, "20240101010101", 0)).iterator());
@@ -217,7 +217,7 @@ class TestPartitionedRecordIndexer {
       assertEquals("p1", payload.getDataPartition());
 
       mockedBaseFileParsingUtils.verify(() -> BaseFileRecordParsingUtils
-          .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), anyInt(), any(), any(), eq(true)));
+          .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), anyInt(), any(), any(), eq(true), anyBoolean()));
       mockedMetadataUtil.verify(() -> HoodieTableMetadataUtil
           .reduceByKeys(any(), anyInt(), eq(true)));
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
@@ -367,25 +367,6 @@ class TestRecordIndexer {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
-  void testBuildUpdateRejectsClusteringOfTableWithoutRecordKeys() {
-    // the rows of such a table are keyed by file path and position, which clustering changes
-    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
-    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
-    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
-    HoodieTableMetaClient metaClient = mockMetaClientForUpdate(writeConfig, tableConfig);
-    when(tableConfig.hasRecordKey()).thenReturn(false);
-    HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
-    commitMetadata.setOperationType(WriteOperationType.CLUSTER);
-    ExposedRecordIndexer indexer = new ExposedRecordIndexer(engineContext, writeConfig, metaClient,
-        new DataPartitionAndRecords(1, Option.empty(), (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData()));
-
-    IllegalStateException clustering = assertThrows(IllegalStateException.class, () -> indexer.buildUpdate(IndexUpdateContext.of(
-        "20240101010103", mock(HoodieBackedTableMetadata.class), Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)), commitMetadata)));
-    assertTrue(clustering.getMessage().contains("cannot be clustered because it has no record key"), clustering.getMessage());
-  }
-
-  @Test
   void testSnapshotKeysOfTableWithoutRecordKeysNeedBaseFileWithoutLogFiles() {
     // the rows of such a table are keyed by their position in the base file, which the rows of a merged file slice
     // would not line up with

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
@@ -75,6 +75,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class TestRecordIndexer {
@@ -327,6 +328,34 @@ class TestRecordIndexer {
     expected.put("p1/file_1.parquet_1", false);
     expected.put("p1/file_1.parquet_0", true);
     assertEquals(expected, recordKeyToIsDeleted);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBuildUpdateKeepsReplacedFileGroupsOfTableWithRecordKeys() {
+    // a table that carries a record key keeps the behaviour it had before external files were supported: a replace
+    // commit without a known operation type leaves the records of the replaced file groups in the index
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieTableMetaClient metaClient = mockMetaClientForUpdate(writeConfig, tableConfig);
+    when(tableConfig.hasRecordKey()).thenReturn(true);
+
+    HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
+    commitMetadata.setOperationType(null);
+    commitMetadata.addReplaceFileId("p1", "file_1.parquet");
+
+    HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData();
+    ExposedRecordIndexer indexer = new ExposedRecordIndexer(
+        engineContext, writeConfig, metaClient, new DataPartitionAndRecords(1, Option.empty(), records));
+
+    HoodieTableFileSystemView fsView = mock(HoodieTableFileSystemView.class);
+    List<IndexPartitionAndRecords> result = indexer.buildUpdate(IndexUpdateContext.of(
+        "20240101010102", mock(HoodieBackedTableMetadata.class), Lazy.lazily(() -> fsView), commitMetadata));
+
+    assertEquals(1, result.size());
+    assertTrue(result.get(0).indexRecords().collectAsList().isEmpty());
+    verifyNoInteractions(fsView);
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
@@ -19,7 +19,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
-import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -39,6 +38,7 @@ import org.apache.hudi.metadata.index.model.IndexInitializationPlan;
 import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexUpdateContext;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 
@@ -172,21 +172,29 @@ class TestRecordIndexer {
     assertEquals(0, result.get(0).indexRecords().collectAsList().size());
   }
 
-  @Test
-  @SuppressWarnings("unchecked")
-  void testBuildUpdateWithNonEmptyCommitMetadataProducesPartitionEntry() {
-    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
-    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+  /**
+   * Mocks a parquet table at {@code /tmp/hudi-record-index-test} whose record index is updated with a parallelism of 4.
+   */
+  private static HoodieTableMetaClient mockMetaClientForUpdate(HoodieWriteConfig writeConfig, HoodieTableConfig tableConfig) {
     HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
-    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
-
     when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
     when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(4);
     when(metaClient.getTableConfig()).thenReturn(tableConfig);
     when(tableConfig.getBaseFileFormat()).thenReturn(HoodieFileFormat.PARQUET);
     when(metaClient.getBasePath()).thenReturn(new StoragePath("/tmp/hudi-record-index-test"));
-    when(metaClient.getStorageConf()).thenReturn((org.apache.hudi.storage.StorageConfiguration) getDefaultStorageConf());
+    when(metaClient.getStorageConf()).thenReturn((StorageConfiguration) getDefaultStorageConf());
+    return metaClient;
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBuildUpdateWithNonEmptyCommitMetadataProducesPartitionEntry() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieTableMetaClient metaClient = mockMetaClientForUpdate(writeConfig, tableConfig);
+    when(tableConfig.hasRecordKey()).thenReturn(true);
 
     HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData();
     ExposedRecordIndexer indexer = new ExposedRecordIndexer(
@@ -213,8 +221,9 @@ class TestRecordIndexer {
           .thenReturn(Option.empty());
       mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.reduceByKeys(any(), anyInt(), anyBoolean()))
           .thenAnswer(invocation -> invocation.getArgument(0));
+      // the table carries record keys, so none are generated
       mockedBaseFileParsingUtils.when(() -> BaseFileRecordParsingUtils
-              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean()))
+              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean(), eq(false)))
           .thenReturn(Collections.singletonList(
               HoodieMetadataPayload.createRecordIndexUpdate(
                   "rk1", "p1", fileID, "20240101010101", 0)).iterator());
@@ -241,21 +250,15 @@ class TestRecordIndexer {
   @Test
   @SuppressWarnings("unchecked")
   void testBuildUpdateDeletesRecordsOfFileGroupsReplacedByExternalWriter() {
-    // files written outside Hudi are registered through replace commits with an unknown operation type. The records of the
+    // files written outside Hudi are registered through replace commits without a known operation type. The records of the
     // replaced file groups leave the index unless the same key is written again in the commit.
     HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
     HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
-    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
-    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieTableMetaClient metaClient = mockMetaClientForUpdate(writeConfig, tableConfig);
     HoodieTableFileSystemView fsView = mock(HoodieTableFileSystemView.class);
-
-    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
-    when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(4);
-    when(metaClient.getTableConfig()).thenReturn(tableConfig);
-    when(tableConfig.getBaseFileFormat()).thenReturn(HoodieFileFormat.PARQUET);
-    when(metaClient.getBasePath()).thenReturn(new StoragePath("/tmp/hudi-record-index-test"));
-    when(metaClient.getStorageConf()).thenReturn((org.apache.hudi.storage.StorageConfiguration) getDefaultStorageConf());
+    // such a table has no record key, so every row is keyed by file path and position
+    when(tableConfig.hasRecordKey()).thenReturn(false);
     // file ids of external files are file names, not UUIDs, so they are stored as raw strings
     when(writeConfig.getWritesFileIdEncoding()).thenReturn(1);
     HoodieBaseFile replacedBaseFile = new HoodieBaseFile(new StoragePathInfo(
@@ -263,7 +266,8 @@ class TestRecordIndexer {
     when(fsView.getLatestBaseFile("p1", "file_1.parquet")).thenReturn(Option.of(replacedBaseFile));
 
     HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
-    commitMetadata.setOperationType(WriteOperationType.UNKNOWN);
+    // a fresh HoodieCommitMetadata carries UNKNOWN; a writer may also leave the operation type null
+    commitMetadata.setOperationType(null);
     commitMetadata.addReplaceFileId("p1", "file_1.parquet");
     HoodieWriteStat writeStat = new HoodieWriteStat();
     writeStat.setPartitionPath("p1");
@@ -285,12 +289,12 @@ class TestRecordIndexer {
           .thenAnswer(invocation -> invocation.getArgument(0));
       // the new file carries one new key and rewrites one key of the replaced file
       mockedBaseFileParsingUtils.when(() -> BaseFileRecordParsingUtils
-              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean()))
+              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean(), eq(true)))
           .thenReturn(Arrays.asList(
               HoodieMetadataPayload.createRecordIndexUpdate("p1/file_2.parquet_0", "p1", "file_2.parquet", "20240101010102", 1),
               HoodieMetadataPayload.createRecordIndexUpdate("p1/file_1.parquet_1", "p1", "file_2.parquet", "20240101010102", 1)).iterator());
       mockedBaseFileParsingUtils.when(() -> BaseFileRecordParsingUtils
-              .generateRLIMetadataHoodieRecordsForReplacedBaseFile(any(), any(), any(), any(), anyBoolean()))
+              .generateRLIMetadataHoodieRecordsForReplacedBaseFile(any(), any(), any(), any(), anyBoolean(), eq(true)))
           .thenReturn(Arrays.asList(
               HoodieMetadataPayload.createRecordIndexDelete("p1/file_1.parquet_0", "p1", false),
               HoodieMetadataPayload.createRecordIndexDelete("p1/file_1.parquet_1", "p1", false)).iterator());
@@ -300,9 +304,9 @@ class TestRecordIndexer {
       assertEquals(1, result.size());
       indexRecords = result.get(0).indexRecords().collectAsList();
 
-      // the replaced file is read from its location on storage, without the external file marker
+      // the replaced file is read from its location on storage, without the external file marker, with generated keys
       mockedBaseFileParsingUtils.verify(() -> BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForReplacedBaseFile(
-          eq("/tmp/hudi-record-index-test"), eq("p1"), eq(new StoragePath("/tmp/hudi-record-index-test/p1/file_1.parquet")), any(), eq(false)));
+          eq("/tmp/hudi-record-index-test"), eq("p1"), eq(new StoragePath("/tmp/hudi-record-index-test/p1/file_1.parquet")), any(), eq(false), eq(true)));
     }
 
     Map<String, Boolean> recordKeyToIsDeleted = indexRecords.stream()

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
@@ -12,20 +12,27 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
+import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.ExternalFilePathUtil;
 import org.apache.hudi.common.util.Lazy;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metadata.BaseFileRecordParsingUtils;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
@@ -54,9 +61,11 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -153,9 +162,12 @@ class TestRecordIndexer {
     HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
     HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
 
     when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
     when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(4);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.hasRecordKey()).thenReturn(true);
 
     HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData();
     ExposedRecordIndexer indexer = new ExposedRecordIndexer(
@@ -257,10 +269,9 @@ class TestRecordIndexer {
     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
     HoodieTableMetaClient metaClient = mockMetaClientForUpdate(writeConfig, tableConfig);
     HoodieTableFileSystemView fsView = mock(HoodieTableFileSystemView.class);
-    // such a table has no record key, so every row is keyed by file path and position
+    // such a table has no record key, so every row is keyed by file path and position, and the file ids, which are
+    // file names rather than UUIDs, are stored as raw strings whatever the write config says
     when(tableConfig.hasRecordKey()).thenReturn(false);
-    // file ids of external files are file names, not UUIDs, so they are stored as raw strings
-    when(writeConfig.getWritesFileIdEncoding()).thenReturn(1);
     HoodieBaseFile replacedBaseFile = new HoodieBaseFile(new StoragePathInfo(
         new StoragePath("/tmp/hudi-record-index-test/p1/file_1.parquet_20240101010101_hudiext"), 100L, false, (short) 0, 0L, 0L));
     when(fsView.getLatestBaseFile("p1", "file_1.parquet")).thenReturn(Option.of(replacedBaseFile));
@@ -316,6 +327,89 @@ class TestRecordIndexer {
     expected.put("p1/file_1.parquet_1", false);
     expected.put("p1/file_1.parquet_0", true);
     assertEquals(expected, recordKeyToIsDeleted);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBuildUpdateRejectsWritingReplacedFileGroupsOfTableWithoutRecordKeys() {
+    // the file id of such a table is the file path, so writing a replaced file group registers a file again under its
+    // own name: the replaced content is gone and the file system view hides the file group
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieTableMetaClient metaClient = mockMetaClientForUpdate(writeConfig, tableConfig);
+    when(tableConfig.hasRecordKey()).thenReturn(false);
+    HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.UNKNOWN);
+    commitMetadata.addReplaceFileId("p1", "file_1.parquet");
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setPartitionPath("p1");
+    writeStat.setPath("p1/" + ExternalFilePathUtil.appendCommitTimeAndExternalFileMarker("file_1.parquet", "20240101010102"));
+    writeStat.setFileId("file_1.parquet");
+    writeStat.setNumInserts(1);
+    commitMetadata.addWriteStat("p1", writeStat);
+    ExposedRecordIndexer indexer = new ExposedRecordIndexer(engineContext, writeConfig, metaClient,
+        new DataPartitionAndRecords(1, Option.empty(), (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData()));
+
+    try (MockedStatic<BaseFileRecordParsingUtils> mockedBaseFileParsingUtils = mockStatic(BaseFileRecordParsingUtils.class);
+         MockedStatic<HoodieTableMetadataUtil> mockedMetadataUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(any())).thenReturn(Option.empty());
+      mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.reduceByKeys(any(), anyInt(), anyBoolean()))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+      mockedBaseFileParsingUtils.when(() -> BaseFileRecordParsingUtils
+              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean(), eq(true)))
+          .thenReturn(Collections.emptyIterator());
+
+      IllegalStateException rewritten = assertThrows(IllegalStateException.class, () -> indexer.buildUpdate(IndexUpdateContext.of(
+          "20240101010102", mock(HoodieBackedTableMetadata.class), Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)), commitMetadata)));
+      assertTrue(rewritten.getMessage().endsWith("[file_1.parquet]"), rewritten.getMessage());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBuildUpdateRejectsClusteringOfTableWithoutRecordKeys() {
+    // the rows of such a table are keyed by file path and position, which clustering changes
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieTableMetaClient metaClient = mockMetaClientForUpdate(writeConfig, tableConfig);
+    when(tableConfig.hasRecordKey()).thenReturn(false);
+    HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.CLUSTER);
+    ExposedRecordIndexer indexer = new ExposedRecordIndexer(engineContext, writeConfig, metaClient,
+        new DataPartitionAndRecords(1, Option.empty(), (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData()));
+
+    IllegalStateException clustering = assertThrows(IllegalStateException.class, () -> indexer.buildUpdate(IndexUpdateContext.of(
+        "20240101010103", mock(HoodieBackedTableMetadata.class), Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)), commitMetadata)));
+    assertTrue(clustering.getMessage().contains("cannot be clustered because it has no record key"), clustering.getMessage());
+  }
+
+  @Test
+  void testSnapshotKeysOfTableWithoutRecordKeysNeedBaseFileWithoutLogFiles() {
+    // the rows of such a table are keyed by their position in the base file, which the rows of a merged file slice
+    // would not line up with
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieTableMetaClient metaClient = mockMetaClientForUpdate(writeConfig, tableConfig);
+    when(tableConfig.hasRecordKey()).thenReturn(false);
+    HoodieActiveTimeline activeTimeline = mock(HoodieActiveTimeline.class);
+    when(metaClient.getActiveTimeline()).thenReturn(activeTimeline);
+    when(activeTimeline.getCommitsTimeline()).thenReturn(activeTimeline);
+    when(activeTimeline.filterCompletedInstants()).thenReturn(activeTimeline);
+    when(activeTimeline.lastInstant()).thenReturn(Option.of(
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.REPLACE_COMMIT_ACTION, "20240101010101")));
+    FileSlice fileSlice = new FileSlice("p1", "20240101010101", "file1");
+    fileSlice.setBaseFile(new HoodieBaseFile(new StoragePathInfo(
+        new StoragePath("/tmp/hudi-record-index-test/p1/file1_20240101010101_hudiext"), 100L, false, (short) 0, 0L, 0L)));
+    fileSlice.addLogFile(new HoodieLogFile(new StoragePath("/tmp/hudi-record-index-test/p1/.file1_20240101010101.log.1_0-0-0")));
+
+    // the local engine wraps the failure of the key reading task
+    HoodieException logFiles = assertThrows(HoodieException.class, () -> BaseRecordIndexer.readRecordKeysFromFileSliceSnapshot(
+        engineContext, Collections.singletonList(FileSliceAndPartition.of("p1", fileSlice)), 1, "test", metaClient, writeConfig).collectAsList());
+    assertTrue(logFiles.getCause() instanceof IllegalStateException, String.valueOf(logFiles.getCause()));
+    assertTrue(logFiles.getCause().getMessage().contains("needs a base file and no log files"), logFiles.getCause().getMessage());
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
@@ -11,14 +11,19 @@ import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.ExternalFilePathUtil;
 import org.apache.hudi.common.util.Lazy;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -35,14 +40,19 @@ import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexUpdateContext;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -225,6 +236,82 @@ class TestRecordIndexer {
     HoodieRecordGlobalLocation location = payload.getRecordGlobalLocation();
     assertEquals("p1", location.getPartitionPath());
     assertEquals(fileID, location.getFileId());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBuildUpdateDeletesRecordsOfFileGroupsReplacedByExternalWriter() {
+    // files written outside Hudi are registered through replace commits with an unknown operation type. The records of the
+    // replaced file groups leave the index unless the same key is written again in the commit.
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieTableFileSystemView fsView = mock(HoodieTableFileSystemView.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(4);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getBaseFileFormat()).thenReturn(HoodieFileFormat.PARQUET);
+    when(metaClient.getBasePath()).thenReturn(new StoragePath("/tmp/hudi-record-index-test"));
+    when(metaClient.getStorageConf()).thenReturn((org.apache.hudi.storage.StorageConfiguration) getDefaultStorageConf());
+    // file ids of external files are file names, not UUIDs, so they are stored as raw strings
+    when(writeConfig.getWritesFileIdEncoding()).thenReturn(1);
+    HoodieBaseFile replacedBaseFile = new HoodieBaseFile(new StoragePathInfo(
+        new StoragePath("/tmp/hudi-record-index-test/p1/file_1.parquet_20240101010101_hudiext"), 100L, false, (short) 0, 0L, 0L));
+    when(fsView.getLatestBaseFile("p1", "file_1.parquet")).thenReturn(Option.of(replacedBaseFile));
+
+    HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.UNKNOWN);
+    commitMetadata.addReplaceFileId("p1", "file_1.parquet");
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setPartitionPath("p1");
+    writeStat.setPath("p1/" + ExternalFilePathUtil.appendCommitTimeAndExternalFileMarker("file_2.parquet", "20240101010102"));
+    writeStat.setFileId("file_2.parquet");
+    writeStat.setNumInserts(2);
+    writeStat.setTotalWriteBytes(128L);
+    commitMetadata.addWriteStat("p1", writeStat);
+
+    HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData();
+    ExposedRecordIndexer indexer = new ExposedRecordIndexer(
+        engineContext, writeConfig, metaClient, new DataPartitionAndRecords(1, Option.empty(), records));
+
+    List<HoodieRecord> indexRecords;
+    try (MockedStatic<BaseFileRecordParsingUtils> mockedBaseFileParsingUtils = mockStatic(BaseFileRecordParsingUtils.class);
+         MockedStatic<HoodieTableMetadataUtil> mockedMetadataUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(any())).thenReturn(Option.empty());
+      mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.reduceByKeys(any(), anyInt(), anyBoolean()))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+      // the new file carries one new key and rewrites one key of the replaced file
+      mockedBaseFileParsingUtils.when(() -> BaseFileRecordParsingUtils
+              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean()))
+          .thenReturn(Arrays.asList(
+              HoodieMetadataPayload.createRecordIndexUpdate("p1/file_2.parquet_0", "p1", "file_2.parquet", "20240101010102", 1),
+              HoodieMetadataPayload.createRecordIndexUpdate("p1/file_1.parquet_1", "p1", "file_2.parquet", "20240101010102", 1)).iterator());
+      mockedBaseFileParsingUtils.when(() -> BaseFileRecordParsingUtils
+              .generateRLIMetadataHoodieRecordsForReplacedBaseFile(any(), any(), any(), any(), anyBoolean()))
+          .thenReturn(Arrays.asList(
+              HoodieMetadataPayload.createRecordIndexDelete("p1/file_1.parquet_0", "p1", false),
+              HoodieMetadataPayload.createRecordIndexDelete("p1/file_1.parquet_1", "p1", false)).iterator());
+
+      List<IndexPartitionAndRecords> result = indexer.buildUpdate(IndexUpdateContext.of(
+          "20240101010102", mock(HoodieBackedTableMetadata.class), Lazy.lazily(() -> fsView), commitMetadata));
+      assertEquals(1, result.size());
+      indexRecords = result.get(0).indexRecords().collectAsList();
+
+      // the replaced file is read from its location on storage, without the external file marker
+      mockedBaseFileParsingUtils.verify(() -> BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForReplacedBaseFile(
+          eq("/tmp/hudi-record-index-test"), eq("p1"), eq(new StoragePath("/tmp/hudi-record-index-test/p1/file_1.parquet")), any(), eq(false)));
+    }
+
+    Map<String, Boolean> recordKeyToIsDeleted = indexRecords.stream()
+        .collect(Collectors.toMap(HoodieRecord::getRecordKey, record -> record.getData() instanceof EmptyHoodieRecordPayload));
+    Map<String, Boolean> expected = new HashMap<>();
+    expected.put("p1/file_2.parquet_0", false);
+    expected.put("p1/file_1.parquet_1", false);
+    expected.put("p1/file_1.parquet_0", true);
+    assertEquals(expected, recordKeyToIsDeleted);
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
@@ -36,7 +36,7 @@ import org.apache.hudi.storage.StoragePath;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
 
 import java.io.IOException;
@@ -197,17 +197,18 @@ class TestSecondaryIndexer {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void testBuildUpdateForReplaceCommitFromExternalWriterWithoutWriteStats(boolean dropsFileGroups) {
-    // files written outside Hudi are registered through replace commits without a known operation type. A fresh
-    // HoodieCommitMetadata carries UNKNOWN; a writer may also leave the type null. A commit that only drops files has
-    // no write stats but still removes the records of the replaced file groups from the index; one that drops nothing
-    // and writes nothing leaves the index alone.
+  @CsvSource({"true,false", "false,false", "true,true"})
+  void testBuildUpdateForReplaceCommitFromExternalWriterWithoutWriteStats(boolean dropsFileGroups, boolean hasRecordKey) {
+    // files written outside Hudi are registered through replace commits without a known operation type on a table
+    // without a record key. A fresh HoodieCommitMetadata carries UNKNOWN; a writer may also leave the type null. A
+    // commit that only drops files has no write stats but still removes the records of the replaced file groups from
+    // the index; one that drops nothing and writes nothing, and one on a table with a record key, leave the index alone.
     HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
     HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
     HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
     HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
     HoodieTableMetaClient metaClient = mockMetaClientWithSecondaryIndex(writeConfig, metadataConfig, indexDefinition);
+    when(metaClient.getTableConfig().hasRecordKey()).thenReturn(hasRecordKey);
 
     HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
     commitMetadata.setOperationType(null);
@@ -231,7 +232,8 @@ class TestSecondaryIndexer {
 
       assertEquals(1, result.size());
       assertEquals("secondary_index_idx", result.get(0).indexPartitionName());
-      assertEquals(dropsFileGroups ? deletes.collectAsList() : Collections.emptyList(), result.get(0).indexRecords().collectAsList());
+      assertEquals(dropsFileGroups && !hasRecordKey ? deletes.collectAsList() : Collections.emptyList(),
+          result.get(0).indexRecords().collectAsList());
     }
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
@@ -196,21 +196,6 @@ class TestSecondaryIndexer {
     return metaClient;
   }
 
-  @Test
-  void testBuildUpdateRejectsClusteringOfTableWithoutRecordKeys() {
-    // the rows of such a table are keyed by file path and position, which clustering changes
-    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
-    HoodieTableMetaClient metaClient = mockMetaClientWithSecondaryIndex(writeConfig, mock(HoodieMetadataConfig.class), mock(HoodieIndexDefinition.class));
-    when(metaClient.getTableConfig().hasRecordKey()).thenReturn(false);
-    HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
-    commitMetadata.setOperationType(WriteOperationType.CLUSTER);
-
-    SecondaryIndexer indexer = new SecondaryIndexer(new HoodieLocalEngineContext(getDefaultStorageConf()), writeConfig, metaClient);
-    IllegalStateException clustering = assertThrows(IllegalStateException.class, () -> indexer.buildUpdate(IndexUpdateContext.of(
-        "016", mock(HoodieBackedTableMetadata.class), Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)), commitMetadata)));
-    assertTrue(clustering.getMessage().contains("cannot be clustered because it has no record key"), clustering.getMessage());
-  }
-
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testBuildUpdateForReplaceCommitFromExternalWriterWithoutWriteStats(boolean dropsFileGroups) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
@@ -32,8 +32,11 @@ import org.apache.hudi.metadata.index.model.IndexInitializationContext;
 import org.apache.hudi.metadata.index.model.IndexInitializationPlan;
 import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexUpdateContext;
+import org.apache.hudi.storage.StoragePath;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 
 import java.io.IOException;
@@ -176,30 +179,56 @@ class TestSecondaryIndexer {
         commitMetadata)).isEmpty());
   }
 
-  @Test
-  void testBuildUpdateForReplaceCommitFromExternalWriterWithoutWriteStats() {
-    // files written outside Hudi are registered through replace commits without a known operation type. A fresh
-    // HoodieCommitMetadata carries UNKNOWN; a writer may also leave the type null. A commit that only drops files has
-    // no write stats but still removes the records of the replaced file groups from the index.
-    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
-    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
-    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+  /** Mocks a table with one secondary index partition, {@code secondary_index_idx}, on top of the given write config. */
+  private static HoodieTableMetaClient mockMetaClientWithSecondaryIndex(HoodieWriteConfig writeConfig, HoodieMetadataConfig metadataConfig,
+                                                                       HoodieIndexDefinition indexDefinition) {
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
     HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
-    HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
-
     when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
     when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
     when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(metaClient.getBasePath()).thenReturn(new StoragePath("/tmp/table"));
     when(metaClient.getIndexForMetadataPartition("secondary_index_idx")).thenReturn(Option.of(indexDefinition));
     when(tableConfig.getMetadataPartitions()).thenReturn(Collections.singleton("secondary_index_idx"));
     when(indexMetadata.getIndexDefinitions()).thenReturn(Collections.singletonMap("secondary_index_idx", indexDefinition));
     when(indexDefinition.getIndexName()).thenReturn("secondary_index_idx");
+    return metaClient;
+  }
+
+  @Test
+  void testBuildUpdateRejectsClusteringOfTableWithoutRecordKeys() {
+    // the rows of such a table are keyed by file path and position, which clustering changes
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mockMetaClientWithSecondaryIndex(writeConfig, mock(HoodieMetadataConfig.class), mock(HoodieIndexDefinition.class));
+    when(metaClient.getTableConfig().hasRecordKey()).thenReturn(false);
+    HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.CLUSTER);
+
+    SecondaryIndexer indexer = new SecondaryIndexer(new HoodieLocalEngineContext(getDefaultStorageConf()), writeConfig, metaClient);
+    IllegalStateException clustering = assertThrows(IllegalStateException.class, () -> indexer.buildUpdate(IndexUpdateContext.of(
+        "016", mock(HoodieBackedTableMetadata.class), Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)), commitMetadata)));
+    assertTrue(clustering.getMessage().contains("cannot be clustered because it has no record key"), clustering.getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testBuildUpdateForReplaceCommitFromExternalWriterWithoutWriteStats(boolean dropsFileGroups) {
+    // files written outside Hudi are registered through replace commits without a known operation type. A fresh
+    // HoodieCommitMetadata carries UNKNOWN; a writer may also leave the type null. A commit that only drops files has
+    // no write stats but still removes the records of the replaced file groups from the index; one that drops nothing
+    // and writes nothing leaves the index alone.
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
+    HoodieTableMetaClient metaClient = mockMetaClientWithSecondaryIndex(writeConfig, metadataConfig, indexDefinition);
 
     HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
     commitMetadata.setOperationType(null);
-    commitMetadata.addReplaceFileId("p1", "file_1.parquet");
+    if (dropsFileGroups) {
+      commitMetadata.addReplaceFileId("p1", "file_1.parquet");
+    }
 
     HoodieData<HoodieRecord> deletes = engineContext.parallelize(Collections.singletonList(
         HoodieMetadataPayload.createSecondaryIndexRecord("p1/file_1.parquet_0", "alice", "secondary_index_idx", true)), 1);
@@ -217,7 +246,7 @@ class TestSecondaryIndexer {
 
       assertEquals(1, result.size());
       assertEquals("secondary_index_idx", result.get(0).indexPartitionName());
-      assertEquals(1, result.get(0).indexRecords().collectAsList().size());
+      assertEquals(dropsFileGroups ? deletes.collectAsList() : Collections.emptyList(), result.get(0).indexRecords().collectAsList());
     }
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
@@ -26,9 +26,11 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils;
 import org.apache.hudi.metadata.index.model.IndexCleanContext;
 import org.apache.hudi.metadata.index.model.IndexInitializationContext;
 import org.apache.hudi.metadata.index.model.IndexInitializationPlan;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexUpdateContext;
 
 import org.junit.jupiter.api.Test;
@@ -47,6 +49,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -174,31 +177,48 @@ class TestSecondaryIndexer {
   }
 
   @Test
-  void testBuildUpdateForReplaceCommitFromExternalWriterIsNotRejected() {
-    // files written outside Hudi are registered through replace commits with an unknown operation type
-    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+  void testBuildUpdateForReplaceCommitFromExternalWriterWithoutWriteStats() {
+    // files written outside Hudi are registered through replace commits without a known operation type. A fresh
+    // HoodieCommitMetadata carries UNKNOWN; a writer may also leave the type null. A commit that only drops files has
+    // no write stats but still removes the records of the replaced file groups from the index.
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
     HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
     HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
     HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
 
-    when(metaClient.getIndexMetadata()).thenReturn(org.apache.hudi.common.util.Option.of(indexMetadata));
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
     when(metaClient.getTableConfig()).thenReturn(tableConfig);
-    when(tableConfig.getMetadataPartitions()).thenReturn(Collections.emptySet());
+    when(metaClient.getIndexForMetadataPartition("secondary_index_idx")).thenReturn(Option.of(indexDefinition));
+    when(tableConfig.getMetadataPartitions()).thenReturn(Collections.singleton("secondary_index_idx"));
     when(indexMetadata.getIndexDefinitions()).thenReturn(Collections.singletonMap("secondary_index_idx", indexDefinition));
     when(indexDefinition.getIndexName()).thenReturn("secondary_index_idx");
 
     HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
-    commitMetadata.setOperationType(WriteOperationType.UNKNOWN);
+    commitMetadata.setOperationType(null);
     commitMetadata.addReplaceFileId("p1", "file_1.parquet");
 
-    SecondaryIndexer indexer = new SecondaryIndexer(engineContext, writeConfig, metaClient);
-    assertTrue(indexer.buildUpdate(IndexUpdateContext.of(
-        "016",
-        mock(HoodieBackedTableMetadata.class),
-        Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
-        commitMetadata)).isEmpty());
+    HoodieData<HoodieRecord> deletes = engineContext.parallelize(Collections.singletonList(
+        HoodieMetadataPayload.createSecondaryIndexRecord("p1/file_1.parquet_0", "alice", "secondary_index_idx", true)), 1);
+    try (MockedStatic<SecondaryIndexRecordGenerationUtils> mockedGenerationUtils = mockStatic(SecondaryIndexRecordGenerationUtils.class)) {
+      mockedGenerationUtils.when(() -> SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords(
+              eq(Collections.emptyList()), eq("016"), eq(indexDefinition), eq(metadataConfig), eq(metaClient), eq(engineContext), eq(writeConfig), eq(commitMetadata)))
+          .thenReturn(deletes);
+
+      SecondaryIndexer indexer = new SecondaryIndexer(engineContext, writeConfig, metaClient);
+      List<IndexPartitionAndRecords> result = indexer.buildUpdate(IndexUpdateContext.of(
+          "016",
+          mock(HoodieBackedTableMetadata.class),
+          Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+          commitMetadata));
+
+      assertEquals(1, result.size());
+      assertEquals("secondary_index_idx", result.get(0).indexPartitionName());
+      assertEquals(1, result.get(0).indexRecords().collectAsList().size());
+    }
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
@@ -15,7 +15,9 @@ import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Lazy;
@@ -166,6 +168,34 @@ class TestSecondaryIndexer {
     SecondaryIndexer indexer = new SecondaryIndexer(engineContext, writeConfig, metaClient);
     assertTrue(indexer.buildUpdate(IndexUpdateContext.of(
         "015",
+        mock(HoodieBackedTableMetadata.class),
+        Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+        commitMetadata)).isEmpty());
+  }
+
+  @Test
+  void testBuildUpdateForReplaceCommitFromExternalWriterIsNotRejected() {
+    // files written outside Hudi are registered through replace commits with an unknown operation type
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
+
+    when(metaClient.getIndexMetadata()).thenReturn(org.apache.hudi.common.util.Option.of(indexMetadata));
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getMetadataPartitions()).thenReturn(Collections.emptySet());
+    when(indexMetadata.getIndexDefinitions()).thenReturn(Collections.singletonMap("secondary_index_idx", indexDefinition));
+    when(indexDefinition.getIndexName()).thenReturn("secondary_index_idx");
+
+    HoodieReplaceCommitMetadata commitMetadata = new HoodieReplaceCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.UNKNOWN);
+    commitMetadata.addReplaceFileId("p1", "file_1.parquet");
+
+    SecondaryIndexer indexer = new SecondaryIndexer(engineContext, writeConfig, metaClient);
+    assertTrue(indexer.buildUpdate(IndexUpdateContext.of(
+        "016",
         mock(HoodieBackedTableMetadata.class),
         Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
         commitMetadata)).isEmpty());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/index/TestIndexingCatchupTask.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/index/TestIndexingCatchupTask.java
@@ -25,7 +25,9 @@ import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
 import org.apache.hudi.client.transaction.TransactionManager;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -42,11 +44,14 @@ import org.apache.hudi.table.HoodieTable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -306,6 +311,35 @@ public class TestIndexingCatchupTask {
     verify(transactionManager).endStateChange(Option.of(rollback));
   }
 
+  /**
+   * A replace commit that registers files written outside Hudi carries the replaced file groups only in its
+   * {@link HoodieReplaceCommitMetadata}, so both catch-up tasks must read it as such for the indexes to drop them.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testUpdateIndexForWriteActionReadsReplaceCommitMetadata(boolean writeStatBased) throws IOException {
+    HoodieInstant replaceCommit = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.REPLACE_COMMIT_ACTION, "002");
+    HoodieInstant commit = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "003");
+    HoodieActiveTimeline activeTimeline = mock(HoodieActiveTimeline.class);
+    HoodieReplaceCommitMetadata replaceCommitMetadata = new HoodieReplaceCommitMetadata();
+    replaceCommitMetadata.addReplaceFileId("p1", "file_1.parquet");
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    when(metaClient.getActiveTimeline()).thenReturn(activeTimeline);
+    when(activeTimeline.readReplaceCommitMetadata(replaceCommit)).thenReturn(replaceCommitMetadata);
+    when(activeTimeline.readCommitMetadata(commit)).thenReturn(commitMetadata);
+
+    AbstractIndexingCatchupTask task = writeStatBased
+        ? new WriteStatBasedIndexingCatchupTask(metadataWriter, Arrays.asList(replaceCommit, commit), new HashSet<>(), metaClient, metadataMetaClient,
+            "001", transactionManager, engineContext, table, heartbeatClient)
+        : new RecordBasedIndexingCatchupTask(metadataWriter, Arrays.asList(replaceCommit, commit), new HashSet<>(), metaClient, metadataMetaClient,
+            "001", transactionManager, engineContext, table, heartbeatClient);
+    task.updateIndexForWriteAction(replaceCommit);
+    task.updateIndexForWriteAction(commit);
+
+    verify(metadataWriter).update(replaceCommitMetadata, "002");
+    verify(metadataWriter).update(commitMetadata, "003");
+  }
+
   @Test
   public void testRunRejectsUnexpectedCompletedActionAndReleasesTransaction() {
     HoodieInstant instant = INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.SAVEPOINT_ACTION, "002");
@@ -328,7 +362,7 @@ public class TestIndexingCatchupTask {
 
   private RunningIndexingCatchupTask runningTask(HoodieInstant... instants) {
     return new RunningIndexingCatchupTask(
-        metadataWriter, java.util.Arrays.asList(instants), new HashSet<>(), metaClient, metadataMetaClient,
+        metadataWriter, Arrays.asList(instants), new HashSet<>(), metaClient, metadataMetaClient,
         transactionManager, "001", engineContext, table, heartbeatClient);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -184,6 +184,15 @@ public enum WriteOperationType {
     return operationType == BULK_INSERT_PREPPED || operationType == INSERT_PREPPED | operationType == UPSERT_PREPPED || operationType == DELETE_PREPPED;
   }
 
+  /**
+   * @return true when the operation type is not known, either because it is {@link #UNKNOWN} or because it was
+   * never set. Replace commits written by systems other than Hudi, which register existing files, carry no
+   * known operation type.
+   */
+  public static boolean isUnknown(WriteOperationType operationType) {
+    return operationType == null || operationType == UNKNOWN;
+  }
+
   public static boolean isCompactionOrClustering(WriteOperationType operationType) {
     return operationType == COMPACT || operationType == CLUSTER;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -1308,6 +1308,16 @@ public class HoodieTableConfig extends HoodieConfig {
   }
 
   /**
+   * @return true when the rows of this table carry a record key, either in the populated
+   * {@code _hoodie_record_key} meta column or in configured record key fields. A table that only
+   * registers files written by another system has neither; the record index and the secondary
+   * index then key its rows by file path and row position instead.
+   */
+  public boolean hasRecordKey() {
+    return isRecordKeyPopulated() || getRecordKeyFields().map(fields -> fields.length > 0).orElse(false);
+  }
+
+  /**
    * @returns the record key field prop.
    */
   public String getRecordKeyFieldProp() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ExternalFilePathUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ExternalFilePathUtil.java
@@ -94,6 +94,32 @@ public class ExternalFilePathUtil {
   }
 
   /**
+   * Returns the path of a base file relative to its partition, as the file exists on storage.
+   * For an external file name, the commit time and the external file marker are stripped and the file group
+   * prefix, if any, is restored. For example, "data.parquet_123_fg%3Dbucket-0_hudiext" returns "bucket-0/data.parquet".
+   * A file name that was not created externally is returned as is.
+   *
+   * @param fileName The file name as recorded in the commit metadata
+   * @return The path of the file relative to its partition
+   */
+  public static String getFilePathInPartition(String fileName) {
+    return isExternallyCreatedFile(fileName) ? parseFileIdAndCommitTimeFromExternalFile(fileName)[0] : fileName;
+  }
+
+  /**
+   * Generates a record key for a row of an external base file that does not carry a record key of its own.
+   * The key is the path of the file relative to the table base path, followed by the position of the row in the file.
+   * Record index and secondary index use the same key so that a secondary key lookup resolves to the file and row.
+   *
+   * @param relativeFilePath The path of the file relative to the table base path
+   * @param rowPosition      The zero based position of the row in the file
+   * @return The record key for the row
+   */
+  public static String generateRecordKeyForRow(String relativeFilePath, long rowPosition) {
+    return relativeFilePath + "_" + rowPosition;
+  }
+
+  /**
    * Extracts the file group prefix from an external file name.
    * @param fileName The external file name
    * @return Option containing the decoded file group prefix, or empty if not present

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ExternalFilePathUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ExternalFilePathUtil.java
@@ -18,8 +18,11 @@
 
 package org.apache.hudi.common.util;
 
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
+
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 
 /**
  * Utility methods for handling externally created files.
@@ -154,6 +157,9 @@ public class ExternalFilePathUtil {
         ? prefixMarkerIndex
         : fileName.lastIndexOf(EXTERNAL_FILE_SUFFIX);
     int commitTimeStart = fileName.lastIndexOf('_', markerEnd - 1);
+    if (commitTimeStart == -1) {
+      throw new HoodieException("External file name " + fileName + " carries no commit time before its marker");
+    }
     return fileName.substring(0, commitTimeStart);
   }
 
@@ -169,7 +175,12 @@ public class ExternalFilePathUtil {
    */
   public static StoragePath getFullPathOfPartition(StoragePath parent, String fileName) {
     return getExternalFileGroupPrefix(fileName)
-        .map(prefix -> new StoragePath(parent.toString().substring(0, parent.toString().length() - prefix.length() - 1)))
+        .map(prefix -> {
+          String parentPath = parent.toString();
+          checkArgument(parentPath.endsWith(StoragePath.SEPARATOR + prefix),
+              "External file " + fileName + " carries the file group prefix " + prefix + " but its parent " + parentPath + " does not end with it");
+          return new StoragePath(parentPath.substring(0, parentPath.length() - prefix.length() - 1));
+        })
         .orElse(parent);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ExternalFilePathUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ExternalFilePathUtil.java
@@ -178,7 +178,7 @@ public class ExternalFilePathUtil {
         .map(prefix -> {
           String parentPath = parent.toString();
           checkArgument(parentPath.endsWith(StoragePath.SEPARATOR + prefix),
-              "External file " + fileName + " carries the file group prefix " + prefix + " but its parent " + parentPath + " does not end with it");
+              () -> "External file " + fileName + " carries the file group prefix " + prefix + " but its parent " + parentPath + " does not end with it");
           return new StoragePath(parentPath.substring(0, parentPath.length() - prefix.length() - 1));
         })
         .orElse(parent);

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FileFormatUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FileFormatUtils.java
@@ -153,6 +153,20 @@ public abstract class FileFormatUtils {
   }
 
   /**
+   * Read the rowKey list from the given data file. If the data file was written outside Hudi and does not carry
+   * record keys, a key is generated for each row from the file path relative to the table base path and the row position.
+   *
+   * @param storage  {@link HoodieStorage} instance.
+   * @param filePath the data file path.
+   * @param basePath the table base path.
+   * @return set of row keys
+   */
+  public Set<String> readRowKeys(HoodieStorage storage, StoragePath filePath, StoragePath basePath) {
+    return filterRowKeys(storage, filePath, basePath, new HashSet<>())
+        .stream().map(Pair::getKey).collect(Collectors.toSet());
+  }
+
+  /**
    * Read the bloom filter from the metadata of the given data file.
    *
    * @param storage  {@link HoodieStorage} instance.
@@ -251,6 +265,22 @@ public abstract class FileFormatUtils {
    * @return set of pairs of row key and position matching candidateRecordKeys.
    */
   public abstract Set<Pair<String, Long>> filterRowKeys(HoodieStorage storage, StoragePath filePath, Set<String> filter);
+
+  /**
+   * Read the rowKey list matching the given filter, from the given data file.
+   * If the filter is empty, then this will return all the row keys and corresponding positions.
+   * Formats that support data files written outside Hudi override this method to generate a key for rows
+   * that do not carry a record key, from the file path relative to the table base path and the row position.
+   *
+   * @param storage  {@link HoodieStorage} instance.
+   * @param filePath the data file path.
+   * @param basePath the table base path.
+   * @param filter   record keys filter.
+   * @return set of pairs of row key and position matching candidateRecordKeys.
+   */
+  public Set<Pair<String, Long>> filterRowKeys(HoodieStorage storage, StoragePath filePath, StoragePath basePath, Set<String> filter) {
+    return filterRowKeys(storage, filePath, filter);
+  }
 
   /**
    * Fetch {@link HoodieKey}s with positions from the given data file.

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FileFormatUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FileFormatUtils.java
@@ -267,10 +267,10 @@ public abstract class FileFormatUtils {
   public abstract Set<Pair<String, Long>> filterRowKeys(HoodieStorage storage, StoragePath filePath, Set<String> filter);
 
   /**
-   * Read the rowKey list matching the given filter, from the given data file.
-   * If the filter is empty, then this will return all the row keys and corresponding positions.
-   * Formats that support data files written outside Hudi override this method to key every row of such a file,
-   * which carries no record key, by the file path relative to the table base path and the row position.
+   * Read the rowKey list matching the given filter, from the given data file, which was written outside Hudi and
+   * carries no record key. If the filter is empty, then this will return all the row keys and corresponding positions.
+   * Formats that support such files override this method to key every row by the file path relative to the table
+   * base path and the row position.
    *
    * @param storage  {@link HoodieStorage} instance.
    * @param filePath the data file path.
@@ -279,7 +279,25 @@ public abstract class FileFormatUtils {
    * @return set of pairs of row key and position matching candidateRecordKeys.
    */
   public Set<Pair<String, Long>> filterRowKeys(HoodieStorage storage, StoragePath filePath, StoragePath basePath, Set<String> filter) {
-    return filterRowKeys(storage, filePath, filter);
+    throw positionalRowKeysUnsupported();
+  }
+
+  /**
+   * Provides a closable iterator over the row keys of the given data file, which was written outside Hudi and carries
+   * no record key. Every row is keyed by the file path relative to the table base path and the row position, so the
+   * keys stream out in row order without being held in memory. Formats that support such files override this method.
+   *
+   * @param storage  {@link HoodieStorage} instance.
+   * @param filePath the data file path.
+   * @param basePath the table base path.
+   * @return {@link ClosableIterator} of the row keys in row order.
+   */
+  public ClosableIterator<String> getRowKeyIterator(HoodieStorage storage, StoragePath filePath, StoragePath basePath) {
+    throw positionalRowKeysUnsupported();
+  }
+
+  private UnsupportedOperationException positionalRowKeysUnsupported() {
+    return new UnsupportedOperationException("Positional row keys are only supported for parquet base files, not " + getClass().getSimpleName());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FileFormatUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FileFormatUtils.java
@@ -153,8 +153,8 @@ public abstract class FileFormatUtils {
   }
 
   /**
-   * Read the rowKey list from the given data file. If the data file was written outside Hudi and does not carry
-   * record keys, a key is generated for each row from the file path relative to the table base path and the row position.
+   * Read the rowKey list from the given data file, which was written outside Hudi and carries no record keys.
+   * Every row is keyed by the file path relative to the table base path and the row position.
    *
    * @param storage  {@link HoodieStorage} instance.
    * @param filePath the data file path.
@@ -269,8 +269,8 @@ public abstract class FileFormatUtils {
   /**
    * Read the rowKey list matching the given filter, from the given data file.
    * If the filter is empty, then this will return all the row keys and corresponding positions.
-   * Formats that support data files written outside Hudi override this method to generate a key for rows
-   * that do not carry a record key, from the file path relative to the table base path and the row position.
+   * Formats that support data files written outside Hudi override this method to key every row of such a file,
+   * which carries no record key, by the file path relative to the table base path and the row position.
    *
    * @param storage  {@link HoodieStorage} instance.
    * @param filePath the data file path.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseFileRecordParsingUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseFileRecordParsingUtils.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.fs.FileNameParser;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.ExternalFilePathUtil;
 import org.apache.hudi.common.util.FileFormatUtils;
 import org.apache.hudi.common.util.StringUtils;
@@ -59,6 +60,7 @@ public class BaseFileRecordParsingUtils {
    * @param writesFileIdEncoding fileID encoding for the table.
    * @param instantTime          instant time of interest.
    * @param storage              instance of {@link HoodieStorage}.
+   * @param isPartitionedRLI     whether the record index is partitioned.
    * @return Iterator of {@link HoodieRecord}s for RLI Metadata partition.
    */
   public static Iterator<HoodieRecord> generateRLIMetadataHoodieRecordsForBaseFile(String basePath,
@@ -67,6 +69,23 @@ public class BaseFileRecordParsingUtils {
                                                                                    String instantTime,
                                                                                    HoodieStorage storage,
                                                                                    boolean isPartitionedRLI) {
+    return generateRLIMetadataHoodieRecordsForBaseFile(basePath, writeStat, writesFileIdEncoding, instantTime, storage, isPartitionedRLI, false);
+  }
+
+  /**
+   * Generates RLI Metadata records for base files, see
+   * {@link #generateRLIMetadataHoodieRecordsForBaseFile(String, HoodieWriteStat, Integer, String, HoodieStorage, boolean)}.
+   *
+   * @param generateRecordKeys whether the table carries no record key, so that every row is keyed by the file path
+   *                           relative to the table base path and the row position, see {@link HoodieTableConfig#hasRecordKey()}.
+   */
+  public static Iterator<HoodieRecord> generateRLIMetadataHoodieRecordsForBaseFile(String basePath,
+                                                                                   HoodieWriteStat writeStat,
+                                                                                   Integer writesFileIdEncoding,
+                                                                                   String instantTime,
+                                                                                   HoodieStorage storage,
+                                                                                   boolean isPartitionedRLI,
+                                                                                   boolean generateRecordKeys) {
     String partition = writeStat.getPartitionPath();
     String latestFileName = FSUtils.getFileNameFromPath(writeStat.getPath());
     // a file written outside Hudi keeps its own name, which may contain underscores, so the file id is parsed from the marker
@@ -78,7 +97,7 @@ public class BaseFileRecordParsingUtils {
     recordStatuses.add(RecordStatus.DELETE);
     // for RLI, we are only interested in INSERTS and DELETES
     Map<RecordStatus, List<String>> recordStatusListMap = getRecordKeyStatuses(basePath, writeStat.getPartitionPath(), latestFileName, writeStat.getPrevBaseFile(), storage,
-        recordStatuses);
+        recordStatuses, generateRecordKeys);
     List<HoodieRecord> hoodieRecords = new ArrayList<>();
     if (recordStatusListMap.containsKey(RecordStatus.INSERT)) {
       long instantTimeMillis = HoodieMetadataPayload.parseRecordIndexInstantTime(instantTime);
@@ -130,7 +149,27 @@ public class BaseFileRecordParsingUtils {
                                                                      String prevFileName,
                                                                      HoodieStorage storage,
                                                                      Set<RecordStatus> recordStatusesOfInterest) {
-    Set<String> recordKeysFromLatestBaseFile = getRecordKeysFromBaseFile(storage, basePath, partition, latestFileName);
+    return getRecordKeyStatuses(basePath, partition, latestFileName, prevFileName, storage, recordStatusesOfInterest, false);
+  }
+
+  /**
+   * Fetch list of record keys deleted or updated in file referenced in the {@link HoodieWriteStat} passed.
+   *
+   * @param basePath           base path of the table.
+   * @param storage            {@link HoodieStorage} instance of interest.
+   * @param generateRecordKeys whether the table carries no record key, so that every row is keyed by the file path
+   *                           relative to the table base path and the row position.
+   * @return list of record keys deleted or updated.
+   */
+  @VisibleForTesting
+  public static Map<RecordStatus, List<String>> getRecordKeyStatuses(String basePath,
+                                                                     String partition,
+                                                                     String latestFileName,
+                                                                     String prevFileName,
+                                                                     HoodieStorage storage,
+                                                                     Set<RecordStatus> recordStatusesOfInterest,
+                                                                     boolean generateRecordKeys) {
+    Set<String> recordKeysFromLatestBaseFile = getRecordKeysFromBaseFile(storage, basePath, partition, latestFileName, generateRecordKeys);
     if (prevFileName == null) {
       if (recordStatusesOfInterest.contains(RecordStatus.INSERT)) {
         return Collections.singletonMap(RecordStatus.INSERT, new ArrayList<>(recordKeysFromLatestBaseFile));
@@ -141,7 +180,7 @@ public class BaseFileRecordParsingUtils {
     } else {
       // read from previous base file and find difference to also generate delete records.
       // we will return updates and deletes from this code block
-      Set<String> recordKeysFromPreviousBaseFile = getRecordKeysFromBaseFile(storage, basePath, partition, prevFileName);
+      Set<String> recordKeysFromPreviousBaseFile = getRecordKeysFromBaseFile(storage, basePath, partition, prevFileName, generateRecordKeys);
       Map<RecordStatus, List<String>> toReturn = new HashMap<>(recordStatusesOfInterest.size());
       if (recordStatusesOfInterest.contains(RecordStatus.DELETE)) {
         toReturn.put(RecordStatus.DELETE, recordKeysFromPreviousBaseFile.stream()
@@ -176,33 +215,38 @@ public class BaseFileRecordParsingUtils {
    * Used when a file group is replaced by a commit that does not rewrite its records, for example a replace commit
    * that registers files written outside Hudi.
    *
-   * @param basePath        base path of the table.
-   * @param partition       partition of the base file.
-   * @param dataFilePath    path of the base file on storage.
-   * @param storage         instance of {@link HoodieStorage}.
-   * @param isPartitionedRLI whether the record index is partitioned.
+   * @param basePath           base path of the table.
+   * @param partition          partition of the base file.
+   * @param dataFilePath       path of the base file on storage.
+   * @param storage            instance of {@link HoodieStorage}.
+   * @param isPartitionedRLI   whether the record index is partitioned.
+   * @param generateRecordKeys whether the table carries no record key, so that every row is keyed by the file path
+   *                           relative to the table base path and the row position.
    * @return Iterator of delete {@link HoodieRecord}s for RLI Metadata partition.
    */
   public static Iterator<HoodieRecord> generateRLIMetadataHoodieRecordsForReplacedBaseFile(String basePath,
                                                                                            String partition,
                                                                                            StoragePath dataFilePath,
                                                                                            HoodieStorage storage,
-                                                                                           boolean isPartitionedRLI) {
-    return getRecordKeysFromBaseFile(storage, basePath, dataFilePath).stream()
+                                                                                           boolean isPartitionedRLI,
+                                                                                           boolean generateRecordKeys) {
+    return getRecordKeysFromBaseFile(storage, basePath, dataFilePath, generateRecordKeys).stream()
         .map(recordKey -> HoodieMetadataPayload.createRecordIndexDelete(recordKey, partition, isPartitionedRLI))
         .iterator();
   }
 
-  private static Set<String> getRecordKeysFromBaseFile(HoodieStorage storage, String basePath, String partition, String fileName) {
+  private static Set<String> getRecordKeysFromBaseFile(HoodieStorage storage, String basePath, String partition, String fileName, boolean generateRecordKeys) {
     // a file written outside Hudi is recorded with an external file marker that is not part of the name on storage.
     String filePathInPartition = ExternalFilePathUtil.getFilePathInPartition(fileName);
     StoragePath dataFilePath = new StoragePath(basePath, StringUtils.isNullOrEmpty(partition) ? filePathInPartition : (partition + StoragePath.SEPARATOR) + filePathInPartition);
-    return getRecordKeysFromBaseFile(storage, basePath, dataFilePath);
+    return getRecordKeysFromBaseFile(storage, basePath, dataFilePath, generateRecordKeys);
   }
 
-  private static Set<String> getRecordKeysFromBaseFile(HoodieStorage storage, String basePath, StoragePath dataFilePath) {
+  private static Set<String> getRecordKeysFromBaseFile(HoodieStorage storage, String basePath, StoragePath dataFilePath, boolean generateRecordKeys) {
     FileFormatUtils fileFormatUtils = HoodieIOFactory.getIOFactory(storage).getFileFormatUtils(HoodieFileFormat.PARQUET);
-    return fileFormatUtils.readRowKeys(storage, dataFilePath, new StoragePath(basePath));
+    return generateRecordKeys
+        ? fileFormatUtils.readRowKeys(storage, dataFilePath, new StoragePath(basePath))
+        : fileFormatUtils.readRowKeys(storage, dataFilePath);
   }
 
   public enum RecordStatus {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseFileRecordParsingUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseFileRecordParsingUtils.java
@@ -20,9 +20,11 @@
 package org.apache.hudi.metadata;
 
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.fs.FileNameParser;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.util.ExternalFilePathUtil;
 import org.apache.hudi.common.util.FileFormatUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
@@ -67,7 +69,9 @@ public class BaseFileRecordParsingUtils {
                                                                                    boolean isPartitionedRLI) {
     String partition = writeStat.getPartitionPath();
     String latestFileName = FSUtils.getFileNameFromPath(writeStat.getPath());
-    String fileId = FSUtils.getFileId(latestFileName);
+    // a file written outside Hudi keeps its own name, which may contain underscores, so the file id is parsed from the marker
+    String fileId = FileNameParser.parseBaseFile(latestFileName).map(FileNameParser.BaseFileName::getFileId)
+        .orElseGet(() -> FSUtils.getFileId(latestFileName));
 
     Set<RecordStatus> recordStatuses = new HashSet<>();
     recordStatuses.add(RecordStatus.INSERT);
@@ -167,10 +171,38 @@ public class BaseFileRecordParsingUtils {
     }
   }
 
+  /**
+   * Generates RLI Metadata delete records for every record key in the given base file.
+   * Used when a file group is replaced by a commit that does not rewrite its records, for example a replace commit
+   * that registers files written outside Hudi.
+   *
+   * @param basePath        base path of the table.
+   * @param partition       partition of the base file.
+   * @param dataFilePath    path of the base file on storage.
+   * @param storage         instance of {@link HoodieStorage}.
+   * @param isPartitionedRLI whether the record index is partitioned.
+   * @return Iterator of delete {@link HoodieRecord}s for RLI Metadata partition.
+   */
+  public static Iterator<HoodieRecord> generateRLIMetadataHoodieRecordsForReplacedBaseFile(String basePath,
+                                                                                           String partition,
+                                                                                           StoragePath dataFilePath,
+                                                                                           HoodieStorage storage,
+                                                                                           boolean isPartitionedRLI) {
+    return getRecordKeysFromBaseFile(storage, basePath, dataFilePath).stream()
+        .map(recordKey -> HoodieMetadataPayload.createRecordIndexDelete(recordKey, partition, isPartitionedRLI))
+        .iterator();
+  }
+
   private static Set<String> getRecordKeysFromBaseFile(HoodieStorage storage, String basePath, String partition, String fileName) {
-    StoragePath dataFilePath = new StoragePath(basePath, StringUtils.isNullOrEmpty(partition) ? fileName : (partition + StoragePath.SEPARATOR) + fileName);
+    // a file written outside Hudi is recorded with an external file marker that is not part of the name on storage.
+    String filePathInPartition = ExternalFilePathUtil.getFilePathInPartition(fileName);
+    StoragePath dataFilePath = new StoragePath(basePath, StringUtils.isNullOrEmpty(partition) ? filePathInPartition : (partition + StoragePath.SEPARATOR) + filePathInPartition);
+    return getRecordKeysFromBaseFile(storage, basePath, dataFilePath);
+  }
+
+  private static Set<String> getRecordKeysFromBaseFile(HoodieStorage storage, String basePath, StoragePath dataFilePath) {
     FileFormatUtils fileFormatUtils = HoodieIOFactory.getIOFactory(storage).getFileFormatUtils(HoodieFileFormat.PARQUET);
-    return fileFormatUtils.readRowKeys(storage, dataFilePath);
+    return fileFormatUtils.readRowKeys(storage, dataFilePath, new StoragePath(basePath));
   }
 
   public enum RecordStatus {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseFileRecordParsingUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseFileRecordParsingUtils.java
@@ -61,23 +61,9 @@ public class BaseFileRecordParsingUtils {
    * @param instantTime          instant time of interest.
    * @param storage              instance of {@link HoodieStorage}.
    * @param isPartitionedRLI     whether the record index is partitioned.
+   * @param generateRecordKeys   whether the table carries no record key, so that every row is keyed by the file path
+   *                             relative to the table base path and the row position, see {@link HoodieTableConfig#hasRecordKey()}.
    * @return Iterator of {@link HoodieRecord}s for RLI Metadata partition.
-   */
-  public static Iterator<HoodieRecord> generateRLIMetadataHoodieRecordsForBaseFile(String basePath,
-                                                                                   HoodieWriteStat writeStat,
-                                                                                   Integer writesFileIdEncoding,
-                                                                                   String instantTime,
-                                                                                   HoodieStorage storage,
-                                                                                   boolean isPartitionedRLI) {
-    return generateRLIMetadataHoodieRecordsForBaseFile(basePath, writeStat, writesFileIdEncoding, instantTime, storage, isPartitionedRLI, false);
-  }
-
-  /**
-   * Generates RLI Metadata records for base files, see
-   * {@link #generateRLIMetadataHoodieRecordsForBaseFile(String, HoodieWriteStat, Integer, String, HoodieStorage, boolean)}.
-   *
-   * @param generateRecordKeys whether the table carries no record key, so that every row is keyed by the file path
-   *                           relative to the table base path and the row position, see {@link HoodieTableConfig#hasRecordKey()}.
    */
   public static Iterator<HoodieRecord> generateRLIMetadataHoodieRecordsForBaseFile(String basePath,
                                                                                    HoodieWriteStat writeStat,

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestExternalFilePathUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestExternalFilePathUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.util;
 
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 
@@ -27,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestExternalFilePathUtil {
@@ -236,9 +238,23 @@ public class TestExternalFilePathUtil {
     // a file written by Hudi is returned as is
     String hudiFileName = "3a9f-1234_1-0-1_20240101000000.parquet";
     assertEquals(hudiFileName, ExternalFilePathUtil.getFilePathInPartition(hudiFileName));
-    // an external file with a nested prefix resolves to its path below the partition
+    // an external file resolves to its path below the partition, with the prefix restored at any depth
+    assertEquals("file1.parquet", ExternalFilePathUtil.getFilePathInPartition("file1.parquet_20240101000000_hudiext"));
+    assertEquals("bucket-0/file1.parquet", ExternalFilePathUtil.getFilePathInPartition("file1.parquet_20240101000000_fg%3Dbucket-0_hudiext"));
     assertEquals("bucket-0/subdir/file1.parquet",
         ExternalFilePathUtil.getFilePathInPartition("file1.parquet_20240101000000_fg%3Dbucket-0%2Fsubdir_hudiext"));
+  }
+
+  @Test
+  public void testMalformedExternalFileNamesAreRejected() {
+    // a marked name without a commit time cannot be parsed
+    HoodieException noCommitTime = assertThrows(HoodieException.class,
+        () -> ExternalFilePathUtil.parseFileIdAndCommitTimeFromExternalFile("file1.parquet_hudiext"));
+    assertTrue(noCommitTime.getMessage().contains("file1.parquet_hudiext"), noCommitTime.getMessage());
+    // a file group prefix that its parent path does not end with cannot be stripped
+    IllegalArgumentException wrongParent = assertThrows(IllegalArgumentException.class,
+        () -> ExternalFilePathUtil.getFullPathOfPartition(new StoragePath("/table/partition1"), "file1.parquet_20240101000000_fg%3Dbucket-0_hudiext"));
+    assertTrue(wrongParent.getMessage().contains("/table/partition1"), wrongParent.getMessage());
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestExternalFilePathUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestExternalFilePathUtil.java
@@ -230,4 +230,19 @@ public class TestExternalFilePathUtil {
     assertEquals(prefix + "/" + originalFile, parsed[0]);
     assertEquals(COMMIT_TIME, parsed[1]);
   }
+
+  @Test
+  public void testGetFilePathInPartition() {
+    assertEquals("file1.parquet", ExternalFilePathUtil.getFilePathInPartition("file1.parquet_20240101000000_hudiext"));
+    assertEquals("bucket-0/file1.parquet", ExternalFilePathUtil.getFilePathInPartition("file1.parquet_20240101000000_fg%3Dbucket-0_hudiext"));
+    // a file written by Hudi is returned as is
+    String hudiFileName = "3a9f-1234_1-0-1_20240101000000.parquet";
+    assertEquals(hudiFileName, ExternalFilePathUtil.getFilePathInPartition(hudiFileName));
+  }
+
+  @Test
+  public void testGenerateRecordKeyForRow() {
+    assertEquals("partition1/file1.parquet_0", ExternalFilePathUtil.generateRecordKeyForRow("partition1/file1.parquet", 0));
+    assertEquals("file1.parquet_42", ExternalFilePathUtil.generateRecordKeyForRow("file1.parquet", 42));
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestExternalFilePathUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestExternalFilePathUtil.java
@@ -233,11 +233,12 @@ public class TestExternalFilePathUtil {
 
   @Test
   public void testGetFilePathInPartition() {
-    assertEquals("file1.parquet", ExternalFilePathUtil.getFilePathInPartition("file1.parquet_20240101000000_hudiext"));
-    assertEquals("bucket-0/file1.parquet", ExternalFilePathUtil.getFilePathInPartition("file1.parquet_20240101000000_fg%3Dbucket-0_hudiext"));
     // a file written by Hudi is returned as is
     String hudiFileName = "3a9f-1234_1-0-1_20240101000000.parquet";
     assertEquals(hudiFileName, ExternalFilePathUtil.getFilePathInPartition(hudiFileName));
+    // an external file with a nested prefix resolves to its path below the partition
+    assertEquals("bucket-0/subdir/file1.parquet",
+        ExternalFilePathUtil.getFilePathInPartition("file1.parquet_20240101000000_fg%3Dbucket-0%2Fsubdir_hudiext"));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestBaseFileRecordParsingUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestBaseFileRecordParsingUtils.java
@@ -18,7 +18,9 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.util.FileFormatUtils;
 import org.apache.hudi.core.io.storage.HoodieIOFactory;
@@ -28,12 +30,14 @@ import org.apache.hudi.storage.StoragePath;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.metadata.BaseFileRecordParsingUtils.RecordStatus.DELETE;
 import static org.apache.hudi.metadata.BaseFileRecordParsingUtils.RecordStatus.INSERT;
@@ -53,7 +57,7 @@ class TestBaseFileRecordParsingUtils {
     HoodieIOFactory ioFactory = mock(HoodieIOFactory.class);
     FileFormatUtils fileFormatUtils = mock(FileFormatUtils.class);
     when(ioFactory.getFileFormatUtils(HoodieFileFormat.PARQUET)).thenReturn(fileFormatUtils);
-    when(fileFormatUtils.readRowKeys(any(), any(StoragePath.class))).thenAnswer(invocation -> {
+    when(fileFormatUtils.readRowKeys(any(), any(StoragePath.class), any(StoragePath.class))).thenAnswer(invocation -> {
       StoragePath path = invocation.getArgument(1);
       return path.getName().equals("latest.parquet")
           ? new HashSet<>(Arrays.asList("inserted", "updated"))
@@ -85,6 +89,50 @@ class TestBaseFileRecordParsingUtils {
       List<String> changedKeys =
           BaseFileRecordParsingUtils.getRecordKeysDeletedOrUpdated("/table", writeStat, storage);
       assertEquals(new HashSet<>(Arrays.asList("updated", "deleted")), new HashSet<>(changedKeys));
+    }
+  }
+
+  @Test
+  void testExternalFileNamesResolveToFilesOnStorage() {
+    HoodieStorage storage = mock(HoodieStorage.class);
+    HoodieIOFactory ioFactory = mock(HoodieIOFactory.class);
+    FileFormatUtils fileFormatUtils = mock(FileFormatUtils.class);
+    when(ioFactory.getFileFormatUtils(HoodieFileFormat.PARQUET)).thenReturn(fileFormatUtils);
+    List<StoragePath> readPaths = new ArrayList<>();
+    when(fileFormatUtils.readRowKeys(any(), any(StoragePath.class), any(StoragePath.class))).thenAnswer(invocation -> {
+      readPaths.add(invocation.getArgument(1));
+      assertEquals(new StoragePath("/table"), invocation.getArgument(2));
+      return new HashSet<>(Arrays.asList("partition/latest.parquet_0", "partition/latest.parquet_1"));
+    });
+
+    try (MockedStatic<HoodieIOFactory> ioFactoryMock = mockStatic(HoodieIOFactory.class)) {
+      ioFactoryMock.when(() -> HoodieIOFactory.getIOFactory(storage)).thenReturn(ioFactory);
+
+      // the external file marker is not part of the file name on storage
+      Map<BaseFileRecordParsingUtils.RecordStatus, List<String>> statuses = BaseFileRecordParsingUtils.getRecordKeyStatuses(
+          "/table", "partition", "latest.parquet_20240101000000_hudiext", null, storage, EnumSet.of(INSERT));
+      assertEquals(Collections.singletonList(new StoragePath("/table/partition/latest.parquet")), readPaths);
+      assertEquals(new HashSet<>(Arrays.asList("partition/latest.parquet_0", "partition/latest.parquet_1")), new HashSet<>(statuses.get(INSERT)));
+
+      // the file id of an external file is its own name, stored as a raw string in the record index
+      HoodieWriteStat externalWriteStat = new HoodieWriteStat();
+      externalWriteStat.setPartitionPath("partition");
+      externalWriteStat.setPath("partition/latest.parquet_20240101000000_hudiext");
+      List<HoodieRecord> inserts = new ArrayList<>();
+      BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForBaseFile(
+          "/table", externalWriteStat, 1, "20240101000000", storage, false).forEachRemaining(inserts::add);
+      assertEquals(2, inserts.size());
+      inserts.forEach(record -> assertEquals("latest.parquet",
+          ((HoodieMetadataPayload) record.getData()).getRecordGlobalLocation().getFileId()));
+
+      // every record of a replaced base file is deleted
+      List<HoodieRecord> deletes = new ArrayList<>();
+      BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForReplacedBaseFile(
+          "/table", "partition", new StoragePath("/table/partition/latest.parquet"), storage, false).forEachRemaining(deletes::add);
+      assertEquals(2, deletes.size());
+      assertTrue(deletes.stream().allMatch(record -> record.getData() instanceof EmptyHoodieRecordPayload));
+      assertEquals(new HashSet<>(Arrays.asList("partition/latest.parquet_0", "partition/latest.parquet_1")),
+          deletes.stream().map(HoodieRecord::getRecordKey).collect(Collectors.toSet()));
     }
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestBaseFileRecordParsingUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestBaseFileRecordParsingUtils.java
@@ -57,7 +57,8 @@ class TestBaseFileRecordParsingUtils {
     HoodieIOFactory ioFactory = mock(HoodieIOFactory.class);
     FileFormatUtils fileFormatUtils = mock(FileFormatUtils.class);
     when(ioFactory.getFileFormatUtils(HoodieFileFormat.PARQUET)).thenReturn(fileFormatUtils);
-    when(fileFormatUtils.readRowKeys(any(), any(StoragePath.class), any(StoragePath.class))).thenAnswer(invocation -> {
+    // files written by Hudi carry record keys, so they are read without the table base path
+    when(fileFormatUtils.readRowKeys(any(), any(StoragePath.class))).thenAnswer(invocation -> {
       StoragePath path = invocation.getArgument(1);
       return path.getName().equals("latest.parquet")
           ? new HashSet<>(Arrays.asList("inserted", "updated"))
@@ -99,6 +100,7 @@ class TestBaseFileRecordParsingUtils {
     FileFormatUtils fileFormatUtils = mock(FileFormatUtils.class);
     when(ioFactory.getFileFormatUtils(HoodieFileFormat.PARQUET)).thenReturn(fileFormatUtils);
     List<StoragePath> readPaths = new ArrayList<>();
+    // a table without record keys reads its files with the table base path, which keys every row by path and position
     when(fileFormatUtils.readRowKeys(any(), any(StoragePath.class), any(StoragePath.class))).thenAnswer(invocation -> {
       readPaths.add(invocation.getArgument(1));
       assertEquals(new StoragePath("/table"), invocation.getArgument(2));
@@ -110,7 +112,7 @@ class TestBaseFileRecordParsingUtils {
 
       // the external file marker is not part of the file name on storage
       Map<BaseFileRecordParsingUtils.RecordStatus, List<String>> statuses = BaseFileRecordParsingUtils.getRecordKeyStatuses(
-          "/table", "partition", "latest.parquet_20240101000000_hudiext", null, storage, EnumSet.of(INSERT));
+          "/table", "partition", "latest.parquet_20240101000000_hudiext", null, storage, EnumSet.of(INSERT), true);
       assertEquals(Collections.singletonList(new StoragePath("/table/partition/latest.parquet")), readPaths);
       assertEquals(new HashSet<>(Arrays.asList("partition/latest.parquet_0", "partition/latest.parquet_1")), new HashSet<>(statuses.get(INSERT)));
 
@@ -120,7 +122,7 @@ class TestBaseFileRecordParsingUtils {
       externalWriteStat.setPath("partition/latest.parquet_20240101000000_hudiext");
       List<HoodieRecord> inserts = new ArrayList<>();
       BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForBaseFile(
-          "/table", externalWriteStat, 1, "20240101000000", storage, false).forEachRemaining(inserts::add);
+          "/table", externalWriteStat, 1, "20240101000000", storage, false, true).forEachRemaining(inserts::add);
       assertEquals(2, inserts.size());
       inserts.forEach(record -> assertEquals("latest.parquet",
           ((HoodieMetadataPayload) record.getData()).getRecordGlobalLocation().getFileId()));
@@ -128,7 +130,7 @@ class TestBaseFileRecordParsingUtils {
       // every record of a replaced base file is deleted
       List<HoodieRecord> deletes = new ArrayList<>();
       BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForReplacedBaseFile(
-          "/table", "partition", new StoragePath("/table/partition/latest.parquet"), storage, false).forEachRemaining(deletes::add);
+          "/table", "partition", new StoragePath("/table/partition/latest.parquet"), storage, false, true).forEachRemaining(deletes::add);
       assertEquals(2, deletes.size());
       assertTrue(deletes.stream().allMatch(record -> record.getData() instanceof EmptyHoodieRecordPayload));
       assertEquals(new HashSet<>(Arrays.asList("partition/latest.parquet_0", "partition/latest.parquet_1")),

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -21,6 +21,7 @@ package org.apache.hudi.common.util;
 
 import org.apache.hudi.avro.HoodieAvroWriteSupport;
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -119,7 +120,23 @@ public class ParquetUtils extends FileFormatUtils {
    */
   @Override
   public Set<Pair<String, Long>> filterRowKeys(HoodieStorage storage, StoragePath filePath, Set<String> filter) {
-    return filterParquetRowKeys(storage, new Path(filePath.toUri()), filter, HoodieSchemaUtils.getRecordKeySchema());
+    return filterParquetRowKeys(storage, new Path(filePath.toUri()), Option.empty(), filter, HoodieSchemaUtils.getRecordKeySchema());
+  }
+
+  /**
+   * Read the rowKey list matching the given filter, from the given parquet file. If the filter is empty, then this will
+   * return all the rowkeys and corresponding positions. Rows without a record key, as written by systems other than Hudi,
+   * get a key generated from the file path relative to the table base path and the row position.
+   *
+   * @param storage  {@link HoodieStorage} instance.
+   * @param filePath The parquet file path.
+   * @param basePath The table base path.
+   * @param filter   record keys filter
+   * @return Set Set of pairs of row key and position matching candidateRecordKeys
+   */
+  @Override
+  public Set<Pair<String, Long>> filterRowKeys(HoodieStorage storage, StoragePath filePath, StoragePath basePath, Set<String> filter) {
+    return filterParquetRowKeys(storage, new Path(filePath.toUri()), Option.of(basePath), filter, HoodieSchemaUtils.getRecordKeySchema());
   }
 
   public static ParquetMetadata readMetadata(HoodieStorage storage, StoragePath parquetFilePath) {
@@ -149,12 +166,15 @@ public class ParquetUtils extends FileFormatUtils {
    *
    * @param storage    {@link HoodieStorage} instance.
    * @param filePath   The parquet file path.
+   * @param basePath   The table base path, required to generate keys for rows that do not carry a record key
    * @param filter     record keys filter
    * @param readSchema schema of columns to be read
    * @return Set of pairs of row key and position matching candidateRecordKeys
    */
   private static Set<Pair<String, Long>> filterParquetRowKeys(HoodieStorage storage,
-                                                              Path filePath, Set<String> filter,
+                                                              Path filePath,
+                                                              Option<StoragePath> basePath,
+                                                              Set<String> filter,
                                                               HoodieSchema readSchema) {
     Option<RecordKeysFilterFunction> filterFunction = Option.empty();
     if (filter != null && !filter.isEmpty()) {
@@ -165,12 +185,21 @@ public class ParquetUtils extends FileFormatUtils {
     AvroReadSupport.setAvroReadSchema(conf, readSchema.toAvroSchema());
     AvroReadSupport.setRequestedProjection(conf, readSchema.toAvroSchema());
     Set<Pair<String, Long>> rowKeys = new HashSet<>();
+    Option<String> relativeFilePath = basePath.map(path -> FSUtils.getRelativePartitionPath(path, convertToStoragePath(filePath)));
     long rowPosition = 0;
     try (ParquetReader reader = AvroParquetReader.builder(filePath).withConf(conf).build()) {
       Object obj = reader.read();
       while (obj != null) {
         if (obj instanceof GenericRecord) {
-          String recordKey = ((GenericRecord) obj).get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString();
+          Object recordKeyValue = ((GenericRecord) obj).get(HoodieRecord.RECORD_KEY_METADATA_FIELD);
+          String recordKey;
+          if (recordKeyValue != null) {
+            recordKey = recordKeyValue.toString();
+          } else {
+            ValidationUtils.checkArgument(relativeFilePath.isPresent(),
+                "Record key is missing in " + filePath + " and no table base path is available to generate one");
+            recordKey = ExternalFilePathUtil.generateRecordKeyForRow(relativeFilePath.get(), rowPosition);
+          }
           if (!filterFunction.isPresent() || filterFunction.get().apply(recordKey)) {
             rowKeys.add(Pair.of(recordKey, rowPosition));
           }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -34,6 +34,7 @@ import org.apache.hudi.core.io.HoodieParquetConfigInjector;
 import org.apache.hudi.core.io.ParquetZstdCompressionLevelInjector;
 import org.apache.hudi.core.io.storage.HoodieFileWriter;
 import org.apache.hudi.core.io.storage.HoodieFileWriterFactory;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.MetadataNotFoundException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
@@ -125,8 +126,8 @@ public class ParquetUtils extends FileFormatUtils {
 
   /**
    * Read the rowKey list matching the given filter, from the given parquet file. If the filter is empty, then this will
-   * return all the rowkeys and corresponding positions. Rows without a record key, as written by systems other than Hudi,
-   * get a key generated from the file path relative to the table base path and the row position.
+   * return all the rowkeys and corresponding positions. The rows of a file written by a system other than Hudi carry no
+   * record key; every row is keyed by the file path relative to the table base path and the row position instead.
    *
    * @param storage  {@link HoodieStorage} instance.
    * @param filePath The parquet file path.
@@ -166,7 +167,8 @@ public class ParquetUtils extends FileFormatUtils {
    *
    * @param storage    {@link HoodieStorage} instance.
    * @param filePath   The parquet file path.
-   * @param basePath   The table base path, required to generate keys for rows that do not carry a record key
+   * @param basePath   The table base path; when present, the file carries no record keys and every row is keyed
+   *                   by its relative path and position
    * @param filter     record keys filter
    * @param readSchema schema of columns to be read
    * @return Set of pairs of row key and position matching candidateRecordKeys
@@ -185,20 +187,23 @@ public class ParquetUtils extends FileFormatUtils {
     AvroReadSupport.setAvroReadSchema(conf, readSchema.toAvroSchema());
     AvroReadSupport.setRequestedProjection(conf, readSchema.toAvroSchema());
     Set<Pair<String, Long>> rowKeys = new HashSet<>();
+    // with the table base path given, the file was written outside Hudi and carries no record key: every row is keyed
+    // by the file path relative to the table and its position, the same key the secondary index generates for it
     Option<String> relativeFilePath = basePath.map(path -> FSUtils.getRelativePartitionPath(path, convertToStoragePath(filePath)));
     long rowPosition = 0;
     try (ParquetReader reader = AvroParquetReader.builder(filePath).withConf(conf).build()) {
       Object obj = reader.read();
       while (obj != null) {
         if (obj instanceof GenericRecord) {
-          Object recordKeyValue = ((GenericRecord) obj).get(HoodieRecord.RECORD_KEY_METADATA_FIELD);
           String recordKey;
-          if (recordKeyValue != null) {
-            recordKey = recordKeyValue.toString();
-          } else {
-            ValidationUtils.checkArgument(relativeFilePath.isPresent(),
-                "Record key is missing in " + filePath + " and no table base path is available to generate one");
+          if (relativeFilePath.isPresent()) {
             recordKey = ExternalFilePathUtil.generateRecordKeyForRow(relativeFilePath.get(), rowPosition);
+          } else {
+            Object recordKeyValue = ((GenericRecord) obj).get(HoodieRecord.RECORD_KEY_METADATA_FIELD);
+            if (recordKeyValue == null) {
+              throw new HoodieException("Record key is missing in row " + rowPosition + " of " + filePath);
+            }
+            recordKey = recordKeyValue.toString();
           }
           if (!filterFunction.isPresent() || filterFunction.get().apply(recordKey)) {
             rowKeys.add(Pair.of(recordKey, rowPosition));

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -121,7 +121,7 @@ public class ParquetUtils extends FileFormatUtils {
    */
   @Override
   public Set<Pair<String, Long>> filterRowKeys(HoodieStorage storage, StoragePath filePath, Set<String> filter) {
-    return filterParquetRowKeys(storage, new Path(filePath.toUri()), Option.empty(), filter, HoodieSchemaUtils.getRecordKeySchema());
+    return filterParquetRowKeys(storage, new Path(filePath.toUri()), filter, HoodieSchemaUtils.getRecordKeySchema());
   }
 
   /**
@@ -137,7 +137,63 @@ public class ParquetUtils extends FileFormatUtils {
    */
   @Override
   public Set<Pair<String, Long>> filterRowKeys(HoodieStorage storage, StoragePath filePath, StoragePath basePath, Set<String> filter) {
-    return filterParquetRowKeys(storage, new Path(filePath.toUri()), Option.of(basePath), filter, HoodieSchemaUtils.getRecordKeySchema());
+    Set<Pair<String, Long>> rowKeys = new HashSet<>();
+    long rowPosition = 0;
+    try (ClosableIterator<String> rowKeyIterator = getRowKeyIterator(storage, filePath, basePath)) {
+      while (rowKeyIterator.hasNext()) {
+        String rowKey = rowKeyIterator.next();
+        if (filter.isEmpty() || filter.contains(rowKey)) {
+          rowKeys.add(Pair.of(rowKey, rowPosition));
+        }
+        rowPosition++;
+      }
+    }
+    return rowKeys;
+  }
+
+  /**
+   * Streams the row keys of the given parquet file, which was written by a system other than Hudi and carries no
+   * record key. Every row is keyed by the file path relative to the table base path and the row position, the same
+   * key the secondary index generates for it. Only the row count is read from the file, no column.
+   *
+   * @param storage  {@link HoodieStorage} instance.
+   * @param filePath The parquet file path.
+   * @param basePath The table base path.
+   * @return {@link ClosableIterator} of the row keys in row order
+   */
+  @Override
+  public ClosableIterator<String> getRowKeyIterator(HoodieStorage storage, StoragePath filePath, StoragePath basePath) {
+    String relativeFilePath = FSUtils.getRelativePartitionPath(basePath, filePath);
+    Configuration conf = storage.getConf().unwrapCopyAs(Configuration.class);
+    conf.addResource(storage.newInstance(filePath, storage.getConf()).getConf().unwrapAs(Configuration.class));
+    // the record key schema projects no column of the file, so every row is read as an empty record
+    AvroReadSupport.setAvroReadSchema(conf, HoodieSchemaUtils.getRecordKeySchema().toAvroSchema());
+    AvroReadSupport.setRequestedProjection(conf, HoodieSchemaUtils.getRecordKeySchema().toAvroSchema());
+    try {
+      ParquetReaderIterator<GenericRecord> rowIterator = new ParquetReaderIterator<>(
+          AvroParquetReader.<GenericRecord>builder(new Path(filePath.toUri())).withConf(conf).build());
+      return new ClosableIterator<String>() {
+        private long rowPosition = 0;
+
+        @Override
+        public boolean hasNext() {
+          return rowIterator.hasNext();
+        }
+
+        @Override
+        public String next() {
+          rowIterator.next();
+          return ExternalFilePathUtil.generateRecordKeyForRow(relativeFilePath, rowPosition++);
+        }
+
+        @Override
+        public void close() {
+          rowIterator.close();
+        }
+      };
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to read row keys from Parquet " + filePath, e);
+    }
   }
 
   public static ParquetMetadata readMetadata(HoodieStorage storage, StoragePath parquetFilePath) {
@@ -167,15 +223,12 @@ public class ParquetUtils extends FileFormatUtils {
    *
    * @param storage    {@link HoodieStorage} instance.
    * @param filePath   The parquet file path.
-   * @param basePath   The table base path; when present, the file carries no record keys and every row is keyed
-   *                   by its relative path and position
    * @param filter     record keys filter
    * @param readSchema schema of columns to be read
    * @return Set of pairs of row key and position matching candidateRecordKeys
    */
   private static Set<Pair<String, Long>> filterParquetRowKeys(HoodieStorage storage,
                                                               Path filePath,
-                                                              Option<StoragePath> basePath,
                                                               Set<String> filter,
                                                               HoodieSchema readSchema) {
     Option<RecordKeysFilterFunction> filterFunction = Option.empty();
@@ -187,24 +240,16 @@ public class ParquetUtils extends FileFormatUtils {
     AvroReadSupport.setAvroReadSchema(conf, readSchema.toAvroSchema());
     AvroReadSupport.setRequestedProjection(conf, readSchema.toAvroSchema());
     Set<Pair<String, Long>> rowKeys = new HashSet<>();
-    // with the table base path given, the file was written outside Hudi and carries no record key: every row is keyed
-    // by the file path relative to the table and its position, the same key the secondary index generates for it
-    Option<String> relativeFilePath = basePath.map(path -> FSUtils.getRelativePartitionPath(path, convertToStoragePath(filePath)));
     long rowPosition = 0;
     try (ParquetReader reader = AvroParquetReader.builder(filePath).withConf(conf).build()) {
       Object obj = reader.read();
       while (obj != null) {
         if (obj instanceof GenericRecord) {
-          String recordKey;
-          if (relativeFilePath.isPresent()) {
-            recordKey = ExternalFilePathUtil.generateRecordKeyForRow(relativeFilePath.get(), rowPosition);
-          } else {
-            Object recordKeyValue = ((GenericRecord) obj).get(HoodieRecord.RECORD_KEY_METADATA_FIELD);
-            if (recordKeyValue == null) {
-              throw new HoodieException("Record key is missing in row " + rowPosition + " of " + filePath);
-            }
-            recordKey = recordKeyValue.toString();
+          Object recordKeyValue = ((GenericRecord) obj).get(HoodieRecord.RECORD_KEY_METADATA_FIELD);
+          if (recordKeyValue == null) {
+            throw new HoodieException("Record key is missing in row " + rowPosition + " of " + filePath);
           }
+          String recordKey = recordKeyValue.toString();
           if (!filterFunction.isPresent() || filterFunction.get().apply(recordKey)) {
             rowKeys.add(Pair.of(recordKey, rowPosition));
           }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigMetaFieldsMode.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigMetaFieldsMode.java
@@ -156,4 +156,22 @@ class TestHoodieTableConfigMetaFieldsMode {
     HoodieTableConfig cfg = configOf(false, "CoMmIt_TiMe_OnLy");
     assertEquals(MetaFieldsMode.COMMIT_TIME_ONLY, cfg.getMetaFieldsMode());
   }
+
+  @Test
+  void hasRecordKeyWhenTheMetaColumnIsPopulatedOrKeyFieldsAreConfigured() {
+    // the default mode populates _hoodie_record_key
+    assertTrue(configOf(null, null).hasRecordKey());
+    // a selective mode leaves the meta column null but still keys records through the configured fields
+    HoodieTableConfig commitTimeOnlyWithKeyFields = configOf(false, "COMMIT_TIME_ONLY");
+    commitTimeOnlyWithKeyFields.setValue(HoodieTableConfig.RECORDKEY_FIELDS, "id");
+    assertTrue(commitTimeOnlyWithKeyFields.hasRecordKey());
+    HoodieTableConfig noneWithKeyFields = configOf(false, null);
+    noneWithKeyFields.setValue(HoodieTableConfig.RECORDKEY_FIELDS, "id,name");
+    assertTrue(noneWithKeyFields.hasRecordKey());
+    // a table that only registers files written by another system has neither
+    assertFalse(configOf(false, null).hasRecordKey());
+    HoodieTableConfig noneWithEmptyKeyFields = configOf(false, null);
+    noneWithEmptyKeyFields.setValue(HoodieTableConfig.RECORDKEY_FIELDS, "");
+    assertFalse(noneWithEmptyKeyFields.hasRecordKey());
+  }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -129,6 +129,14 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
         HoodieTestUtils.getStorage(filePath), new StoragePath(filePath), new StoragePath(basePath));
     assertEquals(new HashSet<>(Arrays.asList("2024/external.parquet_0", "2024/external.parquet_1", "2024/external.parquet_2")), generatedKeys);
 
+    // the keys stream out in row order
+    List<String> streamedKeys = new ArrayList<>();
+    try (ClosableIterator<String> rowKeyIterator = parquetUtils.getRowKeyIterator(
+        HoodieTestUtils.getStorage(filePath), new StoragePath(filePath), new StoragePath(basePath))) {
+      rowKeyIterator.forEachRemaining(streamedKeys::add);
+    }
+    assertEquals(Arrays.asList("2024/external.parquet_0", "2024/external.parquet_1", "2024/external.parquet_2"), streamedKeys);
+
     Set<Pair<String, Long>> filtered = parquetUtils.filterRowKeys(
         HoodieTestUtils.getStorage(filePath), new StoragePath(filePath), new StoragePath(basePath), Collections.singleton("2024/external.parquet_1"));
     assertEquals(Collections.singleton(Pair.of("2024/external.parquet_1", 1L)), filtered);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -68,6 +68,7 @@ import static org.apache.hudi.common.schema.HoodieSchemaUtils.METADATA_FIELD_SCH
 import static org.apache.hudi.metadata.HoodieIndexVersion.V1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -113,6 +114,26 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
     for (String rowKey : rowKeys) {
       assertTrue(filterInFile.mightContain(rowKey), "key should be found in bloom filter");
     }
+  }
+
+  @Test
+  public void testReadRowKeysFromFileWithoutRecordKeys() throws Exception {
+    // a file written outside Hudi has no record key column, so each row is keyed by the relative file path and row position
+    List<String> rowKeys = Arrays.asList("a", "b", "c");
+    HoodieSchema schema = getSchemaWithFields(Collections.singletonList("id"));
+    String filePath = Paths.get(basePath, "2024", "external.parquet").toUri().toString();
+    writeParquetFile(BloomFilterTypeCode.SIMPLE.name(), filePath, rowKeys, schema, false, "", false, "id", null);
+
+    Set<String> generatedKeys = parquetUtils.readRowKeys(
+        HoodieTestUtils.getStorage(filePath), new StoragePath(filePath), new StoragePath(basePath));
+    assertEquals(new HashSet<>(Arrays.asList("2024/external.parquet_0", "2024/external.parquet_1", "2024/external.parquet_2")), generatedKeys);
+
+    Set<Pair<String, Long>> filtered = parquetUtils.filterRowKeys(
+        HoodieTestUtils.getStorage(filePath), new StoragePath(filePath), new StoragePath(basePath), Collections.singleton("2024/external.parquet_1"));
+    assertEquals(Collections.singleton(Pair.of("2024/external.parquet_1", 1L)), filtered);
+
+    // without the table base path no key can be generated
+    assertThrows(IllegalArgumentException.class, () -> parquetUtils.readRowKeys(HoodieTestUtils.getStorage(filePath), new StoragePath(filePath)));
   }
 
   @ParameterizedTest

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.StoragePath;
@@ -132,8 +133,10 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
         HoodieTestUtils.getStorage(filePath), new StoragePath(filePath), new StoragePath(basePath), Collections.singleton("2024/external.parquet_1"));
     assertEquals(Collections.singleton(Pair.of("2024/external.parquet_1", 1L)), filtered);
 
-    // without the table base path no key can be generated
-    assertThrows(IllegalArgumentException.class, () -> parquetUtils.readRowKeys(HoodieTestUtils.getStorage(filePath), new StoragePath(filePath)));
+    // without the table base path the missing record key is an error
+    HoodieException missingKey = assertThrows(HoodieException.class,
+        () -> parquetUtils.readRowKeys(HoodieTestUtils.getStorage(filePath), new StoragePath(filePath)));
+    assertTrue(missingKey.getMessage().startsWith("Record key is missing in row 0 of "));
   }
 
   @ParameterizedTest

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/GlobalRecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/GlobalRecordLevelIndexSupport.scala
@@ -17,7 +17,6 @@
 
 package org.apache.hudi
 
-import org.apache.hudi.RecordLevelIndexSupport.getPrunedStoragePaths
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.data.HoodieListData
 import org.apache.hudi.common.model.FileSlice
@@ -40,11 +39,10 @@ class GlobalRecordLevelIndexSupport(spark: SparkSession,
   override protected def lookupCandidateFilesForRecordKeys(fileIndex: HoodieFileIndex,
                                                            prunedPartitionsAndFileSlices: Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])],
                                                            recordKeys: List[String]): Option[Set[String]] = {
-    val prunedStoragePaths = getPrunedStoragePaths(prunedPartitionsAndFileSlices, fileIndex)
     val recordIndexData = metadataTable.readRecordIndexLocationsWithKeys(HoodieListData.eager(recordKeys.asJava))
     try {
       val fileIdToPartitionMap = collectFileIdToPartitionMap(recordIndexData)
-      Option.apply(filterCandidateFiles(prunedStoragePaths, fileIdToPartitionMap))
+      Option.apply(filterCandidateFiles(prunedPartitionsAndFileSlices, fileIndex, fileIdToPartitionMap))
     } finally {
       // Clean up the RDD to avoid memory leaks
       recordIndexData.unpersistWithDependencies()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionedRecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/PartitionedRecordLevelIndexSupport.scala
@@ -17,7 +17,7 @@
 
 package org.apache.hudi
 
-import org.apache.hudi.RecordLevelIndexSupport.{getPrunedStoragePaths, MAX_PARTITIONS}
+import org.apache.hudi.RecordLevelIndexSupport.MAX_PARTITIONS
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.table.HoodieTableMetaClient
@@ -64,8 +64,7 @@ class PartitionedRecordLevelIndexSupport(spark: SparkSession,
     } else {
       lookupRecordKeys(partitions, recordKeys) match {
         case Some(fileIdToPartitionMap) =>
-          val prunedStoragePaths = getPrunedStoragePaths(prunedPartitionsAndFileSlices, fileIndex)
-          Option.apply(filterCandidateFiles(prunedStoragePaths, fileIdToPartitionMap))
+          Option.apply(filterCandidateFiles(prunedPartitionsAndFileSlices, fileIndex, fileIdToPartitionMap))
         case None =>
           // None of the candidate partitions are indexed by the partitioned RLI (e.g. partitions
           // not yet indexed), so we cannot determine the matching files. Fall back to other indexes

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/RecordLevelIndexSupport.scala
@@ -20,7 +20,6 @@ package org.apache.hudi
 import org.apache.hudi.DataSourceReadOptions.{QUERY_TYPE, TIME_TRAVEL_AS_OF_INSTANT}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.data.HoodiePairData
-import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{FileSlice, HoodieRecordGlobalLocation}
 import org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField
 import org.apache.hudi.common.model.HoodieTableQueryType.SNAPSHOT
@@ -33,7 +32,6 @@ import org.apache.hudi.core.read.BaseHoodieTableFileIndex
 import org.apache.hudi.keygen.KeyGenerator
 import org.apache.hudi.metadata.HoodieTableMetadataUtil
 import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX
-import org.apache.hudi.storage.StoragePath
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, Cast, EqualTo, Expression, In, Literal}
@@ -103,17 +101,17 @@ abstract class RecordLevelIndexSupport(spark: SparkSession,
   }
 
   /**
-   * Filters the input files, keeping only those whose fileId is present in the record index lookup results.
+   * Returns the names of the files of the pruned file slices whose file id is present in the record index lookup
+   * results. The file id is taken from the file slice rather than parsed from the file name, because a file written
+   * outside Hudi keeps its own name, which does not follow Hudi's naming convention.
    */
-  protected def filterCandidateFiles(allFiles: Seq[StoragePath], fileIdToPartitionMap: mutable.Map[String, String]): Set[String] = {
-    val candidateFiles: mutable.Set[String] = mutable.Set.empty
-    for (file <- allFiles) {
-      val fileId = FSUtils.getFileIdFromFilePath(file)
-      if (fileIdToPartitionMap.contains(fileId)) {
-        candidateFiles += file.getName
-      }
-    }
-    candidateFiles.toSet
+  protected def filterCandidateFiles(prunedPartitionsAndFileSlices: Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])],
+                                     fileIndex: HoodieFileIndex,
+                                     fileIdToPartitionMap: mutable.Map[String, String]): Set[String] = {
+    RecordLevelIndexSupport.getPrunedFileSlices(prunedPartitionsAndFileSlices, fileIndex)
+      .filter(fileSlice => fileIdToPartitionMap.contains(fileSlice.getFileId))
+      .flatMap(fileSlice => RecordLevelIndexSupport.getFileNames(fileSlice, fileIndex))
+      .toSet
   }
 
   /**
@@ -284,33 +282,33 @@ object RecordLevelIndexSupport {
   }
 
   /**
-   * Returns the list of storage paths from the pruned partitions and file slices.
+   * Returns the pruned file slices, or every file slice of the table when nothing was pruned.
    *
    * @param prunedPartitionsAndFileSlices - List of pruned partitions and file slices
-   * @return List of storage paths
+   * @return List of file slices
    */
-  def getPrunedStoragePaths(prunedPartitionsAndFileSlices: Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])],
-                            fileIndex: HoodieFileIndex): Seq[StoragePath] = {
-    if (prunedPartitionsAndFileSlices.isEmpty) {
-      fileIndex.inputFiles.map(strPath => new StoragePath(strPath)).toSeq
+  def getPrunedFileSlices(prunedPartitionsAndFileSlices: Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])],
+                          fileIndex: HoodieFileIndex): Seq[FileSlice] = {
+    val partitionsAndFileSlices = if (prunedPartitionsAndFileSlices.isEmpty) {
+      fileIndex.prunePartitionsAndGetFileSlices(Seq.empty, Seq.empty)._2
     } else {
       prunedPartitionsAndFileSlices
-        .flatMap { case (_, fileSlices) =>
-          fileSlices
-        }
-        .flatMap { fileSlice =>
-          val baseFileOption = Option(fileSlice.getBaseFile.orElse(null))
-          val logFiles = if (fileIndex.includeLogFiles) {
-            fileSlice.getLogFiles.iterator().asScala
-          } else {
-            Iterator.empty
-          }
-          val baseFilePaths = baseFileOption.map(baseFile => baseFile.getStoragePath).toSeq
-          val logFilePaths = logFiles.map(logFile => logFile.getPath).toSeq
-
-          baseFilePaths ++ logFilePaths
-        }
     }
+    partitionsAndFileSlices.flatMap { case (_, fileSlices) => fileSlices }
+  }
+
+  /**
+   * Returns the names of the files of the file slice as they exist on storage: the base file, and the log files
+   * when the file index reads them.
+   */
+  def getFileNames(fileSlice: FileSlice, fileIndex: HoodieFileIndex): Seq[String] = {
+    val baseFileNames = Option(fileSlice.getBaseFile.orElse(null)).map(_.getFileName).toSeq
+    val logFileNames = if (fileIndex.includeLogFiles) {
+      fileSlice.getLogFiles.iterator().asScala.map(_.getFileName).toSeq
+    } else {
+      Seq.empty
+    }
+    baseFileNames ++ logFileNames
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SecondaryIndexSupport.scala
@@ -19,22 +19,19 @@
 
 package org.apache.hudi
 
-import org.apache.hudi.RecordLevelIndexSupport.{filterQueryWithRecordKey, getPrunedStoragePaths}
+import org.apache.hudi.RecordLevelIndexSupport.filterQueryWithRecordKey
 import org.apache.hudi.SecondaryIndexSupport.filterQueriesWithSecondaryKey
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.data.HoodieListData
-import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.table.HoodieTableMetaClient
-import org.apache.hudi.common.util.HoodieDataUtils
 import org.apache.hudi.core.read.BaseHoodieTableFileIndex
 import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX
-import org.apache.hudi.storage.StoragePath
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
 
-import scala.collection.{mutable, JavaConverters}
+import scala.collection.JavaConverters
 import scala.collection.JavaConverters._
 
 class SecondaryIndexSupport(spark: SparkSession,
@@ -54,8 +51,7 @@ class SecondaryIndexSupport(spark: SparkSession,
     }
     lazy val (_, secondaryKeys) = if (isIndexAvailable) filterQueriesWithSecondaryKey(queryFilters, secondaryKeyConfigOpt.map(_._2)) else (List.empty, List.empty)
     if (isIndexAvailable && queryFilters.nonEmpty && secondaryKeys.nonEmpty) {
-      val prunedStoragePaths = getPrunedStoragePaths(prunedPartitionsAndFileSlices, fileIndex)
-      Some(getCandidateFilesFromSecondaryIndex(prunedStoragePaths, secondaryKeys, secondaryKeyConfigOpt.get._1))
+      Some(getCandidateFilesFromSecondaryIndex(prunedPartitionsAndFileSlices, fileIndex, secondaryKeys, secondaryKeyConfigOpt.get._1))
     } else {
       Option.empty
     }
@@ -79,23 +75,14 @@ class SecondaryIndexSupport(spark: SparkSession,
    * @param secondaryKeys - List of secondary keys.
    * @return Sequence of file names which need to be queried
    */
-  private def getCandidateFilesFromSecondaryIndex(allFiles: Seq[StoragePath], secondaryKeys: List[String], secondaryIndexName: String): Set[String] = {
+  private def getCandidateFilesFromSecondaryIndex(prunedPartitionsAndFileSlices: Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])],
+                                                  fileIndex: HoodieFileIndex,
+                                                  secondaryKeys: List[String],
+                                                  secondaryIndexName: String): Set[String] = {
     val secondaryIndexData = metadataTable.readSecondaryIndexLocationsWithKeys(
         HoodieListData.eager(JavaConverters.seqAsJavaListConverter(secondaryKeys).asJava), secondaryIndexName)
     try {
-      val recordKeyLocationsList = HoodieDataUtils.dedupeAndCollectAsList(secondaryIndexData)
-      val fileIdToPartitionMap: mutable.Map[String, String] = mutable.Map.empty
-      val candidateFiles: mutable.Set[String] = mutable.Set.empty
-      recordKeyLocationsList.forEach(recordKeyAndLocation => fileIdToPartitionMap.put(recordKeyAndLocation.getValue.getFileId, recordKeyAndLocation.getValue.getPartitionPath))
-
-      for (file <- allFiles) {
-        val fileId = FSUtils.getFileIdFromFilePath(file)
-        val partitionOpt = fileIdToPartitionMap.get(fileId)
-        if (partitionOpt.isDefined) {
-          candidateFiles += file.getName
-        }
-      }
-      candidateFiles.toSet
+      filterCandidateFiles(prunedPartitionsAndFileSlices, fileIndex, collectFileIdToPartitionMap(secondaryIndexData))
     } finally {
       // Clean up the RDD to avoid memory leaks
       secondaryIndexData.unpersistWithDependencies()

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestExternalFileRecordAndSecondaryIndex.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestExternalFileRecordAndSecondaryIndex.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.functional;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.model.HoodieDeltaWriteStat;
+import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.ExternalFilePathUtil;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.data.HoodieJavaRDD;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.testutils.HoodieClientTestBase;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
+import static org.apache.hudi.index.HoodieIndex.IndexType.INMEMORY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Asserts that the record index and the secondary index are maintained for parquet files written outside Hudi
+ * and registered in the table through replace commits, the way tables converted from other formats are.
+ * Such files carry no record key, so every row is keyed by the file path relative to the table and the row position.
+ */
+public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBase {
+
+  private static final String ID_FIELD = "id";
+  private static final String NAME_FIELD = "name";
+  private static final HoodieSchema SCHEMA = HoodieSchema.createRecord("external", null, null, false, Arrays.asList(
+      HoodieSchemaField.of(ID_FIELD, HoodieSchema.create(HoodieSchemaType.INT)),
+      HoodieSchemaField.of(NAME_FIELD, HoodieSchema.create(HoodieSchemaType.STRING))));
+
+  @ParameterizedTest
+  @ValueSource(strings = {"americas/brazil", ""})
+  public void testRecordAndSecondaryIndexForExternalFiles(String partitionPath) throws Exception {
+    // tables registered from other formats carry neither meta fields nor record key fields
+    Properties tableProperties = new Properties();
+    tableProperties.setProperty(HoodieTableConfig.POPULATE_META_FIELDS.key(), "false");
+    tableProperties.setProperty(HoodieTableConfig.RECORDKEY_FIELDS.key(), "");
+    initMetaClient(tableProperties);
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(metaClient.getBasePath())
+        .withSchema(SCHEMA.toString())
+        .withPopulateMetaFields(false)
+        // file ids of external files are file names, not UUIDs, so the record index stores them as raw strings
+        .withWritesFileIdEncoding(1)
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(INMEMORY).build())
+        .withEmbeddedTimelineServerEnabled(false)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withMetadataIndexColumnStats(false)
+            .withEnableGlobalRecordLevelIndex(true)
+            .withSecondaryIndexEnabled(true)
+            .withSecondaryIndexForColumn(NAME_FIELD)
+            .build())
+        .build();
+    writeClient = getHoodieWriteClient(writeConfig);
+    writeClient.setOperationType(WriteOperationType.UNKNOWN);
+
+    // first commit registers one file with three rows
+    String fileName1 = "file_1.parquet";
+    List<Pair<Integer, String>> rows1 = Arrays.asList(Pair.of(1, "alice"), Pair.of(2, "bob"), Pair.of(3, "alice"));
+    commitExternalFile(partitionPath, fileName1, rows1, Collections.emptyMap());
+
+    String relativePath1 = relativeFilePath(partitionPath, fileName1);
+    HoodieBackedTableMetadata tableMetadata = new HoodieBackedTableMetadata(
+        context, metaClient.getStorage(), writeConfig.getMetadataConfig(), writeConfig.getBasePath(), true);
+    Map<String, HoodieRecordGlobalLocation> recordIndex = readRecordIndex(tableMetadata, generatedKeys(relativePath1, 3));
+    assertEquals(3, recordIndex.size());
+    recordIndex.values().forEach(location -> {
+      assertEquals(partitionPath, location.getPartitionPath());
+      assertEquals(fileName1, location.getFileId());
+    });
+    String secondaryIndexPartition = secondaryIndexPartition();
+    assertEquals(new HashMap<String, Set<String>>() {
+      {
+        put("alice", setOf(generatedKey(relativePath1, 0), generatedKey(relativePath1, 2)));
+        put("bob", setOf(generatedKey(relativePath1, 1)));
+      }
+    }, readSecondaryIndex(tableMetadata, secondaryIndexPartition, Arrays.asList("alice", "bob", "carol")));
+
+    // second commit replaces the file with one that keeps bob and adds carol
+    String fileName2 = "file_2.parquet";
+    List<Pair<Integer, String>> rows2 = Arrays.asList(Pair.of(2, "bob"), Pair.of(4, "carol"));
+    commitExternalFile(partitionPath, fileName2, rows2, Collections.singletonMap(partitionPath, Collections.singletonList(fileName1)));
+
+    String relativePath2 = relativeFilePath(partitionPath, fileName2);
+    tableMetadata = new HoodieBackedTableMetadata(
+        context, metaClient.getStorage(), writeConfig.getMetadataConfig(), writeConfig.getBasePath(), true);
+    assertTrue(readRecordIndex(tableMetadata, generatedKeys(relativePath1, 3)).isEmpty());
+    recordIndex = readRecordIndex(tableMetadata, generatedKeys(relativePath2, 2));
+    assertEquals(2, recordIndex.size());
+    recordIndex.values().forEach(location -> assertEquals(fileName2, location.getFileId()));
+    assertEquals(new HashMap<String, Set<String>>() {
+      {
+        put("bob", setOf(generatedKey(relativePath2, 0)));
+        put("carol", setOf(generatedKey(relativePath2, 1)));
+      }
+    }, readSecondaryIndex(tableMetadata, secondaryIndexPartition, Arrays.asList("alice", "bob", "carol")));
+  }
+
+  private void commitExternalFile(String partitionPath, String fileName, List<Pair<Integer, String>> rows,
+                                  Map<String, List<String>> partitionToReplacedFileIds) throws IOException {
+    String instantTime = writeClient.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION, metaClient);
+    String relativePath = relativeFilePath(partitionPath, fileName);
+    long fileSize = writeParquetFile(new Path(metaClient.getBasePath().toString(), relativePath), rows);
+    WriteStatus writeStatus = new WriteStatus();
+    writeStatus.setFileId(fileName);
+    writeStatus.setPartitionPath(partitionPath);
+    HoodieDeltaWriteStat writeStat = new HoodieDeltaWriteStat();
+    writeStat.setFileId(fileName);
+    writeStat.setPath(ExternalFilePathUtil.appendCommitTimeAndExternalFileMarker(relativePath, instantTime));
+    writeStat.setPartitionPath(partitionPath);
+    writeStat.setNumWrites(rows.size());
+    writeStat.setNumInserts(rows.size());
+    writeStat.setTotalWriteBytes(fileSize);
+    writeStat.setFileSizeInBytes(fileSize);
+    writeStatus.setStat(writeStat);
+    metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime), Option.empty());
+    writeClient.commit(instantTime, jsc.parallelize(Collections.singletonList(writeStatus), 1), Option.empty(),
+        HoodieTimeline.REPLACE_COMMIT_ACTION, partitionToReplacedFileIds);
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+  }
+
+  private long writeParquetFile(Path path, List<Pair<Integer, String>> rows) throws IOException {
+    Configuration conf = metaClient.getStorageConf().unwrapAs(Configuration.class);
+    try (ParquetWriter<GenericRecord> writer = AvroParquetWriter.<GenericRecord>builder(path)
+        .withSchema(SCHEMA.toAvroSchema()).withConf(conf).build()) {
+      for (Pair<Integer, String> row : rows) {
+        GenericRecord record = new GenericData.Record(SCHEMA.toAvroSchema());
+        record.put(ID_FIELD, row.getLeft());
+        record.put(NAME_FIELD, row.getRight());
+        writer.write(record);
+      }
+    }
+    return path.getFileSystem(conf).getFileStatus(path).getLen();
+  }
+
+  private String secondaryIndexPartition() {
+    return metaClient.getIndexMetadata().get().getIndexDefinitions().keySet().stream()
+        .filter(indexName -> indexName.startsWith(HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX))
+        .findFirst().get();
+  }
+
+  private Map<String, HoodieRecordGlobalLocation> readRecordIndex(HoodieBackedTableMetadata tableMetadata, List<String> recordKeys) {
+    return tableMetadata.readRecordIndexLocationsWithKeys(HoodieJavaRDD.of(jsc.parallelize(recordKeys, 1))).collectAsList().stream()
+        .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+  }
+
+  private Map<String, Set<String>> readSecondaryIndex(HoodieBackedTableMetadata tableMetadata, String partitionName, List<String> secondaryKeys) {
+    return tableMetadata.readSecondaryIndexDataTableRecordKeysWithKeys(HoodieJavaRDD.of(jsc.parallelize(secondaryKeys, 1)), partitionName)
+        .collectAsList().stream()
+        .collect(Collectors.groupingBy(Pair::getKey, Collectors.mapping(Pair::getValue, Collectors.toSet())));
+  }
+
+  private static String relativeFilePath(String partitionPath, String fileName) {
+    return partitionPath.isEmpty() ? fileName : partitionPath + "/" + fileName;
+  }
+
+  private static String generatedKey(String relativeFilePath, long rowPosition) {
+    return ExternalFilePathUtil.generateRecordKeyForRow(relativeFilePath, rowPosition);
+  }
+
+  private static List<String> generatedKeys(String relativeFilePath, int rowCount) {
+    return java.util.stream.IntStream.range(0, rowCount).mapToObj(row -> generatedKey(relativeFilePath, row)).collect(Collectors.toList());
+  }
+
+  private static Set<String> setOf(String... values) {
+    return Arrays.stream(values).collect(Collectors.toSet());
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestExternalFileRecordAndSecondaryIndex.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestExternalFileRecordAndSecondaryIndex.java
@@ -47,9 +47,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -58,6 +60,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.index.HoodieIndex.IndexType.INMEMORY;
@@ -67,25 +71,124 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Asserts that the record index and the secondary index are maintained for parquet files written outside Hudi
  * and registered in the table through replace commits, the way tables converted from other formats are.
- * Such files carry no record key, so every row is keyed by the file path relative to the table and the row position.
+ * Such a table has no record key, so every row is keyed by the file path relative to the table and the row position.
+ * Some writers, e.g. Paimon, place their files in a directory below the partition; that prefix is part of the file id.
  */
 public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBase {
 
   private static final String ID_FIELD = "id";
   private static final String NAME_FIELD = "name";
+  private static final String PARTITION = "americas/brazil";
+  private static final String PREFIX = "bucket-0";
   private static final HoodieSchema SCHEMA = HoodieSchema.createRecord("external", null, null, false, Arrays.asList(
       HoodieSchemaField.of(ID_FIELD, HoodieSchema.create(HoodieSchemaType.INT)),
       HoodieSchemaField.of(NAME_FIELD, HoodieSchema.create(HoodieSchemaType.STRING))));
 
+  /** Partitioned and unpartitioned tables, with the files placed directly in the partition or below a prefix. */
+  static Stream<Arguments> partitionsAndPrefixes() {
+    return Stream.of(
+        Arguments.of(PARTITION, Option.empty()),
+        Arguments.of("", Option.empty()),
+        Arguments.of(PARTITION, Option.of(PREFIX)),
+        Arguments.of("", Option.of(PREFIX)));
+  }
+
+  /** The shapes above with a global record index, plus a partitioned record index, which the secondary index does not build on. */
+  static Stream<Arguments> partitionsPrefixesAndRecordIndexKinds() {
+    return Stream.concat(
+        partitionsAndPrefixes().map(arguments -> Arguments.of(arguments.get()[0], arguments.get()[1], false)),
+        Stream.of(Arguments.of(PARTITION, Option.empty(), true)));
+  }
+
   @ParameterizedTest
-  @ValueSource(strings = {"americas/brazil", ""})
-  public void testRecordAndSecondaryIndexForExternalFiles(String partitionPath) throws Exception {
-    // tables registered from other formats carry neither meta fields nor record key fields
+  @MethodSource("partitionsPrefixesAndRecordIndexKinds")
+  public void testRecordAndSecondaryIndexForExternalFiles(String partitionPath, Option<String> prefix, boolean partitionedRecordIndex) throws Exception {
+    initExternalTable();
+    HoodieWriteConfig writeConfig = writeConfig(true, partitionedRecordIndex);
+    writeClient = getHoodieWriteClient(writeConfig);
+    writeClient.setOperationType(WriteOperationType.UNKNOWN);
+    Option<String> recordIndexPartition = partitionedRecordIndex ? Option.of(partitionPath) : Option.empty();
+
+    // first commit registers one file with three rows
+    ExternalFile file1 = new ExternalFile(partitionPath, prefix, "file_1.parquet");
+    commitReplace(Collections.singletonList(Pair.of(file1, rows(1, "alice", 2, "bob", 3, "alice"))), Collections.emptyMap());
+
+    HoodieBackedTableMetadata tableMetadata = tableMetadata(writeConfig);
+    assertRecordIndex(tableMetadata, recordIndexPartition, file1, 3);
+    if (!partitionedRecordIndex) {
+      assertEquals(mapOf("alice", setOf(file1.key(0), file1.key(2)), "bob", setOf(file1.key(1))),
+          readSecondaryIndex(tableMetadata, secondaryIndexPartition(), Arrays.asList("alice", "bob", "carol")));
+    }
+
+    // second commit replaces the file with one that keeps bob and adds carol
+    ExternalFile file2 = new ExternalFile(partitionPath, prefix, "file_2.parquet");
+    commitReplace(Collections.singletonList(Pair.of(file2, rows(2, "bob", 4, "carol"))),
+        Collections.singletonMap(partitionPath, Collections.singletonList(file1.fileId())));
+
+    tableMetadata = tableMetadata(writeConfig);
+    assertTrue(readRecordIndex(tableMetadata, recordIndexPartition, file1.keys(3)).isEmpty());
+    assertRecordIndex(tableMetadata, recordIndexPartition, file2, 2);
+    if (!partitionedRecordIndex) {
+      assertEquals(mapOf("bob", setOf(file2.key(0)), "carol", setOf(file2.key(1))),
+          readSecondaryIndex(tableMetadata, secondaryIndexPartition(), Arrays.asList("alice", "bob", "carol")));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("partitionsAndPrefixes")
+  public void testIndexesAreBuiltFromRegisteredFilesWhenEnabledLater(String partitionPath, Option<String> prefix) throws Exception {
+    initExternalTable();
+    // the first file is registered while both indexes are off
+    writeClient = getHoodieWriteClient(writeConfig(false, false));
+    writeClient.setOperationType(WriteOperationType.UNKNOWN);
+    ExternalFile file1 = new ExternalFile(partitionPath, prefix, "file_1.parquet");
+    commitReplace(Collections.singletonList(Pair.of(file1, rows(1, "alice", 2, "bob", 3, "alice"))), Collections.emptyMap());
+
+    // the second file is registered with both indexes on, which first builds them from the registered file
+    HoodieWriteConfig indexedWriteConfig = writeConfig(true, false);
+    writeClient = getHoodieWriteClient(indexedWriteConfig);
+    writeClient.setOperationType(WriteOperationType.UNKNOWN);
+    ExternalFile file2 = new ExternalFile(partitionPath, prefix, "file_2.parquet");
+    commitReplace(Collections.singletonList(Pair.of(file2, rows(4, "carol"))), Collections.emptyMap());
+
+    HoodieBackedTableMetadata tableMetadata = tableMetadata(indexedWriteConfig);
+    assertRecordIndex(tableMetadata, Option.empty(), file1, 3);
+    assertRecordIndex(tableMetadata, Option.empty(), file2, 1);
+    String secondaryIndexPartition = secondaryIndexPartition();
+    assertEquals(mapOf("alice", setOf(file1.key(0), file1.key(2)), "bob", setOf(file1.key(1)), "carol", setOf(file2.key(0))),
+        readSecondaryIndex(tableMetadata, secondaryIndexPartition, Arrays.asList("alice", "bob", "carol")));
+
+    // the third commit only drops the first file
+    commitReplace(Collections.emptyList(), Collections.singletonMap(partitionPath, Collections.singletonList(file1.fileId())));
+
+    tableMetadata = tableMetadata(indexedWriteConfig);
+    assertTrue(readRecordIndex(tableMetadata, Option.empty(), file1.keys(3)).isEmpty());
+    assertRecordIndex(tableMetadata, Option.empty(), file2, 1);
+    assertEquals(mapOf("carol", setOf(file2.key(0))),
+        readSecondaryIndex(tableMetadata, secondaryIndexPartition, Arrays.asList("alice", "bob", "carol")));
+  }
+
+  /** Tables registered from other formats carry neither meta fields nor record key fields. */
+  private void initExternalTable() throws IOException {
     Properties tableProperties = new Properties();
     tableProperties.setProperty(HoodieTableConfig.POPULATE_META_FIELDS.key(), "false");
     tableProperties.setProperty(HoodieTableConfig.RECORDKEY_FIELDS.key(), "");
     initMetaClient(tableProperties);
-    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+  }
+
+  private HoodieWriteConfig writeConfig(boolean withIndexes, boolean partitionedRecordIndex) {
+    HoodieMetadataConfig.Builder metadataConfig = HoodieMetadataConfig.newBuilder()
+        .enable(true)
+        .withMetadataIndexColumnStats(false);
+    if (withIndexes && partitionedRecordIndex) {
+      // the secondary index builds on the global record index only
+      metadataConfig.withEnableRecordLevelIndex(true);
+    } else if (withIndexes) {
+      metadataConfig.withEnableGlobalRecordLevelIndex(true)
+          .withSecondaryIndexEnabled(true)
+          .withSecondaryIndexForColumn(NAME_FIELD);
+    }
+    return HoodieWriteConfig.newBuilder()
         .withPath(metaClient.getBasePath())
         .withSchema(SCHEMA.toString())
         .withPopulateMetaFields(false)
@@ -93,79 +196,38 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
         .withWritesFileIdEncoding(1)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(INMEMORY).build())
         .withEmbeddedTimelineServerEnabled(false)
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
-            .enable(true)
-            .withMetadataIndexColumnStats(false)
-            .withEnableGlobalRecordLevelIndex(true)
-            .withSecondaryIndexEnabled(true)
-            .withSecondaryIndexForColumn(NAME_FIELD)
-            .build())
+        .withMetadataConfig(metadataConfig.build())
         .build();
-    writeClient = getHoodieWriteClient(writeConfig);
-    writeClient.setOperationType(WriteOperationType.UNKNOWN);
-
-    // first commit registers one file with three rows
-    String fileName1 = "file_1.parquet";
-    List<Pair<Integer, String>> rows1 = Arrays.asList(Pair.of(1, "alice"), Pair.of(2, "bob"), Pair.of(3, "alice"));
-    commitExternalFile(partitionPath, fileName1, rows1, Collections.emptyMap());
-
-    String relativePath1 = relativeFilePath(partitionPath, fileName1);
-    HoodieBackedTableMetadata tableMetadata = new HoodieBackedTableMetadata(
-        context, metaClient.getStorage(), writeConfig.getMetadataConfig(), writeConfig.getBasePath(), true);
-    Map<String, HoodieRecordGlobalLocation> recordIndex = readRecordIndex(tableMetadata, generatedKeys(relativePath1, 3));
-    assertEquals(3, recordIndex.size());
-    recordIndex.values().forEach(location -> {
-      assertEquals(partitionPath, location.getPartitionPath());
-      assertEquals(fileName1, location.getFileId());
-    });
-    String secondaryIndexPartition = secondaryIndexPartition();
-    assertEquals(new HashMap<String, Set<String>>() {
-      {
-        put("alice", setOf(generatedKey(relativePath1, 0), generatedKey(relativePath1, 2)));
-        put("bob", setOf(generatedKey(relativePath1, 1)));
-      }
-    }, readSecondaryIndex(tableMetadata, secondaryIndexPartition, Arrays.asList("alice", "bob", "carol")));
-
-    // second commit replaces the file with one that keeps bob and adds carol
-    String fileName2 = "file_2.parquet";
-    List<Pair<Integer, String>> rows2 = Arrays.asList(Pair.of(2, "bob"), Pair.of(4, "carol"));
-    commitExternalFile(partitionPath, fileName2, rows2, Collections.singletonMap(partitionPath, Collections.singletonList(fileName1)));
-
-    String relativePath2 = relativeFilePath(partitionPath, fileName2);
-    tableMetadata = new HoodieBackedTableMetadata(
-        context, metaClient.getStorage(), writeConfig.getMetadataConfig(), writeConfig.getBasePath(), true);
-    assertTrue(readRecordIndex(tableMetadata, generatedKeys(relativePath1, 3)).isEmpty());
-    recordIndex = readRecordIndex(tableMetadata, generatedKeys(relativePath2, 2));
-    assertEquals(2, recordIndex.size());
-    recordIndex.values().forEach(location -> assertEquals(fileName2, location.getFileId()));
-    assertEquals(new HashMap<String, Set<String>>() {
-      {
-        put("bob", setOf(generatedKey(relativePath2, 0)));
-        put("carol", setOf(generatedKey(relativePath2, 1)));
-      }
-    }, readSecondaryIndex(tableMetadata, secondaryIndexPartition, Arrays.asList("alice", "bob", "carol")));
   }
 
-  private void commitExternalFile(String partitionPath, String fileName, List<Pair<Integer, String>> rows,
-                                  Map<String, List<String>> partitionToReplacedFileIds) throws IOException {
+  /**
+   * Registers the given files in one replace commit, the way an external writer does: the files are written to
+   * their location below the table, and the commit records them with the external file marker.
+   */
+  private void commitReplace(List<Pair<ExternalFile, List<Pair<Integer, String>>>> newFiles,
+                             Map<String, List<String>> partitionToReplacedFileIds) throws IOException {
     String instantTime = writeClient.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION, metaClient);
-    String relativePath = relativeFilePath(partitionPath, fileName);
-    long fileSize = writeParquetFile(new Path(metaClient.getBasePath().toString(), relativePath), rows);
-    WriteStatus writeStatus = new WriteStatus();
-    writeStatus.setFileId(fileName);
-    writeStatus.setPartitionPath(partitionPath);
-    HoodieDeltaWriteStat writeStat = new HoodieDeltaWriteStat();
-    writeStat.setFileId(fileName);
-    writeStat.setPath(ExternalFilePathUtil.appendCommitTimeAndExternalFileMarker(relativePath, instantTime));
-    writeStat.setPartitionPath(partitionPath);
-    writeStat.setNumWrites(rows.size());
-    writeStat.setNumInserts(rows.size());
-    writeStat.setTotalWriteBytes(fileSize);
-    writeStat.setFileSizeInBytes(fileSize);
-    writeStatus.setStat(writeStat);
+    List<WriteStatus> writeStatuses = new ArrayList<>();
+    for (Pair<ExternalFile, List<Pair<Integer, String>>> fileAndRows : newFiles) {
+      ExternalFile file = fileAndRows.getLeft();
+      long fileSize = writeParquetFile(new Path(metaClient.getBasePath().toString(), file.relativePath()), fileAndRows.getRight());
+      WriteStatus writeStatus = new WriteStatus();
+      writeStatus.setFileId(file.fileId());
+      writeStatus.setPartitionPath(file.partitionPath);
+      HoodieDeltaWriteStat writeStat = new HoodieDeltaWriteStat();
+      writeStat.setFileId(file.fileId());
+      writeStat.setPath(file.markedPath(instantTime));
+      writeStat.setPartitionPath(file.partitionPath);
+      writeStat.setNumWrites(fileAndRows.getRight().size());
+      writeStat.setNumInserts(fileAndRows.getRight().size());
+      writeStat.setTotalWriteBytes(fileSize);
+      writeStat.setFileSizeInBytes(fileSize);
+      writeStatus.setStat(writeStat);
+      writeStatuses.add(writeStatus);
+    }
     metaClient.getActiveTimeline().transitionReplaceRequestedToInflight(
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, instantTime), Option.empty());
-    writeClient.commit(instantTime, jsc.parallelize(Collections.singletonList(writeStatus), 1), Option.empty(),
+    writeClient.commit(instantTime, jsc.parallelize(writeStatuses, 1), Option.empty(),
         HoodieTimeline.REPLACE_COMMIT_ACTION, partitionToReplacedFileIds);
     metaClient = HoodieTableMetaClient.reload(metaClient);
   }
@@ -184,14 +246,29 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
     return path.getFileSystem(conf).getFileStatus(path).getLen();
   }
 
+  private HoodieBackedTableMetadata tableMetadata(HoodieWriteConfig writeConfig) {
+    return new HoodieBackedTableMetadata(context, metaClient.getStorage(), writeConfig.getMetadataConfig(), writeConfig.getBasePath(), true);
+  }
+
   private String secondaryIndexPartition() {
     return metaClient.getIndexMetadata().get().getIndexDefinitions().keySet().stream()
         .filter(indexName -> indexName.startsWith(HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX))
         .findFirst().get();
   }
 
-  private Map<String, HoodieRecordGlobalLocation> readRecordIndex(HoodieBackedTableMetadata tableMetadata, List<String> recordKeys) {
-    return tableMetadata.readRecordIndexLocationsWithKeys(HoodieJavaRDD.of(jsc.parallelize(recordKeys, 1))).collectAsList().stream()
+  /** Asserts that every row of the file is in the record index and points at the file. */
+  private void assertRecordIndex(HoodieBackedTableMetadata tableMetadata, Option<String> recordIndexPartition, ExternalFile file, int rowCount) {
+    Map<String, HoodieRecordGlobalLocation> locations = readRecordIndex(tableMetadata, recordIndexPartition, file.keys(rowCount));
+    assertEquals(rowCount, locations.size());
+    locations.values().forEach(location -> {
+      assertEquals(file.partitionPath, location.getPartitionPath());
+      assertEquals(file.fileId(), location.getFileId());
+    });
+  }
+
+  private Map<String, HoodieRecordGlobalLocation> readRecordIndex(HoodieBackedTableMetadata tableMetadata, Option<String> recordIndexPartition,
+                                                                  List<String> recordKeys) {
+    return tableMetadata.readRecordIndexLocationsWithKeys(HoodieJavaRDD.of(jsc.parallelize(recordKeys, 1)), recordIndexPartition).collectAsList().stream()
         .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
   }
 
@@ -201,19 +278,65 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
         .collect(Collectors.groupingBy(Pair::getKey, Collectors.mapping(Pair::getValue, Collectors.toSet())));
   }
 
-  private static String relativeFilePath(String partitionPath, String fileName) {
-    return partitionPath.isEmpty() ? fileName : partitionPath + "/" + fileName;
+  private static List<Pair<Integer, String>> rows(Object... idsAndNames) {
+    List<Pair<Integer, String>> rows = new ArrayList<>();
+    for (int i = 0; i < idsAndNames.length; i += 2) {
+      rows.add(Pair.of((Integer) idsAndNames[i], (String) idsAndNames[i + 1]));
+    }
+    return rows;
   }
 
-  private static String generatedKey(String relativeFilePath, long rowPosition) {
-    return ExternalFilePathUtil.generateRecordKeyForRow(relativeFilePath, rowPosition);
-  }
-
-  private static List<String> generatedKeys(String relativeFilePath, int rowCount) {
-    return java.util.stream.IntStream.range(0, rowCount).mapToObj(row -> generatedKey(relativeFilePath, row)).collect(Collectors.toList());
+  private static Map<String, Set<String>> mapOf(Object... keysAndValues) {
+    Map<String, Set<String>> map = new HashMap<>();
+    for (int i = 0; i < keysAndValues.length; i += 2) {
+      @SuppressWarnings("unchecked")
+      Set<String> value = (Set<String>) keysAndValues[i + 1];
+      map.put((String) keysAndValues[i], value);
+    }
+    return map;
   }
 
   private static Set<String> setOf(String... values) {
     return Arrays.stream(values).collect(Collectors.toSet());
+  }
+
+  /** A parquet file written outside Hudi: where it lives below the table, and the file id Hudi registers it under. */
+  private static final class ExternalFile {
+    private final String partitionPath;
+    private final Option<String> prefix;
+    private final String fileName;
+
+    ExternalFile(String partitionPath, Option<String> prefix, String fileName) {
+      this.partitionPath = partitionPath;
+      this.prefix = prefix;
+      this.fileName = fileName;
+    }
+
+    /** The file id of an external file is its path below the partition. */
+    String fileId() {
+      return prefix.map(p -> p + "/" + fileName).orElse(fileName);
+    }
+
+    String relativePath() {
+      return partitionPath.isEmpty() ? fileId() : partitionPath + "/" + fileId();
+    }
+
+    /** The path the commit records: the file name carries the commit time, the prefix and the external file marker. */
+    String markedPath(String instantTime) {
+      String markedFileName = prefix.isPresent()
+          ? ExternalFilePathUtil.appendCommitTimeAndExternalFileMarker(fileName, instantTime, prefix.get())
+          : ExternalFilePathUtil.appendCommitTimeAndExternalFileMarker(fileName, instantTime);
+      String markedFileId = prefix.map(p -> p + "/" + markedFileName).orElse(markedFileName);
+      return partitionPath.isEmpty() ? markedFileId : partitionPath + "/" + markedFileId;
+    }
+
+    /** Every row is keyed by the file path relative to the table and the row position. */
+    String key(long rowPosition) {
+      return ExternalFilePathUtil.generateRecordKeyForRow(relativePath(), rowPosition);
+    }
+
+    List<String> keys(int rowCount) {
+      return IntStream.range(0, rowCount).mapToObj(this::key).collect(Collectors.toList());
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestExternalFileRecordAndSecondaryIndex.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestExternalFileRecordAndSecondaryIndex.java
@@ -34,9 +34,11 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.ExternalFilePathUtil;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
+import org.apache.hudi.keygen.NonpartitionedKeyGenerator;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.testutils.HoodieClientTestBase;
@@ -52,10 +54,10 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.execution.FileSourceScanExec;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -73,6 +75,7 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.index.HoodieIndex.IndexType.INMEMORY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -182,28 +185,43 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
         readSecondaryIndex(tableMetadata, secondaryIndexPartition, Arrays.asList("alice", "bob", "carol")));
   }
 
-  @Test
-  public void testClusteringIsRejectedBecausePositionalKeysDoNotSurviveIt() throws Exception {
+  /**
+   * Clustering rewrites the rows into a new file, so their keys, which are file path and position, would change.
+   * The rejection must hold under the Spark default, which streams the index updates and never reaches the
+   * indexers for the record index and the secondary index, and with streaming off, which updates them from the
+   * commit metadata.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testClusteringIsRejectedBecausePositionalKeysDoNotSurviveIt(boolean streamingWriteEnabled) throws Exception {
     initExternalTable("");
-    HoodieWriteConfig writeConfig = writeConfig(true, false);
+    // the table has no record key, so the clustering writer must not derive keys from a record key field
+    HoodieWriteConfig writeConfig = writeConfigBuilder(true, false, streamingWriteEnabled)
+        .withKeyGenerator(NonpartitionedKeyGenerator.class.getName())
+        .withClusteringConfig(HoodieClusteringConfig.newBuilder().withClusteringMaxNumGroups(10).withClusteringTargetPartitions(0).build())
+        .build();
     writeClient = getHoodieWriteClient(writeConfig);
     writeClient.setOperationType(WriteOperationType.UNKNOWN);
-    commitReplace(Arrays.asList(
-        Pair.of(new ExternalFile("", Option.empty(), "file_1.parquet"), rows(1, "alice", 2, "bob")),
-        Pair.of(new ExternalFile("", Option.empty(), "file_2.parquet"), rows(3, "carol"))), Collections.emptyMap());
+    ExternalFile file1 = new ExternalFile("", Option.empty(), "file_1.parquet");
+    ExternalFile file2 = new ExternalFile("", Option.empty(), "file_2.parquet");
+    commitReplace(Arrays.asList(Pair.of(file1, rows(1, "alice", 2, "bob")), Pair.of(file2, rows(3, "carol"))), Collections.emptyMap());
 
-    // clustering rewrites the rows into a new file, so their keys, which are file path and position, would change.
-    // The clustering commit is replayed the way clustering completes it: a replace commit of the rewritten file that
-    // carries the CLUSTER operation type and updates the indexes from its commit metadata.
-    writeClient.setOperationType(WriteOperationType.CLUSTER);
-    Exception clustering = assertThrows(Exception.class, () -> commitReplace(
-        Collections.singletonList(Pair.of(new ExternalFile("", Option.empty(), "file_3.parquet"), rows(1, "alice", 2, "bob", 3, "carol"))),
-        Collections.singletonMap("", Arrays.asList("file_1.parquet", "file_2.parquet"))));
+    String clusteringInstant = (String) writeClient.scheduleClustering(Option.empty()).get();
+    Exception clustering = assertThrows(Exception.class, () -> writeClient.cluster(clusteringInstant));
     Throwable cause = clustering;
     while (cause.getCause() != null && (cause.getMessage() == null || !cause.getMessage().contains("cannot be clustered"))) {
       cause = cause.getCause();
     }
     assertTrue(String.valueOf(cause.getMessage()).contains("cannot be clustered because it has no record key"), String.valueOf(clustering));
+
+    // the clustering did not complete, and both indexes still point at the registered files
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    assertFalse(metaClient.getActiveTimeline().filterCompletedInstants().containsInstant(clusteringInstant));
+    HoodieBackedTableMetadata tableMetadata = tableMetadata(writeConfig);
+    assertRecordIndex(tableMetadata, Option.empty(), file1, 2);
+    assertRecordIndex(tableMetadata, Option.empty(), file2, 1);
+    assertEquals(mapOf("alice", setOf(file1.key(0)), "bob", setOf(file1.key(1)), "carol", setOf(file2.key(0))),
+        readSecondaryIndex(tableMetadata, secondaryIndexPartition(), Arrays.asList("alice", "bob", "carol")));
   }
 
   /**
@@ -221,10 +239,14 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
   }
 
   private HoodieWriteConfig writeConfig(boolean withIndexes, boolean partitionedRecordIndex) {
+    // the indexes are updated from the commit metadata, the way replace commits and table services update them
+    return writeConfigBuilder(withIndexes, partitionedRecordIndex, false).build();
+  }
+
+  private HoodieWriteConfig.Builder writeConfigBuilder(boolean withIndexes, boolean partitionedRecordIndex, boolean streamingWriteEnabled) {
     HoodieMetadataConfig.Builder metadataConfig = HoodieMetadataConfig.newBuilder()
         .enable(true)
-        // the indexes are updated from the commit metadata, the way replace commits and table services update them
-        .withStreamingWriteEnabled(false)
+        .withStreamingWriteEnabled(streamingWriteEnabled)
         .withMetadataIndexColumnStats(false);
     if (withIndexes && partitionedRecordIndex) {
       // the secondary index builds on the global record index only
@@ -240,8 +262,7 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
         .withPopulateMetaFields(false)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(INMEMORY).build())
         .withEmbeddedTimelineServerEnabled(false)
-        .withMetadataConfig(metadataConfig.build())
-        .build();
+        .withMetadataConfig(metadataConfig.build());
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestExternalFileRecordAndSecondaryIndex.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestExternalFileRecordAndSecondaryIndex.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.functional;
 
+import org.apache.hudi.DataSourceReadOptions;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieDeltaWriteStat;
@@ -46,6 +47,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.execution.FileSourceScanExec;
+import org.apache.spark.sql.execution.SparkPlan;
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -66,6 +73,7 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.index.HoodieIndex.IndexType.INMEMORY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -103,7 +111,7 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
   @ParameterizedTest
   @MethodSource("partitionsPrefixesAndRecordIndexKinds")
   public void testRecordAndSecondaryIndexForExternalFiles(String partitionPath, Option<String> prefix, boolean partitionedRecordIndex) throws Exception {
-    initExternalTable();
+    initExternalTable(partitionPath);
     HoodieWriteConfig writeConfig = writeConfig(true, partitionedRecordIndex);
     writeClient = getHoodieWriteClient(writeConfig);
     writeClient.setOperationType(WriteOperationType.UNKNOWN);
@@ -137,7 +145,7 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
   @ParameterizedTest
   @MethodSource("partitionsAndPrefixes")
   public void testIndexesAreBuiltFromRegisteredFilesWhenEnabledLater(String partitionPath, Option<String> prefix) throws Exception {
-    initExternalTable();
+    initExternalTable(partitionPath);
     // the first file is registered while both indexes are off
     writeClient = getHoodieWriteClient(writeConfig(false, false));
     writeClient.setOperationType(WriteOperationType.UNKNOWN);
@@ -157,6 +165,12 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
     String secondaryIndexPartition = secondaryIndexPartition();
     assertEquals(mapOf("alice", setOf(file1.key(0), file1.key(2)), "bob", setOf(file1.key(1)), "carol", setOf(file2.key(0))),
         readSecondaryIndex(tableMetadata, secondaryIndexPartition, Arrays.asList("alice", "bob", "carol")));
+    if (partitionPath.isEmpty()) {
+      // a query on the indexed column reads only the file the secondary index points at. The partitioned shape is not
+      // read here: the test harness declares a partition field that the schema of the external files does not carry.
+      assertSecondaryIndexPrunesRead("carol", setOf(4), 1);
+      assertSecondaryIndexPrunesRead("alice", setOf(1, 3), 1);
+    }
 
     // the third commit only drops the first file
     commitReplace(Collections.emptyList(), Collections.singletonMap(partitionPath, Collections.singletonList(file1.fileId())));
@@ -168,17 +182,49 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
         readSecondaryIndex(tableMetadata, secondaryIndexPartition, Arrays.asList("alice", "bob", "carol")));
   }
 
-  /** Tables registered from other formats carry neither meta fields nor record key fields. */
-  private void initExternalTable() throws IOException {
+  @Test
+  public void testClusteringIsRejectedBecausePositionalKeysDoNotSurviveIt() throws Exception {
+    initExternalTable("");
+    HoodieWriteConfig writeConfig = writeConfig(true, false);
+    writeClient = getHoodieWriteClient(writeConfig);
+    writeClient.setOperationType(WriteOperationType.UNKNOWN);
+    commitReplace(Arrays.asList(
+        Pair.of(new ExternalFile("", Option.empty(), "file_1.parquet"), rows(1, "alice", 2, "bob")),
+        Pair.of(new ExternalFile("", Option.empty(), "file_2.parquet"), rows(3, "carol"))), Collections.emptyMap());
+
+    // clustering rewrites the rows into a new file, so their keys, which are file path and position, would change.
+    // The clustering commit is replayed the way clustering completes it: a replace commit of the rewritten file that
+    // carries the CLUSTER operation type and updates the indexes from its commit metadata.
+    writeClient.setOperationType(WriteOperationType.CLUSTER);
+    Exception clustering = assertThrows(Exception.class, () -> commitReplace(
+        Collections.singletonList(Pair.of(new ExternalFile("", Option.empty(), "file_3.parquet"), rows(1, "alice", 2, "bob", 3, "carol"))),
+        Collections.singletonMap("", Arrays.asList("file_1.parquet", "file_2.parquet"))));
+    Throwable cause = clustering;
+    while (cause.getCause() != null && (cause.getMessage() == null || !cause.getMessage().contains("cannot be clustered"))) {
+      cause = cause.getCause();
+    }
+    assertTrue(String.valueOf(cause.getMessage()).contains("cannot be clustered because it has no record key"), String.valueOf(clustering));
+  }
+
+  /**
+   * Tables registered from other formats carry neither meta fields nor record key fields. An unpartitioned table
+   * declares no partition field either; the test harness otherwise declares one that the schema does not carry.
+   */
+  private void initExternalTable(String partitionPath) throws IOException {
     Properties tableProperties = new Properties();
     tableProperties.setProperty(HoodieTableConfig.POPULATE_META_FIELDS.key(), "false");
     tableProperties.setProperty(HoodieTableConfig.RECORDKEY_FIELDS.key(), "");
+    if (partitionPath.isEmpty()) {
+      tableProperties.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), "");
+    }
     initMetaClient(tableProperties);
   }
 
   private HoodieWriteConfig writeConfig(boolean withIndexes, boolean partitionedRecordIndex) {
     HoodieMetadataConfig.Builder metadataConfig = HoodieMetadataConfig.newBuilder()
         .enable(true)
+        // the indexes are updated from the commit metadata, the way replace commits and table services update them
+        .withStreamingWriteEnabled(false)
         .withMetadataIndexColumnStats(false);
     if (withIndexes && partitionedRecordIndex) {
       // the secondary index builds on the global record index only
@@ -192,8 +238,6 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
         .withPath(metaClient.getBasePath())
         .withSchema(SCHEMA.toString())
         .withPopulateMetaFields(false)
-        // file ids of external files are file names, not UUIDs, so the record index stores them as raw strings
-        .withWritesFileIdEncoding(1)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(INMEMORY).build())
         .withEmbeddedTimelineServerEnabled(false)
         .withMetadataConfig(metadataConfig.build())
@@ -246,6 +290,24 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
     return path.getFileSystem(conf).getFileStatus(path).getLen();
   }
 
+  /**
+   * Reads the table through Spark with a filter on the indexed column and asserts the rows returned and the number of
+   * files scanned, which the secondary index prunes to the files that hold the secondary key.
+   */
+  private void assertSecondaryIndexPrunesRead(String secondaryKey, Set<Integer> expectedIds, long expectedFileCount) {
+    Dataset<Row> rows = sparkSession.read().format("hudi")
+        .option(HoodieMetadataConfig.ENABLE.key(), "true")
+        .option(DataSourceReadOptions.ENABLE_DATA_SKIPPING().key(), "true")
+        .load(metaClient.getBasePath().toString())
+        .where(NAME_FIELD + " = '" + secondaryKey + "'");
+    assertEquals(expectedIds, rows.collectAsList().stream().map(row -> row.getInt(row.fieldIndex(ID_FIELD))).collect(Collectors.toSet()));
+    SparkPlan scan = rows.queryExecution().executedPlan().collectLeaves().head();
+    if (scan instanceof AdaptiveSparkPlanExec) {
+      scan = ((AdaptiveSparkPlanExec) scan).executedPlan().collectLeaves().head();
+    }
+    assertEquals(expectedFileCount, ((FileSourceScanExec) scan).metrics().apply("numFiles").value());
+  }
+
   private HoodieBackedTableMetadata tableMetadata(HoodieWriteConfig writeConfig) {
     return new HoodieBackedTableMetadata(context, metaClient.getStorage(), writeConfig.getMetadataConfig(), writeConfig.getBasePath(), true);
   }
@@ -296,7 +358,8 @@ public class TestExternalFileRecordAndSecondaryIndex extends HoodieClientTestBas
     return map;
   }
 
-  private static Set<String> setOf(String... values) {
+  @SafeVarargs
+  private static <T> Set<T> setOf(T... values) {
     return Arrays.stream(values).collect(Collectors.toSet());
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -138,7 +138,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
 
         // poll into generateRLIMetadataHoodieRecordsForBaseFile to fetch MDT RLI records for inserts and deletes.
         Iterator<HoodieRecord> rliRecordsItr = BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForBaseFile(metaClient.getBasePath().toString(),
-            writeStatus.getStat(), writeConfig.getWritesFileIdEncoding(), finalCommitTime, metaClient.getStorage(), false);
+            writeStatus.getStat(), writeConfig.getWritesFileIdEncoding(), finalCommitTime, metaClient.getStorage(), false, false);
         while (rliRecordsItr.hasNext()) {
           HoodieRecord rliRecord = rliRecordsItr.next();
           String key = rliRecord.getRecordKey();
@@ -244,7 +244,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
 
         // poll into generateRLIMetadataHoodieRecordsForBaseFile to fetch MDT RLI records for inserts and deletes.
         Iterator<HoodieRecord> rliRecordsItr = BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForBaseFile(metaClient.getBasePath().toString(),
-            writeStatus.getStat(), writeConfig.getWritesFileIdEncoding(), finalCommitTime, metaClient.getStorage(), writeConfig.isRecordLevelIndexEnabled());
+            writeStatus.getStat(), writeConfig.getWritesFileIdEncoding(), finalCommitTime, metaClient.getStorage(), writeConfig.isRecordLevelIndexEnabled(), false);
         while (rliRecordsItr.hasNext()) {
           HoodieRecord rliRecord = rliRecordsItr.next();
           String key = rliRecord.getRecordKey();
@@ -660,7 +660,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
         }
 
         Iterator<HoodieRecord> rliRecordsItr = BaseFileRecordParsingUtils.generateRLIMetadataHoodieRecordsForBaseFile(metaClient.getBasePath().toString(), writeStatus.getStat(),
-            writeConfig.getWritesFileIdEncoding(), commitTime, metaClient.getStorage(), writeConfig.isRecordLevelIndexEnabled());
+            writeConfig.getWritesFileIdEncoding(), commitTime, metaClient.getStorage(), writeConfig.isRecordLevelIndexEnabled(), false);
         while (rliRecordsItr.hasNext()) {
           HoodieRecord rliRecord = rliRecordsItr.next();
           String key = rliRecord.getRecordKey();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -36,6 +36,7 @@ import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -370,7 +371,8 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       metadataView = new HoodieTableFileSystemView(metadata, metaClient, metaClient.getActiveTimeline());
       List<HoodieWriteStat> allWriteStats = writeStatusList2.stream().map(WriteStatus::getStat).collect(Collectors.toList());
       secondaryIndexRecords =
-          convertWriteStatsToSecondaryIndexRecords(allWriteStats, secondCommitTime, indexDefinition, metadataConfig, metaClient, engineContext, writeConfig).collectAsList();
+          convertWriteStatsToSecondaryIndexRecords(allWriteStats, secondCommitTime, indexDefinition, metadataConfig, metaClient, engineContext, writeConfig,
+              toCommitMetadata(allWriteStats)).collectAsList();
       client.commit(secondCommitTime, jsc.parallelize(writeStatusList2));
 
       // There should be 3 SI records:
@@ -404,7 +406,8 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       metadataView = new HoodieTableFileSystemView(metadata, metaClient, metaClient.getActiveTimeline());
       allWriteStats = writeStatusList3.stream().map(WriteStatus::getStat).collect(Collectors.toList());
       secondaryIndexRecords =
-          convertWriteStatsToSecondaryIndexRecords(allWriteStats, thirdCommitTime, indexDefinition, metadataConfig, metaClient, engineContext, writeConfig).collectAsList();
+          convertWriteStatsToSecondaryIndexRecords(allWriteStats, thirdCommitTime, indexDefinition, metadataConfig, metaClient, engineContext, writeConfig,
+              toCommitMetadata(allWriteStats)).collectAsList();
       client.commit(thirdCommitTime, jsc.parallelize(writeStatusList3));
 
       // There should be 1 SI records: 1 delete due to deletes3
@@ -435,7 +438,8 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       metadataView = new HoodieTableFileSystemView(metadata, metaClient, metaClient.getActiveTimeline());
       allWriteStats = writeStatusList4.stream().map(WriteStatus::getStat).collect(Collectors.toList());
       secondaryIndexRecords =
-          convertWriteStatsToSecondaryIndexRecords(allWriteStats, fourthCommitTime, indexDefinition, metadataConfig, metaClient, engineContext, writeConfig).collectAsList();
+          convertWriteStatsToSecondaryIndexRecords(allWriteStats, fourthCommitTime, indexDefinition, metadataConfig, metaClient, engineContext, writeConfig,
+              toCommitMetadata(allWriteStats)).collectAsList();
       client.commit(fourthCommitTime, jsc.parallelize(writeStatusList4));
 
       // There should be 1 SI records: 1 insert due to inserts4
@@ -458,7 +462,8 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       metadataView = new HoodieTableFileSystemView(metadata, metaClient, metaClient.getActiveTimeline());
       allWriteStats = writeStatusList5.stream().map(WriteStatus::getStat).collect(Collectors.toList());
       secondaryIndexRecords =
-          convertWriteStatsToSecondaryIndexRecords(allWriteStats, fifthCommitTime, indexDefinition, metadataConfig, metaClient, engineContext, writeConfig).collectAsList();
+          convertWriteStatsToSecondaryIndexRecords(allWriteStats, fifthCommitTime, indexDefinition, metadataConfig, metaClient, engineContext, writeConfig,
+              toCommitMetadata(allWriteStats)).collectAsList();
       client.commit(fifthCommitTime, jsc.parallelize(writeStatusList5));
 
       // There should be 0 SI records because the secondary key field "rider" value has not changed.
@@ -477,7 +482,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       metadataView = new HoodieTableFileSystemView(metadata, metaClient, metaClient.getActiveTimeline());
       allWriteStats = compactionCommitMetadata.getWriteStats();
       secondaryIndexRecords = convertWriteStatsToSecondaryIndexRecords(
-          allWriteStats, compactionInstantOpt.get(), indexDefinition, metadataConfig, metaClient, engineContext, writeConfig).collectAsList();
+          allWriteStats, compactionInstantOpt.get(), indexDefinition, metadataConfig, metaClient, engineContext, writeConfig, compactionCommitMetadata).collectAsList();
       // Get valid and deleted secondary index records
       List<HoodieRecord> validSecondaryIndexRecords3 = new ArrayList<>();
       List<HoodieRecord> deletedSecondaryIndexRecords3 = new ArrayList<>();
@@ -701,6 +706,13 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
         }
       }
     });
+  }
+
+  private static HoodieCommitMetadata toCommitMetadata(List<HoodieWriteStat> writeStats) {
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.UPSERT);
+    writeStats.forEach(writeStat -> commitMetadata.addWriteStat(writeStat.getPartitionPath(), writeStat));
+    return commitMetadata;
   }
 
   Set<String> getRecordKeys(String partition, String baseInstantTime, String fileId, List<StoragePath> logFilePaths, HoodieTableMetaClient datasetMetaClient,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestGlobalRecordLevelIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestGlobalRecordLevelIndexWithSQL.scala
@@ -297,7 +297,7 @@ class TestGlobalRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
 
   @ParameterizedTest
   @ValueSource(booleans = Array(true, false))
-  def testPrunedStoragePaths(includeLogFiles: Boolean): Unit = {
+  def testPrunedFileSlices(includeLogFiles: Boolean): Unit = {
     val hudiOpts = commonOpts ++ metadataOpts ++ rliEnableOpts + (DataSourceWriteOptions.TABLE_TYPE.key -> "MERGE_ON_READ")
     val df = doWriteAndValidateDataAndRecordIndex(hudiOpts,
       operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
@@ -317,13 +317,14 @@ class TestGlobalRecordLevelIndexWithSQL extends RecordLevelIndexTestBase {
     val selectedPartition = "2016/03/15"
     val partitionFilter: Expression = EqualTo(AttributeReference("partition", StringType)(), Literal(selectedPartition))
     val (isPruned, prunedPaths) = fileIndex.prunePartitionsAndGetFileSlices(Seq.empty, Seq(partitionFilter))
-    val storagePaths = RecordLevelIndexSupport.getPrunedStoragePaths(prunedPaths, fileIndex)
-    // verify pruned paths contain the selected partition and the size of the pruned file paths
-    // when includeLogFiles is set to true, there are two storages paths - base file and log file
+    val fileSlices = RecordLevelIndexSupport.getPrunedFileSlices(prunedPaths, fileIndex)
+    // verify the pruned file slices belong to the selected partition and the number of their files
+    // when includeLogFiles is set to true, there are two files - base file and log file
     // every partition contains only one file slice
     assertTrue(isPruned)
-    assertEquals(if (includeLogFiles) 2 else 1, storagePaths.size)
-    assertTrue(storagePaths.forall(path => path.toString.contains(selectedPartition)))
+    assertEquals(1, fileSlices.size)
+    assertTrue(fileSlices.forall(fileSlice => fileSlice.getPartitionPath == selectedPartition))
+    assertEquals(if (includeLogFiles) 2 else 1, fileSlices.flatMap(fileSlice => RecordLevelIndexSupport.getFileNames(fileSlice, fileIndex)).size)
 
     val recordKey: String = df.filter("partition = '" + selectedPartition + "'").limit(1).collect().apply(0).getAs("_row_key")
     val dataFilter = EqualTo(attribute("_row_key"), Literal(recordKey))


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Tables that register parquet files written by other systems, for example tables converted with Apache XTable, commit them through replace commits with the `_hudiext` marker. The record index (RLI) and the secondary index (SI) did not work for them: the rows carry no record key, the file names in the commit metadata carry a marker that is not part of the name on storage, replaced file groups were never removed from either index, and a fresh table had no completed commit to resolve the schema from.

### Summary and Changelog

- A table without a record key (`HoodieTableConfig.hasRecordKey()` is false) keys every row by the file path relative to the table and the row position (`ExternalFilePathUtil.generateRecordKeyForRow`). RLI and SI use this key on both the update and the initialize path, so a secondary key lookup resolves to the file and row. Tables with a record key are unchanged.
- `ParquetUtils.filterRowKeys` and `FileFormatUtils.readRowKeys` gain overloads that take the table base path; `BaseFileRecordParsingUtils` resolves external file names to their path on storage.
- On a table without a record key, a replace commit without a known operation type (`WriteOperationType.isUnknown`) deletes the records of the replaced file groups from RLI and SI unless the commit wrote the key again, including a commit that only drops files. A table that carries a record key keeps the behaviour of master.
- SI falls back to the commit schema on a fresh table and reads base files from their storage path, which keeps the directory prefix of an external file.

Tables with external files have file ids that are file names, not UUIDs, so RLI needs `_hoodie.writes.fileid.encoding=1`.

### Impact

New public methods on `ExternalFilePathUtil`, `FileFormatUtils`, `ParquetUtils`, `BaseFileRecordParsingUtils`, `HoodieTableConfig` and `WriteOperationType`. `SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords` (`@VisibleForTesting`) takes the commit metadata. No behavior change for tables that carry a record key.

### Risk Level

Low. The new paths are only reached for tables without a record key and for replace commits without a known operation type. `TestExternalFileRecordAndSecondaryIndex` covers partitioned and unpartitioned tables, files below a `bucket-0/` prefix, a partitioned RLI, indexes enabled after files were registered, and a drop-only commit. Async index catch-up over registration commits is not covered yet, and is tracked in #19886.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

