### PR TITLE
fix(common): honor SPARK_LOCAL_DIRS in Hudi spillable map path resolution

### DIFF
--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestFileIOUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestFileIOUtils.java
@@ -80,20 +80,11 @@ public class TestFileIOUtils extends HoodieCommonTestHarness {
   
   @Test
   public void testGetConfiguredLocalDirs() {
-    Map<String, String> env = System.getenv();
-    Class<?> clazz = env.getClass();
-    Map<String, String> envMaps = null;
-    try {
-      Field field = clazz.getDeclaredField("m");
-      field.setAccessible(true);
-      envMaps = (Map<String, String>) field.get(env);
-      envMaps.put("CONTAINER_ID", "xxxxx");
-      // getConfiguredLocalDirs now also consults SPARK_LOCAL_DIRS; drop any value inherited
-      // from the developer's shell so this assertion stays about the tmpdir fallback.
-      envMaps.remove("SPARK_LOCAL_DIRS");
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new IllegalArgumentException(e);
-    }
+    Map<String, String> envMaps = mutableEnv();
+    envMaps.put("CONTAINER_ID", "xxxxx");
+    // getConfiguredLocalDirs now also consults SPARK_LOCAL_DIRS; drop any value inherited
+    // from the developer's shell so this assertion stays about the tmpdir fallback.
+    envMaps.remove("SPARK_LOCAL_DIRS");
     assertEquals(String.join("", FileIOUtils.getConfiguredLocalDirs()),
             System.getProperty("java.io.tmpdir"));
     envMaps.put("LOCAL_DIRS", "/xxx");

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestFileIOUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestFileIOUtils.java
@@ -88,6 +88,9 @@ public class TestFileIOUtils extends HoodieCommonTestHarness {
       field.setAccessible(true);
       envMaps = (Map<String, String>) field.get(env);
       envMaps.put("CONTAINER_ID", "xxxxx");
+      // getConfiguredLocalDirs now also consults SPARK_LOCAL_DIRS; drop any value inherited
+      // from the developer's shell so this assertion stays about the tmpdir fallback.
+      envMaps.remove("SPARK_LOCAL_DIRS");
     } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new IllegalArgumentException(e);
     }
@@ -96,6 +99,61 @@ public class TestFileIOUtils extends HoodieCommonTestHarness {
     envMaps.put("LOCAL_DIRS", "/xxx");
     assertEquals(String.join("", FileIOUtils.getConfiguredLocalDirs()),
             envMaps.get("LOCAL_DIRS"));
+  }
+
+  @Test
+  public void testGetConfiguredLocalDirsPrefersSparkLocalDirs() {
+    Map<String, String> envMaps = mutableEnv();
+    String originalContainerId = envMaps.get("CONTAINER_ID");
+    String originalLocalDirs = envMaps.get("LOCAL_DIRS");
+    String originalSparkLocalDirs = envMaps.get("SPARK_LOCAL_DIRS");
+    try {
+      // Not under YARN: SPARK_LOCAL_DIRS is used in preference to java.io.tmpdir.
+      envMaps.remove("CONTAINER_ID");
+      envMaps.remove("LOCAL_DIRS");
+      envMaps.put("SPARK_LOCAL_DIRS", "/spark-dir-1");
+      assertEquals("/spark-dir-1", String.join("", FileIOUtils.getConfiguredLocalDirs()));
+
+      // Comma separated values are split, as they are for YARN.
+      envMaps.put("SPARK_LOCAL_DIRS", "/spark-dir-1,/spark-dir-2");
+      assertEquals(Arrays.asList("/spark-dir-1", "/spark-dir-2"),
+          Arrays.asList(FileIOUtils.getConfiguredLocalDirs()));
+
+      // YARN keeps precedence when both are present.
+      envMaps.put("CONTAINER_ID", "container_xxx");
+      envMaps.put("LOCAL_DIRS", "/yarn-dir");
+      assertEquals("/yarn-dir", String.join("", FileIOUtils.getConfiguredLocalDirs()));
+
+      // Neither set: unchanged fallback to java.io.tmpdir.
+      envMaps.remove("CONTAINER_ID");
+      envMaps.remove("LOCAL_DIRS");
+      envMaps.remove("SPARK_LOCAL_DIRS");
+      assertEquals(System.getProperty("java.io.tmpdir"),
+          String.join("", FileIOUtils.getConfiguredLocalDirs()));
+    } finally {
+      restoreEnv(envMaps, "CONTAINER_ID", originalContainerId);
+      restoreEnv(envMaps, "LOCAL_DIRS", originalLocalDirs);
+      restoreEnv(envMaps, "SPARK_LOCAL_DIRS", originalSparkLocalDirs);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> mutableEnv() {
+    try {
+      Field field = System.getenv().getClass().getDeclaredField("m");
+      field.setAccessible(true);
+      return (Map<String, String>) field.get(System.getenv());
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  private static void restoreEnv(Map<String, String> envMaps, String key, String original) {
+    if (original == null) {
+      envMaps.remove(key);
+    } else {
+      envMaps.put(key, original);
+    }
   }
 
   @Test

--- a/hudi-io/src/main/java/org/apache/hudi/io/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/util/FileIOUtils.java
@@ -269,6 +269,11 @@ public class FileIOUtils {
       // created the directories already, and that they are secured so that only the
       // user has access to them.
       return getYarnLocalDirs().split(",");
+    } else if (System.getenv("SPARK_LOCAL_DIRS") != null) {
+      // Kubernetes provides no scheduler-side local-dir contract like YARN's, so Spark itself
+      // publishes the mounted scratch paths here. Without this we fall through to
+      // java.io.tmpdir, i.e. /tmp inside the container rather than the mounted disk.
+      return System.getenv("SPARK_LOCAL_DIRS").split(",");
     } else if (System.getProperty("java.io.tmpdir") != null) {
       return System.getProperty("java.io.tmpdir").split(",");
     } else {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

On Spark on Kubernetes, `FileIOUtils#getConfiguredLocalDirs()` only special-cases
YARN's `LOCAL_DIRS` before falling back to `java.io.tmpdir`, i.e. `/tmp` inside
the executor container. Spark itself already resolves a mounted scratch
directory on Kubernetes and publishes it via the `SPARK_LOCAL_DIRS` environment
variable (`LocalDirsFeatureStep`), but Hudi never looks at it.

The practical effect: Spark shuffle correctly lands on a large mounted disk via
`SPARK_LOCAL_DIRS`, while a Hudi spillable map (`ExternalSpillableMap`, used by
merge/compaction/clustering paths) for the same executor silently spills to the
small container root filesystem instead, since it resolves its default base
path from `java.io.tmpdir` rather than `SPARK_LOCAL_DIRS`.

### Summary and Changelog

Add a `SPARK_LOCAL_DIRS`-aware branch to `getConfiguredLocalDirs()`, immediately
after the existing YARN check and before the `java.io.tmpdir` fallback:

```java
} else if (System.getenv("SPARK_LOCAL_DIRS") != null) {
  return System.getenv("SPARK_LOCAL_DIRS").split(",");
}
```

YARN keeps precedence when both are set (this is a pure addition, not a
reordering). No engine dependency is added to `hudi-io`/`hudi-common`: this
reads a well-known environment variable by name, exactly as the existing
branch already does for YARN's `LOCAL_DIRS`. Flink and plain Java/standalone
callers are unaffected, since neither environment variable is set in those
contexts.

Deliberately not adding a writability check on the resolved directory:
`HoodieWriteConfig#getSpillableMapBasePath()` is resolved on every
`ExternalSpillableMap` construction — effectively per merge handle / per
partition on the write path, and uncached — so a filesystem stat here would
add a syscall on the hot path across potentially thousands of partitions. The
existing YARN branch performs no such validation either, so this keeps that
behavior consistent. If `SPARK_LOCAL_DIRS` is set but unwritable, Hudi now
fails loudly at spill time instead of silently falling back to `/tmp`.

Added `testGetConfiguredLocalDirsPrefersSparkLocalDirs` covering:
`SPARK_LOCAL_DIRS` alone, comma-separated multi-directory values, YARN taking
precedence when both are set, and the unchanged fallback when neither is set.

### Impact

No public API change. Behavior change only when `hoodie.memory.spillable.map.path`
is unset (an advanced config with no default) and the process is running under
Spark on Kubernetes: the effective spillable-map location moves from `/tmp` to
whatever directory Spark's own Kubernetes local-dirs feature step publishes.
YARN and non-Spark engines see no behavior change.

### Risk Level

low - purely additive branch in an existing if/else chain; does not touch the
YARN or `java.io.tmpdir` fallback paths. The new branch is gated entirely on an
environment variable that is unset for every engine and deployment mode except
Spark on Kubernetes.

### Documentation Update

none - this changes only the default used when `hoodie.memory.spillable.map.path`
is unset; that config's existing documentation is unaffected.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
