### PR TITLE
test(spark): [DNM] run SQL suites two at a time on the DML shard

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -980,6 +980,7 @@ jobs:
           SPARK_MODULES: ${{ matrix.sparkModules }}
         run:
           mvn clean install -T 2 -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,hudi-common,$SPARK_COMMON_MODULES,$SPARK_MODULES"
+      # sharedSession: the dml packages hold only HoodieSparkSqlTestBase suites, which can share one SparkContext
       - name: Scala UT - Common & Spark
         if: needs.changes.outputs.relevant == 'true'
         env:
@@ -987,7 +988,7 @@ jobs:
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
           SPARK_MODULES: ${{ matrix.sparkModules }}
         run:
-          mvn test -Punit-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "hudi-common,$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+          mvn test -Punit-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "hudi-common,$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false -Dhudi.spark.test.sharedSession=true
       - name: Scala FT - Spark
         if: needs.changes.outputs.relevant == 'true'
         env:
@@ -995,7 +996,7 @@ jobs:
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
           SPARK_MODULES: ${{ matrix.sparkModules }}
         run:
-          mvn test -Pfunctional-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false
+          mvn test -Pfunctional-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false -Dhudi.spark.test.sharedSession=true
       - name: Generate merged coverage report
         if: always() && needs.changes.outputs.relevant == 'true'
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -980,7 +980,7 @@ jobs:
           SPARK_MODULES: ${{ matrix.sparkModules }}
         run:
           mvn clean install -T 2 -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -DskipTests=true $MVN_ARGS -am -pl "hudi-examples/hudi-examples-spark,hudi-common,$SPARK_COMMON_MODULES,$SPARK_MODULES"
-      # sharedSession: the dml packages hold only HoodieSparkSqlTestBase suites, which can share one SparkContext
+      # sharedSession + parallel: the dml packages hold only HoodieSparkSqlTestBase suites, which share one SparkContext and run two at a time
       - name: Scala UT - Common & Spark
         if: needs.changes.outputs.relevant == 'true'
         env:
@@ -988,7 +988,7 @@ jobs:
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
           SPARK_MODULES: ${{ matrix.sparkModules }}
         run:
-          mvn test -Punit-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "hudi-common,$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false -Dhudi.spark.test.sharedSession=true
+          mvn test -Punit-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "hudi-common,$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false -Dhudi.spark.test.sharedSession=true -Dhudi.scalatest.parallel=true -Dhudi.scalatest.threads=2
       - name: Scala FT - Spark
         if: needs.changes.outputs.relevant == 'true'
         env:
@@ -996,7 +996,7 @@ jobs:
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
           SPARK_MODULES: ${{ matrix.sparkModules }}
         run:
-          mvn test -Pfunctional-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false -Dhudi.spark.test.sharedSession=true
+          mvn test -Pfunctional-tests -Pjava17 -D"$SCALA_PROFILE" -D"$SPARK_PROFILE" -Dtest=skipJavaTests $SCALA_TEST_DML_FILTER -Dsurefire.failIfNoSpecifiedTests=false -pl "$SPARK_COMMON_MODULES,$SPARK_MODULES" $MVN_ARGS -Djacoco.skip=false -Dhudi.spark.test.sharedSession=true -Dhudi.scalatest.parallel=true -Dhudi.scalatest.threads=2
       - name: Generate merged coverage report
         if: always() && needs.changes.outputs.relevant == 'true'
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieInMemoryHashIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieInMemoryHashIndex.java
@@ -42,7 +42,10 @@ import java.util.concurrent.ConcurrentMap;
  * Hoodie Index implementation backed by an in-memory Hash map.
  * <p>
  * Record locations are kept per table (keyed by base path) so that tables written in the same JVM
- * do not see each other's keys.
+ * do not see each other's keys. The commit-time check in tagLocation only rejects locations whose
+ * instant is missing from the current timeline; an entry left by an earlier table at the same base
+ * path is accepted, so a caller that re-creates a table at a path it used before must call
+ * clear(basePath) first.
  * <p>
  * ONLY USE FOR LOCAL TESTING
  */

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieInMemoryHashIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieInMemoryHashIndex.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
 
 import java.util.ArrayList;
@@ -40,32 +41,40 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Hoodie Index implementation backed by an in-memory Hash map.
  * <p>
