### PR TITLE
fix(flink): repair test compilation after metadata field mode migration

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestHoodieRowDataLanceReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestHoodieRowDataLanceReader.java
@@ -22,6 +22,7 @@ package org.apache.hudi.table.format;
 import org.apache.hudi.common.bloom.SimpleBloomFilter;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.MetaFieldsMode;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
@@ -125,7 +126,7 @@ class TestHoodieRowDataLanceReader {
         64 * 1024 * 1024L,
         16 * 1024 * 1024L,
         true,
-        false,
+        MetaFieldsMode.NONE,
         false)) {
       writer.writeRow("key1", GenericRowData.of(
           new GenericArrayData(new Object[] {1.25F, 2.5F})));
@@ -166,7 +167,7 @@ class TestHoodieRowDataLanceReader {
         64 * 1024 * 1024L,
         16 * 1024 * 1024L,
         true,
-        false,
+        MetaFieldsMode.NONE,
         false)) {
       writer.writeRow("key1", GenericRowData.of(
           1,

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cow/TestCopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cow/TestCopyOnWriteInputFormat.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.table.format.cow;
 
 import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.MetaFieldsMode;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
@@ -135,7 +136,7 @@ class TestCopyOnWriteInputFormat {
         64 * 1024 * 1024L,
         16 * 1024 * 1024L,
         true,
-        false,
+        MetaFieldsMode.NONE,
         false)) {
       writer.writeRow("key1", GenericRowData.of(
           new GenericArrayData(new Object[] {1.0F, 2.0F})));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Master fails during `hudi-flink` test compilation after #19858 changed the `HoodieRowDataLanceWriter` constructor from `boolean populateMetaFields` to `MetaFieldsMode`. Three calls in `TestHoodieRowDataLanceReader` and `TestCopyOnWriteInputFormat` still pass `false`, producing `boolean cannot be converted to MetaFieldsMode`.

Failing CI job: https://github.com/apache/hudi/actions/runs/34309698586/job/102335126242

### Summary and Changelog

Replace the three obsolete boolean arguments with `MetaFieldsMode.NONE` and add the corresponding imports. This preserves the tests' existing behavior with metadata fields disabled.

Validation:
- Reproduced all three compiler errors on unmodified master (`eccbef97f339`).
- Passed the Flink 2.2 reactor through the `test` phase, including both affected test classes, with Scala 2.12, Avro 1.11.4, and Parquet 1.15.2. Local validation used JDK 17; the linked CI job uses JDK 11.
- Maven Checkstyle and license checks passed; `git diff --check` passed.

```sh
mvn test -T 2 -Punit-tests -Djava17 -Dscala-2.12 -Dflink2.2   -pl hudi-examples/hudi-examples-flink -am   -Davro.version=1.11.4 -Dparquet.version=1.15.2   -Dtest=TestHoodieRowDataLanceReader,TestCopyOnWriteInputFormat   -Dsurefire.failIfNoSpecifiedTests=false -Dgpg.skip -Djacoco.skip -B -ntp
```

### Impact

Restores Flink test compilation on master. Changes are limited to test code, with no production API, storage format, or runtime behavior changes.

### Risk Level

low — only three test constructor arguments are updated to the equivalent enum value. Both affected test classes pass.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable (existing affected tests were updated and run; no new tests needed for this compilation fix)
