### PR TITLE
test(spark): [DNM] shared-session mode for SQL suites

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -980,6 +980,7 @@ jobs:
           SPARK_MODULES: ${{ matrix.sparkModules }}
         run:
           mvn clean install -T 2 -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,hudi-common,$SPARK_COMMON_MODULES,$SPARK_MODULES"
+      # sharedSession: the dml packages hold only HoodieSparkSqlTestBase suites, which can share one SparkContext
       - name: Scala UT - Common & Spark
         if: needs.changes.outputs.relevant == 'true'
         env:
@@ -987,7 +988,7 @@ jobs:
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
           SPARK_MODULES: ${{ matrix.sparkModules }}
         run:
-          mvn test -Punit-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "hudi-common,$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+          mvn test -Punit-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "hudi-common,$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false -Dhudi.spark.test.sharedSession=true
       - name: Scala FT - Spark
         if: needs.changes.outputs.relevant == 'true'
         env:
@@ -995,7 +996,7 @@ jobs:
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
           SPARK_MODULES: ${{ matrix.sparkModules }}
         run:
-          mvn test -Pfunctional-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+          mvn test -Pfunctional-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false -Dhudi.spark.test.sharedSession=true
       - name: Generate merged coverage report
         if: always() && needs.changes.outputs.relevant == 'true'
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -39,7 +39,9 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.checkMessageContains
+import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.hudi.catalog.HoodieCatalog
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.{checkMessageContains, sharedSessionEnabled}
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.Utils
 import org.joda.time.DateTimeZone
@@ -58,7 +60,9 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   org.apache.log4j.Logger.getRootLogger.setLevel(org.apache.log4j.Level.WARN)
   private val LOG = LoggerFactory.getLogger(getClass)
 
