### PR TITLE
chore(ci): align Codecov range with 80% target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -28,7 +28,9 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "50...100"
+  # Dashboard bars turn green only at or above the upper bound, so an upper
+  # bound of 100 can never be green. 80 is the project coverage target.
+  range: "70...80"
   status:
     # Statuses are informational for now: they surface the delta on each PR but do
     # not fail the build. Flip a component to blocking (drop `informational`, set a


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Codecov bar for apache/hudi is yellow at 80.22%, and would stay yellow at any coverage short of 100%. That is a config artifact, not a signal.

### Summary and Changelog

The dashboard bar is a three-state indicator, not a gradient: red below `coverage.range`'s lower bound, yellow in between, green only at or above the upper bound. Our range is `"50...100"`, so green is unreachable.

Changelog:
- `.codecov.yml`: `range: "50...100"` -> `range: "70...80"`, plus a comment on why the upper bound is not 100.

New thresholds read: red below 70, yellow 70-80, green at or above 80, the target the project is working toward. Master is at 80.22% today, so the bar turns green on the first upload after this merges.

<details>
<summary>Where the three-state rule and the 80 come from</summary>

- Color rule: codecov/gazebo, `src/shared/utils/determineProgressColor.ts`. `< lowerRange` is danger, `< upperRange` is warning, otherwise primary.
- A repo with no Codecov YAML gets the API default `[60, 80]`: codecov/umbrella, `apps/codecov-api/graphql_api/types/repository_config/repository_config.py`. That is why apache/spark reads green at 83% with no Codecov config at all.

</details>

### Impact

None on the build and none on users. `coverage.range` feeds only the dashboard bar, the badge gradient and the sunburst colors. Status checks read `coverage.status.project.target`, untouched here; `project` and `patch` stay `informational: true`, so nothing starts gating PRs.

<details>
<summary>One cosmetic side effect</summary>

The badge uses the same range as a continuous gradient rather than as steps, so raising the floor from 50 to 70 makes the badge read slightly less green even as the dashboard turns green, and weakly covered files render red rather than orange in the file explorer.

</details>

### Risk Level

none

Config-only, one line. Validated with the command in the file's own header, `curl -X POST --data-binary @.codecov.yml https://codecov.io/validate`: `Valid!`, with `"range": [70.0, 80.0]`.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
