### PR TITLE
chore(spark): bump Spark 3.5 to 3.5.9 and fast-path the CI download

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1507,17 +1507,9 @@ jobs:
           SPARK_ARCHIVE: ${{ matrix.sparkArchive }}
           SCALA_PROFILE: '-Dscala-2.12 -Dscala.binary.version=2.12'
         run: |
-          # dlcdn is the ASF CDN but only carries the current release of each
-          # line; superseded versions are served by archive.apache.org, a single
-          # un-CDN'd origin measured between 42s and 68min for this same 382MB
-          # file (see #19883). Try the CDN first so a current version is fast,
-          # and fall back so a version that has rolled off still resolves.
-          # Plain --retry (not --retry-all-errors) is deliberate: it retries
-          # transient 5xx and stalls but not a 404, so a CDN miss falls through
-          # immediately instead of sleeping through five pointless retries.
-          # --speed-limit/--speed-time abort a transfer stuck under 100KB/s for
-          # two minutes, which --retry then resumes via -C - against a fresh
-          # connection rather than crawling to the end.
+          # dlcdn only carries the current release of each line; fall back to
+          # the archive for older pins (#19883). Plain --retry, not
+          # --retry-all-errors, so a 404 on the CDN falls through immediately.
           DEST="$GITHUB_WORKSPACE/$SPARK_ARCHIVE"
           downloaded=false
           for base in https://dlcdn.apache.org/spark https://archive.apache.org/dist/spark; do

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1459,7 +1459,7 @@ jobs:
         include:
           - sparkProfile: 'spark3.5'
             flinkProfile: 'flink2.2'
-            sparkArchive: 'spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz'
+            sparkArchive: 'spark-3.5.9/spark-3.5.9-bin-hadoop3.tgz'
     steps:
       - if: needs.changes.outputs.relevant == 'true'
         uses: actions/checkout@v5

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1507,9 +1507,36 @@ jobs:
           SPARK_ARCHIVE: ${{ matrix.sparkArchive }}
           SCALA_PROFILE: '-Dscala-2.12 -Dscala.binary.version=2.12'
         run: |
-          echo "Downloading $SPARK_ARCHIVE"
-          curl --retry 5 https://archive.apache.org/dist/spark/$SPARK_ARCHIVE --create-dirs -o $GITHUB_WORKSPACE/$SPARK_ARCHIVE
-          tar -xvf $GITHUB_WORKSPACE/$SPARK_ARCHIVE -C $GITHUB_WORKSPACE/
+          # dlcdn is the ASF CDN but only carries the current release of each
+          # line; superseded versions are served by archive.apache.org, a single
+          # un-CDN'd origin measured between 42s and 68min for this same 382MB
+          # file (see #19883). Try the CDN first so a current version is fast,
+          # and fall back so a version that has rolled off still resolves.
+          # Plain --retry (not --retry-all-errors) is deliberate: it retries
+          # transient 5xx and stalls but not a 404, so a CDN miss falls through
+          # immediately instead of sleeping through five pointless retries.
+          # --speed-limit/--speed-time abort a transfer stuck under 100KB/s for
+          # two minutes, which --retry then resumes via -C - against a fresh
+          # connection rather than crawling to the end.
+          DEST="$GITHUB_WORKSPACE/$SPARK_ARCHIVE"
+          downloaded=false
+          for base in https://dlcdn.apache.org/spark https://archive.apache.org/dist/spark; do
+            echo "Downloading $SPARK_ARCHIVE from $base"
+            if curl -fL --create-dirs -o "$DEST" \
+                --retry 5 --retry-delay 10 \
+                --connect-timeout 30 --speed-limit 100000 --speed-time 120 \
+                -C - "$base/$SPARK_ARCHIVE"; then
+              downloaded=true
+              break
+            fi
+            echo "$base did not serve $SPARK_ARCHIVE"
+            rm -f "$DEST"
+          done
+          if [ "$downloaded" != true ]; then
+            echo "ERROR: could not download $SPARK_ARCHIVE from any source"
+            exit 1
+          fi
+          tar -xf "$DEST" -C $GITHUB_WORKSPACE/
           mkdir /tmp/spark-events/
           SPARK_ARCHIVE_BASENAME=$(basename $SPARK_ARCHIVE)
           export SPARK_HOME=$GITHUB_WORKSPACE/${SPARK_ARCHIVE_BASENAME%.*}

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1510,14 +1510,17 @@ jobs:
           # dlcdn only carries the current release of each line; fall back to
           # the archive for older pins (#19883). Plain --retry, not
           # --retry-all-errors, so a 404 on the CDN falls through immediately.
