### PR TITLE
feat(flink): support isolate slot group for compact plan generation

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -1026,6 +1026,16 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Parallelism of tasks that do actual compaction, default same as the write task parallelism");
 
   @AdvancedConfig
+  public static final ConfigOption<String> COMPACTION_PLAN_GENERATE_SLOT_SHARING_GROUP = ConfigOptions
+      .key("compaction.plan_generate.slot_sharing_group")
+      .stringType()
+      .noDefaultValue()
+      .withDescription("Slot sharing group for the compact_plan_generate operator, "
+          + "default not set so it shares the default slot sharing group with other operators. "
+          + "Configure this to isolate the plan generation operator onto a dedicated slot, "
+          + "see Flink's fine-grained resource management docs for slot sharing groups.");
+
+  @AdvancedConfig
   public static final ConfigOption<Boolean> COMPACTION_OPERATION_EXECUTE_ASYNC_ENABLED = ConfigOptions
       .key("compaction.operation.execute.async.enabled")
       .booleanType()

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -71,8 +71,11 @@ import org.apache.hudi.sink.transform.RowDataToHoodieFunctions;
 import org.apache.hudi.table.format.FilePathUtils;
 
 import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.api.common.operators.SlotSharingGroup;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -721,11 +724,29 @@ public class Pipelines {
    * @return the compaction pipeline
    */
   public static DataStreamSink<CompactionCommitEvent> compact(Configuration conf, DataStream<RowData> dataStream) {
-    DataStreamSink<CompactionCommitEvent> compactionCommitEventDataStream = dataStream.transform("compact_plan_generate",
+    SingleOutputStreamOperator<CompactionPlanEvent> compactionPlanStream = dataStream.transform("compact_plan_generate",
             TypeInformation.of(CompactionPlanEvent.class),
             new CompactionPlanOperator(conf))
         .setParallelism(1) // plan generate must be singleton
-        .setMaxParallelism(1)
+        .setMaxParallelism(1);
+    if (conf.getOptional(FlinkOptions.COMPACTION_PLAN_GENERATE_SLOT_SHARING_GROUP).isPresent()) {
+      String slotSharingGroup = conf.get(FlinkOptions.COMPACTION_PLAN_GENERATE_SLOT_SHARING_GROUP);
+      SlotSharingGroup.Builder slotSharingGroupBuilder = SlotSharingGroup.newBuilder(slotSharingGroup);
+      // Flink requires cpu cores and task heap memory to be configured together when specifying
+      // resources for a slot sharing group, reuse the TaskManager-level configuration for both.
+      Option<Double> cpuCores = Option.fromJavaOptional(conf.getOptional(TaskManagerOptions.CPU_CORES));
+      Option<MemorySize> taskHeapMemory = Option.fromJavaOptional(conf.getOptional(TaskManagerOptions.TASK_HEAP_MEMORY));
+      if (!taskHeapMemory.isPresent()) {
+        taskHeapMemory = deriveTaskHeapMemory(conf);
+      }
+      if (cpuCores.isPresent() && taskHeapMemory.isPresent()) {
+        slotSharingGroupBuilder.setCpuCores(cpuCores.get()).setTaskHeapMemory(taskHeapMemory.get());
+      }
+      // the slot sharing group must be registered with the environment before it can be referenced by name
+      dataStream.getExecutionEnvironment().registerSlotSharingGroup(slotSharingGroupBuilder.build());
+      compactionPlanStream = compactionPlanStream.slotSharingGroup(slotSharingGroup);
+    }
+    DataStreamSink<CompactionCommitEvent> compactionCommitEventDataStream = compactionPlanStream
         .partitionCustom(new IndexPartitioner(), CompactionPlanEvent::getIndex)
         .transform("compact_task",
             TypeInformation.of(CompactionCommitEvent.class),
@@ -736,6 +757,59 @@ public class Pipelines {
         .setParallelism(1); // compaction commit should be singleton
     compactionCommitEventDataStream.getTransformation().setMaxParallelism(1);
     return compactionCommitEventDataStream;
+  }
+
+  /**
+   * Derives the task heap memory to use for a dedicated slot sharing group from the TaskManager's
+   * other memory configs, following the same total-flink-memory/total-process-memory breakdown
+   * Flink itself uses, in case {@link TaskManagerOptions#TASK_HEAP_MEMORY} is not set explicitly.
+   *
+   * @param conf The configuration
+   * @return the derived task heap memory, or empty if it can not be derived from the given configs
+   */
+  static Option<MemorySize> deriveTaskHeapMemory(Configuration conf) {
+    try {
+      MemorySize totalFlinkMemory;
+      if (conf.getOptional(TaskManagerOptions.TOTAL_FLINK_MEMORY).isPresent()) {
+        totalFlinkMemory = conf.get(TaskManagerOptions.TOTAL_FLINK_MEMORY);
+      } else if (conf.getOptional(TaskManagerOptions.TOTAL_PROCESS_MEMORY).isPresent()) {
+        MemorySize totalProcessMemory = conf.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY);
+        MemorySize jvmMetaspace = conf.get(TaskManagerOptions.JVM_METASPACE);
+        MemorySize jvmOverhead = clampMemorySize(
+            totalProcessMemory.multiply(conf.get(TaskManagerOptions.JVM_OVERHEAD_FRACTION)),
+            conf.get(TaskManagerOptions.JVM_OVERHEAD_MIN),
+            conf.get(TaskManagerOptions.JVM_OVERHEAD_MAX));
+        totalFlinkMemory = totalProcessMemory.subtract(jvmMetaspace).subtract(jvmOverhead);
+      } else {
+        // no memory configs to derive from, let the caller fall back to a resource-less slot sharing group
+        return Option.empty();
+      }
+
+      MemorySize managedMemory = conf.getOptional(TaskManagerOptions.MANAGED_MEMORY_SIZE)
+          .orElseGet(() -> totalFlinkMemory.multiply(conf.get(TaskManagerOptions.MANAGED_MEMORY_FRACTION)));
+      MemorySize networkMemory = clampMemorySize(
+          totalFlinkMemory.multiply(conf.get(TaskManagerOptions.NETWORK_MEMORY_FRACTION)),
+          conf.get(TaskManagerOptions.NETWORK_MEMORY_MIN),
+          conf.get(TaskManagerOptions.NETWORK_MEMORY_MAX));
+      MemorySize taskHeapMemory = totalFlinkMemory
+          .subtract(conf.get(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY))
+          .subtract(conf.get(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY))
+          .subtract(conf.get(TaskManagerOptions.TASK_OFF_HEAP_MEMORY))
+          .subtract(managedMemory)
+          .subtract(networkMemory);
+      // Flink requires task heap memory to be configured with a positive value
+      return taskHeapMemory.getBytes() > 0 ? Option.of(taskHeapMemory) : Option.empty();
+    } catch (IllegalArgumentException | ArithmeticException e) {
+      // the other memory configs already consume the whole budget, fall back to a resource-less slot sharing group
+      return Option.empty();
+    }
+  }
+
+  static MemorySize clampMemorySize(MemorySize value, MemorySize min, MemorySize max) {
+    if (value.compareTo(min) < 0) {
+      return min;
+    }
+    return value.compareTo(max) > 0 ? max : value;
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestPipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestPipelines.java
@@ -31,6 +31,9 @@ import org.apache.hudi.utils.TestConfigurations;
 
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
@@ -396,6 +399,7 @@ public class TestPipelines {
     assertEquals("compact_commit", compaction.getTransformation().getName());
     assertEquals(1, compaction.getTransformation().getParallelism());
     assertEquals(1, compaction.getTransformation().getMaxParallelism());
+    assertTrue(findTransformation(compaction.getTransformation(), "compact_plan_generate").getSlotSharingGroup().isEmpty());
 
     DataStreamSink<?> clustering = Pipelines.cluster(conf, TestConfigurations.ROW_TYPE, input);
     assertEquals("clustering_commit", clustering.getTransformation().getName());
@@ -410,6 +414,61 @@ public class TestPipelines {
     DataStreamSink<?> dummy = Pipelines.dummySink(rowDataInput(5));
     assertEquals("dummy", dummy.getTransformation().getName());
     assertEquals(5, dummy.getTransformation().getParallelism());
+  }
+
+  @Test
+  void testCompactionPlanGenerateSlotSharingGroup() {
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.COMPACTION_TASKS, 4);
+    conf.set(FlinkOptions.COMPACTION_PLAN_GENERATE_SLOT_SHARING_GROUP, "compaction-plan-group");
+    conf.set(TaskManagerOptions.CPU_CORES, 2.0);
+    conf.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.ofMebiBytes(512));
+    DataStream<RowData> input = rowDataInput();
+
+    DataStreamSink<?> compaction = Pipelines.compact(conf, input);
+    assertEquals("compaction-plan-group",
+        findTransformation(compaction.getTransformation(), "compact_plan_generate")
+            .getSlotSharingGroup().get().getName());
+
+    ResourceProfile resource = input.getExecutionEnvironment().getStreamGraph(false)
+        .getSlotSharingGroupResource("compaction-plan-group")
+        .orElseThrow(() -> new AssertionError("Slot sharing group not registered"));
+    assertEquals(2.0, resource.getCpuCores().getValue().doubleValue());
+    assertEquals(MemorySize.ofMebiBytes(512), resource.getTaskHeapMemory());
+  }
+
+  @Test
+  void testCompactionPlanGenerateSlotSharingGroupDerivesTaskHeapMemoryFromProcessMemory() {
+    Configuration conf = defaultConf();
+    conf.set(FlinkOptions.COMPACTION_TASKS, 4);
+    conf.set(FlinkOptions.COMPACTION_PLAN_GENERATE_SLOT_SHARING_GROUP, "compaction-plan-group");
+    conf.set(TaskManagerOptions.CPU_CORES, 2.0);
+    conf.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("10240m"));
+    DataStream<RowData> input = rowDataInput();
+
+    MemorySize expectedTaskHeapMemory = Pipelines.deriveTaskHeapMemory(conf)
+        .orElseThrow(() -> new AssertionError("Task heap memory should be derivable from process memory"));
+    assertTrue(expectedTaskHeapMemory.getBytes() > 0);
+
+    DataStreamSink<?> compaction = Pipelines.compact(conf, input);
+    ResourceProfile resource = input.getExecutionEnvironment().getStreamGraph(false)
+        .getSlotSharingGroupResource("compaction-plan-group")
+        .orElseThrow(() -> new AssertionError("Slot sharing group not registered"));
+    assertEquals(expectedTaskHeapMemory, resource.getTaskHeapMemory());
+  }
+
+  @Test
+  void testDeriveTaskHeapMemoryEmptyWithoutMemoryConfigs() {
+    Configuration conf = defaultConf();
+    assertTrue(Pipelines.deriveTaskHeapMemory(conf).isEmpty());
+  }
+
+  @Test
+  void testDeriveTaskHeapMemoryEmptyWhenBudgetExhausted() {
+    Configuration conf = defaultConf();
+    // the default JVM metaspace (256m) alone already exceeds this tiny process memory budget
+    conf.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("10m"));
+    assertTrue(Pipelines.deriveTaskHeapMemory(conf).isEmpty());
   }
 
   @Test
@@ -460,6 +519,13 @@ public class TestPipelines {
     return stream.getTransformation().getTransitivePredecessors().stream()
         .map(Transformation::getName)
         .collect(Collectors.toList());
+  }
+
+  private Transformation<?> findTransformation(Transformation<?> root, String name) {
+    return root.getTransitivePredecessors().stream()
+        .filter(transformation -> transformation.getName().equals(name))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Transformation not found: " + name));
   }
 
   private long countCustomPartitions(DataStream<?> stream, Class<?> partitionerClass) throws Exception {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Support isolate slot group for compact plan generation

### Summary and Changelog

1. create isolated slot group for compaction plan generator operator with flink conf
2. create test cases to cover the changes

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
