### PR TITLE
fix(core): tolerate a null incoming schema when deducing the writer schema

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/utils/AvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/utils/AvroSchemaEvolutionUtils.java
@@ -308,10 +308,15 @@ public class AvroSchemaEvolutionUtils {
    * and target is long and since int can be promoted to long), colC will be long data type in output schema.
    *
    *
+   * <p>Precedence when a side is degenerate (null, the NULL type, or no fields): an absent source resolves to
+   * {@code target}, and that check runs first, so with both sides degenerate the result is {@code target}. Keep it
+   * first, since {@code reconcileSchema} relies on never being handed a null source.
+   *
    * @param sourceSchema source schema that needs reconciliation
    * @param targetSchema target schema that source schema will be reconciled against
    * @param shouldReorderColumns whether fields should be reordered to match the target schema
-   * @return schema (based off {@code source} one) that has nullability constraints and datatypes reconciled
+   * @return schema (based off {@code source} one, or {@code target} when the source is absent) that has
+   *         nullability constraints and datatypes reconciled
    */
   public static HoodieSchema reconcileSchemaRequirements(HoodieSchema sourceSchema, HoodieSchema targetSchema,
                                                           boolean shouldReorderColumns) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/utils/AvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/internal/utils/AvroSchemaEvolutionUtils.java