+          # --speed-limit is a dead-connection detector, not a slowness one:
+          # --retry truncates the output back to byte 0, so a floor set near
+          # the archive's real throughput re-downloads 382MB per abort.
           DEST="$GITHUB_WORKSPACE/$SPARK_ARCHIVE"
           downloaded=false
           for base in https://dlcdn.apache.org/spark https://archive.apache.org/dist/spark; do
             echo "Downloading $SPARK_ARCHIVE from $base"
             if curl -fL --create-dirs -o "$DEST" \
                 --retry 5 --retry-delay 10 \
-                --connect-timeout 30 --speed-limit 100000 --speed-time 120 \
-                -C - "$base/$SPARK_ARCHIVE"; then
+                --connect-timeout 30 --speed-limit 1000 --speed-time 120 \
+                "$base/$SPARK_ARCHIVE"; then
               downloaded=true
               break
             fi

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieContinuousTestSuiteWriter.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieContinuousTestSuiteWriter.java
@@ -41,7 +41,7 @@ import java.util.Properties;
  * Test suite Writer that assists in testing async table operations with Deltastreamer continuous mode.
  *
  * Sample command
- * ./bin/spark-submit --packages org.apache.spark:spark-avro_2.12:3.5.5 \
+ * ./bin/spark-submit --packages org.apache.spark:spark-avro_2.12:3.5.9 \
  *  --conf spark.task.cpus=1 --conf spark.executor.cores=1 \
  * --conf spark.task.maxFailures=100 \
  * --conf spark.memory.fraction=0.4 \

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieMultiWriterTestSuiteJob.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/HoodieMultiWriterTestSuiteJob.java
@@ -53,7 +53,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * Example command
  * spark-submit
- * --packages org.apache.spark:spark-avro_2.12:3.5.5
+ * --packages org.apache.spark:spark-avro_2.12:3.5.9
  * --conf spark.task.cpus=3
  * --conf spark.executor.cores=3
  * --conf spark.task.maxFailures=100

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/SparkDataSourceContinuousIngestTool.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/SparkDataSourceContinuousIngestTool.java
@@ -43,7 +43,7 @@ import java.util.Map;
 /**
  * Sample command
  *
- * ./bin/spark-submit --packages org.apache.spark:spark-avro_2.12:3.5.5 --driver-memory 4g   --executor-memory 4g \
+ * ./bin/spark-submit --packages org.apache.spark:spark-avro_2.12:3.5.9 --driver-memory 4g   --executor-memory 4g \
  * --conf spark.serializer=org.apache.spark.serializer.KryoSerializer   --conf spark.sql.catalogImplementation=hive \
  * --class org.apache.hudi.integ.testsuite.SparkDSContinuousIngestTool \
  * ${HUDI_ROOT_DIR}/packaging/hudi-integ-test-bundle/target/hudi-integ-test-bundle-0.11.0-SNAPSHOT.jar \

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieDropPartitionsTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieDropPartitionsTool.java
@@ -65,7 +65,7 @@ import scala.Tuple2;
  * ```
  * spark-submit \
  * --class org.apache.hudi.utilities.HoodieDropPartitionsTool \
- * --packages org.apache.spark:spark-avro_2.12:3.5.5 \
+ * --packages org.apache.spark:spark-avro_2.12:3.5.9 \
  * --master local[*]
  * --driver-memory 1g \
  * --executor-memory 1g \
@@ -87,7 +87,7 @@ import scala.Tuple2;
  * ```
  * spark-submit \
  * --class org.apache.hudi.utilities.HoodieDropPartitionsTool \
- * --packages org.apache.spark:spark-avro_2.12:3.5.5 \
+ * --packages org.apache.spark:spark-avro_2.12:3.5.9 \
  * --master local[*]
  * --driver-memory 1g \
  * --executor-memory 1g \

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
     <rocksdbjni.version>7.5.3</rocksdbjni.version>
     <spark33.version>3.3.4</spark33.version>
     <spark34.version>3.4.3</spark34.version>
-    <spark35.version>3.5.5</spark35.version>
+    <spark35.version>3.5.9</spark35.version>
     <spark40.version>4.0.2</spark40.version>
     <spark41.version>4.1.1</spark41.version>
     <spark42.version>4.2.0</spark42.version>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Part of #19883. The `integration-tests` job downloads a 382MB Spark tarball from `archive.apache.org` on every run. That host is a single un-CDN'd origin and was measured between **42 seconds and 1h 08m** for the same file, which at worst turned a 37-minute job into 106 minutes.

Separately, `pom.xml` compiled against 3.5.5 while the job ran its Spark tests on a **3.5.3** runtime. That is the unsafe direction: code built against 3.5.5 can reference APIs absent from 3.5.3.

### Summary and Changelog

Both halves have the same root cause, so they are fixed together.

- `spark35.version` 3.5.5 -> **3.5.9**, and the `integration-tests` archive pin moves to match. 3.5.9 is the current 3.5 release, so it is served by `dlcdn.apache.org` at CDN speed instead of by the archive. The 5 `spark-avro_2.12:3.5.5` spark-submit examples move with it, since spark-avro has to match the runtime it is submitted against.
- The download tries `dlcdn.apache.org` first and falls back to `archive.apache.org`, because the CDN carries only the current release of each line and any pin eventually rolls off it.
- `curl` gains `-f` so an error page becomes a download failure rather than a corrupt tarball, and `--speed-limit`/`--speed-time` so a transfer stuck under 100KB/s for two minutes is aborted and resumed on a fresh connection. `tar` loses `-v`, which was printing 4000 lines of filenames into the job log.

<details>
<summary>Why plain --retry and not --retry-all-errors</summary>

`--retry-all-errors` retries a 404, so a dlcdn miss would sleep through five pointless retries before falling back -- roughly 50 seconds on exactly the path that matters. Plain `--retry` still covers transient 5xx and stalls but returns immediately on 404. Measured 0.06s vs 6.09s on a real 404. There is a comment in the workflow recording this so it does not get "fixed" back.

</details>

<details>
<summary>Measured download times behind the 42s to 68min range</summary>

From curl's own summary line in each job log, same URL, same file, same runner label:

| Download | Avg speed | Job wall clock | Run |
|---|---|---|---|
| 0:00:42 | 9.0 MB/s | 37m | 34314808833 |
| 0:05:52 | 1.1 MB/s | 42m | 34306895783 |
| 0:11:56 | 546 KB/s | 51m | 34237534196 |
| 0:35:04 | 186 KB/s | 73m | 34228343560 |
| 0:42:06 | 154 KB/s | 78m | 34226281866 |
| 0:48:32 | 134 KB/s | 85m | 34226858343 |
| 1:07:42 | 98 KB/s | 106m | 34316284096 |

The `mvn verify` that follows in the same step is constant at 21.8 to 24.1 minutes across all of these, so the variance is the download alone. Full logs are attached to #19883.

</details>

<details>
<summary>What the tarball is for, and what is deliberately not in this PR</summary>

The downloaded distribution is the runtime for `hudi-cli`'s eight `ITTest*Command` classes, which use `SparkLauncher` to resolve `$SPARK_HOME/bin/spark-submit` (`SparkUtil.java:53`). The docker-cluster ITs in `hudi-integ-test` are all `@Disabled` (HUDI-8274, HUDI-8440) and report `Tests run: 9, Skipped: 9`, so there is no client-versus-cluster version coupling to break here.

Three Spark 3.5 pins are still stale and are **not** touched by this PR, because they need new base images published to the `apachehudi` Docker Hub org first (`packaging/bundle-validation/Dockerfile` does `FROM apachehudi/hudi-ci-bundle-validation-base:$IMAGE_TAG`):

- bundle-validation lanes at `spark3.5.0` and `spark3.5.1`
- the hive-sync job's `sparkadhoc_3.5.3` image
- the `docker/compose` spark353 stack

Tracked on #19883.

</details>

### Impact

CI only. No production code paths change. The `integration-tests` job should drop from a 42s-to-68min download to a few seconds, removing roughly 11 minutes of avoidable runner time per run against the ASF 4,200 h/week cap tracked in #19524.

### Risk Level

**low**. CI-only change. The three Spark sources Hudi copies from are byte-identical between `v3.5.5` and `v3.5.9`, and every in-tree Spark version gate is minor-level, so the patch bump crosses none of them.

<details>
<summary>Verification detail</summary>

Byte-identical between `v3.5.5` and `v3.5.9`: `ParquetFileFormat.scala`, `TypeCoercion.scala`, `DecimalPrecision.scala` (compared by git blob SHA). The parquet one is identical from `v3.5.1`, the revision `Spark35ParquetReader` cites. Version gates in tree are all minor-level: `startsWith("3.5")`, `>= "3.5.0"`.

- JDK 17 `mvn install` of `hudi-spark3.5.x_2.12 -am`: BUILD SUCCESS across 16 modules including every Spark-internal shim, resolving `spark-core_2.12-3.5.9`.
- JDK 11 `TestSavepointRestoreCopyOnWrite` under `-Pfunctional-tests`: 7/7 pass with `Running Spark version 3.5.9` in the log.
- Download loop exercised on all three paths: CDN hit (0s), CDN 404 falling back to archive (1s), absent everywhere failing with exit 1 and a clear message (1s).

Scala 2.13 was not gated locally; 3.5.9 artifacts are confirmed on Maven Central for 2.13 and CI covers that lane.

</details>

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
