### PR TITLE
fix(spark): fix incremental file index reporting sizeInBytes=0

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -181,6 +181,20 @@ object DataSourceReadOptions {
     .withDocumentation("Whether to skip clustering instants to avoid reading base files of clustering operations "
       + "for streaming read to improve read performance.")
 
+  val INCREMENTAL_REPORT_MAX_FILE_SIZE: ConfigProperty[Boolean] = ConfigProperty
+    .key("hoodie.datasource.read.incr.reportMaxFileSize")
+    .defaultValue(true)
+    .markAdvanced()
+    .sinceVersion("1.2.0")
+    .withDocumentation("When enabled, the incremental file index reports Long.MaxValue as its sizeInBytes "
+      + "to the Spark planner, preventing Spark from choosing BroadcastHashJoin for any "
+      + "subexpression that includes the incremental source. This matches the behavior of the "
+      + "pre-1.0 IncrementalRelation which extended BaseRelation (default sizeInBytes = Long.MaxValue). "
+      + "Without this, Spark's selectivity estimates on filtered subexpressions of the incremental "
+      + "source can drop below the broadcast threshold, causing broadcast timeouts on large tables. "
+      + "When disabled, the actual file size from commit metadata is reported, which may allow "
+      + "Spark to broadcast small incremental reads.")
+
   val TIME_TRAVEL_AS_OF_INSTANT: ConfigProperty[String] = HoodieCommonConfig.TIMESTAMP_AS_OF
 
   val ENABLE_DATA_SKIPPING: ConfigProperty[Boolean] = ConfigProperty

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
@@ -466,9 +466,10 @@ case class HoodieFileIndex(spark: SparkSession,
   override def sizeInBytes: Long = {
     val size = getTotalCachedFilesSize
     if (size == 0 && !enableHoodieExtension) {
-      // Avoid always broadcast the hudi table if not enable HoodieExtension
       logWarning("Note: Please add 'org.apache.spark.sql.hudi.HoodieSparkSessionExtension' to the Spark SQL configuration property " +
         "'spark.sql.extensions'.\n Multiple extensions can be set using a comma-separated list.")
+      Long.MaxValue
+    } else if (size == 0) {
       Long.MaxValue
     } else {
       size

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieIncrementalFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieIncrementalFileIndex.scala
@@ -71,6 +71,20 @@ class HoodieIncrementalFileIndex(override val spark: SparkSession,
     }).map(fileStatus => fileStatus.getPath.toString).toArray
   }
 
+  private val reportMaxFileSize: Boolean = options.getOrElse(
+    DataSourceReadOptions.INCREMENTAL_REPORT_MAX_FILE_SIZE.key,
+    DataSourceReadOptions.INCREMENTAL_REPORT_MAX_FILE_SIZE.defaultValue.toString
+  ).toBoolean
+
+  override def sizeInBytes: Long = {
+    if (reportMaxFileSize) {
+      Long.MaxValue
+    } else {
+      val actualSize = mergeOnReadIncrementalRelation.getIncrementalFilesSize
+      if (actualSize > 0) actualSize else Long.MaxValue
+    }
+  }
+
   def getRequiredFilters: Seq[Filter] = {
     mergeOnReadIncrementalRelation.getRequiredFilters
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV1.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV1.scala
@@ -156,6 +156,10 @@ case class MergeOnReadIncrementalRelationV1(override val sqlContext: SQLContext,
     }
   }
 
+  override def getIncrementalFilesSize: Long = {
+    affectedFilesInCommits.asScala.map(_.getLength).sum
+  }
+
   override def shouldIncludeLogFiles(): Boolean = fullTableScan
 
   private def filterFileSlices(fileSlices: Seq[FileSlice], pathGlobPattern: String): Seq[FileSlice] = {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV2.scala
@@ -45,6 +45,7 @@ import scala.collection.immutable
 trait MergeOnReadIncrementalRelation {
   def listFileSplits(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Map[InternalRow, Seq[FileSlice]]
   def getRequiredFilters: Seq[Filter]
+  def getIncrementalFilesSize: Long
 }
 
 case class MergeOnReadIncrementalRelationV2(override val sqlContext: SQLContext,
@@ -148,6 +149,10 @@ case class MergeOnReadIncrementalRelationV2(override val sqlContext: SQLContext,
     } else {
       incrementalSpanRecordFilters
     }
+  }
+
+  override def getIncrementalFilesSize: Long = {
+    affectedFilesInCommits.asScala.map(_.getLength).sum
   }
 
   override def shouldIncludeLogFiles(): Boolean = fullTableScan


### PR DESCRIPTION
HoodieIncrementalFileIndex inherits sizeInBytes from HoodieFileIndex, which returns getTotalCachedFilesSize(). Since incremental reads bypass the base class file slice cache (using listFileSplits() instead), the cache is always empty and sizeInBytes returns 0.

When Spark sees sizeInBytes=0, it treats the incremental source as tiny and selects BroadcastHashJoin for joins involving data derived from it. Spark's selectivity estimates on filtered subexpressions can drop below autoBroadcastJoinThreshold (default 10MB), causing broadcast exchanges that compete with the main scan for executor resources and time out (300s default) on large pipelines.

In 0.x, IncrementalRelation extended BaseRelation which defaults sizeInBytes to Long.MaxValue, preventing Spark from broadcasting any subexpression that included the incremental source.

Fix:
- Add getIncrementalFilesSize() to MergeOnReadIncrementalRelation trait, implemented in V1 and V2 by summing file sizes from affectedFilesInCommits (commit metadata, no storage I/O).
- Add hoodie.datasource.read.incr.reportMaxFileSize config (default true). When enabled, sizeInBytes returns Long.MaxValue matching pre-1.0 behavior. When disabled, returns actual file size from commit metadata.
- Add safety net in HoodieFileIndex.sizeInBytes: return Long.MaxValue when getTotalCachedFilesSize is 0 even with HoodieSparkSessionExtension enabled, preventing any FileIndex subclass from reporting size=0.

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