+ * Record locations are kept per table (keyed by base path) so that tables written in the same JVM
+ * do not see each other's keys.
+ * <p>
  * ONLY USE FOR LOCAL TESTING
  */
 public class HoodieInMemoryHashIndex
     extends HoodieIndex<Object, Object> {
 
-  private static ConcurrentMap<HoodieKey, HoodieRecordLocation> recordLocationMap;
+  private static final ConcurrentMap<String, ConcurrentMap<HoodieKey, HoodieRecordLocation>> RECORD_LOCATIONS_PER_TABLE =
+      new ConcurrentHashMap<>();
 
   public HoodieInMemoryHashIndex(HoodieWriteConfig config) {
     super(config);
-    synchronized (HoodieInMemoryHashIndex.class) {
-      if (recordLocationMap == null) {
-        recordLocationMap = new ConcurrentHashMap<>();
-      }
-    }
+  }
+
+  private static String tableKey(StoragePath basePath) {
+    return basePath.toUri().getPath();
+  }
+
+  private static ConcurrentMap<HoodieKey, HoodieRecordLocation> locationsOf(String tableKey) {
+    return RECORD_LOCATIONS_PER_TABLE.computeIfAbsent(tableKey, k -> new ConcurrentHashMap<>());
   }
 
   @Override
   public <R> HoodieData<HoodieRecord<R>> tagLocation(
       HoodieData<HoodieRecord<R>> records, HoodieEngineContext context,
       HoodieTable hoodieTable) {
+    String key = tableKey(hoodieTable.getMetaClient().getBasePath());
     return records.mapPartitions(hoodieRecordIterator -> {
       List<HoodieRecord<R>> taggedRecords = new ArrayList<>();
       HoodieTimeline commitsTimeline = hoodieTable.getMetaClient().getCommitsTimeline().filterCompletedInstants();
       while (hoodieRecordIterator.hasNext()) {
         HoodieRecord<R> record = hoodieRecordIterator.next();
-        HoodieRecordLocation location = recordLocationMap.get(record.getKey());
+        HoodieRecordLocation location = locationsOf(key).get(record.getKey());
         if ((location != null) && HoodieIndexUtils.checkIfValidCommit(commitsTimeline, location.getInstantTime())) {
           record.unseal();
           record.setCurrentLocation(location);
@@ -81,15 +90,16 @@ public class HoodieInMemoryHashIndex
   public HoodieData<WriteStatus> updateLocation(
       HoodieData<WriteStatus> writeStatuses, HoodieEngineContext context,
       HoodieTable hoodieTable) {
+    String key = tableKey(hoodieTable.getMetaClient().getBasePath());
     return writeStatuses.map(writeStatus -> {
       for (HoodieRecordDelegate recordDelegate : writeStatus.getIndexStats().getWrittenRecordDelegates()) {
         if (!writeStatus.isErrored(recordDelegate.getHoodieKey())) {
           Option<HoodieRecordLocation> newLocation = recordDelegate.getNewLocation();
           if (newLocation.isPresent()) {
-            recordLocationMap.put(recordDelegate.getHoodieKey(), newLocation.get());
+            locationsOf(key).put(recordDelegate.getHoodieKey(), newLocation.get());
           } else {
             // Delete existing index for a deleted record
-            recordLocationMap.remove(recordDelegate.getHoodieKey());
+            locationsOf(key).remove(recordDelegate.getHoodieKey());
           }
         }
       }
@@ -126,10 +136,19 @@ public class HoodieInMemoryHashIndex
     return false;
   }
 
+  /**
+   * Clears the locations of every table in this JVM.
+   */
   @VisibleForTesting
   public static void clear() {
-    if (recordLocationMap != null) {
-      recordLocationMap.clear();
-    }
+    RECORD_LOCATIONS_PER_TABLE.clear();
+  }
+
+  /**
+   * Clears the locations of a single table.
+   */
+  @VisibleForTesting
+  public static void clear(String basePath) {
+    RECORD_LOCATIONS_PER_TABLE.remove(tableKey(new StoragePath(basePath)));
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithTimestampKeyGenerator.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithTimestampKeyGenerator.scala
@@ -90,15 +90,16 @@ class TestSparkSqlWithTimestampKeyGenerator extends HoodieSparkSqlTestBase {
     withTempDir { tmp =>
       val keyGeneratorSettings = timestampKeyGeneratorSettings(3)
       val tsType = if (keyGeneratorSettings.contains("DATE_STRING")) "string" else "long"
+      val tableName = generateTableName
       spark.sql(
         s"""
-           | CREATE TABLE test_default_path_ts (
+           | CREATE TABLE $tableName (
            |   id int,
            |   name string,
            |   precomb long,
            |   ts TIMESTAMP
            | ) USING HUDI
-           | LOCATION '${tmp.getCanonicalPath + "/test_default_path_ts"}'
+           | LOCATION '${tmp.getCanonicalPath + "/" + tableName}'
            | PARTITIONED BY (ts)
            | TBLPROPERTIES (
            |   type = 'COPY_ON_WRITE',
@@ -111,11 +112,11 @@ class TestSparkSqlWithTimestampKeyGenerator extends HoodieSparkSqlTestBase {
         "(2, 'a3', 1, null)"
       )
       val expectedQueryResult: String = "[1,a1,1,2025-01-15 01:02:03.0]; [2,a3,1,null]"
-      spark.sql(s"INSERT INTO test_default_path_ts VALUES ${dataBatches(0)}")
+      spark.sql(s"INSERT INTO $tableName VALUES ${dataBatches(0)}")
       // inserting value with partition_timestamp value as null
-      spark.sql(s"INSERT INTO test_default_path_ts VALUES ${dataBatches(1)}")
+      spark.sql(s"INSERT INTO $tableName VALUES ${dataBatches(1)}")
 
-      val queryResult = spark.sql(s"SELECT id, name, precomb, ts FROM test_default_path_ts ORDER BY id").collect().mkString("; ")
+      val queryResult = spark.sql(s"SELECT id, name, precomb, ts FROM $tableName ORDER BY id").collect().mkString("; ")
       LOG.warn(s"Query result: $queryResult")
       assertResult(expectedQueryResult)(queryResult)
 
@@ -124,15 +125,16 @@ class TestSparkSqlWithTimestampKeyGenerator extends HoodieSparkSqlTestBase {
 
   test("Test mandatory partitioning for timestamp key generator") {
     withTempDir { tmp =>
+      val tableName = generateTableName
       spark.sql(
         s"""
-           | CREATE TABLE should_fail (
+           | CREATE TABLE $tableName (
            |   id int,
            |   name string,
            |   precomb long,
            |   ts long
            | ) USING HUDI
-           | LOCATION '${tmp.getCanonicalPath + "/should_fail"}'
+           | LOCATION '${tmp.getCanonicalPath + "/" + tableName}'
            | TBLPROPERTIES (
            |   type = 'COPY_ON_WRITE',
            |   primaryKey = 'id',
@@ -143,7 +145,7 @@ class TestSparkSqlWithTimestampKeyGenerator extends HoodieSparkSqlTestBase {
            |""".stripMargin)
       // should fail due to absent partitioning
       assertThrows[HoodieException] {
-        spark.sql(s"INSERT INTO should_fail VALUES ${dataBatchesWithLongOfSeconds(0)}")
+        spark.sql(s"INSERT INTO $tableName VALUES ${dataBatchesWithLongOfSeconds(0)}")
       }
 
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/TestHoodieCommandMetrics.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/command/TestHoodieCommandMetrics.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.hudi.command
 
 import org.apache.hudi.common.model.HoodieCommitMetadata
 
-import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.common.{ExclusiveSuite, HoodieSparkSqlTestBase}
 import org.mockito.Mockito.{mock, when}
 
-class TestHoodieCommandMetrics extends HoodieSparkSqlTestBase {
+class TestHoodieCommandMetrics extends HoodieSparkSqlTestBase with ExclusiveSuite {
 
   override def beforeAll(): Unit = {
     spark.sparkContext

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExclusiveSuite.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExclusiveSuite.scala
@@ -23,8 +23,9 @@ import org.scalatest.{Args, Status}
  * Marks a suite that must not run at the same time as any other suite in the JVM because it
  * mutates JVM-wide state (the shared Hadoop conf, persisted RDDs of the shared context, a
  * static metrics registry). Takes the write side of [[HoodieSparkSqlTestBase.suiteLock]] for
- * its whole run; every other suite holds the read side while a test runs. No effect until
- * suites run concurrently.
+ * its whole run; every other suite holds the read side for its whole run. An exclusive suite
+ * therefore waits for the suites already running to finish, not just for their current test. No
+ * effect until suites run concurrently.
  */
 trait ExclusiveSuite extends HoodieSparkSqlTestBase {
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExclusiveSuite.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExclusiveSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.common
+
+import org.scalatest.{Args, Status}
+
+/**
+ * Marks a suite that must not run at the same time as any other suite in the JVM because it
+ * mutates JVM-wide state (the shared Hadoop conf, persisted RDDs of the shared context, a
+ * static metrics registry). Takes the write side of [[HoodieSparkSqlTestBase.suiteLock]] for
+ * its whole run; every other suite holds the read side while a test runs. No effect until
+ * suites run concurrently.
+ */
+trait ExclusiveSuite extends HoodieSparkSqlTestBase {
+
+  abstract override def run(testName: Option[String], args: Args): Status = {
+    val lock = HoodieSparkSqlTestBase.suiteLock.writeLock()
+    lock.lock()
+    try {
+      super.run(testName, args)
+    } finally {
+      lock.unlock()
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -39,7 +39,9 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.checkMessageContains
+import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.hudi.catalog.HoodieCatalog
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.{checkMessageContains, sharedSessionEnabled}
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.Utils
 import org.joda.time.DateTimeZone
@@ -58,7 +60,9 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   org.apache.log4j.Logger.getRootLogger.setLevel(org.apache.log4j.Level.WARN)
   private val LOG = LoggerFactory.getLogger(getClass)
 
-  private lazy val sparkWareHouse = {
+  private lazy val sparkWareHouse: File = if (sharedSessionEnabled) {
+    HoodieSparkSqlTestBase.sharedWarehouse
+  } else {
     val dir = Utils.createTempDir()
     Utils.deleteRecursively(dir)
     dir
@@ -71,23 +75,51 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   //       is consistent with the fixtures
   DateTimeZone.setDefault(DateTimeZone.UTC)
   TimeZone.setDefault(DateTimeUtils.getTimeZone("UTC"))
-  protected lazy val spark: SparkSession = SparkSession.builder()
-    .config("spark.sql.warehouse.dir", sparkWareHouse.getCanonicalPath)
-    .config("spark.sql.session.timeZone", "UTC")
-    .config("hoodie.insert.shuffle.parallelism", "4")
-    .config("hoodie.upsert.shuffle.parallelism", "4")
-    .config("hoodie.delete.shuffle.parallelism", "4")
-    .config(sparkConf())
-    .getOrCreate()
+  protected lazy val spark: SparkSession = if (sharedSessionEnabled) {
+    val session = HoodieSparkSqlTestBase.sharedBaseSession().newSession()
+    SparkSession.setActiveSession(session)
+    applySuiteConfToSharedSession(session)
+    session
+  } else {
+    HoodieSparkSqlTestBase.sessionBuilder(sparkWareHouse, sparkConf()).getOrCreate()
+  }
 
   private var tableId = new AtomicInteger(0)
 
   private var extraConf = Map[String, String]()
 
+  // Shared mode: spark.hadoop.* keys this suite set on the shared Hadoop conf, with the value they replaced.
+  private var hadoopConfOverrides: Seq[(String, String)] = Seq.empty
+
   def sparkConf(): SparkConf = {
     val conf = getSparkConfForTest("Hoodie SQL Test")
     conf.setAll(extraConf)
     conf
+  }
+
+  /**
+   * Shared mode: the context-level SparkConf is fixed, so the deltas a suite adds through extraConf or a
+   * sparkConf() override go to its session conf, except spark.hadoop.* keys, which the write client reads
+   * from sparkContext.hadoopConfiguration and which are restored in afterAll. Any other context-level key
+   * fails loudly in RuntimeConfig.set.
+   */
+  private def applySuiteConfToSharedSession(session: SparkSession): Unit = {
+    val defaults = getSparkConfForTest("Hoodie SQL Test").getAll.toMap
+    val hadoopConf = session.sparkContext.hadoopConfiguration
+    sparkConf().getAll.filterNot { case (k, v) => defaults.get(k).contains(v) }.foreach {
+      case (k, v) if k.startsWith("spark.hadoop.") =>
+        val key = k.stripPrefix("spark.hadoop.")
+        hadoopConfOverrides :+= (key -> hadoopConf.get(key))
+        hadoopConf.set(key, v)
+      case (k, v) => session.conf.set(k, v)
+    }
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    if (sharedSessionEnabled) {
+      SparkSession.setActiveSession(spark)
+    }
   }
 
   protected def initQueryIndexConf(): Unit = {
@@ -110,6 +142,9 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
     super.test(testName, testTags: _*)(
       try {
+        if (sharedSessionEnabled) {
+          bindSuiteSession()
+        }
         testFun
       } finally {
         // The INMEMORY index keeps a JVM-static record-location map; reset it after every test so
@@ -118,14 +153,47 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
         // it, so a throwing or non-withRecordType INMEMORY test would otherwise leak state here.
         // Runs before the catalog cleanup so it holds even if a drop throws.
         HoodieInMemoryHashIndex.clear()
-        val catalog = spark.sessionState.catalog
-        catalog.listDatabases().foreach { db =>
-          catalog.listTables(db).foreach { table =>
-            catalog.dropTable(table, true, true)
-          }
-        }
+        dropSuiteTables()
       }
     )
+  }
+
+  /**
+   * Shared mode: scalatest runs each suite on its own thread and Hudi reads SparkSession.active in a few
+   * places (HoodieCatalog captures it when the session's catalog is first built, BaseProcedure per CALL),
+   * so pin this suite's child session to the test thread and fail fast if the session's HoodieCatalog was
+   * built against another session.
+   */
+  private def bindSuiteSession(): Unit = {
+    SparkSession.setActiveSession(spark)
+    spark.sessionState.catalogManager.catalog(CatalogManager.SESSION_CATALOG_NAME) match {
+      case hoodieCatalog: HoodieCatalog =>
+        assert(hoodieCatalog.spark eq spark,
+          s"HoodieCatalog of ${getClass.getSimpleName} is bound to another SparkSession")
+      case _ =>
+    }
+  }
+
+  private lazy val tableNamePrefix: String = s"h${getClass.getSimpleName.toLowerCase}_"
+
+  /**
+   * Drops the tables a test left behind. Per-suite mode owns the whole catalog. Shared mode shares the
+   * external catalog with every other suite in the JVM, so it drops only this suite's generateTableName
+   * tables plus any table whose name is not of that form (fixed names and temp views); under serial
+   * execution those can only come from the test that just ran. Fixed names are renamed in a later step.
+   */
+  private def dropSuiteTables(): Unit = {
+    val catalog = spark.sessionState.catalog
+    catalog.listDatabases().foreach { db =>
+      catalog.listTables(db).filter(table => ownsTable(table.table)).foreach { table =>
+        catalog.dropTable(table, true, true)
+      }
+    }
+  }
+
+  private def ownsTable(name: String): Boolean = {
+    !sharedSessionEnabled || name.startsWith(tableNamePrefix) ||
+      !HoodieSparkSqlTestBase.GENERATED_TABLE_NAME.matcher(name).matches()
   }
 
   protected def generateTableName: String = {
@@ -133,8 +201,20 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   }
 
   override protected def afterAll(): Unit = {
-    Utils.deleteRecursively(sparkWareHouse)
-    spark.stop()
+    if (sharedSessionEnabled) {
+      // The context and warehouse outlive the suite; only undo this suite's Hadoop conf overrides.
+      if (hadoopConfOverrides.nonEmpty) {
+        val hadoopConf = spark.sparkContext.hadoopConfiguration
+        hadoopConfOverrides.reverse.foreach {
+          case (key, null) => hadoopConf.unset(key)
+          case (key, previous) => hadoopConf.set(key, previous)
+        }
+        hadoopConfOverrides = Seq.empty
+      }
+    } else {
+      Utils.deleteRecursively(sparkWareHouse)
+      spark.stop()
+    }
   }
 
   protected def checkAnswer(sql: String)(expects: Seq[Any]*): Unit = {
@@ -412,6 +492,53 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
 }
 
 object HoodieSparkSqlTestBase {
+
+  private val LOG = LoggerFactory.getLogger(classOf[HoodieSparkSqlTestBase])
+
+  /**
+   * System property forwarded by the scalatest plugin from the pom property of the same name
+   * (`-Dhudi.spark.test.sharedSession=true`). When set, every suite in the JVM shares one
+   * SparkContext and works in its own `newSession()` child; the context is never stopped by a suite.
+   * Default off: each suite builds and stops its own session, as before.
+   *
+   * Only for runs whose suites all extend HoodieSparkSqlTestBase: a suite that builds its own
+   * SparkContext (for example TestHoodieInternalRowUtils) fails with "Only one SparkContext
+   * should be running in this JVM" and aborts the run, so CI enables the property only on
+   * shards whose packages hold nothing else.
+   */
+  val SHARED_SESSION_PROPERTY = "hudi.spark.test.sharedSession"
+  val sharedSessionEnabled: Boolean = java.lang.Boolean.getBoolean(SHARED_SESSION_PROPERTY)
+
+  // Table names produced by generateTableName (without a database prefix).
+  private[common] val GENERATED_TABLE_NAME: Pattern = Pattern.compile("h[a-z0-9]+_[0-9]+")
+
+  private[common] lazy val sharedWarehouse: File = {
+    val dir = Utils.createTempDir()
+    Utils.deleteRecursively(dir)
+    dir
+  }
+
+  @volatile private var sharedBase: SparkSession = _
+
+  /** The JVM-wide base session; rebuilt if something stopped its context. Only its children are handed to suites. */
+  private[common] def sharedBaseSession(): SparkSession = synchronized {
+    if (sharedBase == null || sharedBase.sparkContext.isStopped) {
+      LOG.warn("Shared session mode on ({}=true): one SparkContext for this JVM, a child session per suite",
+        SHARED_SESSION_PROPERTY)
+      sharedBase = sessionBuilder(sharedWarehouse, getSparkConfForTest("Hoodie SQL Test")).getOrCreate()
+    }
+    sharedBase
+  }
+
+  private[common] def sessionBuilder(warehouse: File, conf: SparkConf): SparkSession.Builder = {
+    SparkSession.builder()
+      .config("spark.sql.warehouse.dir", warehouse.getCanonicalPath)
+      .config("spark.sql.session.timeZone", "UTC")
+      .config("hoodie.insert.shuffle.parallelism", "4")
+      .config("hoodie.upsert.shuffle.parallelism", "4")
+      .config("hoodie.delete.shuffle.parallelism", "4")
+      .config(conf)
+  }
 
   // the naming format of 0.x version
   final val NAME_FORMAT_0_X: Pattern = Pattern.compile("^(\\d+)(\\.\\w+)(\\.\\D+)?$")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -54,7 +54,10 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.util.{Collections, Optional, TimeZone}
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.regex.Pattern
+
+import scala.util.Try
 
 class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   org.apache.log4j.Logger.getRootLogger.setLevel(org.apache.log4j.Level.WARN)
@@ -137,22 +140,41 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   }
 
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
-    super.test(testName, testTags: _*)(
+    super.test(testName, testTags: _*)({
+      // Held for the whole test, cleanup included, so an ExclusiveSuite never overlaps it.
+      val readLock = HoodieSparkSqlTestBase.suiteLock.readLock()
+      readLock.lock()
       try {
-        if (sharedSessionEnabled) {
-          bindSuiteSession()
+        try {
+          if (sharedSessionEnabled) {
+            bindSuiteSession()
+          }
+          testFun
+        } finally {
+          // The INMEMORY index keeps a JVM-static record-location map; reset it after every test so
+          // stale keys from an earlier test cannot misroute writes in a later one. withRecordType
+          // clears it between record-type iterations, but only on success and only for tests that use
+          // it, so a throwing or non-withRecordType INMEMORY test would otherwise leak state here.
+          // Runs before the catalog cleanup so it holds even if a drop throws. In shared mode this is
+          // a no-op, see clearInMemoryIndex.
+          clearInMemoryIndex()
+          dropSuiteTables()
         }
-        testFun
       } finally {
-        // The INMEMORY index keeps a JVM-static record-location map; reset it after every test so
-        // stale keys from an earlier test cannot misroute writes in a later one. withRecordType
-        // clears it between record-type iterations, but only on success and only for tests that use
-        // it, so a throwing or non-withRecordType INMEMORY test would otherwise leak state here.
-        // Runs before the catalog cleanup so it holds even if a drop throws.
-        HoodieInMemoryHashIndex.clear()
-        dropSuiteTables()
+        readLock.unlock()
       }
-    )
+    })
+  }
+
+  /**
+   * Per-suite mode: reset the JVM-static INMEMORY index between tests (see the note in test()).
+   * Shared mode: the index is keyed per table and dropSuiteTables clears each dropped table's
+   * entry, so a global clear would only wipe other suites' tables.
+   */
+  protected def clearInMemoryIndex(): Unit = {
+    if (!sharedSessionEnabled) {
+      HoodieInMemoryHashIndex.clear()
+    }
   }
 
   /**
@@ -184,7 +206,14 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     catalog.listDatabases().foreach { db =>
       val tables = catalog.listTables(db)
       val toDrop = if (sharedSessionEnabled) tables.filter(table => ownsTable(table.table)) else tables
-      toDrop.foreach(table => catalog.dropTable(table, true, true))
+      toDrop.foreach { table =>
+        if (sharedSessionEnabled && !catalog.isTempView(table)) {
+          // Shared mode keeps one index map per table; drop this table's entry with the table.
+          Try(catalog.getTableMetadata(table).location.getPath)
+            .foreach(path => HoodieInMemoryHashIndex.clear(path))
+        }
+        catalog.dropTable(table, true, true)
+      }
     }
   }
 
@@ -431,6 +460,14 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     try {
       f(tableName)
     } finally {
+      if (sharedSessionEnabled) {
+        val catalog = spark.sessionState.catalog
+        val ident = spark.sessionState.sqlParser.parseTableIdentifier(tableName)
+        if (catalog.tableExists(ident) && !catalog.isTempView(ident)) {
+          Try(catalog.getTableMetadata(ident).location.getPath)
+            .foreach(path => HoodieInMemoryHashIndex.clear(path))
+        }
+      }
       spark.sql(s"drop table if exists $tableName purge")
     }
   }
@@ -470,7 +507,7 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
       withSQLConf(config.toList: _*) {
         f
         // We need to clear indexed location in memory after each test.
-        HoodieInMemoryHashIndex.clear()
+        clearInMemoryIndex()
       }
     }
   }
@@ -505,6 +542,9 @@ object HoodieSparkSqlTestBase {
    */
   val SHARED_SESSION_PROPERTY = "hudi.spark.test.sharedSession"
   val sharedSessionEnabled: Boolean = java.lang.Boolean.getBoolean(SHARED_SESSION_PROPERTY)
+
+  // Read side held by every test, write side by an ExclusiveSuite for its whole run.
+  val suiteLock = new ReentrantReadWriteLock(true)
 
   // Table names produced by generateTableName (without a database prefix).
   private[common] val GENERATED_TABLE_NAME: Pattern = Pattern.compile("h[a-z0-9]+_[0-9]+")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -38,6 +38,8 @@ import org.apache.hudi.testutils.HoodieClientTestUtils.{createMetaClient, getSpa
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.SessionCatalog
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.hudi.catalog.HoodieCatalog
@@ -197,29 +199,32 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
 
   /**
    * Drops the tables a test left behind. Per-suite mode owns the whole catalog. Shared mode shares the
-   * external catalog with every other suite in the JVM, so it drops only this suite's generateTableName
-   * tables plus any table whose name is not of that form (fixed names and temp views); under serial
-   * execution those can only come from the test that just ran. Fixed names are renamed in a later step.
+   * external catalog with every other suite in the JVM and those suites may be mid-test, so it drops
+   * only the tables whose name carries this suite's generateTableName prefix, plus its own temp views.
    */
   private def dropSuiteTables(): Unit = {
     val catalog = spark.sessionState.catalog
+    // Concurrent suites may drop their own databases at any time, so every per-database step is best effort.
     catalog.listDatabases().foreach { db =>
-      val tables = catalog.listTables(db)
-      val toDrop = if (sharedSessionEnabled) tables.filter(table => ownsTable(table.table)) else tables
+      val tables = Try(catalog.listTables(db)).getOrElse(Seq.empty)
+      val toDrop = if (sharedSessionEnabled) tables.filter(table => ownsTable(catalog, table)) else tables
       toDrop.foreach { table =>
         if (sharedSessionEnabled && !catalog.isTempView(table)) {
           // Shared mode keeps one index map per table; drop this table's entry with the table.
           Try(catalog.getTableMetadata(table).location.getPath)
             .foreach(path => HoodieInMemoryHashIndex.clear(path))
         }
-        catalog.dropTable(table, true, true)
+        Try(catalog.dropTable(table, true, true))
       }
     }
   }
 
-  /** Shared mode: a table is this suite's if generateTableName produced it, or if no suite's generateTableName could have. */
-  private def ownsTable(name: String): Boolean = {
-    name.startsWith(tableNamePrefix) || !HoodieSparkSqlTestBase.GENERATED_TABLE_NAME.matcher(name).matches()
+  /**
+   * Shared mode: a table is this suite's if generateTableName produced its name (derived names such as
+   * `s"${generateTableName}_pt"` keep the prefix), or if it is a temp view, which is session-scoped.
+   */
+  private def ownsTable(catalog: SessionCatalog, table: TableIdentifier): Boolean = {
+    catalog.isTempView(table) || table.table.startsWith(tableNamePrefix)
   }
 
   protected def generateTableName: String = {
@@ -545,9 +550,6 @@ object HoodieSparkSqlTestBase {
 
   // Read side held by every test, write side by an ExclusiveSuite for its whole run.
   val suiteLock = new ReentrantReadWriteLock(true)
-
-  // Table names produced by generateTableName (without a database prefix).
-  private[common] val GENERATED_TABLE_NAME: Pattern = Pattern.compile("h[a-z0-9]+_[0-9]+")
 
   private[common] lazy val sharedWarehouse: File = {
     val dir = Utils.createTempDir()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -44,6 +44,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.hudi.catalog.HoodieCatalog
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.{checkMessageContains, sharedSessionEnabled}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.Utils
 import org.joda.time.DateTimeZone
@@ -106,22 +107,28 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
    * Shared mode: the context-level SparkConf is fixed, so the deltas a suite adds through extraConf or a
    * sparkConf() override go to its session conf (hoodie.* and spark.sql.* keys), except spark.hadoop.*
    * keys, which the write client reads from sparkContext.hadoopConfiguration and which are restored in
-   * afterAll. Any other spark.* key is a SparkContext setting that a child session cannot change, so it
-   * is rejected here rather than accepted into the session conf with no effect.
+   * afterAll. Any other spark.* key, and any static SQL conf, is a setting a child session cannot change,
+   * so it is rejected before anything is mutated: a partial apply would leave the shared Hadoop conf
+   * changed for every later suite in the JVM.
    */
   private def applySuiteConfToSharedSession(session: SparkSession): Unit = {
     val defaults = getSparkConfForTest("Hoodie SQL Test").getAll.toMap
-    val hadoopConf = session.sparkContext.hadoopConfiguration
-    sparkConf().getAll.filterNot { case (k, v) => defaults.get(k).contains(v) }.foreach {
-      case (k, v) if k.startsWith("spark.hadoop.") =>
-        val key = k.stripPrefix("spark.hadoop.")
-        hadoopConfOverrides :+= (key -> hadoopConf.get(key))
-        hadoopConf.set(key, v)
-      case (k, _) if k.startsWith("spark.") && !k.startsWith("spark.sql.") =>
-        throw new IllegalArgumentException(
-          s"$k is a SparkContext-level setting; shared session mode cannot apply it per suite")
-      case (k, v) => session.conf.set(k, v)
+    val deltas = sparkConf().getAll.filterNot { case (k, v) => defaults.get(k).contains(v) }
+    val (hadoopKeys, sessionKeys) = deltas.partition { case (k, _) => k.startsWith("spark.hadoop.") }
+    val rejected = sessionKeys.collect {
+      case (k, _) if (k.startsWith("spark.") && !k.startsWith("spark.sql.")) || SQLConf.isStaticConfigKey(k) => k
     }
+    if (rejected.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"${rejected.mkString(", ")}: SparkContext-level or static settings; shared session mode cannot apply them per suite")
+    }
+    val hadoopConf = session.sparkContext.hadoopConfiguration
+    hadoopKeys.foreach { case (k, v) =>
+      val key = k.stripPrefix("spark.hadoop.")
+      hadoopConfOverrides :+= (key -> hadoopConf.get(key))
+      hadoopConf.set(key, v)
+    }
+    sessionKeys.foreach { case (k, v) => session.conf.set(k, v) }
   }
 
   protected def initQueryIndexConf(): Unit = {
@@ -195,8 +202,6 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     }
   }
 
-  private lazy val tableNamePrefix: String = s"h${getClass.getSimpleName.toLowerCase}_"
-
   /**
    * Drops the tables a test left behind. Per-suite mode owns the whole catalog. Shared mode shares the
    * external catalog with every other suite in the JVM and those suites may be mid-test, so it drops
@@ -227,15 +232,17 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     catalog.isTempView(table) || table.table.startsWith(tableNamePrefix)
   }
 
+  private lazy val tableNamePrefix: String = s"h${getClass.getSimpleName.toLowerCase}_"
+
   protected def generateTableName: String = {
-    s"h${getClass.getSimpleName.toLowerCase}_${tableId.incrementAndGet()}"
+    s"$tableNamePrefix${tableId.incrementAndGet()}"
   }
 
   override protected def afterAll(): Unit = {
     if (sharedSessionEnabled) {
       // The context and warehouse outlive the suite; only undo this suite's Hadoop conf overrides.
       if (hadoopConfOverrides.nonEmpty) {
-        val hadoopConf = spark.sparkContext.hadoopConfiguration
+        val hadoopConf = HoodieSparkSqlTestBase.sharedBaseSession().sparkContext.hadoopConfiguration
         hadoopConfOverrides.reverse.foreach {
           case (key, null) => hadoopConf.unset(key)
           case (key, previous) => hadoopConf.set(key, previous)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -99,9 +99,10 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
 
   /**
    * Shared mode: the context-level SparkConf is fixed, so the deltas a suite adds through extraConf or a
-   * sparkConf() override go to its session conf, except spark.hadoop.* keys, which the write client reads
-   * from sparkContext.hadoopConfiguration and which are restored in afterAll. Any other context-level key
-   * fails loudly in RuntimeConfig.set.
+   * sparkConf() override go to its session conf (hoodie.* and spark.sql.* keys), except spark.hadoop.*
+   * keys, which the write client reads from sparkContext.hadoopConfiguration and which are restored in
+   * afterAll. Any other spark.* key is a SparkContext setting that a child session cannot change, so it
+   * is rejected here rather than accepted into the session conf with no effect.
    */
   private def applySuiteConfToSharedSession(session: SparkSession): Unit = {
     val defaults = getSparkConfForTest("Hoodie SQL Test").getAll.toMap
@@ -111,14 +112,10 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
         val key = k.stripPrefix("spark.hadoop.")
         hadoopConfOverrides :+= (key -> hadoopConf.get(key))
         hadoopConf.set(key, v)
+      case (k, _) if k.startsWith("spark.") && !k.startsWith("spark.sql.") =>
+        throw new IllegalArgumentException(
+          s"$k is a SparkContext-level setting; shared session mode cannot apply it per suite")
       case (k, v) => session.conf.set(k, v)
-    }
-  }
-
-  override protected def beforeAll(): Unit = {
-    super.beforeAll()
-    if (sharedSessionEnabled) {
-      SparkSession.setActiveSession(spark)
     }
   }
 
@@ -185,15 +182,15 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   private def dropSuiteTables(): Unit = {
     val catalog = spark.sessionState.catalog
     catalog.listDatabases().foreach { db =>
-      catalog.listTables(db).filter(table => ownsTable(table.table)).foreach { table =>
-        catalog.dropTable(table, true, true)
-      }
+      val tables = catalog.listTables(db)
+      val toDrop = if (sharedSessionEnabled) tables.filter(table => ownsTable(table.table)) else tables
+      toDrop.foreach(table => catalog.dropTable(table, true, true))
     }
   }
 
+  /** Shared mode: a table is this suite's if generateTableName produced it, or if no suite's generateTableName could have. */
   private def ownsTable(name: String): Boolean = {
-    !sharedSessionEnabled || name.startsWith(tableNamePrefix) ||
-      !HoodieSparkSqlTestBase.GENERATED_TABLE_NAME.matcher(name).matches()
+    name.startsWith(tableNamePrefix) || !HoodieSparkSqlTestBase.GENERATED_TABLE_NAME.matcher(name).matches()
   }
 
   protected def generateTableName: String = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -55,10 +55,11 @@ import org.scalatest.Assertions.assertResult
 import org.slf4j.LoggerFactory
 
 import java.io.File
-import java.util.{Collections, Optional, TimeZone}
+import java.util.{Optional, TimeZone}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.regex.Pattern
+import java.util.stream.Collectors
 
 import scala.util.Try
 
@@ -659,8 +660,12 @@ object HoodieSparkSqlTestBase {
     val (metaClient, fsView) = getMetaClientAndFileSystemView(basePath)
     val fileSlice: Optional[FileSlice] = fsView.getAllFileSlices("").findFirst()
     assertTrue(fileSlice.isPresent)
-    val logFilePathList: java.util.List[String] = HoodieTestUtils.getLogFileListFromFileSlice(fileSlice.get)
-    Collections.sort(logFilePathList)
+    // Oldest first. A string sort of the paths orders by the Spark write token, which precedes the
+    // instant in the file name and compares stage ids as text.
+    val logFilePathList: java.util.List[String] = fileSlice.get.getLogFiles
+      .sorted(HoodieLogFile.getLogFileComparator)
+      .map[String](logFile => logFile.getPath.toString)
+      .collect(Collectors.toList[String])
     var deleteLogBlockFound = false
     val schema = new TableSchemaResolver(metaClient).getTableSchema
     for (i <- 0 until logFilePathList.size()) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -50,7 +50,7 @@ import org.apache.spark.util.Utils
 import org.joda.time.DateTimeZone
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.scalactic.source
-import org.scalatest.{BeforeAndAfterAll, FunSuite, Tag}
+import org.scalatest.{Args, BeforeAndAfterAll, FunSuite, Status, Tag}
 import org.scalatest.Assertions.assertResult
 import org.slf4j.LoggerFactory
 
@@ -148,29 +148,37 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
     new File(sparkWareHouse, tableName).getCanonicalPath
   }
 
+  /**
+   * Holds the read side of [[HoodieSparkSqlTestBase.suiteLock]] for the whole suite, beforeAll and afterAll
+   * included, so an [[ExclusiveSuite]] never overlaps any part of another suite. ExclusiveSuite takes the
+   * write side around this method; ReentrantReadWriteLock lets a writer also acquire the read side.
+   */
+  override def run(testName: Option[String], args: Args): Status = {
+    val readLock = HoodieSparkSqlTestBase.suiteLock.readLock()
+    readLock.lock()
+    try {
+      super.run(testName, args)
+    } finally {
+      readLock.unlock()
+    }
+  }
+
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position): Unit = {
     super.test(testName, testTags: _*)({
-      // Held for the whole test, cleanup included, so an ExclusiveSuite never overlaps it.
-      val readLock = HoodieSparkSqlTestBase.suiteLock.readLock()
-      readLock.lock()
       try {
-        try {
-          if (sharedSessionEnabled) {
-            bindSuiteSession()
-          }
-          testFun
-        } finally {
-          // The INMEMORY index keeps a JVM-static record-location map; reset it after every test so
-          // stale keys from an earlier test cannot misroute writes in a later one. withRecordType
-          // clears it between record-type iterations, but only on success and only for tests that use
-          // it, so a throwing or non-withRecordType INMEMORY test would otherwise leak state here.
-          // Runs before the catalog cleanup so it holds even if a drop throws. In shared mode this is
-          // a no-op, see clearInMemoryIndex.
-          clearInMemoryIndex()
-          dropSuiteTables()
+        if (sharedSessionEnabled) {
+          bindSuiteSession()
         }
+        testFun
       } finally {
-        readLock.unlock()
+        // The INMEMORY index keeps a JVM-static record-location map; reset it after every test so
+        // stale keys from an earlier test cannot misroute writes in a later one. withRecordType
+        // clears it between record-type iterations, but only on success and only for tests that use
+        // it, so a throwing or non-withRecordType INMEMORY test would otherwise leak state here.
+        // Runs before the catalog cleanup so it holds even if a drop throws. In shared mode this is
+        // a no-op, see clearInMemoryIndex.
+        clearInMemoryIndex()
+        dropSuiteTables()
       }
     })
   }
@@ -178,7 +186,10 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   /**
    * Per-suite mode: reset the JVM-static INMEMORY index between tests (see the note in test()).
    * Shared mode: the index is keyed per table and dropSuiteTables clears each dropped table's
-   * entry, so a global clear would only wipe other suites' tables.
+   * entry, so a global clear would only wipe other suites' tables. A test that drops and re-creates
+   * a table at the same path inside one test must clear that path itself
+   * (HoodieInMemoryHashIndex.clear(basePath)); tagLocation's commit-time check accepts entries from
+   * an earlier table at the same path.
    */
   protected def clearInMemoryIndex(): Unit = {
     if (!sharedSessionEnabled) {
@@ -555,7 +566,7 @@ object HoodieSparkSqlTestBase {
   val SHARED_SESSION_PROPERTY = "hudi.spark.test.sharedSession"
   val sharedSessionEnabled: Boolean = java.lang.Boolean.getBoolean(SHARED_SESSION_PROPERTY)
 
-  // Read side held by every test, write side by an ExclusiveSuite for its whole run.
+  // Read side held by every suite for its whole run, write side by an ExclusiveSuite for its whole run.
   val suiteLock = new ReentrantReadWriteLock(true)
 
   private[common] lazy val sharedWarehouse: File = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieDataUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieDataUtils.scala
@@ -44,13 +44,6 @@ class TestHoodieDataUtils extends HoodieSparkSqlTestBase {
     context = new HoodieSparkEngineContext(jsc)
   }
 
-  override def afterAll(): Unit = {
-    if (jsc != null) {
-      jsc.close()
-    }
-    super.afterAll()
-  }
-
   // Helper method to create a Pair from key and value
   private def pair(key: String, value: String): Pair[String, String] = {
     Pair.of(key, value)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSqlConf.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSqlConf.scala
@@ -31,7 +31,8 @@ import org.scalatest.BeforeAndAfter
 import java.io.File
 import java.nio.file.{Files, Paths}
 
-class TestSqlConf extends HoodieSparkSqlTestBase with BeforeAndAfter {
+// Exclusive: sets HUDI_CONF_DIR and Hudi's JVM-wide global properties, which a concurrent suite would read.
+class TestSqlConf extends HoodieSparkSqlTestBase with BeforeAndAfter with ExclusiveSuite {
 
   // The backing mutable map field name inside java.util.Collections$unmodifiableMap,
   // used to modify JVM environment variables at runtime via reflection
@@ -158,5 +159,8 @@ class TestSqlConf extends HoodieSparkSqlTestBase with BeforeAndAfter {
   after {
     unsetEnv(DFSPropertiesConfiguration.CONF_FILE_DIR_ENV_NAME)
     DFSPropertiesConfiguration.clearGlobalProps()
+    // Reload the globals with HUDI_CONF_DIR unset, so the JVM is back to its pre-suite state
+    // instead of an empty props set that would stop a later reader from loading the defaults.
+    DFSPropertiesConfiguration.refreshGlobalProps()
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -49,7 +49,7 @@ import scala.collection.JavaConverters._
 class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelpers {
 
   test("Test Create Managed Hoodie Table") {
-    val databaseName = "hudi_database"
+    val databaseName = generateTableName
     spark.sql(s"create database if not exists $databaseName")
     spark.sql(s"use $databaseName")
 
@@ -265,8 +265,8 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
       assertTrue(storage.exists(tableConfigPath))
       val tableConfigModificationTime = storage.getPathInfo(tableConfigPath).getModificationTime
       validateExternalTableCreation(storage, basePath, tableConfigModificationTime, Option.empty)
-      validateExternalTableCreation(storage, basePath, tableConfigModificationTime, Option("new_database"))
-      validateExternalTableCreation(storage, basePath, tableConfigModificationTime, Option("another_database"))
+      validateExternalTableCreation(storage, basePath, tableConfigModificationTime, Option(generateTableName))
+      validateExternalTableCreation(storage, basePath, tableConfigModificationTime, Option(generateTableName))
     }
   }
 
@@ -274,7 +274,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
                                             basePath: String,
                                             tableConfigModificationTime: Long,
                                             databaseName: Option[String]): Unit = {
-    val tableName = "table"
+    val tableName = generateTableName
     if (databaseName.isDefined) {
       spark.sql(
         s"""
@@ -987,7 +987,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
 
   test("Test Create Table From Existing Hoodie Table") {
     withTempDir { tmp =>
-      val databaseName = "hudi_database"
+      val databaseName = generateTableName
       spark.sql(s"create database if not exists $databaseName")
       spark.sql(s"use $databaseName")
 
@@ -1465,7 +1465,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
   }
 
   test("Test Create Non-Hudi Table(Parquet Table)") {
-    val databaseName = "test_database"
+    val databaseName = generateTableName
     spark.sql(s"create database if not exists $databaseName")
     spark.sql(s"use $databaseName")
 
@@ -2370,8 +2370,9 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
   // VECTOR type name.
 
   test("test create VECTOR table with CLUSTERED BY bucket spec parses (parser coverage)") {
+    val bucketTableName = generateTableName
     val plan = parseCreateTable(
-      "CREATE TABLE vec_bucket_tbl (id BIGINT, embedding VECTOR(4)) USING hudi " +
+      s"CREATE TABLE $bucketTableName (id BIGINT, embedding VECTOR(4)) USING hudi " +
         "CLUSTERED BY (id) INTO 4 BUCKETS")
     val bucket = transformByName(plan, "bucket")
     assertEquals("4", firstLiteralArg(bucket).value.toString)
@@ -2379,14 +2380,16 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
 
     // SORTED BY ... ASC is accepted by the bucket-spec visitor and yields a sorted_bucket
     // transform; a plain bucket transform here would mean the SORTED BY clause was dropped.
+    val sortedBucketTableName = generateTableName
     val sortedPlan = parseCreateTable(
-      "CREATE TABLE vec_sbucket_tbl (id BIGINT, ts BIGINT, embedding VECTOR(4)) USING hudi " +
+      s"CREATE TABLE $sortedBucketTableName (id BIGINT, ts BIGINT, embedding VECTOR(4)) USING hudi " +
         "CLUSTERED BY (id, ts) SORTED BY (id ASC) INTO 8 BUCKETS")
     assertEquals("sorted_bucket", sortedPlan.partitioning.head.name)
 
     // SORTED BY ... DESC is rejected by the bucket-spec visitor.
+    val badBucketTableName = generateTableName
     checkExceptionContain(
-      "CREATE TABLE vec_bad_bucket_tbl (id BIGINT, embedding VECTOR(4)) USING hudi " +
+      s"CREATE TABLE $badBucketTableName (id BIGINT, embedding VECTOR(4)) USING hudi " +
         "CLUSTERED BY (id) SORTED BY (id DESC) INTO 4 BUCKETS")(
       "Column ordering must be ASC")
   }
@@ -2397,40 +2400,44 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
     // tableSpec (location/comment/properties are stable across Spark 3.3 through 4.2; the parsed
     // options map is not exposed on the 3.5+ TableSpecBase, so OPTIONS is only asserted through
     // the path-folding case below).
+    val tableName = generateTableName
     val plan = parseCreateTable(
       s"""
-         |CREATE TABLE vec_clause_tbl (
+         |CREATE TABLE $tableName (
          |  id BIGINT,
          |  embedding VECTOR(4)
          |) USING hudi
          |COMMENT 'a vector table'
-         |LOCATION '/tmp/vec_clause_tbl'
+         |LOCATION '/tmp/$tableName'
          |OPTIONS ('opt_str' = 'v', 'opt_int' = 1, 'opt_bool' = true)
          |TBLPROPERTIES ('prop_str' = 'v', 'prop_int' = 2, 'prop_bool' = false)
          """.stripMargin)
     assertEquals(ArrayType(FloatType, containsNull = false), plan.tableSchema("embedding").dataType)
     assertEquals(Some("a vector table"), plan.tableSpec.comment)
-    assertEquals(Some("/tmp/vec_clause_tbl"), plan.tableSpec.location)
+    assertEquals(Some(s"/tmp/$tableName"), plan.tableSpec.location)
     assertEquals("v", plan.tableSpec.properties("prop_str"))
     assertEquals("2", plan.tableSpec.properties("prop_int"))
     assertEquals("false", plan.tableSpec.properties("prop_bool"))
 
     // A 'path' option with no LOCATION is folded into the table location by the option cleaner.
+    val pathTableName = generateTableName
     val pathPlan = parseCreateTable(
-      "CREATE TABLE vec_path_tbl (id BIGINT, embedding VECTOR(4)) USING hudi " +
-        "OPTIONS ('path' = '/tmp/vec_path_tbl')")
-    assertEquals(Some("/tmp/vec_path_tbl"), pathPlan.tableSpec.location)
+      s"CREATE TABLE $pathTableName (id BIGINT, embedding VECTOR(4)) USING hudi " +
+        s"OPTIONS ('path' = '/tmp/$pathTableName')")
+    assertEquals(Some(s"/tmp/$pathTableName"), pathPlan.tableSpec.location)
 
     // A 'path' option colliding with LOCATION is rejected by the option cleaner.
+    val dupPathTableName = generateTableName
     interceptParse(
-      "CREATE TABLE vec_dup_path_tbl (id BIGINT, embedding VECTOR(4)) USING hudi " +
+      s"CREATE TABLE $dupPathTableName (id BIGINT, embedding VECTOR(4)) USING hudi " +
         "OPTIONS ('path' = '/tmp/a') LOCATION '/tmp/b'")(
       "Duplicated table paths")
 
     // Each reserved table property (provider, location, owner) is rejected by the property cleaner.
     Seq("provider", "location", "owner").foreach { reserved =>
+      val reservedTableName = generateTableName
       interceptParse(
-        s"CREATE TABLE vec_reserved_$reserved (id BIGINT, embedding VECTOR(4)) USING hudi " +
+        s"CREATE TABLE $reservedTableName (id BIGINT, embedding VECTOR(4)) USING hudi " +
           s"TBLPROPERTIES ('$reserved' = 'x')")(
         "reserved table property")
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
@@ -25,7 +25,6 @@ import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
 import org.apache.hudi.common.table.timeline.HoodieInstant
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.config.HoodieWriteConfig
-import org.apache.hudi.index.HoodieInMemoryHashIndex
 import org.apache.hudi.testutils.DataSourceTestUtils
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
@@ -1064,7 +1063,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
           spark.sql(s"select id, name, cast(price as string), ts from $tableName")
 
           // clear after using INMEMORY index
-          HoodieInMemoryHashIndex.clear()
+          clearInMemoryIndex()
         }
       }
     }
@@ -1148,7 +1147,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
           )
 
           // clear after using INMEMORY index
-          HoodieInMemoryHashIndex.clear()
+          clearInMemoryIndex()
         }
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSparkCatalogSync.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSparkCatalogSync.scala
@@ -39,7 +39,7 @@ class TestSparkCatalogSync extends HoodieSparkSqlTestBase {
       import spark.implicits._
 
       val tableName = generateTableName
-      val databaseName = "testdb"
+      val databaseName = generateTableName
       val basePath = s"${tmp.getCanonicalPath}/$tableName"
 
       val syncProps = buildSyncProps(databaseName, tableName, basePath)
@@ -81,7 +81,7 @@ class TestSparkCatalogSync extends HoodieSparkSqlTestBase {
       import spark.implicits._
 
       val tableName = generateTableName
-      val databaseName = "testdb"
+      val databaseName = generateTableName
       val basePath = s"${tmp.getCanonicalPath}/$tableName"
 
       val syncProps = buildSyncProps(databaseName, tableName, basePath)
@@ -119,7 +119,7 @@ class TestSparkCatalogSync extends HoodieSparkSqlTestBase {
       import spark.implicits._
 
       val tableName = generateTableName
-      val databaseName = "testdb"
+      val databaseName = generateTableName
       val basePath = s"${tmp.getCanonicalPath}/$tableName"
       val syncProps = buildSyncProps(databaseName, tableName, basePath)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable4.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable4.scala
@@ -31,12 +31,12 @@ import org.apache.hudi.config.{HoodieClusteringConfig, HoodieIndexConfig, Hoodie
 import org.apache.hudi.exception.{HoodieDuplicateKeyException, HoodieException}
 import org.apache.hudi.index.HoodieIndex.IndexType
 
-import org.apache.spark.scheduler.{SparkListener, SparkListenerStageSubmitted}
+import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart, SparkListenerStageSubmitted}
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.getLastCommitMetadata
 
 import java.io.File
-import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, TimeUnit}
 
 class TestInsertTable4 extends HoodieSparkSqlTestBase {
   test("Test Bulk Insert Into Consistent Hashing Bucket Index Table") {
@@ -290,10 +290,22 @@ class TestInsertTable4 extends HoodieSparkSqlTestBase {
   var listenerCallCount: Int = 0
   var countDownLatch: CountDownLatch = _
 
-  // add a listener for stages for parallelism checking with stage name
-  class StageParallelismListener(var stageName: String) extends SparkListener {
+  // add a listener for stages for parallelism checking with stage name, restricted to the stages of
+  // the jobs this test started. Hudi overwrites the job group id and description on its own jobs, so
+  // the discriminator is a local property the test sets before the query.
+  class StageParallelismListener(var stageName: String, scope: String) extends SparkListener {
+    private val scopedStageIds = ConcurrentHashMap.newKeySet[Int]()
+
+    override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
+      if (jobStart.properties != null
+        && scope == jobStart.properties.getProperty(TestInsertTable4.SCOPE_PROPERTY)) {
+        jobStart.stageIds.foreach(stageId => scopedStageIds.add(stageId))
+      }
+    }
+
     override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = {
-      if (stageSubmitted.stageInfo.name.contains(stageName)) {
+      if (scopedStageIds.contains(stageSubmitted.stageInfo.stageId)
+        && stageSubmitted.stageInfo.name.contains(stageName)) {
         assertResult(1)(stageSubmitted.stageInfo.numTasks)
         listenerCallCount = listenerCallCount + 1
         countDownLatch.countDown
@@ -338,19 +350,27 @@ class TestInsertTable4 extends HoodieSparkSqlTestBase {
            |select '1' as id, 'aa' as name, 123 as dt, '2023-10-12' as `day`, 12 as `hour`
            |""".stripMargin)
       val stageClassName = classOf[HoodieSparkEngineContext].getSimpleName
-      spark.sparkContext.addSparkListener(new StageParallelismListener(stageName = stageClassName))
-      val df = spark.sql(
-        s"""
-           |select * from ${targetTable} where day='2023-10-12' and hour=11
-           |""".stripMargin)
-      var rddHead = df.rdd
-      while (rddHead.dependencies.size > 0) {
+      val scope = java.util.UUID.randomUUID().toString
+      spark.sparkContext.setLocalProperty(TestInsertTable4.SCOPE_PROPERTY, scope)
+      val listener = new StageParallelismListener(stageName = stageClassName, scope = scope)
+      spark.sparkContext.addSparkListener(listener)
+      try {
+        val df = spark.sql(
+          s"""
+             |select * from ${targetTable} where day='2023-10-12' and hour=11
+             |""".stripMargin)
+        var rddHead = df.rdd
+        while (rddHead.dependencies.size > 0) {
+          assertResult(1)(rddHead.partitions.size)
+          rddHead = rddHead.firstParent
+        }
         assertResult(1)(rddHead.partitions.size)
-        rddHead = rddHead.firstParent
+        countDownLatch.await(1, TimeUnit.MINUTES)
+        assert(listenerCallCount >= 1)
+      } finally {
+        spark.sparkContext.removeSparkListener(listener)
+        spark.sparkContext.setLocalProperty(TestInsertTable4.SCOPE_PROPERTY, null)
       }
-      assertResult(1)(rddHead.partitions.size)
-      countDownLatch.await(1, TimeUnit.MINUTES)
-      assert(listenerCallCount >= 1)
     }
   }
 
@@ -391,19 +411,27 @@ class TestInsertTable4 extends HoodieSparkSqlTestBase {
            |select '1' as id, 'aa' as name, 123 as dt, '2023-10-12' as `day`, 12 as `hour`
            |""".stripMargin)
       val stageClassName = classOf[HoodieSparkEngineContext].getSimpleName
-      spark.sparkContext.addSparkListener(new StageParallelismListener(stageName = stageClassName))
-      val df = spark.sql(
-        s"""
-           |select * from ${targetTable} where day='2023-10-12' and hour=11
-           |""".stripMargin)
-      var rddHead = df.rdd
-      while (rddHead.dependencies.size > 0) {
+      val scope = java.util.UUID.randomUUID().toString
+      spark.sparkContext.setLocalProperty(TestInsertTable4.SCOPE_PROPERTY, scope)
+      val listener = new StageParallelismListener(stageName = stageClassName, scope = scope)
+      spark.sparkContext.addSparkListener(listener)
+      try {
+        val df = spark.sql(
+          s"""
+             |select * from ${targetTable} where day='2023-10-12' and hour=11
+             |""".stripMargin)
+        var rddHead = df.rdd
+        while (rddHead.dependencies.size > 0) {
+          assertResult(1)(rddHead.partitions.size)
+          rddHead = rddHead.firstParent
+        }
         assertResult(1)(rddHead.partitions.size)
-        rddHead = rddHead.firstParent
+        countDownLatch.await(1, TimeUnit.MINUTES)
+        assert(listenerCallCount >= 1)
+      } finally {
+        spark.sparkContext.removeSparkListener(listener)
+        spark.sparkContext.setLocalProperty(TestInsertTable4.SCOPE_PROPERTY, null)
       }
-      assertResult(1)(rddHead.partitions.size)
-      countDownLatch.await(1, TimeUnit.MINUTES)
-      assert(listenerCallCount >= 1)
     }
   }
 
@@ -843,4 +871,9 @@ class TestInsertTable4 extends HoodieSparkSqlTestBase {
       }
     }
   }
+}
+
+object TestInsertTable4 {
+  // Local property set by a test so its stage listener only sees the jobs that test started.
+  val SCOPE_PROPERTY = "hoodie.test.stage.listener.scope"
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestPartialUpdateForMergeInto.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestPartialUpdateForMergeInto.scala
@@ -38,7 +38,8 @@ import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.getMetaClientAndF
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructField}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 
-import java.util.{Collections, List, Optional}
+import java.util.{List, Optional}
+import java.util.stream.Collectors
 
 import scala.collection.JavaConverters._
 
@@ -743,8 +744,12 @@ class TestPartialUpdateForMergeInto extends HoodieSparkSqlTestBase {
       })
       .findFirst()
     assertTrue(fileSlice.isPresent)
-    val logFilePathList: List[String] = HoodieTestUtils.getLogFileListFromFileSlice(fileSlice.get)
-    Collections.sort(logFilePathList)
+    // Oldest first. A string sort of the paths orders by the Spark write token, which precedes the
+    // instant in the file name and compares stage ids as text.
+    val logFilePathList: List[String] = fileSlice.get.getLogFiles
+      .sorted(HoodieLogFile.getLogFileComparator)
+      .map[String](logFile => logFile.getPath.toString)
+      .collect(Collectors.toList[String])
 
     val schema = new TableSchemaResolver(metaClient).getTableSchema
     for (i <- 0 until expectedNumLogFile) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -293,9 +293,10 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
 
   test("Test parse CREATE TABLE with BLOB column and primitive data types") {
     // Exercises the primitive-data-type match arms plus NOT NULL and column COMMENT.
+    val tableName = generateTableName
     val plan = parseCreateTable(
       s"""
-         |CREATE TABLE blob_prim_tbl (
+         |CREATE TABLE $tableName (
          |  c_bool BOOLEAN,
          |  c_tiny TINYINT,
          |  c_small SMALLINT,
@@ -341,9 +342,10 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
   test("Test parse CREATE TABLE with BLOB column and complex data types") {
     // Exercises the ARRAY / MAP / STRUCT arms. BLOB-in-struct metadata handling is already
     // covered by "test BLOB in nested struct".
+    val tableName = generateTableName
     val plan = parseCreateTable(
       s"""
-         |CREATE TABLE blob_complex_tbl (
+         |CREATE TABLE $tableName (
          |  c_arr ARRAY<INT>,
          |  c_map MAP<STRING, INT>,
          |  c_struct STRUCT<a: INT, b: STRING>,
@@ -360,9 +362,10 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
   }
 
   test("Test parse CREATE TABLE with BLOB column and interval data types") {
+    val tableName = generateTableName
     val plan = parseCreateTable(
       s"""
-         |CREATE TABLE blob_ivl_tbl (
+         |CREATE TABLE $tableName (
          |  i_year INTERVAL YEAR,
          |  i_ym INTERVAL YEAR TO MONTH,
          |  i_day INTERVAL DAY,
@@ -382,18 +385,21 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // Endpoints where the end field does not follow the start are rejected by both interval
     // data-type visitors. The grammar only allows YEAR/MONTH -> MONTH and DAY/HOUR/MINUTE/SECOND
     // -> HOUR/MINUTE/SECOND, so these stay grammatical yet still hit the builder's end <= start guard.
+    val badYmTableName = generateTableName
     interceptParse(
-      "CREATE TABLE blob_bad_ym (id BIGINT, bad INTERVAL MONTH TO MONTH, data BLOB) USING hudi")(
+      s"CREATE TABLE $badYmTableName (id BIGINT, bad INTERVAL MONTH TO MONTH, data BLOB) USING hudi")(
       "are not supported")
+    val badDtTableName = generateTableName
     interceptParse(
-      "CREATE TABLE blob_bad_dt (id BIGINT, bad INTERVAL SECOND TO HOUR, data BLOB) USING hudi")(
+      s"CREATE TABLE $badDtTableName (id BIGINT, bad INTERVAL SECOND TO HOUR, data BLOB) USING hudi")(
       "are not supported")
   }
 
   test("Test parse CREATE TABLE with BLOB column and partition transforms") {
+    val tableName = generateTableName
     val plan = parseCreateTable(
       s"""
-         |CREATE TABLE blob_tf_tbl (
+         |CREATE TABLE $tableName (
          |  id BIGINT,
          |  ts DATE,
          |  region STRING,
@@ -413,8 +419,9 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // bucket(numBuckets, col) with int, long and short number-of-buckets literals exercises the
     // three numeric arms of the bucket handling.
     Seq("4", "4L", "4S").foreach { numLiteral =>
+      val bucketTableName = generateTableName
       val bp = parseCreateTable(
-        s"CREATE TABLE blob_bkt_tbl (id BIGINT, data BLOB) USING hudi " +
+        s"CREATE TABLE $bucketTableName (id BIGINT, data BLOB) USING hudi " +
           s"PARTITIONED BY (bucket($numLiteral, id))")
       val bkt = transformByName(bp, "bucket")
       assertResult("4")(firstLiteralArg(bkt).value.toString)
@@ -426,24 +433,28 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // The partition-COLUMN arm is the only partitioning branch that changes the emitted schema:
     // the parsed partition columns are appended to the table columns and each becomes an
     // identity transform.
+    val tableName = generateTableName
     val plan = parseCreateTable(
-      "CREATE TABLE blob_pcol_tbl (id BIGINT, data BLOB) USING hudi PARTITIONED BY (p STRING)")
+      s"CREATE TABLE $tableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (p STRING)")
     assertResult(StringType)(plan.tableSchema("p").dataType)
     assertResult(BlobType())(plan.tableSchema("data").dataType)
     assertResult(Seq(Seq("p")))(transformFieldRefs(transformByName(plan, "identity")))
 
     // Mixing partition columns and transform expressions is rejected.
+    val mixTableName = generateTableName
     checkExceptionContain(
-      "CREATE TABLE blob_mix_tbl (id BIGINT, data BLOB) USING hudi " +
+      s"CREATE TABLE $mixTableName (id BIGINT, data BLOB) USING hudi " +
         "PARTITIONED BY (p STRING, bucket(4, id))")(
       "Cannot mix partition expressions and partition columns")
 
     // SKEWED BY and CREATE TEMPORARY TABLE are rejected by the clause and header visitors.
+    val skewTableName = generateTableName
     checkExceptionContain(
-      "CREATE TABLE blob_skew_tbl (id BIGINT, data BLOB) USING hudi SKEWED BY (id) ON (1, 2)")(
+      s"CREATE TABLE $skewTableName (id BIGINT, data BLOB) USING hudi SKEWED BY (id) ON (1, 2)")(
       "CREATE TABLE ... SKEWED BY")
+    val tmpTableName = generateTableName
     checkExceptionContain(
-      "CREATE TEMPORARY TABLE blob_tmp_tbl (id BIGINT, data BLOB) USING hudi")(
+      s"CREATE TEMPORARY TABLE $tmpTableName (id BIGINT, data BLOB) USING hudi")(
       "use CREATE TEMPORARY VIEW instead")
   }
 
@@ -458,9 +469,10 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // dependent: only TRUE is ansiNonReserved, so a bare true always parses as a column
     // reference, while false and null are column references under the default non-ANSI keyword
     // mode but typed literals under ANSI mode (both cases are asserted below).
+    val tableName = generateTableName
     val plan = parseCreateTable(
       s"""
-         |CREATE TABLE blob_lit_tbl (
+         |CREATE TABLE $tableName (
          |  id BIGINT,
          |  data BLOB
          |) USING hudi
@@ -489,8 +501,9 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // and visitNullLiteral as typed literals, while a bare true stays a column reference
     // (TRUE is ansiNonReserved; FALSE and NULL are not).
     withSQLConf("spark.sql.ansi.enabled" -> "true") {
+      val boolTableName = generateTableName
       val ansiPlan = parseCreateTable(
-        "CREATE TABLE blob_bool_tbl (id BIGINT, data BLOB) USING hudi " +
+        s"CREATE TABLE $boolTableName (id BIGINT, data BLOB) USING hudi " +
           "PARTITIONED BY (bool_t(false, id), true_t(true, id), null_t(null, id))")
       assertResult(BooleanType)(firstLiteralArg(transformByName(ansiPlan, "bool_t")).dataType)
       assertResult(false)(firstLiteralArg(transformByName(ansiPlan, "bool_t")).value)
@@ -506,30 +519,37 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // clean ParseException on every Spark profile (#19450). Assertions stay substring-based
     // because the Spark 4.x builders add an "Operation not allowed: " prefix.
     // Non-numeric number of buckets.
-    interceptParse("CREATE TABLE blob_e1 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket('x', id))")(
+    val e1TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e1TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket('x', id))")(
       "Invalid number of buckets")
     // A non-column-reference where a column is required. The buggy interpolation rendered the
     // literal text "5.describe" (a superstring of the expected message), so pin its absence too.
-    val e2 = interceptParse("CREATE TABLE blob_e2 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(4, 5))")(
+    val e2TableName = generateTableName
+    val e2 = interceptParse(s"CREATE TABLE $e2TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(4, 5))")(
       "Expected a column reference for transform bucket: 5")
     assert(!e2.getMessage.contains(".describe"))
     // A single-field transform given more than one argument.
-    interceptParse("CREATE TABLE blob_e3 (id BIGINT, ts DATE, data BLOB) USING hudi PARTITIONED BY (years(id, ts))")(
+    val e3TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e3TableName (id BIGINT, ts DATE, data BLOB) USING hudi PARTITIONED BY (years(id, ts))")(
       "Too many arguments")
     // Typed literal that fails to parse (visitTypeConstructor arm).
-    interceptParse("CREATE TABLE blob_e4 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(DATE 'nope', id))")(
+    val e4TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e4TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(DATE 'nope', id))")(
       "Cannot parse the DATE value: nope")
     // Invalid INTERVAL literal: the builders copy the triggering exception's stack trace onto the
     // ParseException (the construct-then-setStackTrace arm), so the thrower must be visible.
-    val e5 = interceptParse("CREATE TABLE blob_e5 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 'x', id))")(
+    val e5TableName = generateTableName
+    val e5 = interceptParse(s"CREATE TABLE $e5TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 'x', id))")(
       "Cannot parse the INTERVAL value: x")
     assert(e5.getStackTrace.exists(_.getClassName.contains("IntervalUtils")))
     // Out-of-range fractional literal; pre-fix the message's interior dots broke Spark 3.4+
     // error-class lookup and surfaced as a bare AssertionError.
-    interceptParse("CREATE TABLE blob_e6 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(1e40F, id))")(
+    val e6TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e6TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(1e40F, id))")(
       "does not fit in range")
     // Mixed year-month and day-time interval fields.
-    interceptParse("CREATE TABLE blob_e7 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL '1 year 2 hours', id))")(
+    val e7TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e7TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL '1 year 2 hours', id))")(
       "Cannot mix year-month and day-time fields")
   }
 
@@ -537,25 +557,32 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // Remaining error arms of the literal and interval visitors, one SQL per throw site; all must
     // surface as a clean ParseException on every Spark profile (#19450).
     // A typed literal whose type keyword has no visitor arm.
-    interceptParse("CREATE TABLE blob_e8 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(FOO 'bar', id))")(
+    val e8TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e8TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(FOO 'bar', id))")(
       "Literals of type 'FOO' are currently not supported")
     // A hex literal with a non-hex character (the IllegalArgumentException fallback arm).
-    interceptParse("CREATE TABLE blob_e9 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(X'zz', id))")(
+    val e9TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e9TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(X'zz', id))")(
       "hexBinary")
     // Multi-unit interval combined with a from-to unit.
-    interceptParse("CREATE TABLE blob_e10 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 1 DAY 2 HOUR TO MINUTE, id))")(
+    val e10TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e10TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 1 DAY 2 HOUR TO MINUTE, id))")(
       "Can only have a single from-to unit in the interval literal syntax")
     // From-to unit combined with a trailing multi-unit interval (the error-recovery arm).
-    interceptParse("CREATE TABLE blob_e11 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL '1' DAY TO HOUR '2' MINUTE, id))")(
+    val e11TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e11TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL '1' DAY TO HOUR '2' MINUTE, id))")(
       "Can only have a single from-to unit in the interval literal syntax")
     // A non-numeric value in a unit-value pair.
-    interceptParse("CREATE TABLE blob_e12 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 'x' DAY, id))")(
+    val e12TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e12TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 'x' DAY, id))")(
       "Can only use numbers in the interval value part")
     // A from-to interval whose value is not a string literal.
-    interceptParse("CREATE TABLE blob_e13 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 1 DAY TO HOUR, id))")(
+    val e13TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e13TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 1 DAY TO HOUR, id))")(
       "The value of from-to unit must be a string")
     // A from-to unit pair outside the supported YEAR TO MONTH / DAY TO SECOND family.
-    interceptParse("CREATE TABLE blob_e14 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL '1' MONTH TO HOUR, id))")(
+    val e14TableName = generateTableName
+    interceptParse(s"CREATE TABLE $e14TableName (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL '1' MONTH TO HOUR, id))")(
       "Intervals FROM month TO hour are not supported")
   }
 
@@ -564,36 +591,43 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // Spark 3.3 through 4.2 via tableSpec.serde); asserting only the BLOB column type would pass
     // even if the file/row-format visitors dropped their clause.
     // Generic STORED AS format.
-    val ff1 = parseCreateTable("CREATE TABLE blob_ff1 (id BIGINT, data BLOB) STORED AS PARQUET")
+    val ff1TableName = generateTableName
+    val ff1 = parseCreateTable(s"CREATE TABLE $ff1TableName (id BIGINT, data BLOB) STORED AS PARQUET")
     assertResult(BlobType())(ff1.tableSchema("data").dataType)
     assertResult(Some("PARQUET"))(ff1.tableSpec.serde.get.storedAs)
     // STORED AS INPUTFORMAT ... OUTPUTFORMAT ... (the table-file-format arm).
-    val ff2 = parseCreateTable("CREATE TABLE blob_ff2 (id BIGINT, data BLOB) " +
+    val ff2TableName = generateTableName
+    val ff2 = parseCreateTable(s"CREATE TABLE $ff2TableName (id BIGINT, data BLOB) " +
       "STORED AS INPUTFORMAT 'com.example.InFmt' OUTPUTFORMAT 'com.example.OutFmt'")
     assertResult(Some(FormatClasses("com.example.InFmt", "com.example.OutFmt")))(
       ff2.tableSpec.serde.get.formatClasses)
     // ROW FORMAT SERDE on its own.
-    val ff3 = parseCreateTable("CREATE TABLE blob_ff3 (id BIGINT, data BLOB) " +
+    val ff3TableName = generateTableName
+    val ff3 = parseCreateTable(s"CREATE TABLE $ff3TableName (id BIGINT, data BLOB) " +
       "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'")
     assertResult(Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))(
       ff3.tableSpec.serde.get.serde)
     // ROW FORMAT DELIMITED on its own.
-    val ff4 = parseCreateTable("CREATE TABLE blob_ff4 (id BIGINT, data BLOB) " +
+    val ff4TableName = generateTableName
+    val ff4 = parseCreateTable(s"CREATE TABLE $ff4TableName (id BIGINT, data BLOB) " +
       "ROW FORMAT DELIMITED FIELDS TERMINATED BY ','")
     assertResult(",")(ff4.tableSpec.serde.get.serdeProperties("field.delim"))
     // Compatible ROW FORMAT SERDE + STORED AS SEQUENCEFILE merges both into one SerdeInfo.
-    val ff5 = parseCreateTable("CREATE TABLE blob_ff5 (id BIGINT, data BLOB) " +
+    val ff5TableName = generateTableName
+    val ff5 = parseCreateTable(s"CREATE TABLE $ff5TableName (id BIGINT, data BLOB) " +
       "ROW FORMAT SERDE 'com.example.Serde' STORED AS SEQUENCEFILE")
     assertResult(Some("SEQUENCEFILE"))(ff5.tableSpec.serde.get.storedAs)
     assertResult(Some("com.example.Serde"))(ff5.tableSpec.serde.get.serde)
     // Compatible ROW FORMAT DELIMITED + STORED AS TEXTFILE.
-    val ff6 = parseCreateTable("CREATE TABLE blob_ff6 (id BIGINT, data BLOB) " +
+    val ff6TableName = generateTableName
+    val ff6 = parseCreateTable(s"CREATE TABLE $ff6TableName (id BIGINT, data BLOB) " +
       "ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE")
     assertResult(Some("TEXTFILE"))(ff6.tableSpec.serde.get.storedAs)
     assertResult(",")(ff6.tableSpec.serde.get.serdeProperties("field.delim"))
     // Any ROW FORMAT combined with STORED AS INPUTFORMAT/OUTPUTFORMAT is accepted (the
     // table-file-format arm of validateRowFormatFileFormat).
-    val ff7 = parseCreateTable("CREATE TABLE blob_ff7 (id BIGINT, data BLOB) " +
+    val ff7TableName = generateTableName
+    val ff7 = parseCreateTable(s"CREATE TABLE $ff7TableName (id BIGINT, data BLOB) " +
       "ROW FORMAT SERDE 'com.example.Serde' " +
       "STORED AS INPUTFORMAT 'com.example.InFmt' OUTPUTFORMAT 'com.example.OutFmt'")
     assertResult(Some("com.example.Serde"))(ff7.tableSpec.serde.get.serde)
@@ -601,31 +635,36 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
       ff7.tableSpec.serde.get.formatClasses)
 
     // ROW FORMAT DELIMITED with a non-text file format is rejected.
+    val ferr1TableName = generateTableName
     checkExceptionContain(
-      "CREATE TABLE blob_ferr1 (id BIGINT, data BLOB) " +
+      s"CREATE TABLE $ferr1TableName (id BIGINT, data BLOB) " +
         "ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS PARQUET")(
       "only compatible with 'textfile'")
     // ROW FORMAT SERDE with a format that also specifies a serde is rejected.
+    val ferr2TableName = generateTableName
     checkExceptionContain(
-      "CREATE TABLE blob_ferr2 (id BIGINT, data BLOB) " +
+      s"CREATE TABLE $ferr2TableName (id BIGINT, data BLOB) " +
         "ROW FORMAT SERDE 'com.example.Serde' STORED AS PARQUET")(
       "incompatible with format")
     // STORED BY (a storage handler) is not allowed. The full "Operation not allowed" prefix is
     // asserted because ParseException.getMessage echoes the SQL text, so a bare "STORED BY"
     // expectation would match any failure of this statement.
+    val ferr3TableName = generateTableName
     checkExceptionContain(
-      "CREATE TABLE blob_ferr3 (id BIGINT, data BLOB) STORED BY 'com.example.Handler'")(
+      s"CREATE TABLE $ferr3TableName (id BIGINT, data BLOB) STORED BY 'com.example.Handler'")(
       "Operation not allowed: STORED BY")
     // ROW FORMAT combined with STORED BY leaves no file format for the row format to pair with;
     // validateRowFormatFileFormat's catch-all arm rejects the combination before the STORED BY
     // error can fire.
+    val ferr5TableName = generateTableName
     checkExceptionContain(
-      "CREATE TABLE blob_ferr5 (id BIGINT, data BLOB) " +
+      s"CREATE TABLE $ferr5TableName (id BIGINT, data BLOB) " +
         "ROW FORMAT SERDE 'com.example.Serde' STORED BY 'com.example.Handler'")(
       "Unexpected combination of")
     // A USING provider combined with a serde clause is not allowed.
+    val ferr4TableName = generateTableName
     checkExceptionContain(
-      "CREATE TABLE blob_ferr4 (id BIGINT, data BLOB) USING hudi STORED AS PARQUET")(
+      s"CREATE TABLE $ferr4TableName (id BIGINT, data BLOB) USING hudi STORED AS PARQUET")(
       "CREATE TABLE ... USING")
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestCDCForSparkSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestCDCForSparkSQL.scala
@@ -55,7 +55,7 @@ class TestCDCForSparkSQL extends HoodieSparkSqlTestBase {
   test("Test delete all records in filegroup") {
     Seq("cow", "mor").foreach { tableType =>
       withTempDir { tmp =>
-        val databaseName = "hudi_database"
+        val databaseName = generateTableName
         spark.sql(s"create database if not exists $databaseName")
         spark.sql(s"use $databaseName")
         val tableName = generateTableName
@@ -100,7 +100,7 @@ class TestCDCForSparkSQL extends HoodieSparkSqlTestBase {
    * Test CDC in cases that it's a COW/MOR non--partitioned table and `cdcSupplementalLoggingMode` is true or not.
    */
   test("Test Non-Partitioned Hoodie Table") {
-    val databaseName = "hudi_database"
+    val databaseName = generateTableName
     spark.sql(s"create database if not exists $databaseName")
     spark.sql(s"use $databaseName")
 
@@ -226,7 +226,7 @@ class TestCDCForSparkSQL extends HoodieSparkSqlTestBase {
    * Test CDC in cases that it's a COW/MOR partitioned table and `cdcSupplementalLoggingMode` is true or not.
    */
   test("Test Partitioned Hoodie Table") {
-    val databaseName = "hudi_database"
+    val databaseName = generateTableName
     spark.sql(s"create database if not exists $databaseName")
     spark.sql(s"use $databaseName")
 
@@ -307,7 +307,7 @@ class TestCDCForSparkSQL extends HoodieSparkSqlTestBase {
   }
 
   test("Test Partial Updates With Spark CDC") {
-    val databaseName = "hudi_database"
+    val databaseName = generateTableName
     spark.sql(s"create database if not exists $databaseName")
     spark.sql(s"use $databaseName")
     withSQLConf(HoodieWriteConfig.MERGE_SMALL_FILE_GROUP_CANDIDATES_LIMIT.key -> "0",

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
@@ -56,7 +56,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, E
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.hudi.command.{CreateIndexCommand, ShowIndexesCommand}
-import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.common.{ExclusiveSuite, HoodieSparkSqlTestBase}
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 
@@ -64,7 +64,7 @@ import java.util.stream.Collectors
 
 import scala.collection.JavaConverters
 
-class TestExpressionIndex extends HoodieSparkSqlTestBase with SparkAdapterSupport {
+class TestExpressionIndex extends HoodieSparkSqlTestBase with SparkAdapterSupport with ExclusiveSuite {
 
   override protected def beforeAll(): Unit = {
     spark.sql("set hoodie.metadata.index.column.stats.enable=false")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
@@ -35,14 +35,14 @@ import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY
 import org.apache.hudi.storage.StoragePath
 
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.common.{ExclusiveSuite, HoodieSparkSqlTestBase}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
 
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
 
-class TestSecondaryIndex extends HoodieSparkSqlTestBase {
+class TestSecondaryIndex extends HoodieSparkSqlTestBase with ExclusiveSuite {
 
   var instantTime: AtomicInteger = new AtomicInteger(1)
   val metadataOpts: Map[String, String] = Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestClusteringBinaryCopyStrategy.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestClusteringBinaryCopyStrategy.scala
@@ -24,13 +24,14 @@ import org.apache.hudi.common.table.timeline.HoodieInstant
 import org.apache.hudi.common.util.{Option => HOption}
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.hudi.common.ExclusiveSuite
 
 import java.math.BigDecimal
 import java.sql.Date
 import java.sql.Timestamp
 import java.time.LocalDate
 
-class TestClusteringBinaryCopyStrategy extends HoodieSparkProcedureTestBase {
+class TestClusteringBinaryCopyStrategy extends HoodieSparkProcedureTestBase with ExclusiveSuite {
 
   override def sparkConf(): SparkConf = {
     super.sparkConf()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
@@ -126,7 +126,6 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
       val out = fs.create(path)
       prevProps.store(out, "hudi properties")
       out.close()
-      fs.close()
 
       // create commit instant
       val newProps: URL = this.getClass.getClassLoader.getResource("table-config.properties")

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,9 @@
     <lance.skip.tests>false</lance.skip.tests>
     <!-- Scala SQL suites: one shared SparkContext per JVM with a child session per suite (see HoodieSparkSqlTestBase) -->
     <hudi.spark.test.sharedSession>false</hudi.spark.test.sharedSession>
+    <!-- Run scalatest suites concurrently (needs hudi.spark.test.sharedSession=true); 0 threads = scalatest's default -->
+    <hudi.scalatest.parallel>false</hudi.scalatest.parallel>
+    <hudi.scalatest.threads>0</hudi.scalatest.threads>
     <vortex.version>0.76.0</vortex.version>
     <vortex.spark.artifact>vortex-spark_${scala.binary.version}</vortex.spark.artifact>
     <vortex.skip.tests>false</vortex.skip.tests>
@@ -611,6 +614,8 @@
               <vortex.skip.tests>${vortex.skip.tests}</vortex.skip.tests>
               <hudi.spark.test.sharedSession>${hudi.spark.test.sharedSession}</hudi.spark.test.sharedSession>
             </systemProperties>
+            <parallel>${hudi.scalatest.parallel}</parallel>
+            <threadCount>${hudi.scalatest.threads}</threadCount>
           </configuration>
           <executions>
             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,8 @@
     <lance.spark.connector.version>0.4.0</lance.spark.connector.version>
     <lance.spark.artifact>lance-spark-3.5_${scala.binary.version}</lance.spark.artifact>
     <lance.skip.tests>false</lance.skip.tests>
+    <!-- Scala SQL suites: one shared SparkContext per JVM with a child session per suite (see HoodieSparkSqlTestBase) -->
+    <hudi.spark.test.sharedSession>false</hudi.spark.test.sharedSession>
     <vortex.version>0.76.0</vortex.version>
     <vortex.spark.artifact>vortex-spark_${scala.binary.version}</vortex.spark.artifact>
     <vortex.skip.tests>false</vortex.skip.tests>
@@ -607,6 +609,7 @@
               <log4j.configurationFile>${surefire-log4j.file}</log4j.configurationFile>
               <lance.skip.tests>${lance.skip.tests}</lance.skip.tests>
               <vortex.skip.tests>${vortex.skip.tests}</vortex.skip.tests>
+              <hudi.spark.test.sharedSession>${hudi.spark.test.sharedSession}</hudi.spark.test.sharedSession>
             </systemProperties>
           </configuration>
           <executions>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Part of #19524, stacked on #19921 and #19923 (their commits are included until they merge). The Java CI wall clock is set by the Scala SQL shards, and scalatest has no fork count, so the lever is running suites concurrently in one JVM. #19921 made the suites share one SparkContext behind a property and #19923 removed the cross-suite state; this PR turns the concurrency on for the DML shard and measures it.

### Summary and Changelog

- Pom properties `hudi.scalatest.parallel` (default false) and `hudi.scalatest.threads` (default 0) mapped to the scalatest plugin's `parallel` and `threadCount`: suites run concurrently, tests within a suite stay sequential. Set to true and 2 on `test-spark-java17-scala-dml-tests` only.
- Two fixes the local two-thread loop exposed: the per-test cleanup owns a table only by the suite's name prefix or as a session temp view (derived names such as `<generated>_pt` were dropped by other suites), and two helpers that sorted log file paths as strings now sort by the log file comparator (the write token precedes the instant in the name, so stage ids compared as text). The second is latent on master.

Measurement, over three runs of the DML shard: scalatest "Run completed" wall clock against the same job on master, about 41 minutes on a fast runner and 52 to 56 on a slow one (seven recent runs). The scheduling bound at two threads is about half the serial time, so a gain lands below master's fast case in every run; a result inside master's range is no gain. The per-suite sum over the wall clock (about 1.8 locally) is reported too but measures thread utilisation, not speedup.

| run | dml shard scalatest time | master reference |
|---|---|---|
| 1 ([run 34697891947](https://github.com/apache/hudi/actions/runs/34697891947), [dml job](https://github.com/apache/hudi/actions/runs/34697891947/job/103564439549)) | 27:58, 326 tests, 4 canceled, 1 ignored; per-suite sum 3297 s, sum over wall 1.97 | 41 min fast runner, 52 to 56 min slow runner (seven master runs, e.g. [34671326426](https://github.com/apache/hudi/actions/runs/34671326426) fast, [34674848405](https://github.com/apache/hudi/actions/runs/34674848405) slow); the same evening #19921 ([34688434503](https://github.com/apache/hudi/actions/runs/34688434503)) and #19923 ([34693015636](https://github.com/apache/hudi/actions/runs/34693015636)) ran serial at 52:01 and 53:17 with other-tests at 63 min on all three runs, so this was the slow class. Same 326 test names passed, same 4 canceled and 1 ignored as master |
| 2 ([attempt 2, dml job](https://github.com/apache/hudi/actions/runs/34697891947/job/103577205780)) | 35:27, same 326 test names, 4 canceled, 1 ignored; per-suite sum 4177 s, sum over wall 1.96 | slower runner than sample 1 (per-suite sum 27% higher), still below master's fastest serial run |
| 3 ([attempt 3, dml job](https://github.com/apache/hudi/actions/runs/34697891947/job/103583254498)) | 35:32, same 326 test names, 4 canceled, 1 ignored; per-suite sum 4190 s, sum over wall 1.97 | same runner class as sample 2 |

Verdict: all three samples land below master's fastest serial run (41:22) and 33 to 48% below its typical 52 to 56; both threads were busy 96 to 98% of the time in every sample, and the executed test set is identical to master's each time.

<details>
<summary>Local verification</summary>

| check | result |
|---|---|
| Maven run with the two properties on (`-DlogForkedProcessCommand=true`) | forked ScalaTest command carries `-P2` next to the shared-session property; base session created on a pool thread |
| whole dml tree at two threads, Spark 3.5 / Scala 2.12 / JDK 11, three passes | 24 suites; the first two passes exposed the two fixes above, the third was green (284 passed, 46 Spark-version cancels expected on 3.5) |
| twenty-iteration loop of twelve interaction-heavy suites at two threads | 20 of 20 green, 93 tests each, 295 to 446 s per iteration |
| Spark 4.2 / Scala 2.13 / JDK 17 test-compile of the stacked branches | green (phase 2 diff; phase 3 adds pom and workflow lines plus the two helper fixes) |

Local two-thread wall clock for the whole dml tree was 20 to 21 minutes awake time on this laptop; earlier local runs also contained laptop-sleep gaps that expired write heartbeats, which is not reproducible on CI runners.
</details>

### Impact

CI configuration and test infrastructure only.

### Risk Level

low. Off by default; on one shard, whose suites were prepared for it in #19921 and #19923 and which was looped locally at two threads before this PR.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable





