### PR TITLE
fix(core): derive HoodieAvroRecord's ordering value from the record when the payload has none

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
@@ -25,10 +25,12 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.read.DeleteContext;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -104,7 +106,58 @@ public class HoodieAvroRecord<T extends HoodieRecordPayload> extends HoodieRecor
 
   @Override
   public Comparable<?> doGetOrderingValue(HoodieSchema recordSchema, Properties props, String[] orderingFields) {
-    return this.getData().getOrderingValue();
+    Comparable<?> payloadOrderingValue = getData().getOrderingValue();
+    if (!canReadOrderingFieldsFromRecord(payloadOrderingValue, recordSchema, props, orderingFields)) {
+      return payloadOrderingValue;
+    }
+    // The payload carries no ordering value: payloads constructed from the record alone
+    // (HoodieRecordUtils#loadPayload(String, GenericRecord)) default to OrderingValues#getDefault,
+    // an Integer. Read the ordering fields off the record instead, the way
+    // HoodieAvroIndexedRecord#doGetOrderingValue does, so that both Avro record representations
+    // yield an ordering value of the type the ordering field declares. This is best effort: any
+    // record we cannot read leaves the payload's value in place, which is what callers saw before.
+    try {
+      Option<IndexedRecord> avroData = getData().getIndexedRecord(recordSchema.toAvroSchema(), props);
+      if (!avroData.isPresent()) {
+        return payloadOrderingValue;
+      }
+      boolean consistentLogicalTimestampEnabled = Boolean.parseBoolean(props.getProperty(
+          KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
+          KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()));
+      Comparable<?> recordOrderingValue = OrderingValues.create(
+          orderingFields,
+          field -> (Comparable<?>) HoodieAvroUtils.getNestedFieldVal(
+              (GenericRecord) avroData.get(), field, true, consistentLogicalTimestampEnabled));
+      // A nullable ordering field holding null reads back as null, which no caller expects here.
+      return recordOrderingValue == null ? payloadOrderingValue : recordOrderingValue;
+    } catch (Exception e) {
+      // Reading the record is an optimization over the payload's default, never a new failure
+      // mode: a schema the payload cannot decode, or props an exotic payload requires and does
+      // not get here, must not turn an ordering value lookup into a write failure.
+      return payloadOrderingValue;
+    }
+  }
+
+  /**
+   * Whether the ordering value is worth reading off the record rather than taking the payload's.
+   * Only when the payload has none, the table declares ordering fields, and the record is not a
+   * delete: BufferedRecord#isCommitTimeOrderingDelete treats a delete carrying the default
+   * ordering value as commit time ordered, so giving deletes a real value here would silently
+   * change which delete wins.
+   */
+  private boolean canReadOrderingFieldsFromRecord(Comparable<?> payloadOrderingValue,
+      HoodieSchema recordSchema, Properties props, String[] orderingFields) {
+    if (orderingFields == null || orderingFields.length == 0 || props == null) {
+      return false;
+    }
+    if (!OrderingValues.isDefault(payloadOrderingValue)) {
+      return false;
+    }
+    if (Boolean.TRUE.equals(isDelete) || HoodieOperation.isDelete(getOperation())) {
+      return false;
+    }
+    return !(this.data instanceof BaseAvroPayload)
+        || !((BaseAvroPayload) this.data).isDeleted(recordSchema.toAvroSchema(), props);
   }
 
   @Override

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieAvroRecord.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieAvroRecord.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.HoodieRecordUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Tests {@link HoodieAvroRecord}, in particular that its ordering value keeps the type of the
+ * ordering field even when the payload was built without one.
+ */
+class TestHoodieAvroRecord {
+
+  private static final String SCHEMA_STR = "{\"type\":\"record\",\"name\":\"trip\",\"fields\":["
+      + "{\"name\":\"_row_key\",\"type\":\"string\"},"
+      + "{\"name\":\"ts\",\"type\":\"long\"}]}";
+  private static final Schema SCHEMA = new Schema.Parser().parse(SCHEMA_STR);
+  private static final Schema NULLABLE_TS_SCHEMA = new Schema.Parser().parse(
+      "{\"type\":\"record\",\"name\":\"trip\",\"fields\":["
+          + "{\"name\":\"_row_key\",\"type\":\"string\"},"
+          + "{\"name\":\"ts\",\"type\":[\"null\",\"long\"]}]}");
+  private static final Schema DELETABLE_SCHEMA = new Schema.Parser().parse(
+      "{\"type\":\"record\",\"name\":\"trip\",\"fields\":["
+          + "{\"name\":\"_row_key\",\"type\":\"string\"},"
+          + "{\"name\":\"ts\",\"type\":\"long\"},"
+          + "{\"name\":\"_hoodie_is_deleted\",\"type\":\"boolean\",\"default\":false}]}");
+  private static final String[] ORDERING_FIELDS = new String[] {"ts"};
+  private static final long TS = 1757000000000L;
+
+  private static GenericRecord avroRecord() {
+    GenericRecord record = new GenericData.Record(SCHEMA);
+    record.put("_row_key", "key1");
+    record.put("ts", TS);
+    return record;
+  }
+
+  /**
+   * Reproduces the CoW UPDATE failure: prepped Spark SQL writes create the record through the
+   * overload that carries no ordering value, so the payload defaults to {@code Integer} 0 while
+   * the base record read from storage yields the {@code ts} value as a {@code Long}. Comparing the
+   * two threw {@code ClassCastException: class java.lang.Long cannot be cast to class
+   * java.lang.Integer} in BufferedRecordMergerFactory#shouldKeepNewerRecord.
+   */
+  @Test
+  void testOrderingValueIsReadFromRecordWhenPayloadHasNone() {
+    HoodieRecord<?> record = HoodieRecordUtils.createHoodieRecord(
+        avroRecord(), new HoodieKey("key1", "p"), DefaultHoodieRecordPayload.class.getName(),
+        Option.empty(), true, false);
+    assertInstanceOf(HoodieAvroRecord.class, record);
+
+    Comparable<?> orderingValue = record.getOrderingValue(HoodieSchema.fromAvroSchema(SCHEMA), new Properties(), ORDERING_FIELDS);
+
+    assertInstanceOf(Long.class, orderingValue);
+    assertEquals(TS, orderingValue);
+  }
+
+  private static HoodieRecord<?> payloadRecord(GenericRecord data) {
+    return HoodieRecordUtils.createHoodieRecord(
+        data, new HoodieKey("key1", "p"), DefaultHoodieRecordPayload.class.getName(),
+        Option.empty(), true, false);
+  }
+
+  /**
+   * A nullable ordering field holding null must keep the payload's default. Returning the null it
+   * reads back would make BufferedRecordMergerFactory#shouldKeepNewerRecord throw NPE.
+   */
+  @Test
+  void testNullOrderingFieldValueKeepsPayloadDefault() {
+    GenericRecord data = new GenericData.Record(NULLABLE_TS_SCHEMA);
+    data.put("_row_key", "key1");
+    data.put("ts", null);
+    HoodieRecord<?> record = payloadRecord(data);
+
+    assertEquals(OrderingValues.getDefault(),
+        record.getOrderingValue(HoodieSchema.fromAvroSchema(NULLABLE_TS_SCHEMA), new Properties(), ORDERING_FIELDS));
+  }
+
+  /**
+   * Deletes keep the default ordering value. BufferedRecord#isCommitTimeOrderingDelete tests for
+   * it, so giving a delete a real ordering value would change which delete wins.
+   */
+  @Test
+  void testDeleteRecordKeepsPayloadDefault() {
+    GenericRecord data = new GenericData.Record(DELETABLE_SCHEMA);
+    data.put("_row_key", "key1");
+    data.put("ts", TS);
+    data.put("_hoodie_is_deleted", true);
+    HoodieRecord<?> record = payloadRecord(data);
+
+    assertEquals(OrderingValues.getDefault(),
+        record.getOrderingValue(HoodieSchema.fromAvroSchema(DELETABLE_SCHEMA), new Properties(), ORDERING_FIELDS));
+  }
+
+  /**
+   * A schema the payload cannot decode the record with must not turn an ordering value lookup into
+   * a failure; the payload's default stands.
+   */
+  @Test
+  void testUndecodableRecordSchemaKeepsPayloadDefault() {
+    HoodieRecord<?> record = payloadRecord(avroRecord());
+    Schema mismatched = new Schema.Parser().parse(
+        "{\"type\":\"record\",\"name\":\"trip\",\"fields\":["
+            + "{\"name\":\"extra_a\",\"type\":\"string\"},"
+            + "{\"name\":\"extra_b\",\"type\":\"string\"},"
+            + "{\"name\":\"_row_key\",\"type\":\"string\"},"
+            + "{\"name\":\"ts\",\"type\":\"long\"}]}");
+
+    assertEquals(OrderingValues.getDefault(),
+        record.getOrderingValue(HoodieSchema.fromAvroSchema(mismatched), new Properties(), ORDERING_FIELDS));
+  }
+
+  /**
+   * An ordering value supplied at construction time still wins, so payloads that carry their own
+   * ordering semantics are unaffected.
+   */
+  @Test
+  void testExplicitOrderingValueWins() {
+    HoodieRecord<?> record = HoodieRecordUtils.createHoodieRecord(
+        avroRecord(), 42L, new HoodieKey("key1", "p"), DefaultHoodieRecordPayload.class.getName(),
+        true, false);
+
+    assertEquals(42L, record.getOrderingValue(HoodieSchema.fromAvroSchema(SCHEMA), new Properties(), ORDERING_FIELDS));
+  }
+
+  /**
+   * Without ordering fields the record keeps the payload's default, i.e. natural (arrival) order.
+   */
+  @Test
+  void testDefaultOrderingValueWithoutOrderingFields() {
+    HoodieRecord<?> record = HoodieRecordUtils.createHoodieRecord(
+        avroRecord(), new HoodieKey("key1", "p"), DefaultHoodieRecordPayload.class.getName(),
+        Option.empty(), true, false);
+
+    assertEquals(OrderingValues.getDefault(),
+        record.getOrderingValue(HoodieSchema.fromAvroSchema(SCHEMA), new Properties(), new String[0]));
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestOrderingValueMergeFailure.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestOrderingValueMergeFailure.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.read;
+
+import org.apache.hudi.common.avro.AvroRecordContext;
+import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.HoodieRecordUtils;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Demonstrates the merge failure a record built without an ordering value produces, which is the
+ * shape HoodieStreamerUtils#createHoodieRecords emits for INSERT, and HoodieCreateRecordUtils
+ * emitted for prepped Spark SQL writes.
+ */
+class TestOrderingValueMergeFailure {
+
+  private static final Schema SCHEMA = new Schema.Parser().parse(
+      "{\"type\":\"record\",\"name\":\"trip\",\"fields\":["
+          + "{\"name\":\"_row_key\",\"type\":\"string\"},"
+          + "{\"name\":\"ts\",\"type\":\"long\"}]}");
+  private static final HoodieSchema HOODIE_SCHEMA = HoodieSchema.fromAvroSchema(SCHEMA);
+  private static final String[] ORDERING_FIELDS = new String[] {"ts"};
+
+  private static GenericRecord avroRecord(long ts) {
+    GenericRecord record = new GenericData.Record(SCHEMA);
+    record.put("_row_key", "key1");
+    record.put("ts", ts);
+    return record;
+  }
+
+  /**
+   * The incoming record is built through the overload that carries no ordering value, the base
+   * record comes from storage with its real ts. Merging the two compares the incoming record's
+   * ordering value against the base record's.
+   */
+  @Test
+  void testMergingARecordBuiltWithoutAnOrderingValue() throws Exception {
+    AvroRecordContext recordContext = new AvroRecordContext();
+    HoodieReaderContext<IndexedRecord> readerContext = mock(HoodieReaderContext.class);
+    when(readerContext.getRecordContext()).thenReturn(recordContext);
+    TypedProperties props = new TypedProperties();
+
+    BufferedRecordMerger<IndexedRecord> merger = BufferedRecordMergerFactory.create(
+        readerContext, RecordMergeMode.EVENT_TIME_ORDERING, false, Option.empty(),
+        Option.empty(), HOODIE_SCHEMA, props, Option.empty());
+
+    // Base record read from storage: ordering value extracted from the record, a Long.
+    BufferedRecord<IndexedRecord> olderRecord = BufferedRecords.fromEngineRecord(
+        avroRecord(200L), HOODIE_SCHEMA, recordContext, ORDERING_FIELDS, "key1", false);
+
+    // Incoming record built the way HoodieStreamerUtils:138 builds it: no ordering value.
+    HoodieRecord<?> incoming = HoodieRecordUtils.createHoodieRecord(
+        avroRecord(100L), new HoodieKey("key1", "p"),
+        DefaultHoodieRecordPayload.class.getName(), Option.empty(), true, false);
+    BufferedRecord<IndexedRecord> newerRecord = BufferedRecords.fromHoodieRecord(
+        incoming, HOODIE_SCHEMA, recordContext, props, ORDERING_FIELDS, false);
+
+    BufferedRecord<IndexedRecord> merged = merger.finalMerge(olderRecord, newerRecord);
+
+    assertNotNull(merged);
+    // Event time ordering: the stored ts=200 must win over the incoming ts=100.
+    assertEquals(200L, merged.getOrderingValue(),
+        "the record with the higher event time must win");
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

closes #19899

### Summary and Changelog

`HoodieAvroRecord.doGetOrderingValue` delegated unconditionally to the payload, and payloads built
without an explicit ordering value default to `OrderingValues.getDefault()`, an `Integer`. Its
sibling `HoodieAvroIndexedRecord` reads the ordering fields off the record in the same situation,
so the two Avro record representations disagreed on the ordering value and on its type. This reads
the ordering fields off the record when the payload yields the default. The fallback is
deliberately narrow: an explicitly supplied ordering value still wins, deletes keep the default so
`BufferedRecord.isCommitTimeOrderingDelete` keeps classifying them as commit time ordered, a
nullable ordering field holding null keeps the default rather than returning null, and a record the
payload cannot decode keeps the default rather than raising from an ordering value lookup.

### Impact

Fixes a `ClassCastException` on every merged row for copy on write tables whose ordering column is
not an `int`, reached through prepped Spark SQL writes among other paths. No public API change.

### Risk Level

low

The new behaviour is reached only when the payload reports the default ordering value, the table
declares ordering fields, and the record is not a delete, and it then performs the same extraction
`HoodieAvroIndexedRecord` already performs. `TestHoodieAvroRecord` covers the regression plus the
three behaviours that must not change. Against master the regression test fails with `Unexpected
type, expected: <java.lang.Long> but was: <java.lang.Integer>`, and the three guards fail against a
fallback that omits them.

### Documentation Update

None. No new config, no default value change, no user facing feature change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
