### PR TITLE
test(spark): reference disjoint blob ranges in Lance out-of-line test

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -1806,15 +1806,18 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     val externalDir = Files.createDirectories(
       Paths.get(s"$basePath/_blob_ext${modeSuffix}_${tableType.name().toLowerCase}"))
     val filePath1 = BlobTestHelpers.createTestFile(externalDir, "blob_file_1.bin", 1024)
-    val filePath2 = BlobTestHelpers.createTestFile(externalDir, "blob_file_2.bin", 1024)
+    val filePath2 = BlobTestHelpers.createTestFile(externalDir, "blob_file_2.bin", 1536)
 
     val sparkSess = spark
     import sparkSess.implicits._
+    // Every row references a disjoint range. A blob is a distinct entity (#18098), so
+    // BatchedBlobReader rejects overlapping ranges within a task, and which rows share a
+    // task depends only on partitioning.
     val baseDf = Seq(
       (1, filePath1, 0L, 256L),
       (2, filePath1, 256L, 256L),
       (3, filePath2, 0L, 1024L),
-      (4, filePath2, 0L, 512L)
+      (4, filePath2, 1024L, 512L)
     ).toDF("id", "path", "offset", "length")
     val rawDf = baseDf.select($"id",
       BlobTestHelpers.blobStructCol("payload", $"path", $"offset", $"length"))
@@ -1860,7 +1863,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
     assertEquals(4, materialized.length)
 
-    val expectedRanges = Map(1 -> 0L, 2 -> 256L, 3 -> 0L, 4 -> 0L)
+    val expectedRanges = Map(1 -> 0L, 2 -> 256L, 3 -> 0L, 4 -> 1024L)
     val expectedLengths = Map(1 -> 256, 2 -> 256, 3 -> 1024, 4 -> 512)
     materialized.foreach { row =>
       val id = row.getInt(row.fieldIndex("id"))


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`TestLanceDataSource#testBlobOutOfLine` writes two rows pointing at `[0, 1024)` and `[0, 512)` of one external file. A blob is a distinct entity and two blobs never share bytes ([#18098, as stated by Tim](https://github.com/apache/hudi/pull/18098#discussion_r3055076537)), so `BatchedBlobReader` rejects the pair with `Overlapping blob ranges detected`.

The check catches an overlap only when both rows land in the same Spark task, so whether it fires depends on partitioning. At four shuffle partitions the two rows sat in different tasks; #19906 dropped the harness to two, they shared one, and all six cases failed on Azure ([build 17015, log 98](https://dev.azure.com/apachehudi/a1a51da7-8592-47d4-88dc-fd67bed336bb/_apis/build/builds/17015/logs/98)).

Context in #19911.

### Summary and Changelog

- `blob_file_2.bin` grows from 1024 to 1536 bytes. Row 4 now references `[1024, 1536)`, disjoint from row 3's `[0, 1024)`. The expected offset for row 4 follows.
- No production code change.

### Impact

Test only. The Lance out-of-line test no longer depends on which rows share a task.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
