### PR TITLE
fix(spark): merge identical blob descriptors in the batched read

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
@@ -285,8 +285,10 @@ class BatchedBlobReader(
   /**
    * Identify consecutive ranges that can be batched together.
    *
-   * This method groups rows by file path, sorts by offset, and merges
-   * ranges that overlap, are consecutive, or are within maxGapBytes of each other.
+   * This method groups rows by file path, sorts them by (offset, length), and merges
+   * ranges that are adjacent or within maxGapBytes of each other. Rows carrying the identical
+   * descriptor (same file path, offset and length) share one read. Overlapping ranges throw,
+   * because a blob is a distinct entity and two blobs never share bytes.
    *
    * @param rows Sequence of row information
    * @return Sequence of merged ranges
@@ -298,8 +300,8 @@ class BatchedBlobReader(
     val allRanges = ArrayBuffer[MergedRange[R]]()
 
     byFile.foreach { case (filePath, fileRows) =>
-      // Sort by offset
-      val sorted = fileRows.sortBy(_.offset)
+      // Sort by offset, then by length, so rows carrying the identical descriptor are adjacent
+      val sorted = fileRows.sortBy(r => (r.offset, r.length))
 
       // Merge consecutive ranges
       val merged = mergeRanges(sorted, maxGapBytes)
@@ -312,7 +314,13 @@ class BatchedBlobReader(
   /**
    * Merge consecutive ranges within the gap threshold.
    *
-   * @param rows   Sorted rows from the same file
+   * Rows are grouped by file and sorted by (offset, length) before they reach this method.
+   * Adjacent ranges and ranges within the gap threshold are merged into a single read, and rows
+   * carrying the identical descriptor (same file path, offset and length) share one read: that
+   * is one blob referenced by more than one row. Overlapping ranges throw, because a blob is a
+   * distinct entity and two blobs never share bytes.
+   *
+   * @param rows   Rows from the same file, sorted by (offset, length)
    * @param maxGap Maximum gap to consider for merging
    * @return Sequence of merged ranges
    */
@@ -331,16 +339,23 @@ class BatchedBlobReader(
         currentStartOffset = row.offset
         currentEndOffset = row.offset + row.length
         currentRows = ArrayBuffer(row)
+      } else if (row.offset == currentRows.last.offset && row.length == currentRows.last.length) {
+        // Same descriptor as the previous row: one blob referenced by more than one row (join
+        // fan-out, duplicate records). It is served from the current read and the range does
+        // not grow.
+        currentRows += row
       } else {
-        // Rows are sorted by offset, so a negative gap means this row's range overlaps the
-        // current merged range. Overlapping references are legitimate (two rows may point at
-        // nested or shared bytes of one file) and the merged read already covers them: each row
-        // is sliced out of the buffer by its own offset and length below. Which rows share a
-        // task is a partitioning accident, so rejecting overlaps here would make a read fail
-        // or succeed depending on the layout.
         val gap = row.offset - currentEndOffset
-        if (gap <= maxGap) {
-          // Merge into current range (overlapping, adjacent or within the gap threshold)
+        // A blob is a distinct entity, so two blobs never share bytes. Rows are sorted by
+        // (offset, length) and identical descriptors were handled above, so a start inside the
+        // current range means two different blobs overlap, which indicates corruption.
+        if (row.offset < currentEndOffset) {
+          throw new IllegalArgumentException(
+            s"Overlapping blob ranges detected: previous range [${currentStartOffset}, ${currentEndOffset}) and current row [${row.offset}, ${row.offset + row.length}) in file ${row.filePath}"
+          )
+        }
+        if (gap >= 0 && gap <= maxGap) {
+          // Merge into current range
           currentEndOffset = math.max(currentEndOffset, row.offset + row.length)
           currentRows += row
         } else {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
@@ -286,7 +286,7 @@ class BatchedBlobReader(
    * Identify consecutive ranges that can be batched together.
    *
    * This method groups rows by file path, sorts by offset, and merges
-   * ranges that are consecutive or within maxGapBytes of each other.
+   * ranges that overlap, are consecutive, or are within maxGapBytes of each other.
    *
    * @param rows Sequence of row information
    * @return Sequence of merged ranges
@@ -332,15 +332,15 @@ class BatchedBlobReader(
         currentEndOffset = row.offset + row.length
         currentRows = ArrayBuffer(row)
       } else {
+        // Rows are sorted by offset, so a negative gap means this row's range overlaps the
+        // current merged range. Overlapping references are legitimate (two rows may point at
+        // nested or shared bytes of one file) and the merged read already covers them: each row
+        // is sliced out of the buffer by its own offset and length below. Which rows share a
+        // task is a partitioning accident, so rejecting overlaps here would make a read fail
+        // or succeed depending on the layout.
         val gap = row.offset - currentEndOffset
-        // Check for overlap
-        if (row.offset < currentEndOffset) {
-          throw new IllegalArgumentException(
-            s"Overlapping blob ranges detected: previous range [${currentStartOffset}, ${currentEndOffset}) and current row [${row.offset}, ${row.offset + row.length}) in file ${row.filePath}"
-          )
-        }
-        if (gap >= 0 && gap <= maxGap) {
-          // Merge into current range
+        if (gap <= maxGap) {
+          // Merge into current range (overlapping, adjacent or within the gap threshold)
           currentEndOffset = math.max(currentEndOffset, row.offset + row.length)
           currentRows += row
         } else {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/blob/TestBatchedBlobReader.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/blob/TestBatchedBlobReader.scala
@@ -30,6 +30,7 @@ import org.apache.hudi.testutils.HoodieClientTestBase
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileSystem
+import org.apache.spark.SparkException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hudi.blob.BatchedBlobReader
@@ -441,10 +442,9 @@ class TestBatchedBlobReader extends HoodieClientTestBase {
   }
 
   @Test
-  def testOverlappingRangesAreServedFromOneRead(): Unit = {
+  def testOverlappingRangesThrowsException(): Unit = {
     val filePath = createTestFile(tempDir, "overlap.bin", 1000)
-    // Overlapping: [0, 100) and [50, 150). Whether two such rows share a task depends only on
-    // partitioning, so the reader must serve both.
+    // Overlapping: [0, 100) and [50, 100)
     val inputDF = sparkSession.createDataFrame(Seq(
       (filePath, 0L, 100L),
       (filePath, 50L, 100L)
@@ -453,13 +453,36 @@ class TestBatchedBlobReader extends HoodieClientTestBase {
       .select("offset", "data")
       .coalesce(1)
 
+    val thrown = assertThrows(classOf[SparkException], () => {
+      val rows = BatchedBlobReader.readBatched(inputDF, storageConf).collect()
+      // Force access to the data column to trigger the batch read logic
+      rows.foreach(row => row.getAs[Array[Byte]]("data"))
+    })
+    assertTrue(thrown.getCause.isInstanceOf[IllegalArgumentException])
+    assertTrue(thrown.getCause.getMessage.contains("Overlapping blob ranges detected"))
+  }
+
+  @Test
+  def testIdenticalRangesAreServedFromOneRead(): Unit = {
+    // A join fan-out or a duplicate record puts the same descriptor in one task twice. That is one
+    // blob referenced by two rows, not two blobs sharing bytes, so the reader must serve both from
+    // the single read of that range.
+    val filePath = createTestFile(tempDir, "identical.bin", 1000)
+    val inputDF = sparkSession.createDataFrame(Seq(
+      (filePath, 0L, 100L),
+      (filePath, 0L, 100L)
+    )).toDF("external_path", "offset", "length")
+      .withColumn("data", blobStructCol("data", col("external_path"), col("offset"), col("length")))
+      .select("offset", "data")
+      .coalesce(1)
+
     val results = BatchedBlobReader.readBatched(inputDF, storageConf).collect()
+
     assertEquals(2, results.length)
     results.foreach { row =>
-      val offset = row.getAs[Long]("offset")
       val data = row.getAs[Array[Byte]]("data")
       assertEquals(100, data.length)
-      assertBytesContent(data, expectedOffset = offset.toInt)
+      assertBytesContent(data, expectedOffset = 0)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/blob/TestBatchedBlobReader.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/blob/TestBatchedBlobReader.scala
@@ -30,7 +30,6 @@ import org.apache.hudi.testutils.HoodieClientTestBase
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileSystem
-import org.apache.spark.SparkException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hudi.blob.BatchedBlobReader
@@ -442,9 +441,10 @@ class TestBatchedBlobReader extends HoodieClientTestBase {
   }
 
   @Test
-  def testOverlappingRangesThrowsException(): Unit = {
+  def testOverlappingRangesAreServedFromOneRead(): Unit = {
     val filePath = createTestFile(tempDir, "overlap.bin", 1000)
-    // Overlapping: [0, 100) and [50, 100)
+    // Overlapping: [0, 100) and [50, 150). Whether two such rows share a task depends only on
+    // partitioning, so the reader must serve both.
     val inputDF = sparkSession.createDataFrame(Seq(
       (filePath, 0L, 100L),
       (filePath, 50L, 100L)
@@ -453,13 +453,14 @@ class TestBatchedBlobReader extends HoodieClientTestBase {
       .select("offset", "data")
       .coalesce(1)
 
-    val thrown = assertThrows(classOf[SparkException], () => {
-      val rows = BatchedBlobReader.readBatched(inputDF, storageConf).collect()
-      // Force access to the data column to trigger the batch read logic
-      rows.foreach(row => row.getAs[Array[Byte]]("data"))
-    })
-    assertTrue(thrown.getCause.isInstanceOf[IllegalArgumentException])
-    assertTrue(thrown.getCause.getMessage.contains("Overlapping blob ranges detected"))
+    val results = BatchedBlobReader.readBatched(inputDF, storageConf).collect()
+    assertEquals(2, results.length)
+    results.foreach { row =>
+      val offset = row.getAs[Long]("offset")
+      val data = row.getAs[Array[Byte]]("data")
+      assertEquals(100, data.length)
+      assertBytesContent(data, expectedOffset = offset.toInt)
+    }
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/blob/TestReadBlobSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/blob/TestReadBlobSQL.scala
@@ -253,6 +253,57 @@ class TestReadBlobSQL extends HoodieClientTestBase {
     assertBytesContent(data1)
   }
 
+  /**
+   * One blob row matching several rows on the other side of a join puts the same descriptor
+   * into one task several times, and there is no shuffle between the join and the batched
+   * read to collapse them. The reader must serve every row, not just the first.
+   */
+  @Test
+  def testReadBlobWithJoinFanOut(): Unit = {
+    val filePath = createTestFile(tempDir, "join_fanout.bin", 10000)
+
+    // Blob side: one descriptor per id
+    val blobDF = sparkSession.createDataFrame(Seq(
+      (1, filePath, 0L, 100L),
+      (2, filePath, 100L, 100L)
+    )).toDF("id", "external_path", "offset", "length")
+      .withColumn("file_info",
+        blobStructCol("file_info", col("external_path"), col("offset"), col("length")))
+      .select("id", "file_info")
+
+    blobDF.createOrReplaceTempView("blob_table_fanout")
+
+    // Event side: several rows per id, so each descriptor fans out across the join
+    val eventsDF = sparkSession.createDataFrame(Seq(
+      (1, "e1"),
+      (1, "e2"),
+      (1, "e3"),
+      (2, "e4"),
+      (2, "e5")
+    )).toDF("id", "name")
+
+    eventsDF.createOrReplaceTempView("events_fanout")
+
+    val result = sparkSession.sql("""
+      SELECT e.id, e.name, read_blob(b.file_info) AS data
+      FROM events_fanout e
+      JOIN blob_table_fanout b ON e.id = b.id
+      ORDER BY e.id, e.name
+    """)
+
+    val rows = result.collect()
+    assertEquals(5, rows.length)
+
+    val expectedNames = Seq("e1", "e2", "e3", "e4", "e5")
+    rows.zipWithIndex.foreach { case (row, idx) =>
+      assertEquals(expectedNames(idx), row.getAs[String]("name"))
+      val data = row.getAs[Array[Byte]]("data")
+      assertEquals(100, data.length)
+      val expectedOffset = if (row.getAs[Int]("id") == 1) 0 else 100
+      assertBytesContent(data, expectedOffset = expectedOffset)
+    }
+  }
+
   @Test
   def testReadBlobInSubquery(): Unit = {
     val filePath = createTestFile(tempDir, "subquery.bin", 10000)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/blob/TestBatchedBlobReaderMerge.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/blob/TestBatchedBlobReaderMerge.scala
@@ -20,7 +20,7 @@
 package org.apache.spark.sql.hudi.blob
 
 import org.apache.spark.sql.Row
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
 import org.junit.jupiter.api.Test
 
 /**
@@ -170,15 +170,55 @@ class TestBatchedBlobReaderMerge {
   }
 
   @Test
-  def testOverlappingRangesMergeIntoOne(): Unit = {
-    // [0,100) followed by [50,150) -> one merged range [0,150) carrying both rows
+  def testOverlappingRangesThrow(): Unit = {
+    // [0,100) followed by [50,100) -> overlap
     val rows = Seq(
       row("/f", 0, 100, index = 0),
       row("/f", 50, 100, index = 1))
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => reader().mergeRanges(rows, maxGap = 4096))
+    assertTrue(ex.getMessage.contains("Overlapping blob ranges detected"))
+  }
+
+  @Test
+  def testIdenticalRangesMergeIntoOne(): Unit = {
+    // One blob referenced by two rows (join fan-out, duplicate records): a single read serves both
+    // and the range does not grow.
+    val rows = Seq(
+      row("/f", 0, 100, index = 0),
+      row("/f", 0, 100, index = 1))
     val merged = reader().mergeRanges(rows, maxGap = 4096)
     assertEquals(1, merged.size)
     assertEquals(0L, merged.head.startOffset)
-    assertEquals(150L, merged.head.endOffset)
+    assertEquals(100L, merged.head.endOffset)
     assertEquals(Seq(0L, 1L), merged.head.rows.map(_.index))
+  }
+
+  @Test
+  def testNestedRangeThrows(): Unit = {
+    // Containment is still an overlap: [0,512) then [0,1024) are two different blobs sharing
+    // bytes. This is the shape that failed in TestLanceDataSource. Rows are given in the order
+    // mergeRanges expects, sorted by (offset, length).
+    val rows = Seq(
+      row("/f", 0, 512, index = 0),
+      row("/f", 0, 1024, index = 1))
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => reader().mergeRanges(rows, maxGap = 4096))
+    assertTrue(ex.getMessage.contains("Overlapping blob ranges detected"))
+  }
+
+  @Test
+  def testIdenticalRangesDoNotWeakenOverlapCheck(): Unit = {
+    // A duplicate descriptor followed by a genuinely overlapping row still throws
+    val rows = Seq(
+      row("/f", 0, 100, 0),
+      row("/f", 0, 100, 1),
+      row("/f", 50, 100, 2))
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => reader().mergeRanges(rows, maxGap = 4096))
+    assertTrue(ex.getMessage.contains("Overlapping blob ranges detected"))
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/blob/TestBatchedBlobReaderMerge.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/blob/TestBatchedBlobReaderMerge.scala
@@ -20,7 +20,7 @@
 package org.apache.spark.sql.hudi.blob
 
 import org.apache.spark.sql.Row
-import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
 
 /**
@@ -170,14 +170,15 @@ class TestBatchedBlobReaderMerge {
   }
 
   @Test
-  def testOverlappingRangesThrow(): Unit = {
-    // [0,100) followed by [50,100) -> overlap
+  def testOverlappingRangesMergeIntoOne(): Unit = {
+    // [0,100) followed by [50,150) -> one merged range [0,150) carrying both rows
     val rows = Seq(
       row("/f", 0, 100, index = 0),
       row("/f", 50, 100, index = 1))
-    val ex = assertThrows(
-      classOf[IllegalArgumentException],
-      () => reader().mergeRanges(rows, maxGap = 4096))
-    assertTrue(ex.getMessage.contains("Overlapping blob ranges detected"))
+    val merged = reader().mergeRanges(rows, maxGap = 4096)
+    assertEquals(1, merged.size)
+    assertEquals(0L, merged.head.startOffset)
+    assertEquals(150L, merged.head.endOffset)
+    assertEquals(Seq(0L, 1L), merged.head.rows.map(_.index))
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes #19911.

This removes a **false positive** from the overlap check in `BatchedBlobReader`.

**What the reader does.** Each Spark task collects its rows, groups them by file, sorts them by offset, and walks them to plan reads. If a row starts before the previous range ends, it throws `Overlapping blob ranges detected`. That check was added in #18098 to catch corruption: a blob is a distinct entity, so two blobs sharing bytes means bad data. The invariant stands.

**What a fan-out join delivers to it.** Join a blob table to any table with several rows per key and read the blob:

```sql
SELECT e.event_id, read_blob(p.image) FROM events e JOIN products p ON e.product_id = p.id
```

Product 1 has three events, so the join output carries product 1's descriptor `[0, 100)` three times. The join shuffles by key, so all three land in the same task.

**Why the check fires.** On the second `[0, 100)` the reader sees a start of 0 before the previous end of 100 and throws. Nothing is corrupt: one blob, one range, referenced three times. The check only compares a start offset to an end offset, so it cannot tell "same range again" from "different range that overlaps". `TestReadBlobSQL#testReadBlobWithJoinFanOut` fails on master this way.

**Why nobody noticed.** The check only compares rows in the same task, and the only join test was one-to-one, so no task ever held the same descriptor twice. The Lance rows behind #19911 were a true positive on bad test data, hidden until #19906 dropped the harness from four shuffle partitions to two; they are fixed in #19916.

**The fix.** Sort by (offset, length) so identical descriptors are adjacent, and serve a row whose descriptor matches the previous one from the same read. Partial overlaps and containment still throw.

### Summary and Changelog

- `identifyConsecutiveRanges` sorts rows by `(offset, length)` so identical descriptors are adjacent.
- `mergeRanges` adds a row with the identical descriptor to the current range without growing it. Partial overlaps and containment still throw, with the message unchanged.
- The first commit on this branch removed the check entirely; the second restores it and narrows the change as above. The net diff against master is the narrow change.
- Tests: `TestBatchedBlobReaderMerge` gains identical-merge, nested-throws and duplicate-then-overlap-throws cases; `TestBatchedBlobReader` gains an end-to-end identical-descriptor read; `TestReadBlobSQL` gains the fan-out join.

### Impact

Reads that repeat a descriptor within a task, such as joins with fan-out, no longer fail. Overlapping blobs are still rejected. No format or config change.

### Risk Level

low

The only behaviour change is on input that used to fail with the error above.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