@@ -70,7 +70,7 @@ public class AvroSchemaEvolutionUtils {
   public static InternalSchema reconcileSchema(HoodieSchema incomingSchema, InternalSchema oldTableSchema,
                                                boolean makeMissingFieldsNullable, Map<String, Type> timestampLogicalTypeOverrides) {
     /* If incoming schema is null, we fall back on table schema. */
-    if (incomingSchema.isSchemaNull()) {
+    if (incomingSchema == null || incomingSchema.isSchemaNull()) {
       return oldTableSchema;
     }
     InternalSchema inComingInternalSchema = convert(incomingSchema, oldTableSchema.getNameToPosition());
@@ -315,12 +315,12 @@ public class AvroSchemaEvolutionUtils {
    */
   public static HoodieSchema reconcileSchemaRequirements(HoodieSchema sourceSchema, HoodieSchema targetSchema,
                                                           boolean shouldReorderColumns) {
-    if (targetSchema.isSchemaNull() || targetSchema.getFields().isEmpty()) {
-      return sourceSchema;
-    }
-
     if (sourceSchema == null || sourceSchema.isSchemaNull() || sourceSchema.getFields().isEmpty()) {
       return targetSchema;
+    }
+
+    if (targetSchema.isSchemaNull() || targetSchema.getFields().isEmpty()) {
+      return sourceSchema;
     }
 
     InternalSchema targetInternalSchema = convert(targetSchema);

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/internal/utils/TestAvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/internal/utils/TestAvroSchemaEvolutionUtils.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.hudi.common.schema.HoodieSchemaTestUtils.createNullablePrimitiveField;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -939,5 +940,39 @@ public class TestAvroSchemaEvolutionUtils {
       default:
         throw new IllegalArgumentException(token);
     }
+  }
+
+  @Test
+  void testReconcileSchemaWithAbsentIncomingSchemaFallsBackToTableSchema() {
+    HoodieSchema tableSchema = create("simple", createNullablePrimitiveField("a", HoodieSchemaType.BOOLEAN));
+    HoodieSchema emptyTableSchema = create("empty");
+    Map<String, Type> noOverrides = SchemaChangeUtils.parseTimestampLogicalTypeOverrides("");
+
+    for (HoodieSchema incoming : new HoodieSchema[] {null, HoodieSchema.create(HoodieSchemaType.NULL)}) {
+      for (HoodieSchema table : new HoodieSchema[] {tableSchema, emptyTableSchema}) {
+        InternalSchema tableInternalSchema = InternalSchemaConverter.convert(table);
+        assertEquals(tableInternalSchema,
+            AvroSchemaEvolutionUtils.reconcileSchema(incoming, tableInternalSchema, true, noOverrides));
+        assertEquals(tableInternalSchema,
+            InternalSchemaConverter.convert(AvroSchemaEvolutionUtils.reconcileSchema(incoming, table, true, noOverrides)));
+      }
+    }
+  }
+
+  @Test
+  void testReconcileSchemaRequirementsWithAbsentSourceSchema() {
+    HoodieSchema tableSchema = create("simple", createNullablePrimitiveField("a", HoodieSchemaType.BOOLEAN));
+    HoodieSchema emptyTableSchema = create("empty");
+    HoodieSchema nullTableSchema = HoodieSchema.create(HoodieSchemaType.NULL);
+
+    for (HoodieSchema source : new HoodieSchema[] {null, HoodieSchema.create(HoodieSchemaType.NULL), create("emptyIncoming")}) {
+      for (HoodieSchema table : new HoodieSchema[] {tableSchema, emptyTableSchema, nullTableSchema}) {
+        assertEquals(table, AvroSchemaEvolutionUtils.reconcileSchemaRequirements(source, table, false),
+            () -> "source=" + source + ", table=" + table);
+      }
+    }
+    // a populated source has nothing to reconcile against and is returned as-is
+    assertEquals(tableSchema, AvroSchemaEvolutionUtils.reconcileSchemaRequirements(tableSchema, emptyTableSchema, false));
+    assertEquals(tableSchema, AvroSchemaEvolutionUtils.reconcileSchemaRequirements(tableSchema, nullTableSchema, false));
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSchemaUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSchemaUtils.scala
@@ -248,7 +248,7 @@ object HoodieSchemaUtils {
         } else {
           log.error(
             s"""Failed to reconcile incoming batch schema with the table's one.
-               |Incoming schema ${sourceSchema.toString(true)}
+               |Incoming schema ${if (sourceSchema == null) "null" else sourceSchema.toString(true)}
                |Incoming schema (canonicalized) ${canonicalizedSourceSchema.toString(true)}
                |Table's schema ${latestTableSchema.toString(true)}
                |""".stripMargin)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSchemaUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSchemaUtils.scala
@@ -228,7 +228,8 @@ object HoodieSchemaUtils {
         val mergedInternalSchema = AvroSchemaEvolutionUtils.reconcileSchema(canonicalizedSourceSchema, internalSchema,
           setNullForMissingColumns, timestampLogicalTypeOverrides)
         val evolvedSchema = InternalSchemaConverter.convert(mergedInternalSchema, latestTableSchema.getFullName)
-        val shouldRemoveMetaDataFromInternalSchema = sourceSchema.getFields.asScala.filter(f => f.name().equalsIgnoreCase(HoodieRecord.RECORD_KEY_METADATA_FIELD)).isEmpty
+        val shouldRemoveMetaDataFromInternalSchema = sourceSchema == null || sourceSchema.isSchemaNull ||
+          sourceSchema.getFields.asScala.filter(f => f.name().equalsIgnoreCase(HoodieRecord.RECORD_KEY_METADATA_FIELD)).isEmpty
         if (shouldRemoveMetaDataFromInternalSchema) HoodieCommonSchemaUtils.removeMetadataFields(evolvedSchema) else evolvedSchema
 
       case None =>

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieSchemaUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieSchemaUtils.java
@@ -29,9 +29,11 @@ import org.apache.hudi.common.schema.internal.convert.InternalSchemaConverter;
 import org.apache.hudi.common.schema.internal.utils.AvroSchemaEvolutionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNullSchemaTypeException;
 import org.apache.hudi.exception.MissingSchemaFieldException;
 import org.apache.hudi.exception.SchemaBackwardsCompatibilityException;
+import org.apache.hudi.exception.SchemaCompatibilityException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -428,6 +430,15 @@ public class TestHoodieSchemaUtils {
             Option.of(InternalSchemaConverter.convert(table)), reconcileProps));
       }
     }
+
+    // with no internal schema the reconcile branch falls back to the legacy check; an absent incoming schema
+    // must surface as the incompatibility it is, not fail while the error message is built
+    TypedProperties legacyReconcileProps = new TypedProperties();
+    legacyReconcileProps.setProperty(DataSourceWriteOptions.RECONCILE_SCHEMA().key(), "true");
+    legacyReconcileProps.setProperty(HoodieSparkSqlWriter.CANONICALIZE_SCHEMA().key(), "false");
+    legacyReconcileProps.setProperty(HoodieWriteConfig.AVRO_SCHEMA_VALIDATE_ENABLE.key(), "true");
+    assertThrows(SchemaCompatibilityException.class,
+        () -> HoodieSchemaUtils.deduceWriterSchema(null, Option.of(tableSchema), Option.empty(), legacyReconcileProps));
   }
 
   private static final TypedProperties TYPED_PROPERTIES = new TypedProperties();

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieSchemaUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/TestHoodieSchemaUtils.java
@@ -410,6 +410,26 @@ public class TestHoodieSchemaUtils {
     return deduceWriterSchema(incomingSchema, latestTableSchema, false);
   }
 
+  @Test
+  void testDeduceWriterSchemaWithAbsentIncomingSchema() {
+    HoodieSchema tableSchema = createRecord("simple", createPrimitiveField("f", HoodieSchemaType.INT));
+    HoodieSchema emptyTableSchema = createRecord("empty");
+
+    assertEquals(tableSchema, deduceWriterSchema(null, tableSchema, true));
+    assertEquals(emptyTableSchema, deduceWriterSchema(null, emptyTableSchema, true));
+    assertEquals(HoodieSchemaType.NULL, deduceWriterSchema(null, null, true).getType());
+
+    // schema reconciliation takes the schema-on-read branch, which also has to tolerate an absent incoming schema
+    TypedProperties reconcileProps = new TypedProperties();
+    reconcileProps.setProperty(DataSourceWriteOptions.RECONCILE_SCHEMA().key(), "true");
+    for (HoodieSchema incoming : new HoodieSchema[] {null, HoodieSchema.create(HoodieSchemaType.NULL)}) {
+      for (HoodieSchema table : new HoodieSchema[] {tableSchema, emptyTableSchema}) {
+        assertEquals(table, HoodieSchemaUtils.deduceWriterSchema(incoming, Option.of(table),
+            Option.of(InternalSchemaConverter.convert(table)), reconcileProps));
+      }
+    }
+  }
+
   private static final TypedProperties TYPED_PROPERTIES = new TypedProperties();
 
   private static HoodieSchema deduceWriterSchema(HoodieSchema incomingSchema, HoodieSchema latestTableSchema, Boolean addNull) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/MockS3EventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/MockS3EventsHoodieIncrSource.java
@@ -20,6 +20,7 @@ package org.apache.hudi.utilities.sources;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
+import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV1;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
@@ -31,8 +32,11 @@ import org.apache.hudi.utilities.streamer.StreamContext;
 
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+
+import java.util.Arrays;
 
 /**
  * A mock implementation of S3EventsHoodieIncrSource used for testing StreamSync functionality.
@@ -40,6 +44,11 @@ import org.apache.spark.sql.SparkSession;
  * and data ingestion behavior of the StreamSync class.
  */
 public class MockS3EventsHoodieIncrSource extends S3EventsHoodieIncrSource {
+
+  /**
+   * Newline-separated JSON rows to return as the next batch instead of running a dummy operation.
+   */
+  public static final String MOCK_ROWS_JSON = "mockTestRowsJson";
   
   /**
    * Constructs a new MockS3EventsHoodieIncrSource with the specified parameters.
@@ -90,6 +99,12 @@ public class MockS3EventsHoodieIncrSource extends S3EventsHoodieIncrSource {
   @Override
   public Pair<Option<Dataset<Row>>, Checkpoint> fetchNextBatch(Option<Checkpoint> lastCheckpoint, long sourceLimit) {
     CheckpointValidator.validateCheckpointOption(lastCheckpoint, props);
+    if (props.containsKey(MOCK_ROWS_JSON)) {
+      Dataset<Row> rows = sparkSession.read().json(
+          sparkSession.createDataset(Arrays.asList(props.getString(MOCK_ROWS_JSON).split("\n")), Encoders.STRING()));
+      return Pair.of(Option.of(rows),
+          new StreamerCheckpointV1(props.getString(DummyOperationExecutor.RETURN_CHECKPOINT_KEY, DummyOperationExecutor.CUSTOM_CHECKPOINT1)));
+    }
     return DummyOperationExecutor.executeDummyOperation(lastCheckpoint, sourceLimit, props);
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestHoodieIncrSourceE2E.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestHoodieIncrSourceE2E.java
@@ -68,6 +68,7 @@ import static org.apache.hudi.utilities.sources.DummyOperationExecutor.OP_EMPTY_
 import static org.apache.hudi.utilities.sources.DummyOperationExecutor.OP_EMPTY_ROW_SET_NULL_CKP_KEY;
 import static org.apache.hudi.utilities.sources.DummyOperationExecutor.OP_FETCH_NEXT_BATCH;
 import static org.apache.hudi.utilities.sources.DummyOperationExecutor.RETURN_CHECKPOINT_KEY;
+import static org.apache.hudi.utilities.sources.MockS3EventsHoodieIncrSource.MOCK_ROWS_JSON;
 import static org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.MissingCheckpointStrategy.READ_UPTO_LATEST_COMMIT;
 import static org.apache.hudi.utilities.streamer.StreamSync.CHECKPOINT_IGNORE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -532,7 +533,8 @@ public class TestHoodieIncrSourceE2E extends S3EventsHoodieIncrSourceHarness {
    * An empty batch from a source whose schema provider reports no schema at all must still land an empty
    * commit when the table's latest commit carries a schema without fields (what a sync over column-less
    * input leaves behind), so the checkpoint keeps advancing. With an unchanged checkpoint the empty commit
-   * is gated by allowCommitOnNoCheckpointChange, as for any other source.
+   * is gated by allowCommitOnNoCheckpointChange, as for any other source. The non-empty batch that follows
+   * must then evolve the field-less table schema and land its rows.
    */
   @ParameterizedTest
   @CsvSource({
@@ -540,9 +542,8 @@ public class TestHoodieIncrSourceE2E extends S3EventsHoodieIncrSourceHarness {
       "8, 80, false, true",
       "8, 70, false, false",
       "8, 70, true, true"})
-  public void testSyncE2EEmptyBatchWithAbsentSchemaAndFieldlessTableSchema(String tableVersion, String returnedCheckpoint,
-                                                                          boolean allowCommitOnNoCheckpointChange,
-                                                                          boolean expectNewCommit) throws Exception {
+  void testSyncE2EEmptyBatchWithAbsentSchemaAndFieldlessTableSchema(
+      String tableVersion, String returnedCheckpoint, boolean allowCommitOnNoCheckpointChange, boolean expectNewCommit) throws Exception {
     metaClient = getHoodieMetaClientWithTableVersion(storageConf(), basePath(), tableVersion);
     Schema fieldlessSchema = Schema.createRecord("hoodie_trips_record", null, "hoodie.hoodie_trips", false, Collections.emptyList());
     HoodieCommitMetadata seed = new HoodieCommitMetadata();
@@ -557,6 +558,8 @@ public class TestHoodieIncrSourceE2E extends S3EventsHoodieIncrSourceHarness {
     props.put(VAL_INPUT_CKP, VAL_NON_EMPTY_CKP_ALL_MEMBERS);
     props.put(VAL_CKP_KEY_EQ_VAL, "70");
     props.put(HoodieCommonConfig.SET_NULL_FOR_MISSING_COLUMNS.key(), "true");
+    props.put("hoodie.datasource.write.recordkey.field", "_row_key");
+    props.put("hoodie.datasource.write.partitionpath.field", "partition_path");
 
     HoodieDeltaStreamer.Config cfg = createConfig(basePath(), null);
     cfg.operation = WriteOperationType.UPSERT;
@@ -573,6 +576,24 @@ public class TestHoodieIncrSourceE2E extends S3EventsHoodieIncrSourceHarness {
     assertEquals(returnedCheckpoint, last.getMetadata(STREAMER_CHECKPOINT_KEY_V1));
     assertEquals(0, last.getWriteStats().size());
     assertEquals(0, new Schema.Parser().parse(last.getMetadata(HoodieCommitMetadata.SCHEMA_KEY)).getFields().size());
+
+    props.put(MOCK_ROWS_JSON, "{\"_row_key\":\"k1\",\"partition_path\":\"p1\",\"timestamp\":1,\"name\":\"a\"}\n"
+        + "{\"_row_key\":\"k2\",\"partition_path\":\"p1\",\"timestamp\":2,\"name\":\"b\"}");
+    props.put(RETURN_CHECKPOINT_KEY, "90");
+    props.put(VAL_CKP_KEY_EQ_VAL, returnedCheckpoint);
+    new HoodieDeltaStreamer(cfg, jsc, Option.of(props)).sync();
+
+    metaClient.reloadActiveTimeline();
+    commits = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
+    assertEquals(expectNewCommit ? 3 : 2, commits.countInstants());
+    last = HoodieClientTestUtils.getCommitMetadataForInstant(metaClient, commits.lastInstant().get()).get();
+    assertEquals("90", last.getMetadata(STREAMER_CHECKPOINT_KEY_V1));
+    assertEquals(2, last.fetchTotalRecordsWritten());
+    Schema evolved = new Schema.Parser().parse(last.getMetadata(HoodieCommitMetadata.SCHEMA_KEY));
+    for (String column : new String[] {"_row_key", "partition_path", "timestamp", "name"}) {
+      assertFalse(evolved.getField(column) == null, column);
+    }
+    assertEquals(2, spark().read().format("hudi").load(basePath()).count());
   }
 
   /**

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestHoodieIncrSourceE2E.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestHoodieIncrSourceE2E.java
@@ -19,20 +19,27 @@
 package org.apache.hudi.utilities.streamer;
 
 import org.apache.hudi.common.config.DFSPropertiesConfiguration;
+import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
+import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.testutils.HoodieClientTestUtils;
 import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer;
 import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerTestBase;
+import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.GcsEventsHoodieIncrSource;
 import org.apache.hudi.utilities.sources.MockS3EventsHoodieIncrSource;
 import org.apache.hudi.utilities.sources.S3EventsHoodieIncrSource;
 import org.apache.hudi.utilities.sources.S3EventsHoodieIncrSourceHarness;
+import org.apache.hudi.utilities.transform.FlatteningTransformer;
 
+import org.apache.avro.Schema;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -519,5 +526,66 @@ public class TestHoodieIncrSourceE2E extends S3EventsHoodieIncrSourceHarness {
     assertFalse(StreamerCheckpointUtils.shouldTargetCheckpointV2(6, S3EventsHoodieIncrSource.class.getName()));
     assertFalse(StreamerCheckpointUtils.shouldTargetCheckpointV2(8, GcsEventsHoodieIncrSource.class.getName()));
     assertFalse(StreamerCheckpointUtils.shouldTargetCheckpointV2(6, GcsEventsHoodieIncrSource.class.getName()));
+  }
+
+  /**
+   * An empty batch from a source whose schema provider reports no schema at all must still land an empty
+   * commit when the table's latest commit carries a schema without fields (what a sync over column-less
+   * input leaves behind), so the checkpoint keeps advancing. With an unchanged checkpoint the empty commit
+   * is gated by allowCommitOnNoCheckpointChange, as for any other source.
+   */
+  @ParameterizedTest
+  @CsvSource({
+      "6, 80, false, true",
+      "8, 80, false, true",
+      "8, 70, false, false",
+      "8, 70, true, true"})
+  public void testSyncE2EEmptyBatchWithAbsentSchemaAndFieldlessTableSchema(String tableVersion, String returnedCheckpoint,
+                                                                          boolean allowCommitOnNoCheckpointChange,
+                                                                          boolean expectNewCommit) throws Exception {
+    metaClient = getHoodieMetaClientWithTableVersion(storageConf(), basePath(), tableVersion);
+    Schema fieldlessSchema = Schema.createRecord("hoodie_trips_record", null, "hoodie.hoodie_trips", false, Collections.emptyList());
+    HoodieCommitMetadata seed = new HoodieCommitMetadata();
+    seed.setOperationType(WriteOperationType.INSERT);
+    seed.addMetadata(HoodieCommitMetadata.SCHEMA_KEY, fieldlessSchema.toString());
+    seed.addMetadata(STREAMER_CHECKPOINT_KEY_V1, "70");
+    HoodieTestTable.of(metaClient).addCommit(metaClient.createNewInstantTime(false), Option.of(seed));
+
+    TypedProperties props = setupBaseProperties(tableVersion);
+    props.put(OP_FETCH_NEXT_BATCH, OP_EMPTY_ROW_SET_NONE_NULL_CKP_V1_KEY);
+    props.put(RETURN_CHECKPOINT_KEY, returnedCheckpoint);
+    props.put(VAL_INPUT_CKP, VAL_NON_EMPTY_CKP_ALL_MEMBERS);
+    props.put(VAL_CKP_KEY_EQ_VAL, "70");
+    props.put(HoodieCommonConfig.SET_NULL_FOR_MISSING_COLUMNS.key(), "true");
+
+    HoodieDeltaStreamer.Config cfg = createConfig(basePath(), null);
+    cfg.operation = WriteOperationType.UPSERT;
+    // an empty batch never reaches the transformer, but its presence selects the row-based path in StreamSync
+    cfg.transformerClassNames = Collections.singletonList(FlatteningTransformer.class.getName());
+    cfg.schemaProviderClassName = AbsentSchemaProvider.class.getName();
+    cfg.allowCommitOnNoCheckpointChange = allowCommitOnNoCheckpointChange;
+    new HoodieDeltaStreamer(cfg, jsc, Option.of(props)).sync();
+
+    metaClient.reloadActiveTimeline();
+    HoodieTimeline commits = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
+    assertEquals(expectNewCommit ? 2 : 1, commits.countInstants());
+    HoodieCommitMetadata last = HoodieClientTestUtils.getCommitMetadataForInstant(metaClient, commits.lastInstant().get()).get();
+    assertEquals(returnedCheckpoint, last.getMetadata(STREAMER_CHECKPOINT_KEY_V1));
+    assertEquals(0, last.getWriteStats().size());
+    assertEquals(0, new Schema.Parser().parse(last.getMetadata(HoodieCommitMetadata.SCHEMA_KEY)).getFields().size());
+  }
+
+  /**
+   * Reports no schema, like a row source that derives its schema from each batch.
+   */
+  public static class AbsentSchemaProvider extends SchemaProvider {
+    public AbsentSchemaProvider(TypedProperties props, JavaSparkContext jssc) {
+      super(props, jssc);
+    }
+
+    @Override
+    public Schema getSourceSchema() {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

closes #19870

`AvroSchemaEvolutionUtils.reconcileSchema` dereferences the incoming schema before the Avro NULL check its own comment promises, and `reconcileSchemaRequirements` hands a null source schema back untouched whenever the table schema has no fields. A HoodieStreamer row source whose schema provider reports no target schema, writing to a table whose latest commit carries a zero-column record schema, therefore fails every empty batch with a `NullPointerException` and never advances its checkpoint.

### Summary and Changelog

An absent incoming schema now falls back to the table schema everywhere the writer schema is deduced, so an empty batch lands an empty commit and the checkpoint keeps moving.

- `AvroSchemaEvolutionUtils.reconcileSchema`: treat a Java `null` like Avro NULL.
- `AvroSchemaEvolutionUtils.reconcileSchemaRequirements`: check the source schema before the empty-target early return, so a null source is never returned.
- `HoodieSchemaUtils.deduceWriterSchemaWithReconcile`: tolerate an absent incoming schema on the schema-on-read branch as well, including the legacy-reconciliation error message.
- Tests: `TestAvroSchemaEvolutionUtils` (both utilities), `TestHoodieSchemaUtils` (full deduction, reconcile on and off), and `TestHoodieIncrSourceE2E` (a HoodieStreamer run over the S3 incremental source with a schema provider returning null and a zero-column table schema: the empty batch commits with the advanced checkpoint, an unchanged checkpoint commits only with `allowCommitOnNoCheckpointChange`, and the non-empty batch that follows evolves the zero-column schema and writes its rows). The utility and deduction tests fail with the reported NPE without the fix. The streamer test pins the end-to-end behavior; on this line `StreamSync.getDeducedSchemaProvider` already maps a null provider schema to a NULL schema before deduction, so it passes either way, and the NPE is reachable only by callers that hand `deduceWriterSchema` or `reconcileSchema` a null directly.

### Impact

None to public APIs. An empty batch against a table with no usable schema resolves to the table schema instead of throwing. The reconcileSchemaRequirements reorder also flips the result when both schemas are degenerate: a fieldless or NULL source against a fieldless or NULL target now yields the target where it previously yielded the source.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable




