### PR TITLE
refactor(common): hoist shared instant file name bodies

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseInstantFileNameGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseInstantFileNameGenerator.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline;
+
+import org.apache.hudi.common.util.StringUtils;
+
+/**
+ * Holds the layout-independent instant file naming shared by all timeline layout versions.
+ * Layout-specific members are left abstract for the concrete per-version generators.
+ */
+public abstract class BaseInstantFileNameGenerator implements InstantFileNameGenerator {
+
+  @Override
+  public String makeCommitFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightCommitFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeRequestedCommitFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeCleanerFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.CLEAN_EXTENSION);
+  }
+
+  @Override
+  public String makeRequestedCleanerFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.REQUESTED_CLEAN_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightCleanerFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_CLEAN_EXTENSION);
+  }
+
+  @Override
+  public String makeRollbackFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.ROLLBACK_EXTENSION);
+  }
+
+  @Override
+  public String makeRequestedRollbackFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION);
+  }
+
+  @Override
+  public String makeRequestedRestoreFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.REQUESTED_RESTORE_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightRollbackFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_ROLLBACK_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightSavePointFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_SAVEPOINT_EXTENSION);
+  }
+
+  @Override
+  public String makeSavePointFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.SAVEPOINT_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightDeltaFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_DELTA_COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeRequestedDeltaFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_DELTA_COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightCompactionFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_COMPACTION_EXTENSION);
+  }
+
+  @Override
+  public String makeRequestedCompactionFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightLogCompactionFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_LOG_COMPACTION_EXTENSION);
+  }
+
+  @Override
+  public String makeRequestedLogCompactionFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_LOG_COMPACTION_EXTENSION);
+  }
+
+  @Override
+  public String makeRestoreFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.RESTORE_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightRestoreFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_RESTORE_EXTENSION);
+  }
+
+  @Override
+  public String makeReplaceFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.REPLACE_COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightReplaceFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeRequestedReplaceFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeDeltaFileName(String instantTime) {
+    return instantTime + HoodieTimeline.DELTA_COMMIT_EXTENSION;
+  }
+
+  @Override
+  public String getCommitFromCommitFile(String commitFileName) {
+    return commitFileName.split("\\.")[0];
+  }
+
+  @Override
+  public String makeFileNameAsComplete(String fileName) {
+    return fileName.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
+  }
+
+  @Override
+  public String makeFileNameAsInflight(String fileName) {
+    return StringUtils.join(fileName, HoodieTimeline.INFLIGHT_EXTENSION);
+  }
+
+  @Override
+  public String makeIndexCommitFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.INDEX_COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightIndexFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_INDEX_COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeRequestedIndexFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.REQUESTED_INDEX_COMMIT_EXTENSION);
+  }
+
+  @Override
+  public String makeSchemaFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.SAVE_SCHEMA_ACTION_EXTENSION);
+  }
+
+  @Override
+  public String makeInflightSchemaFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_SAVE_SCHEMA_ACTION_EXTENSION);
+  }
+
+  @Override
+  public String makeRequestSchemaFileName(String instantTime) {
+    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_SAVE_SCHEMA_ACTION_EXTENSION);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/InstantFileNameGeneratorV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/InstantFileNameGeneratorV1.java
@@ -18,16 +18,16 @@
 
 package org.apache.hudi.common.table.timeline.versioning.v1;
 
+import org.apache.hudi.common.table.timeline.BaseInstantFileNameGenerator;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.InstantFileNameGenerator;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
-import org.apache.hudi.common.util.StringUtils;
 
 /**
- *
+ * Instant file naming for timeline layout version 1 (0.x tables), where clustering
+ * shares the replace-commit file names.
  */
-public class InstantFileNameGeneratorV1 implements InstantFileNameGenerator {
+public class InstantFileNameGeneratorV1 extends BaseInstantFileNameGenerator {
 
   @Override
   public TimelineLayoutVersion getLayoutVersion() {
@@ -35,179 +35,14 @@ public class InstantFileNameGeneratorV1 implements InstantFileNameGenerator {
   }
 
   @Override
-  public String makeCommitFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightCommitFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedCommitFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeCleanerFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.CLEAN_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedCleanerFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REQUESTED_CLEAN_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightCleanerFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_CLEAN_EXTENSION);
-  }
-
-  @Override
-  public String makeRollbackFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.ROLLBACK_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedRollbackFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedRestoreFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REQUESTED_RESTORE_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightRollbackFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_ROLLBACK_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightSavePointFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_SAVEPOINT_EXTENSION);
-  }
-
-  @Override
-  public String makeSavePointFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.SAVEPOINT_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightDeltaFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_DELTA_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedDeltaFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_DELTA_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightCompactionFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_COMPACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedCompactionFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightLogCompactionFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_LOG_COMPACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedLogCompactionFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_LOG_COMPACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeRestoreFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.RESTORE_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightRestoreFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_RESTORE_EXTENSION);
-  }
-
-  @Override
-  public String makeReplaceFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REPLACE_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightReplaceFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedReplaceFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeDeltaFileName(String instantTime) {
-    return instantTime + HoodieTimeline.DELTA_COMMIT_EXTENSION;
-  }
-
-  @Override
-  public String getCommitFromCommitFile(String commitFileName) {
-    return commitFileName.split("\\.")[0];
-  }
-
-  @Override
-  public String makeFileNameAsComplete(String fileName) {
-    return fileName.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
-  }
-
-  @Override
-  public String makeFileNameAsInflight(String fileName) {
-    return StringUtils.join(fileName, HoodieTimeline.INFLIGHT_EXTENSION);
-  }
-
-  @Override
-  public String makeIndexCommitFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INDEX_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightIndexFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_INDEX_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedIndexFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REQUESTED_INDEX_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeSchemaFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.SAVE_SCHEMA_ACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightSchemaFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_SAVE_SCHEMA_ACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestSchemaFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_SAVE_SCHEMA_ACTION_EXTENSION);
-  }
-
-  @Override
   public String makeRequestedClusteringFileName(String instant) {
-    // 1n 0.x, clustering and replace commit had the same filename
+    // In 0.x, clustering and replace commit had the same filename
     return makeRequestedReplaceFileName(instant);
   }
 
   @Override
   public String makeInflightClusteringFileName(String instant) {
-    // 1n 0.x, clustering and replace commit had the same filename
+    // In 0.x, clustering and replace commit had the same filename
     return makeInflightReplaceFileName(instant);
   }
 
@@ -276,4 +111,3 @@ public class InstantFileNameGeneratorV1 implements InstantFileNameGenerator {
     return getFileName(instant);
   }
 }
-

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/InstantFileNameGeneratorV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/InstantFileNameGeneratorV2.java
@@ -18,133 +18,22 @@
 
 package org.apache.hudi.common.table.timeline.versioning.v2;
 
+import org.apache.hudi.common.table.timeline.BaseInstantFileNameGenerator;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.timeline.InstantFileNameGenerator;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 
-public class InstantFileNameGeneratorV2 implements InstantFileNameGenerator {
+/**
+ * Instant file naming for timeline layout version 2 (1.x tables), with dedicated clustering
+ * extensions and completed instants named requestedTime_completionTime.
+ */
+public class InstantFileNameGeneratorV2 extends BaseInstantFileNameGenerator {
 
   @Override
   public TimelineLayoutVersion getLayoutVersion() {
     return TimelineLayoutVersion.LAYOUT_VERSION_2;
-  }
-
-  @Override
-  public String makeCommitFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightCommitFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedCommitFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeCleanerFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.CLEAN_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedCleanerFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REQUESTED_CLEAN_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightCleanerFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_CLEAN_EXTENSION);
-  }
-
-  @Override
-  public String makeRollbackFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.ROLLBACK_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedRollbackFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REQUESTED_ROLLBACK_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedRestoreFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REQUESTED_RESTORE_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightRollbackFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_ROLLBACK_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightSavePointFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_SAVEPOINT_EXTENSION);
-  }
-
-  @Override
-  public String makeSavePointFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.SAVEPOINT_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightDeltaFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_DELTA_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedDeltaFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_DELTA_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightCompactionFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_COMPACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedCompactionFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightLogCompactionFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_LOG_COMPACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedLogCompactionFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_LOG_COMPACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeRestoreFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.RESTORE_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightRestoreFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_RESTORE_EXTENSION);
-  }
-
-  @Override
-  public String makeReplaceFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REPLACE_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightReplaceFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_REPLACE_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedReplaceFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REQUESTED_REPLACE_COMMIT_EXTENSION);
   }
 
   @Override
@@ -155,56 +44,6 @@ public class InstantFileNameGeneratorV2 implements InstantFileNameGenerator {
   @Override
   public String makeInflightClusteringFileName(String instant) {
     return StringUtils.join(instant, HoodieTimeline.INFLIGHT_CLUSTERING_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeDeltaFileName(String instantTime) {
-    return instantTime + HoodieTimeline.DELTA_COMMIT_EXTENSION;
-  }
-
-  @Override
-  public String getCommitFromCommitFile(String commitFileName) {
-    return commitFileName.split("\\.")[0];
-  }
-
-  @Override
-  public String makeFileNameAsComplete(String fileName) {
-    return fileName.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
-  }
-
-  @Override
-  public String makeFileNameAsInflight(String fileName) {
-    return StringUtils.join(fileName, HoodieTimeline.INFLIGHT_EXTENSION);
-  }
-
-  @Override
-  public String makeIndexCommitFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INDEX_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightIndexFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_INDEX_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestedIndexFileName(String instant) {
-    return StringUtils.join(instant, HoodieTimeline.REQUESTED_INDEX_COMMIT_EXTENSION);
-  }
-
-  @Override
-  public String makeSchemaFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.SAVE_SCHEMA_ACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeInflightSchemaFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.INFLIGHT_SAVE_SCHEMA_ACTION_EXTENSION);
-  }
-
-  @Override
-  public String makeRequestSchemaFileName(String instantTime) {
-    return StringUtils.join(instantTime, HoodieTimeline.REQUESTED_SAVE_SCHEMA_ACTION_EXTENSION);
   }
 
   private String getPendingFileName(HoodieInstant instant) {


### PR DESCRIPTION

### Describe the issue this Pull Request addresses

`InstantFileNameGeneratorV1` and `InstantFileNameGeneratorV2` were byte-identical except for five members. The other 33 methods (the `StringUtils.join(instantTime, EXTENSION)` one-liners plus `makeDeltaFileName`, `getCommitFromCommitFile`, `makeFileNameAsComplete` and `makeFileNameAsInflight`) were maintained twice, so any new extension had to be added in both places.

### Summary and Changelog

No user-visible change. Pure code motion inside `hudi-common`.

- Add abstract `BaseInstantFileNameGenerator` in `org.apache.hudi.common.table.timeline`, next to the interface, holding the 33 layout-independent bodies unchanged.
- `InstantFileNameGeneratorV1` and `InstantFileNameGeneratorV2` now extend it and keep only what differs per layout version:
  - `getLayoutVersion`
  - `makeRequestedClusteringFileName` / `makeInflightClusteringFileName` (V1 aliases the replace-commit names, V2 has dedicated clustering extensions)
  - `getFileName(HoodieInstant)` / `getFileName(String completionTime, HoodieInstant)` (V2 emits `requestedTime_completionTime` for completed instants)
- The `InstantFileNameGenerator` interface is unchanged, `DefaultInstantFileNameGenerator` still extends V2, and every caller goes through the interface or `TimelineLayout`, so no call site changes.

The five members are left abstract rather than defaulted, so a future layout version still has to state them explicitly.

<details>
<summary>Details</summary>

- A base class was chosen over interface default methods so out-of-repo implementers of `InstantFileNameGenerator` are not affected.
- The only text edit inside a retained body is V1's comment typo `1n 0.x` to `In 0.x`.
- Both concrete classes keep their public no-arg constructors, so the direct constructions in `TimelineLayout`, `TimelineArchiverV1`, `HoodieMetaserverBasedTimeline` and the Spark tests (`TestSparkReaderContextFactory`, `TestHoodieSparkRollback`, `TestColumnStatsIndex`) compile as before.
- Behaviour is pinned by the existing hudi-common timeline tests; no new tests, since no generated name changes.
- Diffstat: 3 files changed, 205 insertions(+), 339 deletions(-)

</details>

### Impact

None. The generated file names are identical for every action, state and layout version.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable