### PR TITLE
fix(utilities): set the ordering value whenever the table's merge mode needs one

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerUtils.java
@@ -23,6 +23,7 @@ import org.apache.hudi.HoodieSchemaConversionUtils;
 import org.apache.hudi.SparkAdapterSupport$;
 import org.apache.hudi.common.avro.AvroRecordContext;
 import org.apache.hudi.common.avro.HoodieAvroUtils;
+import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -91,7 +92,14 @@ public class HoodieStreamerUtils {
                                                                   String instantTime, Option<BaseErrorTableWriter> errorTableWriter, HoodieTableConfig tableConfig) {
     boolean shouldCombine = cfg.filterDupes || cfg.operation.equals(WriteOperationType.UPSERT);
     String orderingFieldsStr = tableConfig.getOrderingFieldsStr().orElse(cfg.sourceOrderingFields);
-    boolean shouldUseOrderingField = shouldCombine && !StringUtils.isNullOrEmpty(orderingFieldsStr);
+    // `shouldCombine` says whether the incoming batch needs de-duplicating, which is not the same
+    // question as whether a record needs an ordering value. It is false for INSERT and
+    // BULK_INSERT, and those records still reach a merge: the partitioner packs inserts into
+    // existing small files as BucketType.UPDATE. A table that orders by event time needs the
+    // value either way.
+    boolean requiresOrderingValue = tableConfig.getRecordMergeMode() != RecordMergeMode.COMMIT_TIME_ORDERING;
+    boolean shouldUseOrderingField = (shouldCombine || requiresOrderingValue)
+        && !StringUtils.isNullOrEmpty(orderingFieldsStr);
     boolean shouldErrorTable = errorTableWriter.isPresent() && props.getBoolean(ERROR_ENABLE_VALIDATE_RECORD_CREATION.key(), ERROR_ENABLE_VALIDATE_RECORD_CREATION.defaultValue());
     boolean useConsistentLogicalTimestamp = ConfigUtils.getBooleanWithAltKeys(
         props, KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED);
@@ -129,11 +137,15 @@ public class HoodieStreamerUtils {
                   HoodieKey hoodieKey = new HoodieKey(builtinKeyGenerator.getRecordKey(genRec), builtinKeyGenerator.getPartitionPath(genRec));
                   GenericRecord gr = isDropPartitionColumns(props) ? HoodieAvroUtils.removeFields(genRec, partitionColumns) : genRec;
                   boolean isDelete = AvroRecordContext.getFieldAccessorInstance().isDeleteRecord(gr, deleteContext);
-                  Comparable orderingValue = shouldUseOrderingField
+                  // Deletes keep the default ordering value: BufferedRecordMergerFactory treats a
+                  // delete carrying the default as commit time ordered, and giving it a real value
+                  // would make a delete lose to a stored record with a higher ordering value.
+                  boolean computeOrderingValue = shouldUseOrderingField && !(isDelete && !shouldCombine);
+                  Comparable orderingValue = computeOrderingValue
                       ? OrderingValues.create(orderingFieldsStr.split(","),
                          field -> (Comparable) HoodieAvroUtils.getNestedFieldVal(gr, field, false, useConsistentLogicalTimestamp))
                       : null;
-                  HoodieRecord record = shouldUseOrderingField ? HoodieRecordUtils.createHoodieRecord(gr, orderingValue, hoodieKey, payloadClassName, requiresPayload, isDelete)
+                  HoodieRecord record = computeOrderingValue ? HoodieRecordUtils.createHoodieRecord(gr, orderingValue, hoodieKey, payloadClassName, requiresPayload, isDelete)
                       : HoodieRecordUtils.createHoodieRecord(gr, hoodieKey, payloadClassName, requiresPayload, isDelete);
                   return Either.left(record);
                 } catch (Exception e) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestHoodieStreamerUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestHoodieStreamerUtils.java
@@ -19,11 +19,14 @@
 
 package org.apache.hudi.utilities.streamer;
 
+import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.PartialUpdateAvroPayload;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
@@ -51,10 +54,12 @@ import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
@@ -84,6 +89,55 @@ public class TestHoodieStreamerUtils extends UtilitiesTestBase {
                 .flatMap(booleanValue ->
                     Stream.of(recordKeyFields)
                         .map(recordKeyField -> Arguments.of(recordType, booleanValue, recordKeyField))));
+  }
+
+  /**
+   * INSERT leaves shouldCombine false, and a payload class outside DEPRECATED_PAYLOADS takes the
+   * HoodieAvroRecord branch of HoodieRecordUtils#createHoodieRecord regardless of requiresPayload.
+   * The record then serves the payload's Integer default instead of the ordering field's value,
+   * and inserts do reach a merge: the partitioner packs them into existing small files as
+   * BucketType.UPDATE, where BufferedRecordMergerFactory compares the two ordering values.
+   */
+  @Test
+  void testInsertWithCustomPayloadCarriesTheOrderingValue() {
+    HoodieSchema schema = HoodieSchema.parse(SCHEMA_STRING);
+    JavaRDD<GenericRecord> recordRdd = jsc.parallelize(Collections.singletonList(1)).map(i -> {
+      GenericRecord genericRecord = new GenericData.Record(schema.toAvroSchema());
+      genericRecord.put(0, 1757000000000L);
+      genericRecord.put(1, "key" + i);
+      genericRecord.put(2, "path" + i);
+      genericRecord.put(3, "rider1");
+      genericRecord.put(4, "driver1");
+      return genericRecord;
+    });
+
+    HoodieStreamer.Config cfg = new HoodieStreamer.Config();
+    // Not in DEPRECATED_PAYLOADS, so the record is a HoodieAvroRecord either way.
+    cfg.payloadClassName = PartialUpdateAvroPayload.class.getName();
+    cfg.operation = WriteOperationType.INSERT;
+    cfg.filterDupes = false;
+
+    TypedProperties props = new TypedProperties();
+    props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition_path");
+    props.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+
+    HoodieTableConfig tableConfig = new HoodieTableConfig();
+    tableConfig.getProps().put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+    tableConfig.getProps().put(HoodieTableConfig.RECORD_MERGE_MODE.key(),
+        RecordMergeMode.EVENT_TIME_ORDERING.name());
+
+    Option<JavaRDD<HoodieRecord>> recordOpt = HoodieStreamerUtils.createHoodieRecords(
+        cfg, props, Option.of(recordRdd), new SimpleSchemaProvider(jsc, schema, props),
+        HoodieRecordType.AVRO, false, "000", Option.empty(), tableConfig);
+
+    assertTrue(recordOpt.isPresent());
+    List<HoodieRecord> records = recordOpt.get().collect();
+    assertEquals(1, records.size());
+    Comparable<?> orderingValue =
+        records.get(0).getOrderingValue(schema, new Properties(), new String[] {"timestamp"});
+    assertInstanceOf(Long.class, orderingValue,
+        "the record must carry the ordering field's value, not the payload's Integer default");
+    assertEquals(1757000000000L, orderingValue);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

part of #19901, same family as #19899 and #19908

### Summary and Changelog

`HoodieStreamerUtils` computed a record's ordering value only when `shouldCombine` was true. That
flag answers whether the incoming batch needs de-duplicating, which is a different question from
whether a record needs an ordering value: it is false for `INSERT` and `BULK_INSERT`.

Those records still reach a merge. `getInsertPartitioner` delegates to `getUpsertPartitioner`, and
`UpsertPartitioner` packs inserts into existing small files as `BucketType.UPDATE`, so they go
through a merge handle where `BufferedRecordMergerFactory` compares their ordering value against
the base record's. A payload class outside `DEPRECATED_PAYLOADS` takes the `HoodieAvroRecord`
branch of `HoodieRecordUtils#createHoodieRecord` regardless of `requiresPayload`, and that record
serves the payload's `Integer` default rather than the ordering field's value.

This is the same gate as #19908, on the Hudi Streamer path rather than the Spark SQL one. Kept
separate so each path's reachability argument stands on its own.

### Impact

On a table that orders by event time, ingesting with `--op INSERT` and a custom payload class
produced records whose ordering value was `Integer` 0. Compared against a base record's `Long`
that throws `ClassCastException`; on an `int` ordering column it silently keeps the stored record.
Commit time ordered tables and delete semantics are unchanged. No public API change.

### Risk Level

low

The new branch is taken only when the table declares ordering fields, the merge mode is not
`COMMIT_TIME_ORDERING`, and the record is not a delete, and it then performs the extraction the
`shouldCombine` branch beside it already performed.
`TestHoodieStreamerUtils#testInsertWithCustomPayloadCarriesTheOrderingValue` fails against master
with `Unexpected type, expected: <java.lang.Long> but was: <java.lang.Integer>`.

### Documentation Update

None. No new config, no default value change, no user facing feature change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