-  private lazy val sparkWareHouse = {
+  private lazy val sparkWareHouse: File = if (sharedSessionEnabled) {
+    HoodieSparkSqlTestBase.sharedWarehouse
+  } else {
     val dir = Utils.createTempDir()
     Utils.deleteRecursively(dir)
     dir
@@ -71,23 +75,51 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   //       is consistent with the fixtures
   DateTimeZone.setDefault(DateTimeZone.UTC)
   TimeZone.setDefault(DateTimeUtils.getTimeZone("UTC"))
-  protected lazy val spark: SparkSession = SparkSession.builder()
-    .config("spark.sql.warehouse.dir", sparkWareHouse.getCanonicalPath)
-    .config("spark.sql.session.timeZone", "UTC")
-    .config("hoodie.insert.shuffle.parallelism", "4")
-    .config("hoodie.upsert.shuffle.parallelism", "4")
-    .config("hoodie.delete.shuffle.parallelism", "4")
-    .config(sparkConf())
-    .getOrCreate()
+  protected lazy val spark: SparkSession = if (sharedSessionEnabled) {
+    val session = HoodieSparkSqlTestBase.sharedBaseSession().newSession()
+    SparkSession.setActiveSession(session)
+    applySuiteConfToSharedSession(session)
+    session
+  } else {
+    HoodieSparkSqlTestBase.sessionBuilder(sparkWareHouse, sparkConf()).getOrCreate()
+  }
 
   private var tableId = new AtomicInteger(0)
 
   private var extraConf = Map[String, String]()
 
+  // Shared mode: spark.hadoop.* keys this suite set on the shared Hadoop conf, with the value they replaced.
+  private var hadoopConfOverrides: Seq[(String, String)] = Seq.empty
+
   def sparkConf(): SparkConf = {
     val conf = getSparkConfForTest("Hoodie SQL Test")
     conf.setAll(extraConf)
     conf
+  }
+
+  /**
+   * Shared mode: the context-level SparkConf is fixed, so the deltas a suite adds through extraConf or a
+   * sparkConf() override go to its session conf, except spark.hadoop.* keys, which the write client reads
+   * from sparkContext.hadoopConfiguration and which are restored in afterAll. Any other context-level key
+   * fails loudly in RuntimeConfig.set.
+   */
+  private def applySuiteConfToSharedSession(session: SparkSession): Unit = {
+    val defaults = getSparkConfForTest("Hoodie SQL Test").getAll.toMap
+    val hadoopConf = session.sparkContext.hadoopConfiguration
+    sparkConf().getAll.filterNot { case (k, v) => defaults.get(k).contains(v) }.foreach {
+      case (k, v) if k.startsWith("spark.hadoop.") =>
+        val key = k.stripPrefix("spark.hadoop.")
+        hadoopConfOverrides :+= (key -> hadoopConf.get(key))
+        hadoopConf.set(key, v)
+      case (k, v) => session.conf.set(k, v)
+    }
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    if (sharedSessionEnabled) {
+      SparkSession.setActiveSession(spark)
+    }
   }
 
   protected def initQueryIndexConf(): Unit = {
@@ -110,6 +142,9 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
     super.test(testName, testTags: _*)(
       try {
+        if (sharedSessionEnabled) {
+          bindSuiteSession()
+        }
         testFun
       } finally {
         // The INMEMORY index keeps a JVM-static record-location map; reset it after every test so
@@ -118,14 +153,47 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
         // it, so a throwing or non-withRecordType INMEMORY test would otherwise leak state here.
         // Runs before the catalog cleanup so it holds even if a drop throws.
         HoodieInMemoryHashIndex.clear()
-        val catalog = spark.sessionState.catalog
-        catalog.listDatabases().foreach { db =>
-          catalog.listTables(db).foreach { table =>
-            catalog.dropTable(table, true, true)
-          }
-        }
+        dropSuiteTables()
       }
     )
+  }
+
+  /**
+   * Shared mode: scalatest runs each suite on its own thread and Hudi reads SparkSession.active in a few
+   * places (HoodieCatalog captures it when the session's catalog is first built, BaseProcedure per CALL),
+   * so pin this suite's child session to the test thread and fail fast if the session's HoodieCatalog was
+   * built against another session.
+   */
+  private def bindSuiteSession(): Unit = {
+    SparkSession.setActiveSession(spark)
+    spark.sessionState.catalogManager.catalog(CatalogManager.SESSION_CATALOG_NAME) match {
+      case hoodieCatalog: HoodieCatalog =>
+        assert(hoodieCatalog.spark eq spark,
+          s"HoodieCatalog of ${getClass.getSimpleName} is bound to another SparkSession")
+      case _ =>
+    }
+  }
+
+  private lazy val tableNamePrefix: String = s"h${getClass.getSimpleName.toLowerCase}_"
+
+  /**
+   * Drops the tables a test left behind. Per-suite mode owns the whole catalog. Shared mode shares the
+   * external catalog with every other suite in the JVM, so it drops only this suite's generateTableName
+   * tables plus any table whose name is not of that form (fixed names and temp views); under serial
+   * execution those can only come from the test that just ran. Fixed names are renamed in a later step.
+   */
+  private def dropSuiteTables(): Unit = {
+    val catalog = spark.sessionState.catalog
+    catalog.listDatabases().foreach { db =>
+      catalog.listTables(db).filter(table => ownsTable(table.table)).foreach { table =>
+        catalog.dropTable(table, true, true)
+      }
+    }
+  }
+
+  private def ownsTable(name: String): Boolean = {
+    !sharedSessionEnabled || name.startsWith(tableNamePrefix) ||
+      !HoodieSparkSqlTestBase.GENERATED_TABLE_NAME.matcher(name).matches()
   }
 
   protected def generateTableName: String = {
@@ -133,8 +201,20 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   }
 
   override protected def afterAll(): Unit = {
-    Utils.deleteRecursively(sparkWareHouse)
-    spark.stop()
+    if (sharedSessionEnabled) {
+      // The context and warehouse outlive the suite; only undo this suite's Hadoop conf overrides.
+      if (hadoopConfOverrides.nonEmpty) {
+        val hadoopConf = spark.sparkContext.hadoopConfiguration
+        hadoopConfOverrides.reverse.foreach {
+          case (key, null) => hadoopConf.unset(key)
+          case (key, previous) => hadoopConf.set(key, previous)
+        }
+        hadoopConfOverrides = Seq.empty
+      }
+    } else {
+      Utils.deleteRecursively(sparkWareHouse)
+      spark.stop()
+    }
   }
 
   protected def checkAnswer(sql: String)(expects: Seq[Any]*): Unit = {
@@ -412,6 +492,53 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
 }
 
 object HoodieSparkSqlTestBase {
+
+  private val LOG = LoggerFactory.getLogger(classOf[HoodieSparkSqlTestBase])
+
+  /**
+   * System property forwarded by the scalatest plugin from the pom property of the same name
+   * (`-Dhudi.spark.test.sharedSession=true`). When set, every suite in the JVM shares one
+   * SparkContext and works in its own `newSession()` child; the context is never stopped by a suite.
+   * Default off: each suite builds and stops its own session, as before.
+   *
+   * Only for runs whose suites all extend HoodieSparkSqlTestBase: a suite that builds its own
+   * SparkContext (for example TestHoodieInternalRowUtils) fails with "Only one SparkContext
+   * should be running in this JVM" and aborts the run, so CI enables the property only on
+   * shards whose packages hold nothing else.
+   */
+  val SHARED_SESSION_PROPERTY = "hudi.spark.test.sharedSession"
+  val sharedSessionEnabled: Boolean = java.lang.Boolean.getBoolean(SHARED_SESSION_PROPERTY)
+
+  // Table names produced by generateTableName (without a database prefix).
+  private[common] val GENERATED_TABLE_NAME: Pattern = Pattern.compile("h[a-z0-9]+_[0-9]+")
+
+  private[common] lazy val sharedWarehouse: File = {
+    val dir = Utils.createTempDir()
+    Utils.deleteRecursively(dir)
+    dir
+  }
+
+  @volatile private var sharedBase: SparkSession = _
+
+  /** The JVM-wide base session; rebuilt if something stopped its context. Only its children are handed to suites. */
+  private[common] def sharedBaseSession(): SparkSession = synchronized {
+    if (sharedBase == null || sharedBase.sparkContext.isStopped) {
+      LOG.warn("Shared session mode on ({}=true): one SparkContext for this JVM, a child session per suite",
+        SHARED_SESSION_PROPERTY)
+      sharedBase = sessionBuilder(sharedWarehouse, getSparkConfForTest("Hoodie SQL Test")).getOrCreate()
+    }
+    sharedBase
+  }
+
+  private[common] def sessionBuilder(warehouse: File, conf: SparkConf): SparkSession.Builder = {
+    SparkSession.builder()
+      .config("spark.sql.warehouse.dir", warehouse.getCanonicalPath)
+      .config("spark.sql.session.timeZone", "UTC")
+      .config("hoodie.insert.shuffle.parallelism", "4")
+      .config("hoodie.upsert.shuffle.parallelism", "4")
+      .config("hoodie.delete.shuffle.parallelism", "4")
+      .config(conf)
+  }
 
   // the naming format of 0.x version
   final val NAME_FORMAT_0_X: Pattern = Pattern.compile("^(\\d+)(\\.\\w+)(\\.\\D+)?$")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -42,6 +42,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.hudi.catalog.HoodieCatalog
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.{checkMessageContains, sharedSessionEnabled}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.Utils
 import org.joda.time.DateTimeZone
@@ -101,22 +102,28 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
    * Shared mode: the context-level SparkConf is fixed, so the deltas a suite adds through extraConf or a
    * sparkConf() override go to its session conf (hoodie.* and spark.sql.* keys), except spark.hadoop.*
    * keys, which the write client reads from sparkContext.hadoopConfiguration and which are restored in
-   * afterAll. Any other spark.* key is a SparkContext setting that a child session cannot change, so it
-   * is rejected here rather than accepted into the session conf with no effect.
+   * afterAll. Any other spark.* key, and any static SQL conf, is a setting a child session cannot change,
+   * so it is rejected before anything is mutated: a partial apply would leave the shared Hadoop conf
+   * changed for every later suite in the JVM.
    */
   private def applySuiteConfToSharedSession(session: SparkSession): Unit = {
     val defaults = getSparkConfForTest("Hoodie SQL Test").getAll.toMap
-    val hadoopConf = session.sparkContext.hadoopConfiguration
-    sparkConf().getAll.filterNot { case (k, v) => defaults.get(k).contains(v) }.foreach {
-      case (k, v) if k.startsWith("spark.hadoop.") =>
-        val key = k.stripPrefix("spark.hadoop.")
-        hadoopConfOverrides :+= (key -> hadoopConf.get(key))
-        hadoopConf.set(key, v)
-      case (k, _) if k.startsWith("spark.") && !k.startsWith("spark.sql.") =>
-        throw new IllegalArgumentException(
-          s"$k is a SparkContext-level setting; shared session mode cannot apply it per suite")
-      case (k, v) => session.conf.set(k, v)
+    val deltas = sparkConf().getAll.filterNot { case (k, v) => defaults.get(k).contains(v) }
+    val (hadoopKeys, sessionKeys) = deltas.partition { case (k, _) => k.startsWith("spark.hadoop.") }
+    val rejected = sessionKeys.collect {
+      case (k, _) if (k.startsWith("spark.") && !k.startsWith("spark.sql.")) || SQLConf.isStaticConfigKey(k) => k
     }
+    if (rejected.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"${rejected.mkString(", ")}: SparkContext-level or static settings; shared session mode cannot apply them per suite")
+    }
+    val hadoopConf = session.sparkContext.hadoopConfiguration
+    hadoopKeys.foreach { case (k, v) =>
+      val key = k.stripPrefix("spark.hadoop.")
+      hadoopConfOverrides :+= (key -> hadoopConf.get(key))
+      hadoopConf.set(key, v)
+    }
+    sessionKeys.foreach { case (k, v) => session.conf.set(k, v) }
   }
 
   protected def initQueryIndexConf(): Unit = {
@@ -171,8 +178,6 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     }
   }
 
-  private lazy val tableNamePrefix: String = s"h${getClass.getSimpleName.toLowerCase}_"
-
   /**
    * Drops the tables a test left behind. Per-suite mode owns the whole catalog. Shared mode shares the
    * external catalog with every other suite in the JVM, so it drops only this suite's generateTableName
@@ -193,15 +198,17 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     name.startsWith(tableNamePrefix) || !HoodieSparkSqlTestBase.GENERATED_TABLE_NAME.matcher(name).matches()
   }
 
+  private lazy val tableNamePrefix: String = s"h${getClass.getSimpleName.toLowerCase}_"
+
   protected def generateTableName: String = {
-    s"h${getClass.getSimpleName.toLowerCase}_${tableId.incrementAndGet()}"
+    s"$tableNamePrefix${tableId.incrementAndGet()}"
   }
 
   override protected def afterAll(): Unit = {
     if (sharedSessionEnabled) {
       // The context and warehouse outlive the suite; only undo this suite's Hadoop conf overrides.
       if (hadoopConfOverrides.nonEmpty) {
-        val hadoopConf = spark.sparkContext.hadoopConfiguration
+        val hadoopConf = HoodieSparkSqlTestBase.sharedBaseSession().sparkContext.hadoopConfiguration
         hadoopConfOverrides.reverse.foreach {
           case (key, null) => hadoopConf.unset(key)
           case (key, previous) => hadoopConf.set(key, previous)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -99,9 +99,10 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
 
   /**
    * Shared mode: the context-level SparkConf is fixed, so the deltas a suite adds through extraConf or a
-   * sparkConf() override go to its session conf, except spark.hadoop.* keys, which the write client reads
-   * from sparkContext.hadoopConfiguration and which are restored in afterAll. Any other context-level key
-   * fails loudly in RuntimeConfig.set.
+   * sparkConf() override go to its session conf (hoodie.* and spark.sql.* keys), except spark.hadoop.*
+   * keys, which the write client reads from sparkContext.hadoopConfiguration and which are restored in
+   * afterAll. Any other spark.* key is a SparkContext setting that a child session cannot change, so it
+   * is rejected here rather than accepted into the session conf with no effect.
    */
   private def applySuiteConfToSharedSession(session: SparkSession): Unit = {
     val defaults = getSparkConfForTest("Hoodie SQL Test").getAll.toMap
@@ -111,14 +112,10 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
         val key = k.stripPrefix("spark.hadoop.")
         hadoopConfOverrides :+= (key -> hadoopConf.get(key))
         hadoopConf.set(key, v)
+      case (k, _) if k.startsWith("spark.") && !k.startsWith("spark.sql.") =>
+        throw new IllegalArgumentException(
+          s"$k is a SparkContext-level setting; shared session mode cannot apply it per suite")
       case (k, v) => session.conf.set(k, v)
-    }
-  }
-
-  override protected def beforeAll(): Unit = {
-    super.beforeAll()
-    if (sharedSessionEnabled) {
-      SparkSession.setActiveSession(spark)
     }
   }
 
@@ -185,15 +182,15 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   private def dropSuiteTables(): Unit = {
     val catalog = spark.sessionState.catalog
     catalog.listDatabases().foreach { db =>
-      catalog.listTables(db).filter(table => ownsTable(table.table)).foreach { table =>
-        catalog.dropTable(table, true, true)
-      }
+      val tables = catalog.listTables(db)
+      val toDrop = if (sharedSessionEnabled) tables.filter(table => ownsTable(table.table)) else tables
+      toDrop.foreach(table => catalog.dropTable(table, true, true))
     }
   }
 
+  /** Shared mode: a table is this suite's if generateTableName produced it, or if no suite's generateTableName could have. */
   private def ownsTable(name: String): Boolean = {
-    !sharedSessionEnabled || name.startsWith(tableNamePrefix) ||
-      !HoodieSparkSqlTestBase.GENERATED_TABLE_NAME.matcher(name).matches()
+    name.startsWith(tableNamePrefix) || !HoodieSparkSqlTestBase.GENERATED_TABLE_NAME.matcher(name).matches()
   }
 
   protected def generateTableName: String = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieDataUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieDataUtils.scala
@@ -44,13 +44,6 @@ class TestHoodieDataUtils extends HoodieSparkSqlTestBase {
     context = new HoodieSparkEngineContext(jsc)
   }
 
-  override def afterAll(): Unit = {
-    if (jsc != null) {
-      jsc.close()
-    }
-    super.afterAll()
-  }
-
   // Helper method to create a Pair from key and value
   private def pair(key: String, value: String): Pair[String, String] = {
     Pair.of(key, value)

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,8 @@
     <lance.spark.connector.version>0.4.0</lance.spark.connector.version>
     <lance.spark.artifact>lance-spark-3.5_${scala.binary.version}</lance.spark.artifact>
     <lance.skip.tests>false</lance.skip.tests>
+    <!-- Scala SQL suites: one shared SparkContext per JVM with a child session per suite (see HoodieSparkSqlTestBase) -->
+    <hudi.spark.test.sharedSession>false</hudi.spark.test.sharedSession>
     <vortex.version>0.76.0</vortex.version>
     <vortex.spark.artifact>vortex-spark_${scala.binary.version}</vortex.spark.artifact>
     <vortex.skip.tests>false</vortex.skip.tests>
@@ -607,6 +609,7 @@
               <log4j.configurationFile>${surefire-log4j.file}</log4j.configurationFile>
               <lance.skip.tests>${lance.skip.tests}</lance.skip.tests>
               <vortex.skip.tests>${vortex.skip.tests}</vortex.skip.tests>
+              <hudi.spark.test.sharedSession>${hudi.spark.test.sharedSession}</hudi.spark.test.sharedSession>
             </systemProperties>
           </configuration>
           <executions>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Part of #19524. The Java CI wall clock is now set by the Scala SQL shards (about 40 min). scalatest has no fork count, so the only in-job lever is running suites concurrently in one JVM, which needs one shared SparkContext. This is the first step: make that shared lifecycle exist behind a switch and gate it serially. Concurrency itself is a later PR.

### Summary and Changelog

- New pom property `hudi.spark.test.sharedSession` (default `false`), forwarded to the scalatest JVM. With it on, every suite on `HoodieSparkSqlTestBase` shares one never-stopped SparkContext and works in its own `SparkSession.newSession()` child: own SQL conf, temp views and HoodieCatalog; shared external catalog and warehouse.
- Per-suite conf deltas (`extraConf`, `sparkConf()` overrides) are applied to the child session; `spark.hadoop.*` keys go to the shared Hadoop conf and are restored in `afterAll`. Any other context-level key fails loudly.
- The per-test cleanup drops only the suite's own tables, since the catalog is shared.
- The child session is pinned as the active session on the suite thread, with a fail-fast check that the session's HoodieCatalog is bound to it.
- Switched on for `test-spark-java17-scala-dml-tests` only; those packages hold nothing but `HoodieSparkSqlTestBase` suites. `scala-other-tests` mixes in suites that create their own SparkContext and stays on the default.
- `TestHoodieDataUtils` no longer closes its JavaSparkContext in `afterAll` (it stopped the context).

With the property off, nothing changes: one session per suite, stopped in `afterAll`.

<details>
<summary>Why a switch, and what newSession() does and does not isolate</summary>

`HoodieSparkClientTestHarness` does `new SparkContext`, which throws while another context is live, so a never-stopped context cannot be the default while a JVM mixes both suite families (scala-other-tests, any full module run). The switch keeps the change to the shard being measured.

`newSession()` isolates SQL conf, temp views, UDFs and the per-session catalog plugin. It cannot isolate SparkConf entries, static SQL confs (warehouse dir, extensions) or SharedState (external catalog, global temp views, cache manager, listener bus). Hudi reads `SparkSession.active` in `HoodieCatalog` (captured at construction), `BaseProcedure` (per CALL), `HoodieInternalV2Table` and `SparkCatalogMetaStoreClient`, all on the calling thread; inside tasks `getActiveSession` is `None` and `SQLConf.get` reads task-local properties, unchanged. The write client reads `jsc.hadoopConfiguration()`, hence the Hadoop conf handling for `spark.hadoop.*`.
</details>

<details>
<summary>Local verification (Spark 3.5 / Scala 2.12 / JDK 11 unless noted)</summary>

Maven-free scalatest runs against the reactor-compiled worktree, plus one Maven run for the pom wiring.

| run | mode | result |
|---|---|---|
| 12 SQL-base suites of `org.apache.spark.sql.hudi.common` | shared | 49 tests, 0 failures, one base session (WARN line once) |
| TestClusteringBinaryCopyStrategy, TestShowCleansProcedures, TestCopyToTempViewProcedure, TestRepairsProcedure, TestCallProcedure, TestHelpProcedure, TestSparkCatalogSync, TestDropTable, TestInsertTable5 (sparkConf override, extraConf, newSession, global temp views, FileSystem close, procedures, catalog listing) | shared | 54 tests, 0 failures |
| whole `org.apache.spark.sql.hudi.common` package, including TestHoodieInternalRowUtils which builds its own SparkContext | default | 61 tests, 16 suites, 0 failures |
| `mvn test` of TestHoodieDataUtils with `-Dhudi.spark.test.sharedSession=true`, Spark 4.2 / Scala 2.13 / JDK 17, fresh reactor | shared | green; the WARN line appears in the Maven log, so the pom forwards the property |
| whole `org.apache.spark.sql.hudi.common` package with the flag on | shared | aborts at TestHoodieInternalRowUtils with "Only one SparkContext should be running in this JVM": the documented reason the flag is limited to SQL-only shards |

The full dml packages run on CI in shared mode through the wired shard; that run is the phase gate.
</details>

### Impact

Test infrastructure only. No production code changes.

### Risk Level

low. Default behaviour is unchanged; the shared mode runs on one CI shard and is verified locally on the packages listed above.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
