### PR TITLE
fix(common)!: preserve writer schemas when decoding Avro payloads

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/HoodieSparkKryoRegistrar.scala
@@ -19,7 +19,7 @@
 package org.apache.spark
 
 import org.apache.hudi.client.model.HoodieInternalRow
-import org.apache.hudi.common.model.{HoodieKey, HoodieSparkRecord}
+import org.apache.hudi.common.model.{BaseAvroPayload, HoodieKey, HoodieSparkRecord}
 import org.apache.hudi.common.util.HoodieCommonKryoRegistrar
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.io.HoodieKeyLookupResult
@@ -59,6 +59,10 @@ class HoodieSparkKryoRegistrar extends HoodieCommonKryoRegistrar with KryoRegist
     // NOTE: DO NOT REORDER REGISTRATIONS
     ///////////////////////////////////////////////////////////////////////////
     super[HoodieCommonKryoRegistrar].registerClasses(kryo)
+
+    // Spark supplies the schema to payload readers. Preserve its compact shuffle format instead
+    // of repeating the writer schema in every record. Standalone Kryo users remain self-contained.
+    BaseAvroPayload.useLegacyKryoFormat(kryo)
 
     kryo.register(classOf[HoodieKey], new HoodieKeySerializer)
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/spark/TestHoodieSparkKryoRegistrar.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/spark/TestHoodieSparkKryoRegistrar.java
@@ -19,26 +19,78 @@
 
 package org.apache.spark;
 
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Tests {@link HoodieSparkKryoRegistrar}
  */
 public class TestHoodieSparkKryoRegistrar {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testLegacyPayloadFormatAcrossIndependentKryoInstances(boolean deleted) throws IOException {
+    Schema writerSchema = SchemaBuilder.record("payload").fields()
+        .requiredString("id").requiredLong("ts").requiredString("value").endRecord();
+    Schema projection = SchemaBuilder.record("payload").fields()
+        .requiredString("value").requiredString("id").endRecord();
+    GenericRecord record = deleted ? null : new GenericRecordBuilder(writerSchema)
+        .set("id", "key").set("ts", 42L).set("value", "updated").build();
+    OverwriteWithLatestAvroPayload payload = new OverwriteWithLatestAvroPayload(record, 42L);
+    Kryo writer = newKryo();
+
+    // Reusing a Spark Kryo instance must preserve its format after each graph is reset.
+    for (int round = 0; round < 3; round++) {
+      try (Output header = new Output(256, -1)) {
+        payload.write(writer, header);
+        try (Input input = new Input(header.toBytes())) {
+          assertEquals(payload.getRecordBytes().length, input.readInt());
+        }
+      }
+      byte[] bytes;
+      try (Output output = new Output(256, -1)) {
+        writer.writeClassAndObject(output, payload);
+        bytes = output.toBytes();
+      }
+      try (Input input = new Input(bytes)) {
+        payload = (OverwriteWithLatestAvroPayload) newKryo().readClassAndObject(input);
+      }
+      assertEquals(42L, payload.getOrderingVal());
+      if (deleted) {
+        assertFalse(payload.getInsertValue(writerSchema).isPresent());
+      } else {
+        // Legacy Spark transport supplies the writer schema before requesting projections.
+        assertEquals("key", payload.getInsertValue(writerSchema).get().get(0).toString());
+        IndexedRecord projected = payload.getInsertValue(projection).get();
+        assertEquals("updated", projected.get(0).toString());
+        assertEquals("key", projected.get(1).toString());
+        assertEquals(42L, payload.getInsertValue(writerSchema).get().get(1));
+      }
+    }
+  }
+
   @Test
   public void testSerdeHoodieHadoopConfiguration() {
     Kryo kryo = newKryo();

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
@@ -20,25 +20,44 @@ package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.avro.HoodieAvroUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import lombok.Getter;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OptionalDataException;
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Base class for all AVRO record based payloads, that can be ordered based on a field.
+ *
+ * <p>Retains the writer schema across serialization and projections. Named fields and aliases take
+ * precedence over the legacy same-position rename convention used by older realtime readers.
  */
 public abstract class BaseAvroPayload implements Serializable, KryoSerializable {
+  // Preserve Java serialization compatibility with payloads written before writer-schema retention.
+  private static final long serialVersionUID = 4076216714695518773L;
+
+  private static final String KRYO_WRITE_LEGACY_FORMAT = BaseAvroPayload.class.getName() + ".writeLegacyFormat";
+
   /**
    * Avro data extracted from the source converted to bytes.
    */
@@ -54,6 +73,14 @@ public abstract class BaseAvroPayload implements Serializable, KryoSerializable 
 
   private transient GenericRecord record;
 
+  // The schema of recordBytes must remain independent of the last requested projection.
+  private transient Schema writerSchema;
+
+  private static final LoadingCache<Schema, String> SCHEMA_STRINGS = Caffeine.newBuilder()
+      .maximumSize(1024).build(Schema::toString);
+  private static final LoadingCache<String, Schema> PARSED_SCHEMAS = Caffeine.newBuilder()
+      .maximumSize(1024).build(json -> new Schema.Parser().parse(json));
+
   /**
    * Instantiate {@link BaseAvroPayload}.
    *
@@ -63,6 +90,7 @@ public abstract class BaseAvroPayload implements Serializable, KryoSerializable 
   public BaseAvroPayload(GenericRecord record, Comparable orderingVal) {
     this.record = record;
     this.recordBytes = null; // only initialized when needed
+    this.writerSchema = record == null ? null : record.getSchema();
     this.orderingVal = orderingVal;
     this.isDeletedRecord = record == null || isDeleteRecord(record);
 
@@ -126,24 +154,129 @@ public abstract class BaseAvroPayload implements Serializable, KryoSerializable 
   }
 
   protected Option<IndexedRecord> getRecord(Schema schema) throws IOException {
-    if (record != null) {
-      if (record.getSchema() == schema) {
-        return Option.of(record);
-      }
-      // if the schema does not match, we need to deserialize with the proper schema to match legacy behavior
-      recordBytes = getRecordBytes();
+    if (record != null && record.getSchema() == schema) {
+      return Option.of(record);
     }
-    if (recordBytes == null || recordBytes.length == 0) {
+    byte[] bytes = getRecordBytes();
+    if (bytes.length == 0) {
       return Option.empty();
     }
-    record = SerializableIndexedRecord.fromAvroBytes(schema, recordBytes);
+    if (writerSchema == null) {
+      // Legacy serialized payloads did not include a writer schema.
+      writerSchema = schema;
+    }
+    Map<String, String> renames = new HashMap<>();
+    collectRenames(writerSchema, schema, "", renames, new HashSet<>());
+    if (renames.isEmpty()) {
+      record = HoodieAvroUtils.bytesToAvro(bytes, writerSchema, schema);
+    } else {
+      GenericRecord original = HoodieAvroUtils.bytesToAvro(bytes, writerSchema);
+      record = HoodieAvroUtils.rewriteRecordWithNewSchema(original, schema, renames);
+    }
     return Option.of(record);
+  }
+
+  private static void collectRenames(Schema writer, Schema reader, String prefix,
+                                     Map<String, String> renames, Set<Pair<Schema, Schema>> visiting) {
+    if (writer.equals(reader)) {
+      return;
+    }
+    Pair<Schema, Schema> pair = Pair.of(writer, reader);
+    if (!visiting.add(pair)) {
+      return;
+    }
+    try {
+      if (writer.getType() == Schema.Type.UNION || reader.getType() == Schema.Type.UNION) {
+        for (Schema w : writer.getType() == Schema.Type.UNION ? writer.getTypes() : java.util.Collections.singletonList(writer)) {
+          for (Schema r : reader.getType() == Schema.Type.UNION ? reader.getTypes() : java.util.Collections.singletonList(reader)) {
+            boolean sameRecordBranch = w.getType() != Schema.Type.RECORD || r.getType() != Schema.Type.RECORD
+                || w.getFullName().equals(r.getFullName()) || r.getAliases().contains(w.getFullName())
+                || (writer.getType() != Schema.Type.UNION || writer.getTypes().stream().filter(s -> s.getType() == Schema.Type.RECORD).count() == 1)
+                && (reader.getType() != Schema.Type.UNION || reader.getTypes().stream().filter(s -> s.getType() == Schema.Type.RECORD).count() == 1);
+            if (w.getType() == r.getType() && sameRecordBranch) {
+              collectRenames(w, r, prefix, renames, visiting);
+            }
+          }
+        }
+      } else if (writer.getType() == Schema.Type.RECORD && reader.getType() == Schema.Type.RECORD) {
+        for (Schema.Field field : reader.getFields()) {
+          Schema.Field source = writer.getField(field.name());
+          if (source == null) {
+            for (String alias : field.aliases()) {
+              if (writer.getField(alias) != null) {
+                source = writer.getField(alias);
+                break;
+              }
+            }
+          }
+          // Preserve the historical rename contract only for a defaulted field replacing a removed
+          // field at the same position. Added fields and named projections must never shift values.
+          if (source == null && field.defaultVal() != null
+              && writer.getFields().size() == reader.getFields().size()) {
+            Schema.Field candidate = writer.getFields().get(field.pos());
+            if (reader.getField(candidate.name()) == null) {
+              source = candidate;
+            }
+          }
+          if (source == null) {
+            if (field.defaultVal() == null) {
+              throw new AvroTypeException("Field '" + prefix + field.name() + "' has no writer field or default");
+            }
+            continue;
+          }
+          if (!source.name().equals(field.name())) {
+            renames.put(prefix + field.name(), source.name());
+          }
+          collectRenames(source.schema(), field.schema(), prefix + field.name() + ".", renames, visiting);
+        }
+      } else if (writer.getType() == Schema.Type.ARRAY && reader.getType() == Schema.Type.ARRAY) {
+        collectRenames(writer.getElementType(), reader.getElementType(), prefix + "element.", renames, visiting);
+      } else if (writer.getType() == Schema.Type.MAP && reader.getType() == Schema.Type.MAP) {
+        collectRenames(writer.getValueType(), reader.getValueType(), prefix + "value.", renames, visiting);
+      }
+    } finally {
+      visiting.remove(pair);
+    }
+  }
+
+  private void writeObject(ObjectOutputStream output) throws IOException {
+    getRecordBytes();
+    output.defaultWriteObject();
+    output.writeObject(writerSchema == null ? null : SCHEMA_STRINGS.get(writerSchema));
+  }
+
+  private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
+    input.defaultReadObject();
+    try {
+      String schemaJson = (String) input.readObject();
+      writerSchema = schemaJson == null ? null : PARSED_SCHEMAS.get(schemaJson);
+    } catch (OptionalDataException e) {
+      if (!e.eof) {
+        throw e;
+      }
+      // Java-serialized payloads from before schema retention contain only the default fields.
+    }
+  }
+
+  /**
+   * Selects the legacy payload format for a transport that supplies the writer schema separately.
+   * Other Kryo instances retain a self-contained writer schema by default. The setting survives
+   * graph resets and does not affect Java serialization or other Kryo instances.
+   */
+  public static void useLegacyKryoFormat(Kryo kryo) {
+    kryo.getContext().put(KRYO_WRITE_LEGACY_FORMAT, Boolean.TRUE);
   }
 
   @Override
   public void write(Kryo kryo, Output output) {
     byte[] bytes = getRecordBytes();
-    output.writeInt(bytes.length);
+    if (Boolean.TRUE.equals(kryo.getContext().get(KRYO_WRITE_LEGACY_FORMAT))) {
+      output.writeInt(bytes.length);
+    } else {
+      // Negative lengths distinguish schema-bearing payloads from the legacy non-negative format.
+      output.writeInt(-bytes.length - 1);
+      output.writeString(writerSchema == null ? null : SCHEMA_STRINGS.get(writerSchema));
+    }
     output.writeBytes(bytes);
     kryo.writeClassAndObject(output, orderingVal);
     output.writeBoolean(isDeletedRecord);
@@ -152,6 +285,13 @@ public abstract class BaseAvroPayload implements Serializable, KryoSerializable 
   @Override
   public void read(Kryo kryo, Input input) {
     int length = input.readInt();
+    this.record = null;
+    this.writerSchema = null;
+    if (length < 0) {
+      length = -length - 1;
+      String schemaJson = input.readString();
+      this.writerSchema = schemaJson == null ? null : PARSED_SCHEMAS.get(schemaJson);
+    }
     this.recordBytes = input.readBytes(length);
     this.orderingVal = (Comparable) kryo.readClassAndObject(input);
     this.isDeletedRecord = input.readBoolean();

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestBaseAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestBaseAvroPayload.java
@@ -1,0 +1,482 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.util.Option;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.generic.IndexedRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Base64;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link BaseAvroPayload#getRecord(Schema)}, exercised through the concrete
+ * {@link OverwriteWithLatestAvroPayload} subclass.
+ *
+ * <p>Regression coverage for a positional-misdecode bug: when a payload's true (writer) schema
+ * differs from the schema requested by the caller -- e.g. the caller asks for a data-fields-only
+ * projection of a schema that also declares the five {@code _hoodie_} meta fields -- decoding must
+ * resolve fields by name, not by position.
+ */
+class TestBaseAvroPayload {
+
+  // Mirrors what withPopulateMetaFields(true) produces: the five _hoodie_ meta fields ahead of the
+  // data fields.
+  private final Schema fullSchema = SchemaBuilder.record("full")
+      .fields()
+      .optionalString(HoodieRecord.COMMIT_TIME_METADATA_FIELD)
+      .optionalString(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD)
+      .optionalString(HoodieRecord.RECORD_KEY_METADATA_FIELD)
+      .optionalString(HoodieRecord.PARTITION_PATH_METADATA_FIELD)
+      .optionalString(HoodieRecord.FILENAME_METADATA_FIELD)
+      .requiredString("id")
+      .requiredLong("ts")
+      .requiredString("name")
+      .requiredString("price")
+      .optionalBoolean(HoodieRecord.HOODIE_IS_DELETED_FIELD)
+      .endRecord();
+
+  // Same data fields, without the meta fields -- e.g. a merge path's data-only projection schema.
+  private final Schema dataOnlySchema = SchemaBuilder.record("dataOnly")
+      .fields()
+      .requiredString("id")
+      .requiredLong("ts")
+      .requiredString("name")
+      .requiredString("price")
+      .optionalBoolean(HoodieRecord.HOODIE_IS_DELETED_FIELD)
+      .endRecord();
+
+  // Same fields as fullSchema, plus one required field with no default that the writer never had --
+  // used to lock in the intentional loud-failure contract (AvroTypeException), not silent corruption.
+  private final Schema readerSchemaWithUnresolvableField = SchemaBuilder.record("fullPlusUnresolvable")
+      .fields()
+      .optionalString(HoodieRecord.COMMIT_TIME_METADATA_FIELD)
+      .optionalString(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD)
+      .optionalString(HoodieRecord.RECORD_KEY_METADATA_FIELD)
+      .optionalString(HoodieRecord.PARTITION_PATH_METADATA_FIELD)
+      .optionalString(HoodieRecord.FILENAME_METADATA_FIELD)
+      .requiredString("id")
+      .requiredLong("ts")
+      .requiredString("name")
+      .requiredString("price")
+      .optionalBoolean(HoodieRecord.HOODIE_IS_DELETED_FIELD)
+      .requiredString("unresolvable_field_with_no_default")
+      .endRecord();
+
+  private GenericRecord newFullRecord() {
+    return new GenericRecordBuilder(fullSchema)
+        .set(HoodieRecord.COMMIT_TIME_METADATA_FIELD, "20260807120000000")
+        .set(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, "20260807120000000_0_0")
+        .set(HoodieRecord.RECORD_KEY_METADATA_FIELD, "id:1")
+        .set(HoodieRecord.PARTITION_PATH_METADATA_FIELD, "partition0")
+        .set(HoodieRecord.FILENAME_METADATA_FIELD, "file1.parquet")
+        .set("id", "1")
+        .set("ts", 100L)
+        .set("name", "alice")
+        .set("price", "9.99")
+        .set(HoodieRecord.HOODIE_IS_DELETED_FIELD, false)
+        .build();
+  }
+
+  @Test
+  void getInsertValueProjectsByNameWhenRequestedSchemaOmitsMetaFields() throws IOException {
+    OverwriteWithLatestAvroPayload payload = new OverwriteWithLatestAvroPayload(newFullRecord(), 100L);
+
+    // The record's true schema (10 fields, meta fields first) is a distinct instance from the
+    // requested schema (5 fields, no meta fields) even though the shared fields have identical
+    // names/types -- this bypasses the reference-equality fast path and forces a re-decode, which is
+    // exactly where the positional-misdecode defect corrupted data fields to null.
+    IndexedRecord projected = payload.getInsertValue(dataOnlySchema).get();
+
+    // Binary-decoded Avro strings come back as org.apache.avro.util.Utf8, not java.lang.String -- compare
+    // via toString() rather than equals() so this test only asserts on the actual data-corruption bug
+    // (fields nulled/misaligned) and not on that unrelated representational detail.
+    assertEquals("1", String.valueOf(projected.get(dataOnlySchema.getField("id").pos())));
+    assertEquals(100L, projected.get(dataOnlySchema.getField("ts").pos()));
+    assertEquals("alice", String.valueOf(projected.get(dataOnlySchema.getField("name").pos())));
+    assertEquals("9.99", String.valueOf(projected.get(dataOnlySchema.getField("price").pos())));
+    assertEquals(false, projected.get(dataOnlySchema.getField(HoodieRecord.HOODIE_IS_DELETED_FIELD).pos()));
+  }
+
+  @Test
+  void getRecordStaysCorrectAcrossMultipleDifferentSchemaRequestsNarrowThenFull() throws IOException {
+    OverwriteWithLatestAvroPayload payload = new OverwriteWithLatestAvroPayload(newFullRecord(), 100L);
+
+    // First call: project down to the narrow, data-only schema -- this reassigns the payload's internal
+    // cached record to the narrow-schema decode result.
+    IndexedRecord narrow = payload.getInsertValue(dataOnlySchema).get();
+    assertEquals("1", String.valueOf(narrow.get(dataOnlySchema.getField("id").pos())));
+
+    // Second call: request the FULL schema again, via a schema instance that is NOT reference-equal to the
+    // original `fullSchema` (a fresh parse of the same definition) -- this still misses the
+    // reference-equality fast path and forces a real re-decode. Before the writer-schema-caching fix, this
+    // call derived the "writer schema" from the now-narrow cached record left behind by the FIRST call
+    // above, instead of the payload's true (full) writer schema -- decoding the full-width bytes as if
+    // they were narrow-width. Depending on the exact bytes, this pre-fix bug surfaced as either silent,
+    // positionally-misaligned garbage or a hard decoding exception (e.g. "Malformed data. Length is
+    // negative") -- this test covers that direction of the two-call sequence; the reverse direction
+    // (full-schema call first) is covered separately below.
+    Schema fullSchemaCopy = new Schema.Parser().parse(fullSchema.toString());
+    IndexedRecord full = payload.getInsertValue(fullSchemaCopy).get();
+
+    assertEquals("20260807120000000",
+        String.valueOf(full.get(fullSchemaCopy.getField(HoodieRecord.COMMIT_TIME_METADATA_FIELD).pos())));
+    assertEquals("1", String.valueOf(full.get(fullSchemaCopy.getField("id").pos())));
+    assertEquals(100L, full.get(fullSchemaCopy.getField("ts").pos()));
+    assertEquals("alice", String.valueOf(full.get(fullSchemaCopy.getField("name").pos())));
+    assertEquals("9.99", String.valueOf(full.get(fullSchemaCopy.getField("price").pos())));
+  }
+
+  @Test
+  void getRecordStaysCorrectAcrossMultipleDifferentSchemaRequestsFullThenNarrow() throws IOException {
+    OverwriteWithLatestAvroPayload payload = new OverwriteWithLatestAvroPayload(newFullRecord(), 100L);
+
+    // First call: request the FULL schema via a schema instance that is NOT reference-equal to the
+    // original `fullSchema` (a fresh parse of the same definition) -- this misses the reference-equality
+    // fast path and forces a real re-decode, reassigning the payload's internal cached record to this
+    // (still full-width) decode result.
+    Schema fullSchemaCopy = new Schema.Parser().parse(fullSchema.toString());
+    IndexedRecord full = payload.getInsertValue(fullSchemaCopy).get();
+    assertEquals("1", String.valueOf(full.get(fullSchemaCopy.getField("id").pos())));
+
+    // Second call: project down to the narrow, data-only schema. This is the OTHER call order a second,
+    // independent verifier found the pre-fix bug in: because the two orders decode against structurally
+    // different byte layouts, this direction is not guaranteed to fail the same way as narrow-then-full
+    // above (that one produced silent garbage; this one produced a hard AvroRuntimeException) -- both
+    // orders must be covered, not just one.
+    IndexedRecord narrow = payload.getInsertValue(dataOnlySchema).get();
+
+    assertEquals("1", String.valueOf(narrow.get(dataOnlySchema.getField("id").pos())));
+    assertEquals(100L, narrow.get(dataOnlySchema.getField("ts").pos()));
+    assertEquals("alice", String.valueOf(narrow.get(dataOnlySchema.getField("name").pos())));
+    assertEquals("9.99", String.valueOf(narrow.get(dataOnlySchema.getField("price").pos())));
+    assertEquals(false, narrow.get(dataOnlySchema.getField(HoodieRecord.HOODIE_IS_DELETED_FIELD).pos()));
+  }
+
+  @Test
+  void defaultHoodieRecordPayloadIsDeletedThenGetInsertValueStaysCorrect() throws IOException {
+    DefaultHoodieRecordPayload payload = new DefaultHoodieRecordPayload(newFullRecord(), 100L);
+
+    // isDeleted() decodes against the narrow (data-only) schema first, exercising getRecord(schema)
+    // exactly like the CoW/MoR merge paths reached during a real write.
+    assertFalse(payload.isDeleted(dataOnlySchema, new Properties()));
+
+    // ...then getInsertValue() is asked for a DIFFERENT (full) schema instance: this is the
+    // isDeleted -> getInsertValue sequence that reaches the writer-schema-caching bug via
+    // DefaultHoodieRecordPayload#isDeleted (getRecord(schema)) followed by prependMetaFields /
+    // rewriteRecordWithNewSchema calling getInsertValue(recordSchema) with a distinct Schema instance.
+    Schema fullSchemaCopy = new Schema.Parser().parse(fullSchema.toString());
+    IndexedRecord result = payload.getInsertValue(fullSchemaCopy, new Properties()).get();
+
+    assertEquals("1", String.valueOf(result.get(fullSchemaCopy.getField("id").pos())));
+    assertEquals("alice", String.valueOf(result.get(fullSchemaCopy.getField("name").pos())));
+    assertEquals(100L, result.get(fullSchemaCopy.getField("ts").pos()));
+  }
+
+  @Test
+  void getRecordThrowsWhenReaderSchemaHasNonDefaultedFieldMissingFromWriterSchema() {
+    OverwriteWithLatestAvroPayload payload = new OverwriteWithLatestAvroPayload(newFullRecord(), 100L);
+
+    // A reader-schema field with no default that the writer schema never had must fail loudly
+    // (AvroTypeException) rather than silently decode a garbage/positionally-misaligned value -- this is
+    // the documented, intentional contract of resolving-by-name decoding (see class javadoc).
+    assertThrows(AvroTypeException.class, () -> payload.getInsertValue(readerSchemaWithUnresolvableField),
+        "a reader schema field with no default that the writer schema lacks must fail loudly, not decode garbage");
+  }
+
+  @Test
+  void getRecordFallsBackToPositionalDecodeForRenamedFieldWithDefault() throws IOException {
+    // Schema-evolution shape seen on the Hive/Presto MoR realtime read path: a column was renamed after
+    // the log record was written, so the requested schema carries the NEW name (a nullable field with a
+    // null default) while the payload's writer schema still has the OLD name at the same position. The
+    // merge path relies on the legacy positional decode to carry the value across the rename -- resolving
+    // by name instead would silently null the field out (see TestHiveTableSchemaEvolution).
+    Schema writerSchema = SchemaBuilder.record("renamedWriter")
+        .fields()
+        .optionalString("col1")
+        .optionalString("col2")
+        .endRecord();
+    Schema readerSchema = SchemaBuilder.record("renamedReader")
+        .fields()
+        .optionalString("col1")
+        .optionalString("col2_new")
+        .endRecord();
+    GenericRecord record = new GenericRecordBuilder(writerSchema)
+        .set("col1", "1.1")
+        .set("col2", "text2")
+        .build();
+
+    OverwriteWithLatestAvroPayload payload = new OverwriteWithLatestAvroPayload(record, 100L);
+    IndexedRecord decoded = payload.getInsertValue(readerSchema).get();
+
+    assertEquals("1.1", String.valueOf(decoded.get(readerSchema.getField("col1").pos())));
+    assertEquals("text2", String.valueOf(decoded.get(readerSchema.getField("col2_new").pos())));
+  }
+
+  @Test
+  void resolvesOnlyMatchingNamedUnionBranchesDuringEvolution() throws Exception {
+    Schema writer = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"unionRoot\",\"fields\":["
+        + "{\"name\":\"item\",\"type\":[{\"type\":\"record\",\"name\":\"left\",\"fields\":["
+        + "{\"name\":\"id\",\"type\":\"string\"}]},{\"type\":\"record\",\"name\":\"right\",\"fields\":["
+        + "{\"name\":\"name\",\"type\":\"string\"}]}]}]}");
+    Schema reader = new Schema.Parser().parse(writer.toString().replace(
+        "\"name\":\"id\",\"type\":\"string\"", "\"name\":\"id\",\"type\":\"string\"},"
+            + "{\"name\":\"added\",\"type\":[\"null\",\"string\"],\"default\":null"));
+    for (int branch = 0; branch < 2; branch++) {
+      Schema branchSchema = writer.getField("item").schema().getTypes().get(branch);
+      GenericRecord item = new GenericRecordBuilder(branchSchema).set(branch == 0 ? "id" : "name", "value").build();
+      GenericRecord original = new GenericRecordBuilder(writer).set("item", item).build();
+      IndexedRecord decoded = new OverwriteWithLatestAvroPayload(original, 1L).getInsertValue(reader).get();
+      IndexedRecord actual = (IndexedRecord) decoded.get(0);
+      assertEquals("value", actual.get(0).toString());
+      if (branch == 0) {
+        assertNull(actual.get(1));
+      }
+    }
+  }
+
+  @Test
+  void javaSerializationRetainsOriginalSchemaAfterProjection() throws Exception {
+    OverwriteWithLatestAvroPayload payload = new OverwriteWithLatestAvroPayload(newFullRecord(), 100L);
+    payload.getInsertValue(dataOnlySchema);
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(payload);
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      OverwriteWithLatestAvroPayload restored = (OverwriteWithLatestAvroPayload) input.readObject();
+      IndexedRecord full = restored.getInsertValue(fullSchema).get();
+      assertEquals("alice", full.get(fullSchema.getField("name").pos()).toString());
+      assertEquals("1", restored.getInsertValue(dataOnlySchema).get().get(dataOnlySchema.getField("id").pos()).toString());
+    }
+  }
+
+  @Test
+  void readsLegacyKryoPayloadWithSuppliedWriterSchema() throws Exception {
+    OverwriteWithLatestAvroPayload payload = new OverwriteWithLatestAvroPayload(newFullRecord(), 100L);
+    Kryo kryo = new Kryo();
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (Output output = new Output(bytes)) {
+      byte[] recordBytes = payload.getRecordBytes();
+      output.writeInt(recordBytes.length);
+      output.writeBytes(recordBytes);
+      kryo.writeClassAndObject(output, 100L);
+      output.writeBoolean(false);
+    }
+    OverwriteWithLatestAvroPayload restored = new OverwriteWithLatestAvroPayload(Option.empty());
+    try (Input input = new Input(bytes.toByteArray())) {
+      restored.read(kryo, input);
+    }
+    assertEquals("alice", restored.getInsertValue(fullSchema).get().get(fullSchema.getField("name").pos()).toString());
+    assertEquals("1", restored.getInsertValue(dataOnlySchema).get().get(dataOnlySchema.getField("id").pos()).toString());
+    assertEquals(100L, restored.getOrderingValue());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void javaSerializationReadsPreMorPayloads(boolean deleted) throws Exception {
+    // Generated with BaseAvroPayload from pre-MOR commit 8e884960820a081e34cdce8e78505e9ed54dff28.
+    // Materialize record bytes before using that version's default Java serializer. Golden bytes
+    // catch serialVersionUID changes that a same-version round trip cannot detect.
+    String bytes = deleted
+        ? "rO0ABXNyADtvcmcuYXBhY2hlLmh1ZGkuY29tbW9uLm1vZGVsLk92ZXJ3cml0ZVdpdGhMYXRlc3RBdnJvUGF5bG9hZGa/j5KgaG9h"
+        + "AgAAeHIALG9yZy5hcGFjaGUuaHVkaS5jb21tb24ubW9kZWwuQmFzZUF2cm9QYXlsb2FkOJGhgVrvqjUCAANaAA9pc0RlbGV0ZWRS"
+        + "ZWNvcmRMAAtvcmRlcmluZ1ZhbHQAFkxqYXZhL2xhbmcvQ29tcGFyYWJsZTtbAAtyZWNvcmRCeXRlc3QAAltCeHABc3IADmphdmEu"
+        + "bGFuZy5Mb25nO4vkkMyPI98CAAFKAAV2YWx1ZXhyABBqYXZhLmxhbmcuTnVtYmVyhqyVHQuU4IsCAAB4cAAAAAAAAAAqdXIAAltC"
+        + "rPMX+AYIVOACAAB4cAAAAAA="
+        : "rO0ABXNyADtvcmcuYXBhY2hlLmh1ZGkuY29tbW9uLm1vZGVsLk92ZXJ3cml0ZVdpdGhMYXRlc3RBdnJvUGF5bG9hZGa/j5KgaG9h"
+        + "AgAAeHIALG9yZy5hcGFjaGUuaHVkaS5jb21tb24ubW9kZWwuQmFzZUF2cm9QYXlsb2FkOJGhgVrvqjUCAANaAA9pc0RlbGV0ZWRS"
+        + "ZWNvcmRMAAtvcmRlcmluZ1ZhbHQAFkxqYXZhL2xhbmcvQ29tcGFyYWJsZTtbAAtyZWNvcmRCeXRlc3QAAltCeHAAc3IADmphdmEu"
+        + "bGFuZy5Mb25nO4vkkMyPI98CAAFKAAV2YWx1ZXhyABBqYXZhLmxhbmcuTnVtYmVyhqyVHQuU4IsCAAB4cAAAAAAAAAAqdXIAAltC"
+        + "rPMX+AYIVOACAAB4cAAAAA0Ga2V5VA51cGRhdGVk";
+    OverwriteWithLatestAvroPayload restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(bytes)))) {
+      restored = (OverwriteWithLatestAvroPayload) input.readObject();
+    }
+    assertEquals(42L, restored.getOrderingVal());
+    Schema writerSchema = SchemaBuilder.record("payload").fields()
+        .requiredString("id").requiredLong("ts").requiredString("value").endRecord();
+    if (deleted) {
+      assertFalse(restored.getInsertValue(writerSchema).isPresent());
+    } else {
+      assertEquals("key", restored.getInsertValue(writerSchema).get().get(0).toString());
+      Schema projection = SchemaBuilder.record("payload").fields().requiredString("value").requiredString("id").endRecord();
+      IndexedRecord record = restored.getInsertValue(projection).get();
+      assertEquals("updated", record.get(0).toString());
+      assertEquals("key", record.get(1).toString());
+      assertEquals(42L, restored.getInsertValue(writerSchema).get().get(1));
+    }
+  }
+
+  @Test
+  void legacyFormatDoesNotAffectIndependentSelfContainedPayloads() throws IOException {
+    Kryo legacy = new Kryo();
+    BaseAvroPayload.useLegacyKryoFormat(legacy);
+    OverwriteWithLatestAvroPayload payload = new OverwriteWithLatestAvroPayload(newFullRecord(), 100L);
+    try (Output output = new Output(256, -1)) {
+      payload.write(legacy, output);
+      try (Input input = new Input(output.toBytes())) {
+        assertEquals(payload.getRecordBytes().length, input.readInt());
+      }
+    }
+    assertProjectionByNameAfterKryoRoundTrip();
+  }
+
+  @Test
+  void getRecordHandlesProjectionSerializationAndEvolutionWithoutDataLoss() {
+    assertAll(
+        this::assertProjectionByNameAfterKryoRoundTrip,
+        this::assertReaderFieldAliasIsResolved,
+        this::assertNestedRenameCompatibilityIsPreserved,
+        this::assertDefaultIsAppliedForAddedReaderField,
+        this::assertReorderedFieldsAreProjectedByName);
+  }
+
+  private void assertProjectionByNameAfterKryoRoundTrip() throws IOException {
+    OverwriteWithLatestAvroPayload payload = new OverwriteWithLatestAvroPayload(newFullRecord(), 100L);
+
+    // Self-contained payloads must support projection without the original record or Kryo instance.
+    Kryo kryo = new Kryo();
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (Output output = new Output(bytes)) {
+      payload.write(kryo, output);
+    }
+    OverwriteWithLatestAvroPayload restored = new OverwriteWithLatestAvroPayload(Option.empty());
+    try (Input input = new Input(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored.read(new Kryo(), input);
+    }
+    IndexedRecord projected = restored.getInsertValue(dataOnlySchema).get();
+
+    assertEquals("1", String.valueOf(projected.get(dataOnlySchema.getField("id").pos())));
+    assertEquals(100L, projected.get(dataOnlySchema.getField("ts").pos()));
+    assertEquals("alice", String.valueOf(projected.get(dataOnlySchema.getField("name").pos())));
+    assertEquals("9.99", String.valueOf(projected.get(dataOnlySchema.getField("price").pos())));
+  }
+
+  private void assertReaderFieldAliasIsResolved() throws IOException {
+    Schema writerSchema = new Schema.Parser().parse("{"
+        + "\"type\":\"record\",\"name\":\"aliasedRecord\",\"fields\":["
+        + "{\"name\":\"old_name\",\"type\":\"string\"}]}");
+    Schema readerSchema = new Schema.Parser().parse("{"
+        + "\"type\":\"record\",\"name\":\"aliasedRecord\",\"fields\":["
+        + "{\"name\":\"new_name\",\"aliases\":[\"old_name\"],\"type\":\"string\"}]}");
+    GenericRecord record = new GenericRecordBuilder(writerSchema)
+        .set("old_name", "preserved-through-alias")
+        .build();
+
+    IndexedRecord decoded = new OverwriteWithLatestAvroPayload(record, 100L)
+        .getInsertValue(readerSchema)
+        .get();
+
+    assertEquals("preserved-through-alias",
+        String.valueOf(decoded.get(readerSchema.getField("new_name").pos())),
+        "Avro reader-field aliases must participate in name-based schema resolution");
+  }
+
+  private void assertNestedRenameCompatibilityIsPreserved() throws IOException {
+    Schema writerSchema = new Schema.Parser().parse("{"
+        + "\"type\":\"record\",\"name\":\"outerRecord\",\"namespace\":\"org.apache.hudi\",\"fields\":["
+        + "{\"name\":\"nested\",\"type\":{\"type\":\"record\",\"name\":\"nestedRecord\",\"fields\":["
+        + "{\"name\":\"old_name\",\"type\":[\"null\",\"string\"],\"default\":null}]}}]}");
+    Schema readerSchema = new Schema.Parser().parse("{"
+        + "\"type\":\"record\",\"name\":\"outerRecord\",\"namespace\":\"org.apache.hudi\",\"fields\":["
+        + "{\"name\":\"nested\",\"type\":{\"type\":\"record\",\"name\":\"nestedRecord\",\"fields\":["
+        + "{\"name\":\"new_name\",\"type\":[\"null\",\"string\"],\"default\":null}]}}]}");
+    Schema writerNestedSchema = writerSchema.getField("nested").schema();
+    GenericRecord nestedRecord = new GenericRecordBuilder(writerNestedSchema)
+        .set("old_name", "nested-value")
+        .build();
+    GenericRecord record = new GenericRecordBuilder(writerSchema)
+        .set("nested", nestedRecord)
+        .build();
+
+    IndexedRecord decoded = new OverwriteWithLatestAvroPayload(record, 100L)
+        .getInsertValue(readerSchema)
+        .get();
+    GenericRecord decodedNested = (GenericRecord) decoded.get(readerSchema.getField("nested").pos());
+
+    assertEquals("nested-value",
+        String.valueOf(decodedNested.get(readerSchema.getField("nested").schema().getField("new_name").pos())),
+        "nested evolution must not be misclassified as a pure top-level projection and silently null data");
+  }
+
+  private void assertDefaultIsAppliedForAddedReaderField() throws IOException {
+    Schema writerSchema = SchemaBuilder.record("addedFieldRecord")
+        .fields()
+        .requiredString("id")
+        .endRecord();
+    Schema readerSchema = SchemaBuilder.record("addedFieldRecord")
+        .fields()
+        .requiredString("id")
+        .optionalString("new_field")
+        .endRecord();
+    GenericRecord record = new GenericRecordBuilder(writerSchema)
+        .set("id", "1")
+        .build();
+
+    IndexedRecord decoded = new OverwriteWithLatestAvroPayload(record, 100L)
+        .getInsertValue(readerSchema)
+        .get();
+
+    assertEquals("1", String.valueOf(decoded.get(readerSchema.getField("id").pos())));
+    assertNull(decoded.get(readerSchema.getField("new_field").pos()),
+        "an added reader field must receive its Avro default instead of being decoded past the writer bytes");
+  }
+
+  private void assertReorderedFieldsAreProjectedByName() throws IOException {
+    Schema reorderedSchema = SchemaBuilder.record("reorderedProjection")
+        .fields()
+        .requiredString("price")
+        .requiredString("id")
+        .requiredString("name")
+        .requiredLong("ts")
+        .endRecord();
+
+    IndexedRecord decoded = new OverwriteWithLatestAvroPayload(newFullRecord(), 100L)
+        .getInsertValue(reorderedSchema)
+        .get();
+
+    assertEquals("9.99", String.valueOf(decoded.get(reorderedSchema.getField("price").pos())));
+    assertEquals("1", String.valueOf(decoded.get(reorderedSchema.getField("id").pos())));
+    assertEquals("alice", String.valueOf(decoded.get(reorderedSchema.getField("name").pos())));
+    assertEquals(100L, decoded.get(reorderedSchema.getField("ts").pos()));
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

An Avro payload decoded with a projected schema can lose or misassign values when the requested schema differs from the schema that encoded the record. Repeated projections, metadata-declaring schemas, nested renames, and serialization round trips expose this in merge paths.

This is a prerequisite for the standalone Java work in [discussion #19798](https://github.com/apache/hudi/discussions/19798) and the [dev-list proposal](https://www.mail-archive.com/dev%40hudi.apache.org/msg06536.html).

### Summary and Changelog

- Retain the writer schema and resolve projections, aliases, defaults, and supported legacy positional renames without shifting unrelated fields.
- Restrict positional renames to compatible source fields that are not already claimed by another reader field or alias. Incompatible drop/add replacements receive their reader default.
- Avoid inferring a legacy writer schema from a prefix read that leaves unread record bytes. Later full-schema reads can still recover trailing values.
- Preserve the writer schema through Java serialization and default Kryo serialization. Cache compressed schema strings when smaller, keeping each serialized payload independently readable across threads and random-access spills.
- Preserve the original Java serialVersionUID and accept golden legacy streams. Keep Spark's registered compact Kryo representation and its existing size assertions unchanged.
- Add regression coverage for the review cases, compressed/uncompressed transport, tombstones, and Spark Kryo without the Hudi registrar. Split recursive reconciliation into named helpers.

This uses Hudi's Avro rewrite utilities, Apache Avro's compatibility checker, and JDK gzip/Base64. No dependency or third-party source is added.

### Impact

Shared payload decoding affects every engine using these payloads. No new table storage layout or table version is introduced.

**Breaking transport change (the `!` in the title):** default non-Spark Kryo writers emit a schema-bearing representation with a negative-length discriminator. The schema string contains JSON or `gzip:` followed by Base64-encoded compressed JSON. Updated readers accept legacy non-negative-length payloads, uncompressed schema-bearing payloads, and compressed schema-bearing payloads. Pre-change readers cannot read the schema-bearing representation; readers from an earlier revision of this PR that only understand JSON cannot read its compressed form.

`BaseAvroPayload.useLegacyKryoFormat(kryo)` retains the old representation for transports supplying the writer schema separately. The Spark Hudi registrar selects that mode. Mixed-version users must upgrade readers first or explicitly retain legacy transport; arbitrary mixed-version compatibility is not claimed. Legacy bytes remain schema-free: consuming all bytes avoids caching a truncated prefix, but does not prove historical field names/types.

Compression reduces repeated schema overhead without introducing stream-local IDs. A sparse 128-column size probe changed from 8,016 to 729 bytes per serialized payload (146 bytes in legacy mode). This is a size measurement, not an end-to-end performance claim; compression and schema parsing are cached with a 1,024-entry bound.

### Risk Level

high

Shared merge behavior and the default in-memory Kryo representation change. Review regressions were reproduced against the previous PR head before the fixes. Local validation in the Hudi Java 11 CI image passed 70 focused cases with zero failures, errors, skips or retry events: 26 payload cases, four shared serializer cases, 32 existing disk-spill cases, five Spark registrar/default-serializer cases, and the three unchanged Spark record-serialization/size cases. The dependency reactor builds successfully; Checkstyle passes for both changed modules. Unrelated ScalaTest suites were excluded from this targeted run. This is not a full repository test run. The previous head `a8530e348f` passed [Azure CI](https://dev.azure.com/apachehudi/a1a51da7-8592-47d4-88dc-fd67bed336bb/_build/results?buildId=16927); that result does not validate this revision.

### Documentation Update

The transport boundary and migration requirements are documented above. The prepared companion change for the `asf-site` branch will document this in `website/docs/java-client.md` and be linked before merge.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
