### PR TITLE
fix(client): keep sibling compaction ops when unscheduling fileId

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
@@ -147,7 +147,7 @@ public class CompactionAdminClient extends BaseHoodieClient {
       HoodieCompactionPlan plan =
           CompactionUtils.getCompactionPlan(metaClient, compactionOperationWithInstant.getKey());
       List<HoodieCompactionOperation> newOps = plan.getOperations().stream().filter(op ->
-              (!op.getFileId().equals(fgId.getFileId())) && (!op.getPartitionPath().equals(fgId.getPartitionPath())))
+              !(op.getFileId().equals(fgId.getFileId()) && op.getPartitionPath().equals(fgId.getPartitionPath())))
           .collect(Collectors.toList());
       if (newOps.size() == plan.getOperations().size()) {
         return new ArrayList<>();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCompactionAdminClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCompactionAdminClient.java
@@ -18,8 +18,11 @@
 
 package org.apache.hudi.client;
 
+import org.apache.hudi.avro.model.HoodieCompactionOperation;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.client.CompactionAdminClient.ValidationOpResult;
 import org.apache.hudi.common.model.CompactionOperation;
+import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -81,6 +84,35 @@ public class TestCompactionAdminClient extends HoodieClientTestBase {
     validateUnSchedulePlan(client, "004", "005", numEntriesPerInstant);
     // There are no delta-commits after compaction instant
     validateUnSchedulePlan(client, "006", "007", numEntriesPerInstant);
+  }
+
+  @Test
+  public void testUnscheduleCompactionFileIdKeepsSiblingOpsInSamePartition() throws Exception {
+    int numOpsInPlan = 3;
+    CompactionTestUtils.setupAndValidateCompactionOperations(metaClient, false, numOpsInPlan,
+        0, 0, 0);
+    String compactionInstant = "001";
+    HoodieCompactionPlan planBefore = CompactionUtils.getCompactionPlan(metaClient, compactionInstant);
+    assertEquals(numOpsInPlan, planBefore.getOperations().size());
+
+    HoodieCompactionOperation targetOp = planBefore.getOperations().get(0);
+    Set<String> siblingFileIds = planBefore.getOperations().stream()
+        .skip(1)
+        .map(HoodieCompactionOperation::getFileId)
+        .collect(Collectors.toSet());
+
+    client.unscheduleCompactionFileId(
+        new HoodieFileGroupId(targetOp.getPartitionPath(), targetOp.getFileId()), false, false);
+
+    metaClient = HoodieTestUtils.createMetaClient(metaClient.getStorageConf(), basePath);
+    HoodieCompactionPlan planAfter = CompactionUtils.getCompactionPlan(metaClient, compactionInstant);
+    assertEquals(numOpsInPlan - 1, planAfter.getOperations().size(),
+        "Only the target file group should be removed from the plan");
+    Set<String> remainingFileIds = planAfter.getOperations().stream()
+        .map(HoodieCompactionOperation::getFileId)
+        .collect(Collectors.toSet());
+    assertEquals(siblingFileIds, remainingFileIds,
+        "Sibling operations in the same partition must remain scheduled");
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`CompactionAdminClient.unscheduleCompactionFileId` used an AND filter that dropped every pending operation in the same partition except the target file group logic was inverted — sibling file groups were removed from the rewritten compaction plan.

Closes #19881

### Summary and Changelog

- Fix the stream filter to remove only the operation matching both the target `fileId` and `partitionPath` (`!(sameFile && samePart)` instead of `(!sameFile) && (!samePart)`).
- Add `testUnscheduleCompactionFileIdKeepsSiblingOpsInSamePartition` in `TestCompactionAdminClient` with three operations in one partition; after unscheduling one file group, the plan must still contain the other two.

### Impact

Behavior change for `unscheduleCompactionFileId` / `compaction unscheduleFileId`: sibling operations in the same partition remain in the pending plan. No API or config changes.

### Risk Level

low — one-line boolean fix in admin tooling; regression test covers the reported scenario.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

### Test plan

- [ ] `mvn test -pl hudi-client/hudi-spark-client -Dtest=TestCompactionAdminClient#testUnscheduleCompactionFileIdKeepsSiblingOpsInSamePartition`
- [ ] `mvn test -pl hudi-client/hudi-spark-client -Dtest=TestCompactionAdminClient`