### PR TITLE
fix(hfile): bound compressed block decompression

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileBlock.java
@@ -92,6 +92,7 @@ public abstract class HFileBlock {
   @Getter
   private final HFileBlockType blockType;
   protected final int onDiskSizeWithoutHeader;
+  protected final int onDiskDataSizeWithHeader;
   protected final int uncompressedSizeWithoutHeader;
   protected final int bytesPerChecksum;
   private boolean isUnpacked = false;
@@ -115,6 +116,8 @@ public abstract class HFileBlock {
     this.blockType = blockType;
     this.onDiskSizeWithoutHeader = readInt(
         byteBuff, startOffsetInBuff + Header.ON_DISK_SIZE_WITHOUT_HEADER_INDEX);
+    this.onDiskDataSizeWithHeader = readInt(
+        byteBuff, startOffsetInBuff + Header.ON_DISK_DATA_SIZE_WITH_HEADER_INDEX);
     this.uncompressedSizeWithoutHeader = readInt(
         byteBuff, startOffsetInBuff + Header.UNCOMPRESSED_SIZE_WITHOUT_HEADER_INDEX);
     this.bytesPerChecksum = readInt(
@@ -149,6 +152,7 @@ public abstract class HFileBlock {
     this.sizeCheckSum = -1;
     this.uncompressedEndOffset = -1;
     this.onDiskSizeWithoutHeader = -1;
+    this.onDiskDataSizeWithHeader = -1;
     this.uncompressedSizeWithoutHeader = -1;
     this.bytesPerChecksum = -1;
   }
@@ -232,13 +236,19 @@ public abstract class HFileBlock {
         // Copy the block header which is not compressed
         System.arraycopy(
             compressedByteBuff, startOffsetInCompressedBuff, byteBuff, 0, HFILEBLOCK_HEADER_SIZE);
+        // onDiskSizeWithoutHeader includes the trailing checksum bytes, while
+        // onDiskDataSizeWithHeader ends immediately after the compressed payload.
+        // Passing the former to GZIPInputStream lets it interpret checksum bytes as
+        // another gzip member and can result in ZipException (for example, during
+        // metadata table compaction).
+        int compressedDataSize = onDiskDataSizeWithHeader - HFILEBLOCK_HEADER_SIZE;
         try (InputStream byteBuffInputStream = new ByteArrayInputStream(
-            compressedByteBuff, startOffsetInCompressedBuff + HFILEBLOCK_HEADER_SIZE, onDiskSizeWithoutHeader)) {
+            compressedByteBuff, startOffsetInCompressedBuff + HFILEBLOCK_HEADER_SIZE, compressedDataSize)) {
           context.getCompressor().decompress(
               byteBuffInputStream,
               byteBuff,
               HFILEBLOCK_HEADER_SIZE,
-              byteBuff.length - HFILEBLOCK_HEADER_SIZE);
+              uncompressedSizeWithoutHeader);
         }
       }
       isUnpacked = true;

--- a/hudi-io/src/test/java/org/apache/hudi/io/hfile/TestHFileBlockDecompression.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/hfile/TestHFileBlockDecompression.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.io.hfile;
+
+import org.apache.hudi.io.ByteArraySeekableDataInputStream;
+import org.apache.hudi.io.ByteBufferBackedInputStream;
+import org.apache.hudi.io.compress.CompressionCodec;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.apache.hudi.io.hfile.HFileBlock.HFILEBLOCK_HEADER_SIZE;
+import static org.apache.hudi.io.util.IOUtils.readInt;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Regression tests for compressed HFile block boundaries. */
+class TestHFileBlockDecompression {
+
+  // A valid gzip member header without a body. If checksum bytes are passed to the gzip decoder,
+  // the decoder treats these bytes as a second member and fails with "invalid block type".
+  private static final byte[] GZIP_MEMBER_HEADER = {
+      0x1f, (byte) 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00
+  };
+
+  @Test
+  void compressedBlockDoesNotDecodeTrailingChecksums() throws IOException {
+    HFileContext context = HFileContext.builder()
+        .compressionCodec(CompressionCodec.GZIP)
+        .blockSize(1024 * 1024)
+        .build();
+    byte[] value = new byte[128 * 1024];
+    new Random(19929L).nextBytes(value);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (HFileWriter writer = new HFileWriterImpl(context, output)) {
+      writer.append("row", value);
+    }
+
+    byte[] hfile = output.toByteArray();
+    int dataBlockOffset;
+    try (HFileReaderImpl reader = openReader(hfile)) {
+      reader.initializeMetadata();
+      dataBlockOffset = (int) reader.getDataBlockIndexMap().values().iterator().next().getOffset();
+    }
+
+    int onDiskSizeWithoutHeader = readInt(
+        hfile, dataBlockOffset + HFileBlock.Header.ON_DISK_SIZE_WITHOUT_HEADER_INDEX);
+    int onDiskDataSizeWithHeader = readInt(
+        hfile, dataBlockOffset + HFileBlock.Header.ON_DISK_DATA_SIZE_WITH_HEADER_INDEX);
+    int compressedDataSize = onDiskDataSizeWithHeader - HFILEBLOCK_HEADER_SIZE;
+    int checksumStart = dataBlockOffset + onDiskDataSizeWithHeader;
+    int checksumLength = onDiskSizeWithoutHeader - compressedDataSize;
+    assertTrue(checksumLength >= GZIP_MEMBER_HEADER.length,
+        "the block must have enough checksum bytes for the gzip-boundary regression");
+    System.arraycopy(GZIP_MEMBER_HEADER, 0, hfile, checksumStart, GZIP_MEMBER_HEADER.length);
+
+    try (HFileReaderImpl reader = openReader(hfile)) {
+      reader.initializeMetadata();
+      assertEquals(1, reader.getNumKeyValueEntries());
+      assertTrue(reader.seekTo());
+      KeyValue keyValue = reader.getKeyValue().get();
+      assertEquals("row", keyValue.getKey().getContentInString());
+      assertArrayEquals(value, Arrays.copyOfRange(
+          keyValue.getBytes(), keyValue.getValueOffset(),
+          keyValue.getValueOffset() + keyValue.getValueLength()));
+    }
+  }
+
+  private static HFileReaderImpl openReader(byte[] hfile) {
+    return new HFileReaderImpl(
+        new ByteArraySeekableDataInputStream(new ByteBufferBackedInputStream(hfile)), hfile.length);
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The native HFile reader can fail with `java.util.zip.ZipException: invalid block type` while reading valid compressed metadata blocks because trailing checksum bytes are passed to the GZIP decoder. This addresses #19929.

### Summary and Changelog

- Exclude trailing checksum bytes from native compressed HFile block decompression.
- Limit decompression output to the block's uncompressed payload size.
- Add a regression test covering checksum bytes that resemble a second gzip member.

The HFile writer records two distinct sizes: `onDiskDataSizeWithHeader` ends after the compressed payload, while `onDiskSizeWithoutHeader` includes trailing checksum bytes. The fix uses `onDiskDataSizeWithHeader - HFILEBLOCK_HEADER_SIZE` for decoder input and `uncompressedSizeWithoutHeader` for the output limit.

Cross-validation with the issue-era Aircompressor 0.27 dependency shows that the pre-fix commit fails with the exact `ZipException` from `HFileBlock.unpack`, while this fixed commit passes. The current Aircompressor 2.0.3 behavior can hide the over-read, so the version-matched check is included for reproducibility.

Tests completed:

- Full hudi-io test suite: 127 tests passed, 0 failures, 0 errors, 0 skipped.
- Focused regression test passes with both the current dependency and Aircompressor 0.27.

### Impact

No public API, storage format, writer serialization, metadata logic, or block navigation changes. The fix only narrows the native reader's decompression input and output bounds.

### Risk Level

low. The change is limited to decompression boundaries and is covered by a real-HFile regression test plus the full hudi-io test suite.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable