### PR TITLE
fix(spark): avoid full partition listing in incremental reads

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieIncrementalFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieIncrementalFileIndex.scala
@@ -17,7 +17,7 @@
 
 package org.apache.hudi
 
-import org.apache.hudi.common.model.HoodieLogFile
+import org.apache.hudi.common.model.{FileSlice, HoodieLogFile}
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.storage.StoragePathInfo
 import org.apache.hudi.util.JFunction
@@ -42,6 +42,25 @@ class HoodieIncrementalFileIndex(override val spark: SparkSession,
   extends HoodieFileIndex(
     spark, metaClient, schemaSpec, options, fileStatusCache, includeLogFiles, shouldEmbedFileSlices = true
   ) with FileIndex {
+
+  // Skip the Spark optimizer's partition pruning rule (e.g. Spark33HoodiePruneFileSourcePartitions)
+  // which would trigger a full-table partition listing via the base class. The incremental file
+  // index already selects only modified file groups via listFileSplits().
+  hasPushedDownPartitionPredicates = true
+
+  override def filterFileSlices(dataFilters: Seq[Expression], partitionFilters: Seq[Expression], isPartitionPruned: Boolean = false)
+  : Seq[(Option[BaseHoodieTableFileIndex.PartitionPath], Seq[FileSlice])] = {
+    hasPushedDownPartitionPredicates = true
+    val fileSliceMap = mergeOnReadIncrementalRelation.listFileSplits(partitionFilters, dataFilters)
+    fileSliceMap.toSeq.flatMap { case (partitionValues, fileSlices) =>
+      val nonEmpty = fileSlices.filter(!_.isEmpty)
+      if (nonEmpty.nonEmpty) {
+        Seq((Option.empty[BaseHoodieTableFileIndex.PartitionPath], nonEmpty))
+      } else {
+        Seq.empty
+      }
+    }
+  }
 
   override def listFiles(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
     val fileSlices = mergeOnReadIncrementalRelation.listFileSplits(partitionFilters, dataFilters).toSeq.flatMap(

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV1.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV1.scala
@@ -130,11 +130,9 @@ case class MergeOnReadIncrementalRelationV1(override val sqlContext: SQLContext,
         val fsView = new HoodieTableFileSystemView(metaClient, timeline, affectedFilesInCommits)
         val modifiedPartitions = getWritePartitionPaths(commitsMetadata)
 
-        fileIndex.listMatchingPartitionPaths(HoodieFileIndex.convertFilterForTimestampKeyGenerator(metaClient, partitionFilters))
-          .map(p => p.getPath).filter(p => modifiedPartitions.contains(p))
-          .flatMap { relativePartitionPath =>
-            fsView.getLatestMergedFileSlicesBeforeOrOn(relativePartitionPath, latestCommit).iterator().asScala
-          }
+        modifiedPartitions.asScala.flatMap { relativePartitionPath =>
+          fsView.getLatestMergedFileSlicesBeforeOrOn(relativePartitionPath, latestCommit).iterator().asScala
+        }.toSeq
       }
       filterFileSlices(fileSlices, globPattern)
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV2.scala
@@ -124,11 +124,9 @@ case class MergeOnReadIncrementalRelationV2(override val sqlContext: SQLContext,
         val fsView = new HoodieTableFileSystemView(metaClient, timeline, affectedFilesInCommits)
         val modifiedPartitions = getWritePartitionPaths(commitsMetadata)
 
-        fileIndex.listMatchingPartitionPaths(HoodieFileIndex.convertFilterForTimestampKeyGenerator(metaClient, partitionFilters))
-          .map(p => p.getPath).filter(p => modifiedPartitions.contains(p))
-          .flatMap { relativePartitionPath =>
-            fsView.getLatestMergedFileSlicesBeforeOrOn(relativePartitionPath, latestCommit).iterator().asScala
-          }
+        modifiedPartitions.asScala.flatMap { relativePartitionPath =>
+          fsView.getLatestMergedFileSlicesBeforeOrOn(relativePartitionPath, latestCommit).iterator().asScala
+        }.toSeq
       }
       filterFileSlices(fileSlices, globPattern)
     }


### PR DESCRIPTION
HoodieIncrementalFileIndex delegates file listing to MergeOnReadIncrementalRelation.listFileSplits(), which already determines the exact set of modified partitions from commit metadata. However, two code paths still trigger an O(all-partitions) listing that is redundant and expensive for large tables:

1. listFileSplits() in both V1 and V2 calls fileIndex.listMatchingPartitionPaths() which, without partition-filter pushdown (e.g. a plain incremental pull with no predicate on the partition column), falls through to listing every partition via the metadata table or catalog before the modifiedPartitions filter is even applied. On tables with tens of thousands of partitions this adds minutes of latency to what should be a sub-second file listing.

2. Spark's partition pruning optimizer rule (Spark33HoodiePruneFileSourcePartitions) invokes HoodieFileIndex.filterFileSlices() which calls ensurePreloadedPartitions(), triggering the same full-table partition enumeration. This is redundant for incremental reads that already select only modified file groups.

Fix:
- Replace listMatchingPartitionPaths() in listFileSplits() with direct iteration over modifiedPartitions, matching the pattern already used by collectFileSplits() in both V1 and V2.
- Set hasPushedDownPartitionPredicates=true in the HoodieIncrementalFileIndex constructor so the optimizer rule skips this file index entirely.
- Override filterFileSlices() as a safety net: if anything still calls it, delegate to listFileSplits() instead of the base class which would enumerate all partitions.

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
