### PR TITLE
fix(spark): support empty projection and count queries for Lance tables

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
@@ -140,12 +140,12 @@ class SparkLanceReaderBase(enableVectorizedReader: Boolean) extends SparkColumna
       } else {
         null
       }
-      // For empty projections (e.g. COUNT(*), partition-only queries, or missing columns under schema
-      // evolution), use metadata-only row count without reading data columns. For BLOB-containing reads,
-      // drain the file in <=512-row range chunks to avoid JNI aborts. Otherwise, keep the single streamed reader.
+      // Empty projections (e.g. COUNT(*), partition-only queries, or missing columns under
+      // schema evolution) can use the Lance metadata row count without reading data columns.
       lanceIterator = if (iteratorSchema.isEmpty) {
         new ClosableIterator[UnsafeRow] {
           private var remaining = lanceReader.numRows()
+          private var closed = false
           private val emptyRow = {
             val r = new UnsafeRow(0)
             r.pointTo(new Array[Byte](0), 0)
@@ -163,14 +163,20 @@ class SparkLanceReaderBase(enableVectorizedReader: Boolean) extends SparkColumna
           }
 
           override def close(): Unit = {
-            try {
-              lanceReader.close()
-            } finally {
-              allocator.close()
+            if (!closed) {
+              closed = true
+              try {
+                lanceReader.close()
+              } finally {
+                allocator.close()
+              }
             }
           }
         }
       } else if (containsBlobField(iteratorSchema)) {
+        // lance-core 4.0.0 aborts the JVM when a single readAll stream crosses Lance's internal
+        // BLOB page boundary (512 rows). Drain BLOB reads in <=512-row range chunks; non-BLOB reads
+        // keep the single streamed reader.
         LanceRecordIterator.chunkedBlobReader(
           allocator, lanceReader, columnNames, readOpts, lanceReader.numRows(),
           iteratorSchema, filePath, blobTransform)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
@@ -45,6 +45,7 @@ import org.lance.file.{BlobReadMode, FileReadOptions, LanceFileReader}
 import java.io.IOException
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 /**
  * Reader for Lance files in Spark datasource.
@@ -78,141 +79,165 @@ class SparkLanceReaderBase(enableVectorizedReader: Boolean) extends SparkColumna
 
     val filePath = file.filePath.toString
 
-    if (requiredSchema.isEmpty && partitionSchema.isEmpty) {
-      // No columns requested - return empty iterator
-      Iterator.empty
-    } else {
-      // Track iterator for cleanup. Typed as ClosableIterator so we can swap in the
-      // DESCRIPTOR-mode iterator when the user opts into that blob read mode.
-      var lanceIterator: ClosableIterator[UnsafeRow] = null
+    // Track iterator for cleanup. Typed as ClosableIterator so we can swap in the
+    // DESCRIPTOR-mode iterator when the user opts into that blob read mode.
+    var lanceIterator: ClosableIterator[UnsafeRow] = null
+    var lanceReader: LanceFileReader = null
 
-      // Create child allocator for reading
-      val dataAllocatorSize = storageConf.unwrap().getLong(
-        HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES.key(),
-        HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES.defaultValue().toLong)
-      val allocator = HoodieArrowAllocator.newChildAllocator(
-        getClass.getSimpleName + "-data-" + filePath, dataAllocatorSize)
+    // Create child allocator for reading
+    val dataAllocatorSize = storageConf.unwrap().getLong(
+      HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES.key(),
+      HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES.defaultValue().toLong)
+    val allocator = HoodieArrowAllocator.newChildAllocator(
+      getClass.getSimpleName + "-data-" + filePath, dataAllocatorSize)
 
-      try {
-        // Open Lance file reader
-        val lanceReader = LanceFileReader.open(filePath, allocator)
+    try {
+      // Open Lance file reader
+      lanceReader = LanceFileReader.open(filePath, allocator)
 
-        // Get schema from Lance file. lance-spark strips Hudi's VECTOR descriptor during
-        // Arrow→Spark conversion but keeps the fixed-size-list dimension on the Spark
-        // field metadata; rebuild the descriptor from that, using requiredSchema
-        // as the source of truth for which columns are Hudi VECTORs — so non-Hudi fixed-size-lists aren't mis-tagged.
-        val arrowSchema = lanceReader.schema()
-        val vectorColumnNames: java.util.Set[String] = VectorConversionUtils
-          .detectVectorColumnsFromMetadata(requiredSchema)
-          .keySet()
-          .asScala
-          .map(i => requiredSchema.fields(i).name)
-          .toSet
-          .asJava
-        val fileSchema = VectorConversionUtils.restoreVectorMetadata(
-          LanceArrowUtils.fromArrowSchema(arrowSchema), vectorColumnNames)
+      // Get schema from Lance file. lance-spark strips Hudi's VECTOR descriptor during
+      // Arrow→Spark conversion but keeps the fixed-size-list dimension on the Spark
+      // field metadata; rebuild the descriptor from that, using requiredSchema
+      // as the source of truth for which columns are Hudi VECTORs — so non-Hudi fixed-size-lists aren't mis-tagged.
+      val arrowSchema = lanceReader.schema()
+      val vectorColumnNames: java.util.Set[String] = VectorConversionUtils
+        .detectVectorColumnsFromMetadata(requiredSchema)
+        .keySet()
+        .asScala
+        .map(i => requiredSchema.fields(i).name)
+        .toSet
+        .asJava
+      val fileSchema = VectorConversionUtils.restoreVectorMetadata(
+        LanceArrowUtils.fromArrowSchema(arrowSchema), vectorColumnNames)
 
-        // Build type change info for schema evolution
-        val (implicitTypeChangeInfo, sparkRequestSchema) =
-          SparkSchemaTransformUtils.buildImplicitSchemaChangeInfo(fileSchema, requiredSchema)
+      // Build type change info for schema evolution
+      val (implicitTypeChangeInfo, sparkRequestSchema) =
+        SparkSchemaTransformUtils.buildImplicitSchemaChangeInfo(fileSchema, requiredSchema)
 
-        // Filter schema to only fields that exist in file (Lance can only read columns present in file).
-        val requestSchema =
-          SparkSchemaTransformUtils.filterSchemaByFileSchema(sparkRequestSchema, fileSchema)
+      // Filter schema to only fields that exist in file (Lance can only read columns present in file).
+      val requestSchema =
+        SparkSchemaTransformUtils.filterSchemaByFileSchema(sparkRequestSchema, fileSchema)
 
-        // Lance returns null BLOB sub-structs as non-null parents with null children; widen
-        // nullability inside BLOB subtrees so the codegen projection doesn't NPE on them.
-        val iteratorSchema = widenBlobSubtreeNullability(requestSchema)
+      // Lance returns null BLOB sub-structs as non-null parents with null children; widen
+      // nullability inside BLOB subtrees so the codegen projection doesn't NPE on them.
+      val iteratorSchema = widenBlobSubtreeNullability(requestSchema)
 
-        val columnNames = if (iteratorSchema.nonEmpty) {
-          iteratorSchema.fieldNames.toList.asJava
-        } else {
-          // If only partition columns requested, read minimal data
-          null
-        }
+      val columnNames = iteratorSchema.fieldNames.toList.asJava
 
-        // Honor `hoodie.read.blob.inline.mode`. DESCRIPTOR (default) surfaces per-row
-        // {position, size} which the descriptor iterator turns into a synthesized `reference`
-        // while leaving `type = INLINE`; CONTENT is the opt-in mode that materializes INLINE
-        // bytes in the `data` column. Non-blob Lance columns ignore the option regardless.
-        val blobMode = resolveBlobReadMode(storageConf)
-        val readOpts = FileReadOptions.builder().blobReadMode(blobMode).build()
+      // Honor `hoodie.read.blob.inline.mode`. DESCRIPTOR (default) surfaces per-row
+      // {position, size} which the descriptor iterator turns into a synthesized `reference`
+      // while leaving `type = INLINE`; CONTENT is the opt-in mode that materializes INLINE
+      // bytes in the `data` column. Non-blob Lance columns ignore the option regardless.
+      val blobMode = resolveBlobReadMode(storageConf)
+      val readOpts = FileReadOptions.builder().blobReadMode(blobMode).build()
 
-        // Compose the DESCRIPTOR-aware blob transform only when the user opted into that mode
-        // AND the request actually has BLOB columns (otherwise the rewrite has nothing to do).
-        val blobFieldNames: Set[String] =
-          iteratorSchema.fields.collect { case f if isBlobField(f) => f.name }.toSet
-        val blobTransform = if (blobMode == BlobReadMode.DESCRIPTOR && blobFieldNames.nonEmpty) {
-          new BlobDescriptorTransform(blobFieldNames.asJava, filePath)
-        } else {
-          null
-        }
-        // lance-core 4.0.0 aborts the JVM when a single readAll stream crosses Lance's internal
-        // BLOB page boundary (512 rows). For BLOB-containing reads, drain the file in <=512-row
-        // range chunks (one fresh readAll each); non-BLOB reads keep the single streamed reader.
-        // The detection recurses so a nested BLOB (unsupported by the writer today) still chunks.
-        lanceIterator = if (containsBlobField(iteratorSchema)) {
-          LanceRecordIterator.chunkedBlobReader(
-            allocator, lanceReader, columnNames, readOpts, lanceReader.numRows(),
-            iteratorSchema, filePath, blobTransform)
-        } else {
-          val arrowReader = lanceReader.readAll(columnNames, null, DEFAULT_BATCH_SIZE, readOpts)
-          new LanceRecordIterator(
-            allocator, lanceReader, arrowReader, iteratorSchema, filePath, blobTransform)
-        }
-
-        // Register cleanup listener
-        Option(TaskContext.get()).foreach { ctx =>
-          ctx.addTaskCompletionListener[Unit](_ => lanceIterator.close())
-        }
-
-        val baseIter: Iterator[InternalRow] = lanceIterator.asScala
-
-        // Create the following projections for schema evolution:
-        // 1. Padding projection: add NULL for missing columns
-        // 2. Casting projection: handle type conversions
-        val schemaUtils = sparkAdapter.getSchemaUtils
-        val paddingProj = SparkSchemaTransformUtils.generateNullPaddingProjection(iteratorSchema, requiredSchema)
-        val castProj = SparkSchemaTransformUtils.generateUnsafeProjection(
-          schemaUtils.toAttributes(requiredSchema),
-          Some(SQLConf.get.sessionLocalTimeZone),
-          implicitTypeChangeInfo,
-          requiredSchema,
-          new StructType(),
-          schemaUtils
-        )
-
-        // Unify projections by applying padding and then casting for each row
-        val projection: UnsafeProjection = new UnsafeProjection {
-          def apply(row: InternalRow): UnsafeRow =
-            castProj(paddingProj(row))
-        }
-        val projectedIter = baseIter.map(projection.apply)
-
-        // Handle partition columns
-        if (partitionSchema.length == 0) {
-          // No partition columns - return rows directly
-          projectedIter
-        } else {
-          // Create UnsafeProjection to convert JoinedRow to UnsafeRow
-          val fullSchema = (requiredSchema.fields ++ partitionSchema.fields).map(f =>
-            AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
-          val unsafeProjection = GenerateUnsafeProjection.generate(fullSchema, fullSchema)
-
-          // Append partition values to each row using JoinedRow, then convert to UnsafeRow
-          val joinedRow = new JoinedRow()
-          projectedIter.map(row => unsafeProjection(joinedRow(row, file.partitionValues)))
-        }
-
-      } catch {
-        case e: Exception =>
-          if (lanceIterator != null) {
-            lanceIterator.close()  // Close iterator which handles lifecycle for all objects
-          } else {
-            allocator.close()      // Close allocator directly
-          }
-          throw new IOException(s"Failed to read Lance file: $filePath", e)
+      // Compose the DESCRIPTOR-aware blob transform only when the user opted into that mode
+      // AND the request actually has BLOB columns (otherwise the rewrite has nothing to do).
+      val blobFieldNames: Set[String] =
+        iteratorSchema.fields.collect { case f if isBlobField(f) => f.name }.toSet
+      val blobTransform = if (blobMode == BlobReadMode.DESCRIPTOR && blobFieldNames.nonEmpty) {
+        new BlobDescriptorTransform(blobFieldNames.asJava, filePath)
+      } else {
+        null
       }
+      // For empty projections (e.g. COUNT(*), partition-only queries, or missing columns under schema
+      // evolution), use metadata-only row count without reading data columns. For BLOB-containing reads,
+      // drain the file in <=512-row range chunks to avoid JNI aborts. Otherwise, keep the single streamed reader.
+      lanceIterator = if (iteratorSchema.isEmpty) {
+        new ClosableIterator[UnsafeRow] {
+          private var remaining = lanceReader.numRows()
+          private val emptyRow = {
+            val r = new UnsafeRow(0)
+            r.pointTo(new Array[Byte](0), 0)
+            r
+          }
+
+          override def hasNext: Boolean = remaining > 0
+
+          override def next(): UnsafeRow = {
+            if (remaining <= 0) {
+              throw new NoSuchElementException("No more records available")
+            }
+            remaining -= 1
+            emptyRow
+          }
+
+          override def close(): Unit = {
+            try {
+              lanceReader.close()
+            } finally {
+              allocator.close()
+            }
+          }
+        }
+      } else if (containsBlobField(iteratorSchema)) {
+        LanceRecordIterator.chunkedBlobReader(
+          allocator, lanceReader, columnNames, readOpts, lanceReader.numRows(),
+          iteratorSchema, filePath, blobTransform)
+      } else {
+        val arrowReader = lanceReader.readAll(columnNames, null, DEFAULT_BATCH_SIZE, readOpts)
+        new LanceRecordIterator(
+          allocator, lanceReader, arrowReader, iteratorSchema, filePath, blobTransform)
+      }
+
+      // Register cleanup listener
+      Option(TaskContext.get()).foreach { ctx =>
+        ctx.addTaskCompletionListener[Unit](_ => lanceIterator.close())
+      }
+
+      val baseIter: Iterator[InternalRow] = lanceIterator.asScala
+
+      // Create the following projections for schema evolution:
+      // 1. Padding projection: add NULL for missing columns
+      // 2. Casting projection: handle type conversions
+      val schemaUtils = sparkAdapter.getSchemaUtils
+      val paddingProj = SparkSchemaTransformUtils.generateNullPaddingProjection(iteratorSchema, requiredSchema)
+      val castProj = SparkSchemaTransformUtils.generateUnsafeProjection(
+        schemaUtils.toAttributes(requiredSchema),
+        Some(SQLConf.get.sessionLocalTimeZone),
+        implicitTypeChangeInfo,
+        requiredSchema,
+        new StructType(),
+        schemaUtils
+      )
+
+      // Unify projections by applying padding and then casting for each row
+      val projection: UnsafeProjection = new UnsafeProjection {
+        def apply(row: InternalRow): UnsafeRow =
+          castProj(paddingProj(row))
+      }
+      val projectedIter = baseIter.map(projection.apply)
+
+      // Handle partition columns
+      if (partitionSchema.length == 0) {
+        // No partition columns - return rows directly
+        projectedIter
+      } else {
+        // Create UnsafeProjection to convert JoinedRow to UnsafeRow
+        val fullSchema = (requiredSchema.fields ++ partitionSchema.fields).map(f =>
+          AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
+        val unsafeProjection = GenerateUnsafeProjection.generate(fullSchema, fullSchema)
+
+        // Append partition values to each row using JoinedRow, then convert to UnsafeRow
+        val joinedRow = new JoinedRow()
+        projectedIter.map(row => unsafeProjection(joinedRow(row, file.partitionValues)))
+      }
+
+    } catch {
+      case e: Exception =>
+        if (lanceIterator != null) {
+          lanceIterator.close()  // Close iterator which handles lifecycle for all objects
+        } else {
+          if (lanceReader != null) {
+            try {
+              lanceReader.close()
+            } catch {
+              case NonFatal(_) => // suppress secondary exception during cleanup
+            }
+          }
+          allocator.close()      // Close allocator directly
+        }
+        throw new IOException(s"Failed to read Lance file: $filePath", e)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -585,6 +585,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
 
     // Read and verify data
     val readDf = spark.read.format("hudi").load(tablePath)
+    assertEquals(3L, readDf.count(), "Count after delete must match surviving records")
     val actual = readDf.select("id", "name", "age", "score")
 
     val expectedDf = createDataFrame(Seq(
@@ -2318,14 +2319,214 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
 
     val readDf = spark.read.format("hudi").load(tablePath)
     val actual = readDf.select("id", "name", "age", "score")
-    // Use collect().length instead of count() — Spark's count optimization pushes down an
-    // empty schema which SparkLanceReaderBase short-circuits to Iterator.empty (separate bug).
-    val total = actual.collect().length
+    val total = actual.count()
+    val dfTotal = readDf.count()
     val distinct = actual.select("id").distinct().count()
     assertEquals(100, total, "Lance read should not produce duplicate rows")
+    assertEquals(100, dfTotal, "Total count from readDf should match")
     assertEquals(100, distinct, "All record keys should be unique")
     assertTrue(inputDf.except(actual).isEmpty)
     assertTrue(actual.except(inputDf).isEmpty)
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testEmptyProjectionAndCountUnpartitioned(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_count_unpart_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    // Initial batch: 50 records without partitioning (requiredSchema.isEmpty && partitionSchema.isEmpty)
+    val records1 = (1 to 50).map(i => (i, s"name_$i", 20 + i))
+    val df1 = spark.createDataFrame(records1).toDF("id", "name", "age").coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, df1, saveMode = SaveMode.Overwrite,
+      operation = Some("insert"))
+
+    // Second batch (multi-commit): 50 more records
+    val records2 = (51 to 100).map(i => (i, s"name_$i", 20 + i))
+    val df2 = spark.createDataFrame(records2).toDF("id", "name", "age").coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, df2, saveMode = SaveMode.Append,
+      operation = Some("insert"))
+
+    val readDf = spark.read.format("hudi").load(tablePath)
+    readDf.createOrReplaceTempView(tableName)
+
+    // 1. DataFrame.count() and projection on empty required and partition schema
+    assertEquals(100L, readDf.count(), "DataFrame count() should return 100 on unpartitioned table")
+
+    // 2. SQL COUNT(*) and COUNT(1)
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName")(Seq(100L))
+    checkAnswer(s"SELECT COUNT(1) FROM $tableName")(Seq(100L))
+
+    // 3. SELECT 1 FROM table (empty data schema returning N constant rows)
+    val constRows = spark.sql(s"SELECT 1 FROM $tableName").collect()
+    assertEquals(100, constRows.length, "SELECT 1 should return 100 rows on unpartitioned table")
+    constRows.foreach(r => assertEquals(1, r.getInt(0)))
+
+    // 4. SELECT 1 FROM table LIMIT 1
+    val limitRows = spark.sql(s"SELECT 1 FROM $tableName LIMIT 1").collect()
+    assertEquals(1, limitRows.length)
+    assertEquals(1, limitRows(0).getInt(0))
+
+    // 5. EXISTS subquery
+    val existsRows = spark.sql(s"SELECT EXISTS(SELECT 1 FROM $tableName)").collect()
+    assertEquals(1, existsRows.length)
+    assertEquals(true, existsRows(0).getBoolean(0))
+
+    // 6. Data-filtered COUNT regression
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName WHERE age > 70")(Seq(50L))
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName WHERE age > 9999")(Seq(0L))
+
+    // 7. Delete 20 records (uncompacted delta delete on MOR, standard delete on COW)
+    // Ensures MOR count merges base + log files and does NOT naively return base file row count.
+    val recordsToDelete = (1 to 20).map(i => (i, s"name_$i", 20 + i))
+    val deleteDf = spark.createDataFrame(recordsToDelete).toDF("id", "name", "age").coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, deleteDf, saveMode = SaveMode.Append,
+      operation = Some("delete"))
+
+    val postDeleteDf = spark.read.format("hudi").load(tablePath)
+    postDeleteDf.createOrReplaceTempView(tableName)
+
+    assertEquals(80L, postDeleteDf.count(), "Count after delete must reflect deleted records, not base file count")
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName")(Seq(80L))
+    checkAnswer(s"SELECT COUNT(1) FROM $tableName")(Seq(80L))
+    val postDeleteConstRows = spark.sql(s"SELECT 1 FROM $tableName").collect()
+    assertEquals(80, postDeleteConstRows.length, "SELECT 1 after delete must return exactly surviving row count")
+
+    // 8. Delete all remaining 80 records and verify zero-row empty count
+    val remainingRecords = (21 to 100).map(i => (i, s"name_$i", 20 + i))
+    val deleteRemainingDf = spark.createDataFrame(remainingRecords).toDF("id", "name", "age").coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, deleteRemainingDf, saveMode = SaveMode.Append,
+      operation = Some("delete"))
+
+    val allDeletedDf = spark.read.format("hudi").load(tablePath)
+    allDeletedDf.createOrReplaceTempView(tableName)
+
+    assertEquals(0L, allDeletedDf.count(), "Count after deleting all records must return 0")
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName")(Seq(0L))
+    checkAnswer(s"SELECT COUNT(1) FROM $tableName")(Seq(0L))
+    val allDeletedConstRows = spark.sql(s"SELECT 1 FROM $tableName").collect()
+    assertEquals(0, allDeletedConstRows.length, "SELECT 1 on fully deleted table must return 0 rows")
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testEmptyProjectionAndCountPartitioned(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_count_part_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    // Initial batch: 50 records with partition column 'department'
+    val records1 = (1 to 50).map(i => (i, s"name_$i", 20 + i, if (i % 2 == 0) "engineering" else "sales"))
+    val df1 = spark.createDataFrame(records1).toDF("id", "name", "age", "department").coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, df1, saveMode = SaveMode.Overwrite,
+      operation = Some("insert"), extraOptions = Map(PARTITIONPATH_FIELD.key() -> "department"))
+
+    // Second batch (multi-commit): 50 more records
+    val records2 = (51 to 100).map(i => (i, s"name_$i", 20 + i, if (i % 2 == 0) "engineering" else "sales"))
+    val df2 = spark.createDataFrame(records2).toDF("id", "name", "age", "department").coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, df2, saveMode = SaveMode.Append,
+      operation = Some("insert"), extraOptions = Map(PARTITIONPATH_FIELD.key() -> "department"))
+
+    val readDf = spark.read.format("hudi").load(tablePath)
+    readDf.createOrReplaceTempView(tableName)
+
+    // 1. DataFrame.count() and projection on empty required schema with partition column
+    assertEquals(100L, readDf.count(), "DataFrame count() should return 100")
+
+    // 2. SQL COUNT(*) and COUNT(1)
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName")(Seq(100L))
+    checkAnswer(s"SELECT COUNT(1) FROM $tableName")(Seq(100L))
+
+    // 3. SELECT 1 FROM table (empty data schema returning N constant rows)
+    val constRows = spark.sql(s"SELECT 1 FROM $tableName").collect()
+    assertEquals(100, constRows.length, "SELECT 1 should return 100 rows")
+    constRows.foreach(r => assertEquals(1, r.getInt(0)))
+
+    // 4. SELECT 1 FROM table LIMIT 1
+    val limitRows = spark.sql(s"SELECT 1 FROM $tableName LIMIT 1").collect()
+    assertEquals(1, limitRows.length)
+    assertEquals(1, limitRows(0).getInt(0))
+
+    // 5. EXISTS subquery
+    val existsRows = spark.sql(s"SELECT EXISTS(SELECT 1 FROM $tableName)").collect()
+    assertEquals(1, existsRows.length)
+    assertEquals(true, existsRows(0).getBoolean(0))
+
+    // 6. Partitioned count pushdown (queries only partition column without reading data columns)
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName WHERE department = 'engineering'")(Seq(50L))
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName WHERE department = 'sales'")(Seq(50L))
+
+    // 7. Data-filtered COUNT regression
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName WHERE age > 70")(Seq(50L))
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName WHERE age > 9999")(Seq(0L))
+
+    // 8. Delete 20 records (uncompacted delta delete on MOR, standard delete on COW)
+    // Ensures MOR count merges base + log files and does NOT naively return base file row count.
+    val recordsToDelete = (1 to 20).map(i => (i, s"name_$i", 20 + i, if (i % 2 == 0) "engineering" else "sales"))
+    val deleteDf = spark.createDataFrame(recordsToDelete).toDF("id", "name", "age", "department").coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, deleteDf, saveMode = SaveMode.Append,
+      operation = Some("delete"), extraOptions = Map(PARTITIONPATH_FIELD.key() -> "department"))
+
+    val postDeleteDf = spark.read.format("hudi").load(tablePath)
+    postDeleteDf.createOrReplaceTempView(tableName)
+
+    assertEquals(80L, postDeleteDf.count(), "Count after delete must reflect deleted records, not base file count")
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName")(Seq(80L))
+    checkAnswer(s"SELECT COUNT(1) FROM $tableName")(Seq(80L))
+    val postDeleteConstRows = spark.sql(s"SELECT 1 FROM $tableName").collect()
+    assertEquals(80, postDeleteConstRows.length, "SELECT 1 after delete must return exactly surviving row count")
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName WHERE department = 'engineering'")(Seq(40L))
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName WHERE department = 'sales'")(Seq(40L))
+  }
+
+  /**
+   * Tests schema evolution where an older file slice does not contain a newly added column.
+   * When Spark selects only the new column ("new_col"), filterSchemaByFileSchema produces an
+   * empty iteratorSchema for the older file slice.
+   * Verifies that the older file slice safely takes empty projection (numRows() metadata count)
+   * and null padding synthesizes NULLs, correctly yielding NULL for V1 records while V2 records
+   * retain their actual values.
+   */
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testSchemaEvolutionMissingColumn(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_schema_evolution_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    // Commit 1: Schema V1 has (id, name, age, score)
+    val records1 = (1 to 10).map(i => (i, s"name_$i", 20 + i, 90.0 + i))
+    val df1 = spark.createDataFrame(records1).toDF("id", "name", "age", "score").coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, df1, saveMode = SaveMode.Overwrite,
+      extraOptions = Map("hoodie.schema.on.read.enable" -> "true"))
+
+    // Commit 2: Schema V2 adds "new_col"
+    val records2 = (11 to 20).map(i => (i, s"name_$i", 20 + i, 90.0 + i, s"v2_$i"))
+    val df2 = spark.createDataFrame(records2).toDF("id", "name", "age", "score", "new_col").coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, df2, saveMode = SaveMode.Append,
+      extraOptions = Map("hoodie.schema.on.read.enable" -> "true"))
+
+    val readDf = spark.read.format("hudi")
+      .option("hoodie.schema.on.read.enable", "true")
+      .load(tablePath)
+    readDf.createOrReplaceTempView(tableName)
+
+    assertEquals(20L, readDf.count(), "Total record count across evolved commits must be 20")
+
+    // Selecting ONLY the evolved column:
+    // File 1 has no "new_col", so filterSchemaByFileSchema produces iteratorSchema = {} (empty).
+    // File 1 takes empty projection (metadata-only numRows() = 10) + null-padding to produce NULLs.
+    // File 2 has "new_col", so it reads the column data.
+    val rows = spark.sql(s"SELECT new_col FROM $tableName").collect()
+    assertEquals(20, rows.length)
+    val nullCount = rows.count(_.isNullAt(0))
+    val nonNullValues = rows.filterNot(_.isNullAt(0)).map(_.getString(0)).sorted
+    assertEquals(10, nullCount, "V1 records must have NULL for newly added column")
+    assertEquals((11 to 20).map(i => s"v2_$i"), nonNullValues.toSeq, "V2 records must have non-null values")
+
+    // WHERE new_col IS NULL returns exactly the 10 records from V1
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName WHERE new_col IS NULL")(Seq(10L))
+
+    // WHERE new_col IS NOT NULL returns exactly the 10 records from V2
+    checkAnswer(s"SELECT COUNT(*) FROM $tableName WHERE new_col IS NOT NULL")(Seq(10L))
   }
 
   private def createDataFrame(records: Seq[(Int, String, Int, Double)]) = {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18727

Queries with empty projections against Lance-backed Hudi tables, such as `df.count()`, `COUNT(*)`, `COUNT(1)`, `SELECT 1`, and `EXISTS(...)`, could return incorrect results or fail.

For empty data projections, `SparkLanceReaderBase` previously returned `Iterator.empty` when `requiredSchema.isEmpty && partitionSchema.isEmpty`, causing queries that should produce one result per input row to see zero rows.

Other empty-schema cases reached `LanceRecordIterator` with a physical Lance batch containing columns while the Spark schema contained none, resulting in errors such as:
```
Lance batch column count X does not match expected Spark schema size 0
  for file: ...lance
  at org.apache.hudi.io.storage.LanceRecordIterator.hasNext
```
This can also occur under schema evolution when an older Lance file slice does not contain any of the columns requested by Spark.

### Summary and Changelog

1. **DataSource-level empty projection handling**:
   - Replaced the premature `Iterator.empty` path in `SparkLanceReaderBase.scala` with an `iteratorSchema.isEmpty` branch.
   - The branch uses the Lance file's metadata row count via `lanceReader.numRows()` without reading or decoding data columns.
   - Returns the corresponding number of initialized zero-field `UnsafeRow`s, reusing a single row instance per iterator.

2. **Schema evolution and null padding**:
   - When an older file slice does not contain a newly requested column, `filterSchemaByFileSchema` can produce an empty `iteratorSchema`.
   - The reader still emits the rows from that file using the metadata row count.
   - Spark's existing `generateNullPaddingProjection` then supplies `NULL` values for the missing columns.

3. **Resource lifecycle**:
   - Tracks the `LanceFileReader` explicitly so it can be closed if an exception occurs before the iterator is constructed.
   - Preserves normal iterator-owned cleanup for the Lance reader and Arrow allocator.
   - `LanceRecordIterator` remains unchanged and continues to handle Arrow batch decoding.

4. **Integration regression tests**:
   - Added end-to-end coverage in `TestLanceDataSource.scala` for:
     - unpartitioned and partitioned empty projections
     - `COUNT(*)`, `COUNT(1)`, and `SELECT 1`
     - `EXISTS` and `LIMIT 1`
     - data and partition predicates
     - counts after deletes, including the zero-row case
     - schema evolution where older file slices are missing newly added columns
     - both Copy-on-Write and Merge-on-Read tables

### Impact

- Fixes incorrect empty-projection results for Lance-backed Hudi tables.
- Avoids reading and decoding data columns for empty projections by using the Lance file's metadata row count.
- Correctly preserves rows from older file slices during schema evolution and produces `NULL` for columns that are absent from those slices.
- Keeps the implementation localized to the Spark Lance DataSource layer, with changes limited to two files.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
